### PR TITLE
add ios to fma matmul

### DIFF
--- a/linalg/x86_64/fma/fma_mmm_f32_16x6.tmpl
+++ b/linalg/x86_64/fma/fma_mmm_f32_16x6.tmpl
@@ -20,7 +20,7 @@ Windows ABI:
 */
 {% endcomment %}
 
-{% if os == "macos" %}
+{% if os == "macos" or os == "ios" %}
 
 .intel_syntax noprefix
 .text

--- a/linalg/x86_64/fma/fma_mmm_i8_8x8.tmpl
+++ b/linalg/x86_64/fma/fma_mmm_i8_8x8.tmpl
@@ -19,7 +19,7 @@ Windows ABI:
 */
 {% endcomment %}
 
-{% if os == "macos" %}
+{% if os == "macos" or os == "ios" %}
 
 .intel_syntax noprefix
 .text


### PR DESCRIPTION
We encountered an error while compiling `tract-onnx` for `--target x86_64-apple-ios` due to hard-coded os checks in some `.tmpl` files of `tract-linalg`.

```
error: linking with `cc` failed: exit code: 1
  = note: Undefined symbols for architecture x86_64:
            "_fma_mmm_i8_8x8", referenced from: ...
            "_fma_mmm_f32_16x6", referenced from: ...
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This pr fixes the issue for the given target, it might still occur for other targets.