### PR TITLE
Add a "cargo deny" config.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+# add whatever else we support.
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "aarch64-linux-android" },
+]
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "deny"
+ignore = []
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+deny = [
+    # List crates we don't want in our dependency tree here.
+]
+
+# Skip some multiple-versions checks, until they can be fixed.
+skip = [
+    { name = "rand" },  # A patched version is used.
+    { name = "rand_core" },  # A patched version is used.
+    { name = "rand_chacha" },  # A patched version is used.
+    { name = "num-bigint", version="<0.3.1" },  # ndarray-npy brings in a different version.
+    { name = "itertools", version="<0.9.0" },  # ndarray/criterion brings in an older version.
+    { name = "ansi_term", version="<0.12.1" },  # clap brings in an old one.
+]
+
+[sources]
+# trusted git sources.
+allow-git = [
+    "https://github.com/rust-lang-nursery/rand"
+]
+
+[licenses]
+allow = [
+    "Apache-2.0",                     # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
+    "BSD-2-Clause",                   # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
+    "MIT",                            # https://tldrlegal.com/license/mit-license
+    "Zlib",                           # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
+]

--- a/examples/jupyter-keras-tract-tf1/Cargo.toml
+++ b/examples/jupyter-keras-tract-tf1/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jupyter-keras-tract-tf1"
 version = "0.1.0"
 authors = ["Matthew Alhonte <mattalhonte@gmail.com>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/jupyter-keras-tract-tf2/Cargo.toml
+++ b/examples/jupyter-keras-tract-tf2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jupyter-keras-tract-tf2"
 version = "0.1.0"
 authors = ["Matthew Alhonte <mattalhonte@gmail.com>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/nnef-dump-mobilenet-v2/Cargo.toml
+++ b/examples/nnef-dump-mobilenet-v2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-dump-nnef-mobilenet-v2"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/examples/nnef-mobilenet-v2/Cargo.toml
+++ b/examples/nnef-mobilenet-v2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-nnef-mobilenet-v2"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/examples/onnx-mobilenet-v2/Cargo.toml
+++ b/examples/onnx-mobilenet-v2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-onnx-mobilenet-v2"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/examples/pytorch-resnet/Cargo.toml
+++ b/examples/pytorch-resnet/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-pytorch-resnet"
 version = "0.1.0"
 authors = ["Teddy Koker <teddy.koker@gmail.com>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/tensorflow-mobilenet-v2/Cargo.toml
+++ b/examples/tensorflow-mobilenet-v2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-tensorflow-mobilenet-v2"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/harness/core-proptest-pulse/Cargo.toml
+++ b/harness/core-proptest-pulse/Cargo.toml
@@ -2,6 +2,7 @@
 name = "core-proptest-pulse"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/harness/lstm-proptest-onnx-vs-tf/Cargo.toml
+++ b/harness/lstm-proptest-onnx-vs-tf/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lstm-proptest-onnx-vs-tf"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/harness/nnef-inceptionv3/Cargo.toml
+++ b/harness/nnef-inceptionv3/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nnef-inceptionv3"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/harness/onnx-test-suite/Cargo.toml
+++ b/harness/onnx-test-suite/Cargo.toml
@@ -2,6 +2,7 @@
 name = "onnx-test-suite"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]

--- a/harness/tf-inceptionv3/Cargo.toml
+++ b/harness/tf-inceptionv3/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tf-inceptionv3"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 
 [dependencies]
 image = "0.23"

--- a/harness/tf-mobilenet-v2/Cargo.toml
+++ b/harness/tf-mobilenet-v2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tf-mobilenet-v2"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+license = "MIT/Apache-2.0"
 
 [dependencies]
 image = "0.23"

--- a/harness/tf-moz-deepspeech/Cargo.toml
+++ b/harness/tf-moz-deepspeech/Cargo.toml
@@ -3,6 +3,7 @@ name = "tf-moz-deepspeech"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 edition = "2018"
+license = "MIT/Apache-2.0"
 
 [dependencies]
 log = "0.4"


### PR DESCRIPTION
To keep our dependency tree sane, we use `cargo deny`. Thought it might be useful for tract as well.

After merging this, all you need to do is: `cargo install cargo-deny`, and then, `cargo deny check`, from the tract root directory.

It warns about security advisories for crates in the entire dependency tree, detects duplicate versions, bad licenses, and has a mechanism where you can ban crates you don't like from your whole dependency tree.

I've preconfigured this one to be suitable for tract, but of course change whatever you like - and I'd recommend to add this to CI as well.

As is, it will give you two security advisory warnings, about the `memmap` and `image` crates. I have suppressed a few bans of duplicate crates, you'll see those warnings if you remove those lines.