### PR TITLE
Add 'ai.onnx' as default domain

### DIFF
--- a/onnx/src/model.rs
+++ b/onnx/src/model.rs
@@ -192,8 +192,12 @@ pub struct Onnx {
 
 impl Onnx {
     pub fn parse(&self, proto: &pb::ModelProto) -> TractResult<ParseResult> {
-        let onnx_operator_set_version =
-            proto.opset_import.iter().find(|import| import.domain == "").unwrap().version;
+        let onnx_operator_set_version = proto
+            .opset_import
+            .iter()
+            .find(|import| import.domain == "" || import.domain == "ai.onnx")
+            .unwrap()
+            .version;
         let graph = &proto.graph;
         debug!("ONNX operator set version: {:?}", onnx_operator_set_version);
         if onnx_operator_set_version < 9 || onnx_operator_set_version > 12 {


### PR DESCRIPTION
Add 'ai.onnx' as a valid default domain name.

I did not found any official documentation that state that it is a possiile value for the default domain but I have a model that use it and I found it mentioned here as a default domain:
https://github.com/onnx/onnx/issues/688
https://github.com/onnx/onnx/blame/master/onnx/version_converter/convert.h
