### PR TITLE
Add generic multiplication for i8 u8

### DIFF
--- a/core/src/ops/matmul/mir.rs
+++ b/core/src/ops/matmul/mir.rs
@@ -38,6 +38,18 @@ fn eval(
                     MMMWrapper::Quant((tract_linalg::ops().qmmm_u8_u8)(m, k, n))
                 });
             }
+        } else if (a.datum_type(), b.datum_type(), q.c_datum_type)
+            == (i8::datum_type(), u8::datum_type(), i32::datum_type())
+        {
+            return eval_t(a, b, a_trans, b_trans, c_trans, q_params, &|m, k, n| {
+                MMMWrapper::Quant((tract_linalg::ops().qmmm_i8_u8_i32)(m, k, n))
+            });
+        } else if (a.datum_type(), b.datum_type(), q.c_datum_type)
+            == (u8::datum_type(), i8::datum_type(), i32::datum_type())
+        {
+            return eval_t(b, a, !a_trans, !b_trans, !c_trans, q_params, &|m, k, n| {
+                MMMWrapper::Quant((tract_linalg::ops().qmmm_i8_u8_i32)(m, k, n))
+            });
         }
     } else if (a.datum_type(), b.datum_type()) == (f32::datum_type(), f32::datum_type()) {
         return eval_t(a, b, a_trans, b_trans, c_trans, q_params, &|m, k, n| {
@@ -614,6 +626,23 @@ impl TypedOp for MatMulUnary {
                         self.c_trans,
                         self.q_params.as_ref(),
                         &|m, k, n| MMMWrapper::Quant((tract_linalg::ops().qmmm_i8_i32)(m, k, n)),
+                    )?
+                } else if (
+                    self.a.datum_type(),
+                    b.datum_type,
+                    self.q_params.as_ref().map(|q| q.c_datum_type),
+                ) == (i8::datum_type(), u8::datum_type(), Some(i32::datum_type()))
+                {
+                    new_mat_mul_unary_finite(
+                        model,
+                        node,
+                        self.a.clone(),
+                        &b_shape,
+                        self.a_trans,
+                        self.b_trans,
+                        self.c_trans,
+                        self.q_params.as_ref(),
+                        &|m, k, n| MMMWrapper::Quant((tract_linalg::ops().qmmm_i8_u8_i32)(m, k, n)),
                     )?
                 } else {
                     bail!(

--- a/linalg/src/frame/mmm/kernel.rs
+++ b/linalg/src/frame/mmm/kernel.rs
@@ -94,6 +94,22 @@ macro_rules! test_mmm_kernel_i8_i32 {
 }
 
 #[macro_export]
+macro_rules! test_mmm_kernel_i8_u8_i32 {
+    ($k: ty, $id: ident, $cond: expr) => {
+        #[cfg(test)]
+        #[allow(non_snake_case)]
+        mod $id {
+            mmm_kernel_tests!($cond, $k, i8, u8, i32, i32);
+            mmm_kernel_fuse_tests!($cond, $k, i8, u8, i32, i32);
+            mmm_frame_tests!($cond, $k, i8, u8, i32, i32);
+            mmm_s_frame_tests!($cond, $k, i8, u8, i32, i32);
+            qmmm_kernel_fuse_tests!($cond, $k, i8, u8, i32, i32);
+            qmmm_frame_tests!($cond, $k, i8, u8, i32, i32);
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! test_mmm_kernel_u8 {
     ($k: ty, $id: ident, $cond: expr) => {
         #[cfg(test)]

--- a/linalg/src/generic/mmm.rs
+++ b/linalg/src/generic/mmm.rs
@@ -629,8 +629,10 @@ test_mmm_kernel_f32!(crate::generic::mmm::GenericMmm4x4<f32, f32, f32, f32>, tes
 test_mmm_kernel_i8!(crate::generic::mmm::GenericMmm4x4<i8, i8, i8, i32>, test_GenericMmm4x4_i8, true);
 test_mmm_kernel_u8!(crate::generic::mmm::GenericMmm4x4<u8, u8, u8, i32>, test_GenericMmm4x4_u8, true);
 test_mmm_kernel_i8_i32!(crate::generic::mmm::GenericMmm4x4<i8, i8, i32, i32>, test_GenericMmm4x4_i8_i32, true);
+test_mmm_kernel_i8_u8_i32!(crate::generic::mmm::GenericMmm4x4<i8, u8, i32, i32>, test_GenericMmm4x4_i8_u8_i32, true);
 
 test_mmm_kernel_f32!(crate::generic::mmm::GenericMmmTest3x2<f32, f32, f32, f32>, test_GenericMmmTest3x2_f32, true);
 test_mmm_kernel_i8!(crate::generic::mmm::GenericMmmTest3x2<i8, i8, i8, i32>, test_GenericMmmTest3x2_i8, true);
 test_mmm_kernel_u8!(crate::generic::mmm::GenericMmmTest3x2<u8, u8, u8, i32>, test_GenericMmmTest3x2_u8, true);
 test_mmm_kernel_i8_i32!(crate::generic::mmm::GenericMmmTest3x2<i8, i8, i32, i32>, test_GenericMmmTest3x2_i8_i32, true);
+test_mmm_kernel_i8_u8_i32!(crate::generic::mmm::GenericMmmTest3x2<i8, u8, i32, i32>, test_GenericMmmTest3x2_i8_u8_i32, true);

--- a/linalg/src/lib.rs
+++ b/linalg/src/lib.rs
@@ -34,6 +34,9 @@ pub struct Ops {
     pub qmmm_i8_i32: Box<
         dyn Fn(usize, usize, usize) -> Box<dyn mmm::QMatMatMul<i8, i8, i32, i32>> + Send + Sync,
     >,
+    pub qmmm_i8_u8_i32: Box<
+            dyn Fn(usize, usize, usize) -> Box<dyn mmm::QMatMatMul<i8, u8, i32, i32>> + Send + Sync,
+        >,
     pub qmmm_u8_i32: Box<
         dyn Fn(usize, usize, usize) -> Box<dyn mmm::QMatMatMul<u8, u8, i32, i32>> + Send + Sync,
     >,
@@ -65,6 +68,15 @@ pub fn generic() -> Ops {
                 i32,
                 i32,
             >::new(m, k, n)))
+        }),
+        qmmm_i8_u8_i32: Box::new(|m, k, n| {
+            Box::new(mmm::QMatMatMulImpl::from(mmm::MatMatMulImpl::<
+                    generic::GenericMmm4x4<i8, u8, i32, i32>,
+                i8,
+                u8,
+                i32,
+                i32,
+                >::new(m, k, n)))
         }),
         qmmm_u8_i32: Box::new(|m, k, n| {
             Box::new(mmm::QMatMatMulImpl::from(mmm::MatMatMulImpl::<


### PR DESCRIPTION
This allow to multiply two matrices with different type (`i8` and `u8`).
This add only the generic multiplication and not the optimized one.