### PR TITLE
fix relative indexing in qparams inline static & add tests

### DIFF
--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -313,7 +313,6 @@ impl std::fmt::Display for Box<dyn TypedOp> {
     }
 }
 
-
 #[derive(Debug, Clone, Hash, PartialEq)]
 pub enum AttrOrInput {
     Attr(Arc<Tensor>),
@@ -331,6 +330,12 @@ impl AttrOrInput {
     fn remove_input(&mut self, ix: usize) {
         if let AttrOrInput::Input(slot) = self {
             *slot = *slot - (*slot > ix) as usize;
+        }
+    }
+
+    fn insert_input(&mut self, ix: usize) {
+        if let AttrOrInput::Input(slot) = self {
+            *slot = *slot + (*slot >= ix) as usize;
         }
     }
 
@@ -365,5 +370,3 @@ impl<'a> From<&'a Arc<Tensor>> for AttrOrInput {
         AttrOrInput::Attr(t.clone())
     }
 }
-
-


### PR DESCRIPTION
**Problem**

during the work on #413 we encountered indexing errors in the qparams inlining during codegen under certain circumstances, depending on the relative order of the inputs compared to the order of qparams. for example at one point of the codegen we have the following node

```rust
Node {
    id: 119,
    name: "MatMul_101_quant",
    inputs: [117/0>, 117/2>, 118/0>],
    op: QMatMulUnary {
        a: 1,128,512,I8 35, 39, -1, 30, -13, -25, 32, 8, -19, 6, 33, 47...,
        bias: None,
        a_trans: true,
        b_trans: true,
        c_trans: true,
        output_type: I32,
        params: MatMulQParams {
            a0: Input(2),
            a_scale: Attr(,F32 1),
            b0: Input(1),
            b_scale: Attr(,F32 1),
            c0: Attr(,I32 0),
            c_scale: Attr(,F32 1),
        },
    },
    outputs: [1,64,512,I32 >120/0],
}
```

where the inputs are `b`, `b0` and `a0` and the inlining is going to replace the `a0`, resulting in a wrong index for `b0`

```rust
Node {
    id: 228,
    name: "MatMul_101_quant",
    inputs: [227/0>, 227/2>],
    op: QMatMulUnary {
        a: 1,128,512,I8 35, 39, -1, 30, -13, -25, 32, 8, -19, 6, 33, 47...,
        bias: None,
        a_trans: true,
        b_trans: true,
        c_trans: true,
        output_type: I32,
        params: MatMulQParams {
            a0: Attr(,I8 24),
            a_scale: Attr(,F32 1),
            b0: Input(0),
            b_scale: Attr(,F32 1),
            c0: Attr(,I32 0),
            c_scale: Attr(,F32 1),
        },
    },
    outputs: [1,64,512,I32 >229/0],
}
```

**Solution**

- fixes the relative indexing: the `remove_input()` must not be called on the `position` which is relative to the `MatMulQParams` order, but on `ix - number_removed` which is relative to the `node.inputs` order (where `number_removed` can be calculated as `ix - inputs.len()`)
- add three tests, where the second and third test wouldn't previously pass (and the first would just pass due to the coincidental same order of `position` and `ix`)
