### PR TITLE
Implement DynamicQuantizeLinear

### DIFF
--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -1,6 +1,5 @@
 use crate::internal::*;
 use crate::ops::element_wise::ElementWiseOp;
-use ndarray::ArrayViewD;
 use num_traits::AsPrimitive;
 use num_traits::Zero;
 use tract_linalg::lut::Lut;
@@ -145,110 +144,6 @@ fn info_quantize_linear_i8(q: &QuantizeLinearI8) -> TractResult<Vec<String>> {
         q.zero_point,
         q.scale.recip()
     )])
-}
-
-fn dynamic_quantize_linear_f32_u8(x: f32, scale: f32, zero_point: u8) -> u8 {
-    (((x / scale).round() as i32) + zero_point as i32)
-        .max(u8::min_value() as i32)
-        .min(u8::max_value() as i32) as u8
-}
-
-fn dynamic_quantize_linear_u8(scale: f32, zero_point: u8, xs: &[f32], ys: &mut [u8]) {
-    xs.iter()
-        .zip(ys.iter_mut())
-        .for_each(|(x, y)| *y = dynamic_quantize_linear_f32_u8(*x, scale, zero_point));
-}
-
-fn scale_and_zero_point<'a>(v: ArrayViewD<'a, f32>) -> (f32, u8) {
-    // get the min and max of v and extend it to have zero included
-    // in the interval [min, max]
-    let (min, max) = v.fold((0., 0.), |(a_min, a_max), &v| {
-        if v < a_min {
-            (v, a_max)
-        } else if v > a_max {
-            (a_min, v)
-        } else {
-            (a_min, a_max)
-        }
-    });
-
-    // quantize range
-    let min_t = u8::min_value() as f32;
-    let max_t = u8::max_value() as f32;
-
-    let scale = (max - min) / max_t;
-
-    let zero_point = -min / scale;
-    let zero_point = zero_point.round();
-    // clipping to [0, 255]
-    let zero_point = zero_point.max(min_t);
-    let zero_point = zero_point.min(max_t);
-
-    let zero_point: u8 = zero_point as u8;
-
-    (scale, zero_point)
-}
-
-#[derive(Clone, Debug, new, Hash)]
-pub struct DynamicQuantizeLinearU8;
-
-impl Op for DynamicQuantizeLinearU8 {
-    fn name(&self) -> Cow<str> {
-        "DynamicQuantizeLinearU8".into()
-    }
-
-    fn info(&self) -> TractResult<Vec<String>> {
-        Ok(vec![])
-    }
-
-    fn validation(&self) -> Validation {
-        Validation::Accurate
-    }
-
-    op_core_mir!();
-    op_as_typed_op!();
-}
-
-tract_linalg::impl_dyn_hash!(DynamicQuantizeLinearU8);
-
-impl EvalOp for DynamicQuantizeLinearU8 {
-    fn is_stateless(&self) -> bool {
-        true
-    }
-    fn eval(&self, inputs: TVec<Arc<Tensor>>) -> TractResult<TVec<Arc<Tensor>>> {
-        let input = &inputs[0];
-        let a_input = input.to_array_view::<f32>()?;
-        let (scale, zero_point) = scale_and_zero_point(a_input);
-
-        let mut dst = unsafe { Tensor::uninitialized_dt(u8::datum_type(), input.shape())? };
-        // We cannot use quantize_linear_u8 here because it does `x * scale.recip()`
-        // instead of `x / scale`. This change some number enough to be rounded to another integer.
-        dynamic_quantize_linear_u8(
-            scale,
-            zero_point,
-            input.as_slice::<f32>()?,
-            dst.as_slice_mut::<u8>()?,
-        );
-
-        let quantized_tensor = dst.into_arc_tensor();
-        let scale_tensor = rctensor0(scale);
-        let zero_point_tensor = rctensor0(zero_point);
-
-        Ok(tvec!(quantized_tensor, scale_tensor, zero_point_tensor))
-    }
-}
-
-impl TypedOp for DynamicQuantizeLinearU8 {
-    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
-        let mut quantized_fact = inputs[0].clone();
-        quantized_fact.datum_type = u8::datum_type();
-        let shape = ShapeFact::from_dims(&[])?;
-        let scale_fact = TypedFact::dt_shape(f32::datum_type(), shape.clone())?;
-        let zero_fact = TypedFact::dt_shape(u8::datum_type(), shape)?;
-        Ok(tvec!(quantized_fact, scale_fact, zero_fact))
-    }
-
-    as_op!();
 }
 
 #[derive(Clone, Debug, new, Educe)]
@@ -451,57 +346,4 @@ element_wise_oop!(lookup_table,
 
 fn hash_lookup_table<H: std::hash::Hasher>(lut: &Box<dyn Lut>, h: &mut H) {
     Hash::hash_slice(lut.table(), h)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ndarray::arr1;
-
-    // Data for tests is from:
-    // https://github.com/onnx/onnx/blob/master/docs/Operators.md#DynamicQuantizeLinear
-    #[test]
-    fn test_scale_and_zero_point() {
-        let data: [(&[f32], f32, u8); 3] = [
-            (&[0., 2., -3., -2.5, 1.34, 0.5], 0.0196078438, 153),
-            (&[-1., -2.1, -1.3, -2.5, -3.34, -4.], 0.0156862754, 255),
-            (&[1., 2.1, 1.3, 2.5, 3.34, 4., 1.5, 2.6, 3.9, 4., 3., 2.345], 0.0156862754, 0),
-        ];
-
-        let epsilon = 0.00000001;
-        for (v, scale_ok, zero_point_ok) in &data {
-            let v = arr1(v).into_dyn();
-            let v = v.view();
-            let (scale, zero_point) = scale_and_zero_point(v);
-            assert!((scale - scale_ok).abs() < epsilon);
-            assert_eq!(zero_point, *zero_point_ok);
-        }
-    }
-
-    #[test]
-    fn test_dynamic_quantize_linear_u8() {
-        let data: [(&[f32], &[u8]); 3] = [
-            (&[0., 2., -3., -2.5, 1.34, 0.5], &[153, 255, 0, 26, 221, 179]),
-            (&[-1., -2.1, -1.3, -2.5, -3.34, -4.], &[191, 121, 172, 96, 42, 0]),
-            (
-                &[1., 2.1, 1.3, 2.5, 3.34, 4., 1.5, 2.6, 3.9, 4., 3., 2.345],
-                &[64, 134, 83, 159, 213, 255, 96, 166, 249, 255, 191, 149],
-            ),
-        ];
-
-        for (v, quantized_ok) in &data {
-            let v = arr1(v).into_dyn();
-            let (scale, zero_point) = scale_and_zero_point(v.view());
-
-            // same shape of v but with u8 type, values will be overwritten
-            let mut quantized = v.mapv(|_| 0 as u8);
-            dynamic_quantize_linear_u8(
-                scale,
-                zero_point,
-                v.as_slice().unwrap(),
-                quantized.as_slice_mut().unwrap(),
-            );
-            assert_eq!(quantized.as_slice().unwrap(), *quantized_ok);
-        }
-    }
 }

--- a/harness/onnx-test-suite/node-1.6.0.txt
+++ b/harness/onnx-test-suite/node-1.6.0.txt
@@ -110,7 +110,10 @@ test_div_bcast
 test_div_example
 test_dropout_default
 test_dropout_random
+test_dynamicquantizelinear  not-nnef
+test_dynamicquantizelinear_max_adjusted  not-nnef
 test_dynamicquantizelinear_max_adjusted_expanded  not-typable not-nnef
+test_dynamicquantizelinear_min_adjusted  not-nnef
 test_dynamicquantizelinear_min_adjusted_expanded  not-typable not-nnef
 test_edge_pad input:x
 test_elu

--- a/harness/onnx-test-suite/node-1.7.0.txt
+++ b/harness/onnx-test-suite/node-1.7.0.txt
@@ -134,7 +134,10 @@ test_dropout_default_mask  not-typable not-nnef
 test_dropout_default_old
 test_dropout_random not-nnef
 test_dropout_random_old
+test_dynamicquantizelinear  not-nnef
+test_dynamicquantizelinear_max_adjusted  not-nnef
 test_dynamicquantizelinear_max_adjusted_expanded  not-typable not-nnef
+test_dynamicquantizelinear_min_adjusted  not-nnef
 test_dynamicquantizelinear_min_adjusted_expanded  not-typable not-nnef
 test_edge_pad input:x
 test_elu

--- a/onnx/src/ops/quant.rs
+++ b/onnx/src/ops/quant.rs
@@ -2,6 +2,7 @@ use crate::model::{OnnxOpRegister, ParsingContext};
 use crate::pb::NodeProto;
 use tract_hir::internal::*;
 use tract_hir::ops::quant::*;
+use tract_ndarray::ArrayViewD;
 
 pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("QuantizeLinear", quantize_linear);
@@ -207,5 +208,162 @@ impl Expansion for DynamicQuantizeLinear {
     ) -> TractResult<TVec<OutletId>> {
         let op: Box<dyn TypedOp> = Box::new(DynamicQuantizeLinearU8::new());
         target.wire_node(format!("{}.dynamic_quantize", prefix), op, &[inputs[0]])
+    }
+}
+
+fn dynamic_quantize_linear_f32_u8(x: f32, scale: f32, zero_point: u8) -> u8 {
+    (((x / scale).round() as i32) + zero_point as i32)
+        .max(u8::min_value() as i32)
+        .min(u8::max_value() as i32) as u8
+}
+
+fn dynamic_quantize_linear_u8(scale: f32, zero_point: u8, xs: &[f32], ys: &mut [u8]) {
+    xs.iter()
+        .zip(ys.iter_mut())
+        .for_each(|(x, y)| *y = dynamic_quantize_linear_f32_u8(*x, scale, zero_point));
+}
+
+fn scale_and_zero_point<'a>(v: ArrayViewD<'a, f32>) -> (f32, u8) {
+    // get the min and max of v and extend it to have zero included
+    // in the interval [min, max]
+    let (min, max) = v.fold((0., 0.), |(a_min, a_max), &v| {
+        if v < a_min {
+            (v, a_max)
+        } else if v > a_max {
+            (a_min, v)
+        } else {
+            (a_min, a_max)
+        }
+    });
+
+    // quantize range
+    let min_t = u8::min_value() as f32;
+    let max_t = u8::max_value() as f32;
+
+    let scale = (max - min) / max_t;
+
+    let zero_point = -min / scale;
+    let zero_point = zero_point.round();
+    // clipping to [0, 255]
+    let zero_point = zero_point.max(min_t);
+    let zero_point = zero_point.min(max_t);
+
+    let zero_point: u8 = zero_point as u8;
+
+    (scale, zero_point)
+}
+
+#[derive(Clone, Debug, new, Hash)]
+pub struct DynamicQuantizeLinearU8;
+
+impl Op for DynamicQuantizeLinearU8 {
+    fn name(&self) -> Cow<str> {
+        "DynamicQuantizeLinearU8".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(vec![])
+    }
+
+    fn validation(&self) -> Validation {
+        Validation::Accurate
+    }
+
+    op_onnx!();
+    op_as_typed_op!();
+}
+
+tract_linalg::impl_dyn_hash!(DynamicQuantizeLinearU8);
+
+impl EvalOp for DynamicQuantizeLinearU8 {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+    fn eval(&self, inputs: TVec<Arc<Tensor>>) -> TractResult<TVec<Arc<Tensor>>> {
+        let input = &inputs[0];
+        let a_input = input.to_array_view::<f32>()?;
+        let (scale, zero_point) = scale_and_zero_point(a_input);
+
+        let mut dst = unsafe { Tensor::uninitialized_dt(u8::datum_type(), input.shape())? };
+        // We cannot use quantize_linear_u8 here because it does `x * scale.recip()`
+        // instead of `x / scale`. This change some number enough to be rounded to another integer.
+        dynamic_quantize_linear_u8(
+            scale,
+            zero_point,
+            input.as_slice::<f32>()?,
+            dst.as_slice_mut::<u8>()?,
+        );
+
+        let quantized_tensor = dst.into_arc_tensor();
+        let scale_tensor = rctensor0(scale);
+        let zero_point_tensor = rctensor0(zero_point);
+
+        Ok(tvec!(quantized_tensor, scale_tensor, zero_point_tensor))
+    }
+}
+
+impl TypedOp for DynamicQuantizeLinearU8 {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        let mut quantized_fact = inputs[0].clone();
+        quantized_fact.datum_type = u8::datum_type();
+        let shape: &[usize] = [].as_ref();
+        let scale_fact = TypedFact::dt_shape(f32::datum_type(), shape)?;
+        let zero_fact = TypedFact::dt_shape(u8::datum_type(), shape)?;
+        Ok(tvec!(quantized_fact, scale_fact, zero_fact))
+    }
+
+    as_op!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tract_ndarray::arr1;
+
+    // Data for tests is from:
+    // https://github.com/onnx/onnx/blob/master/docs/Operators.md#DynamicQuantizeLinear
+    #[test]
+    fn test_scale_and_zero_point() {
+        let data: [(&[f32], f32, u8); 3] = [
+            (&[0., 2., -3., -2.5, 1.34, 0.5], 0.0196078438, 153),
+            (&[-1., -2.1, -1.3, -2.5, -3.34, -4.], 0.0156862754, 255),
+            (&[1., 2.1, 1.3, 2.5, 3.34, 4., 1.5, 2.6, 3.9, 4., 3., 2.345], 0.0156862754, 0),
+        ];
+
+        let epsilon = 0.00000001;
+        for (v, scale_ok, zero_point_ok) in &data {
+            let v = arr1(v).into_dyn();
+            let v = v.view();
+            let (scale, zero_point) = scale_and_zero_point(v);
+            assert!((scale - scale_ok).abs() < epsilon);
+            assert_eq!(zero_point, *zero_point_ok);
+        }
+    }
+
+    #[test]
+    fn test_dynamic_quantize_linear_u8() {
+        let data: [(&[f32], &[u8]); 3] = [
+            (&[0., 2., -3., -2.5, 1.34, 0.5], &[153, 255, 0, 26, 221, 179]),
+            (&[-1., -2.1, -1.3, -2.5, -3.34, -4.], &[191, 121, 172, 96, 42, 0]),
+            (
+                &[1., 2.1, 1.3, 2.5, 3.34, 4., 1.5, 2.6, 3.9, 4., 3., 2.345],
+                &[64, 134, 83, 159, 213, 255, 96, 166, 249, 255, 191, 149],
+            ),
+        ];
+
+        for (v, quantized_ok) in &data {
+            let v = arr1(v).into_dyn();
+            let (scale, zero_point) = scale_and_zero_point(v.view());
+
+            // same shape of v but with u8 type, values will be overwritten
+            let mut quantized = v.mapv(|_| 0 as u8);
+            dynamic_quantize_linear_u8(
+                scale,
+                zero_point,
+                v.as_slice().unwrap(),
+                quantized.as_slice_mut().unwrap(),
+            );
+            assert_eq!(quantized.as_slice().unwrap(), *quantized_ok);
+        }
     }
 }


### PR DESCRIPTION
This PR implement the onnx operator [DynamicQuantizeLinear](https://github.com/onnx/onnx/blob/master/docs/Operators.md#DynamicQuantizeLinear).
I could not reuse `quantize_linear_u8` because it does `x * scale.recip()` instead of `x / scale`, This change some number enough to be rounded to another integer and the onnx testsuite fails.

Is not currently possible to implement it using the operations already provided (like is done in the `dynamicquantizelinear_expanded` test) because not all needed operations are `TypedOp` and in particular `QuantizeLinear` expect the zero point and the scale to be constant tensor.

Close #380 