### PR TITLE
Get scale and zero_point from inputs

### DIFF
--- a/harness/onnx-test-suite/node-1.5.0.txt
+++ b/harness/onnx-test-suite/node-1.5.0.txt
@@ -170,7 +170,7 @@ test_lstm_with_peepholes
 test_matmul_2d
 test_matmul_3d
 test_matmul_4d
-test_matmulinteger                                                                   not-typable not-nnef
+test_matmulinteger                                                                   not-nnef
 test_max_example
 test_max_one_input
 test_max_two_inputs
@@ -223,8 +223,8 @@ test_pow_example
 test_prelu_broadcast
 test_prelu_example
 test_qlinearconv                                                                     not-typable not-nnef
-test_qlinearmatmul_2D                                                                not-typable not-nnef
-test_qlinearmatmul_3D                                                                not-typable not-nnef
+test_qlinearmatmul_2D                                                                not-nnef
+test_qlinearmatmul_3D                                                                not-nnef
 test_quantizelinear                                                                 input:x not-nnef
 test_reciprocal
 test_reciprocal_example

--- a/harness/onnx-test-suite/node-1.6.0.txt
+++ b/harness/onnx-test-suite/node-1.6.0.txt
@@ -197,7 +197,7 @@ test_lstm_with_peepholes
 test_matmul_2d
 test_matmul_3d
 test_matmul_4d
-test_matmulinteger                                                                   not-typable not-nnef
+test_matmulinteger                                                                   not-nnef
 test_max_example
 test_max_one_input
 test_max_two_inputs
@@ -261,8 +261,8 @@ test_pow_example
 test_prelu_broadcast
 test_prelu_example
 test_qlinearconv                                                                     not-typable not-nnef
-test_qlinearmatmul_2D                                                                not-typable not-nnef
-test_qlinearmatmul_3D                                                                not-typable not-nnef
+test_qlinearmatmul_2D                                                                not-nnef
+test_qlinearmatmul_3D                                                                not-nnef
 test_quantizelinear                                                                 input:x not-nnef
 test_reciprocal
 test_reciprocal_example

--- a/harness/onnx-test-suite/node-1.7.0.txt
+++ b/harness/onnx-test-suite/node-1.7.0.txt
@@ -229,7 +229,7 @@ test_lstm_with_peepholes
 test_matmul_2d
 test_matmul_3d
 test_matmul_4d
-test_matmulinteger                                                                   not-typable not-nnef
+test_matmulinteger                                                                   not-nnef
 test_max_example
 test_max_float32
 test_max_float64
@@ -323,8 +323,8 @@ test_pow_types_int64_int64
 test_prelu_broadcast
 test_prelu_example
 test_qlinearconv                                                                     not-typable not-nnef
-test_qlinearmatmul_2D                                                                not-typable not-nnef
-test_qlinearmatmul_3D                                                                not-typable not-nnef
+test_qlinearmatmul_2D                                                                not-nnef
+test_qlinearmatmul_3D                                                                not-nnef
 test_quantizelinear                                                                 input:x not-nnef
 test_reciprocal
 test_reciprocal_example


### PR DESCRIPTION
Allow onnx operators `MatMulInteger` and `QLinearMatMul` to read `zero_point` and `scale` from the input at evaluation time when they are not constant.

Close #389 