### PR TITLE
Move pulse to dev deps

### DIFF
--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -18,7 +18,7 @@ derive-new = "0.5"
 educe = "=0.4.11" # locked for rust 1.41.0
 log = "0.4"
 tract-core = { path = "../core" }
-tract-pulse = { path = "../pulse" }
 
 [dev-dependencies]
 env_logger = "0.7"
+tract-pulse = { path = "../pulse" }


### PR DESCRIPTION
This is mainly because tract-pulse depends on ctor that does not work on wasm. tract-pulse is only used in tests.
