### PR TITLE
Fix NNEF model reader

### DIFF
--- a/nnef/Cargo.toml
+++ b/nnef/Cargo.toml
@@ -17,6 +17,9 @@ maintenance = { status = "actively-developed" }
 log = "0.4"
 nom = "5"
 tar = "0.4"
-flate2 = "1.0"
+flate2 = { version = "1.0", optional = true }
 tract-core = { path = "../core" }
 walkdir = "2"
+
+[features]
+default = ["flate2"]

--- a/nnef/Cargo.toml
+++ b/nnef/Cargo.toml
@@ -17,5 +17,6 @@ maintenance = { status = "actively-developed" }
 log = "0.4"
 nom = "5"
 tar = "0.4"
+flate2 = "1.0"
 tract-core = { path = "../core" }
 walkdir = "2"

--- a/nnef/src/framework.rs
+++ b/nnef/src/framework.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-
+use std::io::{Read, Seek, SeekFrom};
 use crate::ast::ProtoModel;
 use crate::internal::*;
 
@@ -105,7 +105,24 @@ impl tract_core::prelude::Framework<ProtoModel, TypedModel> for Nnef {
         let path = path.as_ref();
         if path.is_file() {
             let mut f = std::fs::File::open(path)?;
-            return self.proto_model_for_read(&mut f);
+            let mut buf = [0u8; 2];
+            f.read_exact(&mut buf)?;
+            if buf[0] == 31 && buf[1] == 139 {
+                f.seek(SeekFrom::Start(0));
+                #[cfg(feature = "flate2")]
+                {
+                    let mut f = flate2::read::GzDecoder::new(f);
+                    return self.proto_model_for_read(&mut f);
+                }
+                #[cfg(not(feature = "flate2"))]
+                {
+                    eprintln!("Cannot read file {:?} without flate2 enabled.", path);
+                    std::process::exit(1);
+                }
+            } else {
+                return self.proto_model_for_read(&mut f);
+            }
+           
         }
         let mut text: Option<String> = None;
         let mut tensors: Vec<(String, Arc<Tensor>)> = Default::default();
@@ -128,8 +145,7 @@ impl tract_core::prelude::Framework<ProtoModel, TypedModel> for Nnef {
     fn proto_model_for_read(&self, reader: &mut dyn std::io::Read) -> TractResult<ProtoModel> {
         let mut text: Option<String> = None;
         let mut tensors: Vec<(String, Arc<Tensor>)> = Default::default();
-        let decoded = flate2::read::GzDecoder::new(reader);
-        let mut tar = tar::Archive::new(decoded);
+        let mut tar = tar::Archive::new(reader);
         for entry in tar.entries()? {
             let mut entry = entry?;
             let path = entry.path()?.to_path_buf();

--- a/nnef/src/framework.rs
+++ b/nnef/src/framework.rs
@@ -128,7 +128,8 @@ impl tract_core::prelude::Framework<ProtoModel, TypedModel> for Nnef {
     fn proto_model_for_read(&self, reader: &mut dyn std::io::Read) -> TractResult<ProtoModel> {
         let mut text: Option<String> = None;
         let mut tensors: Vec<(String, Arc<Tensor>)> = Default::default();
-        let mut tar = tar::Archive::new(reader);
+        let decoded = flate2::read::GzDecoder::new(reader);
+        let mut tar = tar::Archive::new(decoded);
         for entry in tar.entries()? {
             let mut entry = entry?;
             let path = entry.path()?.to_path_buf();

--- a/nnef/src/framework.rs
+++ b/nnef/src/framework.rs
@@ -115,10 +115,7 @@ impl tract_core::prelude::Framework<ProtoModel, TypedModel> for Nnef {
                     return self.proto_model_for_read(&mut f);
                 }
                 #[cfg(not(feature = "flate2"))]
-                {
-                    eprintln!("Cannot read file {:?} without flate2 enabled.", path);
-                    std::process::exit(1);
-                }
+                bail!("Cannot read file {:?} without flate2 enabled.", path);
             } else {
                 return self.proto_model_for_read(&mut f);
             }


### PR DESCRIPTION
Problem: The code for reading an NNEF model file with ext `.tgz` is not taking care of the GZ decoding.
Quick Solution: Added flate2 library to decode the file before read by tar.
Ideal Solution: Detect the file extension and add GZ decoding for `.tgz` file only. But it is not in scope as the NNEF tools always generate `.tgz` file.