### PR TITLE
qmatmul for i8xu8 and friends

### DIFF
--- a/core/src/ops/element_wise.rs
+++ b/core/src/ops/element_wise.rs
@@ -251,7 +251,7 @@ macro_rules! element_wise {
 
 #[macro_export]
 macro_rules! element_wise_oop {
-    ($func:ident, $Op:ident $({$( $(#[$meta: meta])? $var: ident : $var_typ: path),*})?,
+    ($(#[$fmeta:meta])* $func:ident, $Op:ident $({$( $(#[$meta: meta])? $var: ident : $var_typ: path),*})?,
         $( [$($typ:ident),*] => $typ_dst:ident $f:expr ),*
         $(; cost: $cost:expr )?
         $(; info: $info:expr )?
@@ -318,6 +318,7 @@ macro_rules! element_wise_oop {
             }
             )?
         }
+        $(#[$fmeta])*
         pub fn $func($( $($var: $var_typ),* )?) -> $crate::ops::element_wise::ElementWiseOp {
             $crate::ops::element_wise::ElementWiseOp(Box::new($Op { $( $($var),* )? } ))
         }

--- a/core/src/ops/matmul/mir_quant.rs
+++ b/core/src/ops/matmul/mir_quant.rs
@@ -150,13 +150,16 @@ impl EvalOp for QMatMul {
         let b = model.add_const("source_b", inputs[1].clone())?;
         let bias = model.add_const("source_bias", inputs[2].clone())?;
 
-        let params = self
+        let mut params = self
             .params
             .iter()
             .map(|(name, qp)| {
                 model.add_const(format!("source_{}", name), qp.tensor(&inputs).clone())
             })
             .collect::<TractResult<Vec<_>>>()?;
+
+        let a = wire_offset_u8_as_i8(&mut model, "adhoc", a, "a", &mut params[0], "a0")?;
+        let b = wire_offset_u8_as_i8(&mut model, "adhoc", b, "b", &mut params[2], "b0")?;
 
         let new_op = MatMul { a_trans: self.a_trans, b_trans: self.b_trans, c_trans: self.c_trans };
         let result = model.wire_node("adhoc.matmul", new_op, &[a, b])?[0];
@@ -240,7 +243,8 @@ impl TypedOp for QMatMul {
         let flip = konst_ix == 1;
         let t_konst = [self.a_trans, self.b_trans][konst_ix] ^ flip;
         let t_var = [self.b_trans, self.a_trans][konst_ix] ^ flip;
-        let konst = model.outlet_fact(node.inputs[konst_ix])?.konst.clone().unwrap();
+        let konst =
+            model.outlet_fact(node.inputs[konst_ix])?.konst.as_ref().unwrap().offset_u8_as_i8();
         let bias = model.outlet_fact(node.inputs[2])?.konst.clone().unwrap();
 
         let inputs: Vec<_> = node
@@ -260,15 +264,14 @@ impl TypedOp for QMatMul {
             }
             if flip {
                 MatMulQParams {
-                    a0: qp.b0,
+                    a0: qp.b0.offset_u8_as_i8(model, &node.inputs)?,
                     a_scale: qp.b_scale,
                     b0: qp.a0,
                     b_scale: qp.a_scale,
-                    c0: qp.c0,
-                    c_scale: qp.c_scale,
+                    ..qp
                 }
             } else {
-                qp
+                MatMulQParams { a0: qp.a0.offset_u8_as_i8(model, &node.inputs)?, ..qp }
             }
         };
 
@@ -325,7 +328,7 @@ impl TypedOp for QMatMul {
         let b = patch.tap_model(model, node.inputs[1])?;
         let bias = patch.tap_model(model, node.inputs[2])?;
 
-        let params = self
+        let mut params = self
             .params
             .iter()
             .map(|(name, qp)| match qp {
@@ -335,6 +338,9 @@ impl TypedOp for QMatMul {
                 }
             })
             .collect::<TractResult<Vec<OutletId>>>()?;
+
+        let a = wire_offset_u8_as_i8(&mut patch, &node.name, a, "a", &mut params[0], "a0")?;
+        let b = wire_offset_u8_as_i8(&mut patch, &node.name, b, "b", &mut params[2], "b0")?;
 
         let new_op = MatMul { a_trans: self.a_trans, b_trans: self.b_trans, c_trans: self.c_trans };
         let result = patch.wire_node(format!("{}.matmul", &node.name), new_op, &[a, b])?[0];
@@ -356,6 +362,35 @@ impl TypedOp for QMatMul {
     }
 
     as_op!();
+}
+
+/// Wires the offsetting of a matrix and zero point node.
+///
+/// Only wires nodes of u8 type and leaves nodes of different type untouched.
+pub(crate) fn wire_offset_u8_as_i8(
+    model: &mut TypedModel,
+    model_name: &str,
+    matrix: OutletId,
+    matrix_name: &str,
+    zero_point: &mut OutletId,
+    zero_point_name: &str,
+) -> TractResult<OutletId> {
+    if let DatumType::U8 = model.outlet_fact(*zero_point)?.datum_type.unquantized() {
+        *zero_point = model.wire_node(
+            format!("{}.offset_{}_as_i8", model_name, zero_point_name),
+            ops::quant::offset_u8_as_i8(),
+            &[*zero_point],
+        )?[0];
+    }
+    if let DatumType::U8 = model.outlet_fact(matrix)?.datum_type.unquantized() {
+        Ok(model.wire_node(
+            format!("{}.offset_{}_as_i8", model_name, matrix_name),
+            ops::quant::offset_u8_as_i8(),
+            &[matrix],
+        )?[0])
+    } else {
+        Ok(matrix)
+    }
 }
 
 pub(crate) fn wire_matmul_quant(
@@ -602,14 +637,49 @@ mod test {
 
     proptest! {
         #[test]
-        fn prop(pb in any::<QMatMulProblem>()) {
-            pb.check()
+        fn prop_i8_i8_i8(pb in any::<QMatMulProblemI8I8I8>()) {
+            pb.check();
+        }
+
+        #[test]
+        fn prop_i8_i8_u8(pb in any::<QMatMulProblemI8I8U8>()) {
+            pb.check();
+        }
+
+        #[test]
+        fn prop_i8_u8_i8(pb in any::<QMatMulProblemI8U8I8>()) {
+            pb.check();
+        }
+
+        #[test]
+        fn prop_u8_i8_i8(pb in any::<QMatMulProblemU8I8I8>()) {
+            pb.check();
+        }
+
+        #[test]
+        fn prop_i8_u8_u8(pb in any::<QMatMulProblemI8U8U8>()) {
+            pb.check();
+        }
+
+        #[test]
+        fn prop_u8_i8_u8(pb in any::<QMatMulProblemU8I8U8>()) {
+            pb.check();
+        }
+
+        #[test]
+        fn prop_u8_u8_i8(pb in any::<QMatMulProblemU8U8I8>()) {
+            pb.check();
+        }
+
+        #[test]
+        fn prop_u8_u8_u8(pb in any::<QMatMulProblemU8U8U8>()) {
+            pb.check();
         }
     }
 
     #[test]
     fn c0() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[0]]),
             b: arr2(&[[0]]),
             bias: tensor0(0i32),
@@ -620,12 +690,12 @@ mod test {
             b_scale: 1.0,
             c_scale: 1.0,
         }
-        .check()
+        .check();
     }
 
     #[test]
     fn b_scale() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[0]]),
             b: arr2(&[[0]]),
             bias: tensor0(0i32),
@@ -641,7 +711,7 @@ mod test {
 
     #[test]
     fn sat() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[0]]),
             b: arr2(&[[34]]),
             bias: tensor0(0i32),
@@ -657,7 +727,7 @@ mod test {
 
     #[test]
     fn rounding() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[26]]),
             b: arr2(&[[0]]),
             bias: tensor0(0i32),
@@ -673,7 +743,7 @@ mod test {
 
     #[test]
     fn neg_rounding() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[-23]]),
             b: arr2(&[[-2]]),
             bias: tensor0(0i32),
@@ -689,7 +759,7 @@ mod test {
 
     #[test]
     fn rounding_ties_2() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[47], [0]]),
             b: arr2(&[[1, 0, 30]]),
             bias: tensor0(0i32),
@@ -705,7 +775,7 @@ mod test {
 
     #[test]
     fn rounding_ties_3() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[-30]]),
             b: arr2(&[[0, 107, 0]]),
             bias: tensor0(0i32),
@@ -715,12 +785,13 @@ mod test {
             a_scale: 1.0,
             b_scale: 0.15,
             c_scale: 0.6,
-        };
+        }
+        .check();
     }
 
     #[test]
     fn onnx_test_matmulinteger() {
-        QMatMulProblem {
+        QMatMulProblemI8I8I8 {
             a: arr2(&[[11, 7, 3], [10, 6, 2], [9, 5, 1], [8, 4, 0]]),
             b: arr2(&[[1, 4], [2, 5], [3, 6]]),
             bias: tensor0(0i32),
@@ -731,149 +802,330 @@ mod test {
             b_scale: 1.0,
             c_scale: 1.0,
         }
-        .check()
-    }
-
-    #[derive(Debug)]
-    struct QMatMulProblem {
-        a: Array2<i8>,
-        b: Array2<i8>,
-        bias: Tensor,
-        a0: i8,
-        b0: i8,
-        c0: i8,
-        a_scale: f32,
-        b_scale: f32,
-        c_scale: f32,
+        .check();
     }
 
     fn round_ties_to_right(x: f32) -> i32 {
         (x + 0.5).floor() as i32
     }
 
-    impl QMatMulProblem {
-        fn check(&self) {
-            let r = self.reference();
-            let t = self.tract();
-            if r.iter().zip(t.iter()).any(|(r, t)| r.max(t) - r.min(t) > 1) {
-                panic!("mismatch! refernce: {:?} tract: {:?}", r, t)
-            }
-        }
-
-        fn reference(&self) -> Array2<i8> {
-            let a = self.a.map(|&x| (x as f32 - self.a0 as f32) * self.a_scale);
-            let b = self.b.map(|&x| (x as f32 - self.b0 as f32) * self.b_scale);
-            let c = a.dot(&b);
-            let c = c.map(|&x| round_ties_to_right(x / self.c_scale) + self.c0 as i32);
-            c.map(|&x| x.max(-128).min(127) as i8)
-        }
-
-        fn tract(&self) -> Array2<i8> {
-            let mut model = TypedModel::default();
-            let mut inputs = tvec!();
-            inputs.push(
-                model
-                    .add_source(
-                        "a",
-                        TypedFact::dt_shape(i8::datum_type(), &[self.a.nrows(), self.a.ncols()]),
-                    )
-                    .unwrap(),
-            );
-            inputs.push(
-                model
-                    .add_source(
-                        "b",
-                        TypedFact::dt_shape(i8::datum_type(), &[self.b.nrows(), self.b.ncols()]),
-                    )
-                    .unwrap(),
-            );
-            inputs.push(
-                model
-                    .add_source("bias", TypedFact::dt_shape(i32::datum_type(), self.bias.shape()))
-                    .unwrap(),
-            );
-            inputs.push(model.add_source("a0", TypedFact::scalar::<i8>()).unwrap());
-            inputs.push(model.add_source("a_scale", TypedFact::scalar::<f32>()).unwrap());
-            inputs.push(model.add_source("b0", TypedFact::scalar::<i8>()).unwrap());
-            inputs.push(model.add_source("b_scale", TypedFact::scalar::<f32>()).unwrap());
-            inputs.push(model.add_source("c0", TypedFact::scalar::<i8>()).unwrap());
-            inputs.push(model.add_source("c_scale", TypedFact::scalar::<f32>()).unwrap());
-            let result = model
-                .wire_node(
-                    "qmm",
-                    QMatMul::new(
-                        false,
-                        false,
-                        false,
-                        i8::datum_type(),
-                        MatMulQParams::all_dynamic(3),
-                    ),
-                    &inputs,
-                )
-                .unwrap();
-            model.set_output_outlets(&result).unwrap();
-            let mut result = model
-                .into_runnable()
-                .unwrap()
-                .run(tvec!(
-                    self.a.clone().into_tensor(),
-                    self.b.clone().into_tensor(),
-                    self.bias.clone(),
-                    self.a0.into(),
-                    self.a_scale.into(),
-                    self.b0.into(),
-                    self.b_scale.into(),
-                    self.c0.into(),
-                    self.c_scale.into(),
-                ))
-                .unwrap();
-            result
-                .remove(0)
-                .into_tensor()
-                .into_array::<i8>()
-                .unwrap()
-                .into_dimensionality()
-                .unwrap()
-        }
-    }
-
     fn scale() -> BoxedStrategy<f32> {
         prop_oneof![Just(1.0), (1i32..=20).prop_map(|x| x as f32 / 20.0)].boxed()
     }
 
-    impl Arbitrary for QMatMulProblem {
-        type Parameters = ();
-        type Strategy = BoxedStrategy<QMatMulProblem>;
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            (1usize..=4, 1usize..=4, 1usize..=4)
-                .prop_flat_map(|(m, k, n)| {
-                    (
-                        Just((m, k, n)),
-                        vec(any::<i8>(), m * k..=m * k),
-                        vec(any::<i8>(), k * n..=k * n),
-                        any::<i8>(),
-                        any::<i8>(),
-                        any::<i8>(),
-                        scale(),
-                        scale(),
-                        scale(),
-                    )
-                })
-                .prop_map(|((m, k, n), a, b, a0, b0, c0, a_scale, b_scale, c_scale)| {
-                    QMatMulProblem {
-                        a: Array2::from_shape_vec((m, k), a).unwrap(),
-                        b: Array2::from_shape_vec((k, n), b).unwrap(),
-                        bias: tensor0(0i32),
-                        a0,
-                        b0,
-                        c0,
-                        a_scale,
-                        b_scale,
-                        c_scale,
-                    }
-                })
-                .boxed()
+    macro_rules! impl_qmmp {
+        ($name:ident, $a:ty, $b:ty, $c:ty $(,)?) => {
+            #[derive(Debug)]
+            struct $name {
+                a: Array2<$a>,
+                b: Array2<$b>,
+                bias: Tensor,
+                a0: $a,
+                b0: $b,
+                c0: $c,
+                a_scale: f32,
+                b_scale: f32,
+                c_scale: f32,
+            }
+
+            impl $name {
+                fn check(&self) {
+                    let check_with = |r: &Array2<$c>, opt: bool, qp: bool| {
+                        let t = self.tract(opt, qp);
+                        assert!(
+                            r.iter().zip(t.iter()).all(|(r, t)| r.max(t) - r.min(t) <= 1),
+                            "mismatch! optimized plan: {}, dynamic qparams: {}, reference: {:?}, tract: {:?}",
+                            opt,
+                            qp,
+                            r,
+                            t,
+                        );
+                    };
+
+                    let r = self.reference();
+                    check_with(&r, false, false);
+                    check_with(&r, false, true);
+                    check_with(&r, true, false);
+                    check_with(&r, true, true);
+                }
+
+                fn reference(&self) -> Array2<$c> {
+                    let a = self.a.map(|&x| (x as f32 - self.a0 as f32) * self.a_scale);
+                    let b = self.b.map(|&x| (x as f32 - self.b0 as f32) * self.b_scale);
+                    let c = a.dot(&b);
+                    let c = c.map(|&x| round_ties_to_right(x / self.c_scale) + self.c0 as i32);
+                    c.map(|&x| x.max(<$c>::MIN as i32).min(<$c>::MAX as i32) as $c)
+                }
+
+                fn tract(&self, opt: bool, qp: bool) -> Array2<$c> {
+                    let mut model = TypedModel::default();
+                    let mut inputs = tvec![];
+                    inputs.push(
+                        model
+                            .add_source(
+                                "a",
+                                TypedFact::dt_shape(
+                                    <$a>::datum_type(),
+                                    &[self.a.nrows(), self.a.ncols()],
+                                ),
+                            )
+                            .unwrap(),
+                    );
+                    inputs.push(
+                        model
+                            .add_source(
+                                "b",
+                                TypedFact::dt_shape(
+                                    <$b>::datum_type(),
+                                    &[self.b.nrows(), self.b.ncols()],
+                                ),
+                            )
+                            .unwrap(),
+                    );
+                    inputs.push(
+                        model
+                            .add_source(
+                                "bias",
+                                TypedFact::dt_shape(i32::datum_type(), self.bias.shape()),
+                            )
+                            .unwrap(),
+                    );
+                    let qparams = if qp {
+                        inputs.push(model.add_source("a0", TypedFact::scalar::<$a>()).unwrap());
+                        inputs
+                            .push(model.add_source("a_scale", TypedFact::scalar::<f32>()).unwrap());
+                        inputs.push(model.add_source("b0", TypedFact::scalar::<$b>()).unwrap());
+                        inputs
+                            .push(model.add_source("b_scale", TypedFact::scalar::<f32>()).unwrap());
+                        inputs.push(model.add_source("c0", TypedFact::scalar::<$c>()).unwrap());
+                        inputs
+                            .push(model.add_source("c_scale", TypedFact::scalar::<f32>()).unwrap());
+                        MatMulQParams::all_dynamic(3)
+                    } else {
+                        MatMulQParams {
+                            a0: AttrOrInput::Attr(rctensor0::<$a>(self.a0)),
+                            a_scale: AttrOrInput::Attr(rctensor0::<f32>(self.a_scale)),
+                            b0: AttrOrInput::Attr(rctensor0::<$b>(self.b0)),
+                            b_scale: AttrOrInput::Attr(rctensor0::<f32>(self.b_scale)),
+                            c0: AttrOrInput::Attr(rctensor0::<$c>(self.c0)),
+                            c_scale: AttrOrInput::Attr(rctensor0::<f32>(self.c_scale)),
+                        }
+                    };
+                    let result = model
+                        .wire_node(
+                            "qmm",
+                            QMatMul::new(false, false, false, <$c>::datum_type(), qparams),
+                            &inputs,
+                        )
+                        .unwrap();
+                    model.set_output_outlets(&result).unwrap();
+
+                    let inputs = if qp {
+                        tvec![
+                            self.a.clone().into_tensor(),
+                            self.b.clone().into_tensor(),
+                            self.bias.clone(),
+                            self.a0.into(),
+                            self.a_scale.into(),
+                            self.b0.into(),
+                            self.b_scale.into(),
+                            self.c0.into(),
+                            self.c_scale.into(),
+                        ]
+                    } else {
+                        tvec![
+                            self.a.clone().into_tensor(),
+                            self.b.clone().into_tensor(),
+                            self.bias.clone(),
+                        ]
+                    };
+                    let mut outputs = if opt { model.into_optimized().unwrap() } else { model }
+                        .into_runnable()
+                        .unwrap()
+                        .run(inputs)
+                        .unwrap();
+                    outputs
+                        .remove(0)
+                        .into_tensor()
+                        .into_array::<$c>()
+                        .unwrap()
+                        .into_dimensionality()
+                        .unwrap()
+                }
+            }
+
+            impl Arbitrary for $name {
+                type Parameters = ();
+                type Strategy = BoxedStrategy<$name>;
+                fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+                    (1usize..=4, 1usize..=4, 1usize..=4)
+                        .prop_flat_map(|(m, k, n)| {
+                            (
+                                Just((m, k, n)),
+                                vec(any::<$a>(), m * k..=m * k),
+                                vec(any::<$b>(), k * n..=k * n),
+                                any::<$a>(),
+                                any::<$b>(),
+                                any::<$c>(),
+                                scale(),
+                                scale(),
+                                scale(),
+                            )
+                        })
+                        .prop_map(|((m, k, n), a, b, a0, b0, c0, a_scale, b_scale, c_scale)| {
+                            $name {
+                                a: Array2::from_shape_vec((m, k), a).unwrap(),
+                                b: Array2::from_shape_vec((k, n), b).unwrap(),
+                                bias: tensor0(0i32),
+                                a0,
+                                b0,
+                                c0,
+                                a_scale,
+                                b_scale,
+                                c_scale,
+                            }
+                        })
+                        .boxed()
+                }
+            }
+        };
+    }
+
+    impl_qmmp! { QMatMulProblemI8I8I8, i8, i8, i8 }
+    impl_qmmp! { QMatMulProblemI8I8U8, i8, i8, u8 }
+    impl_qmmp! { QMatMulProblemI8U8I8, i8, u8, i8 }
+    impl_qmmp! { QMatMulProblemU8I8I8, u8, i8, i8 }
+    impl_qmmp! { QMatMulProblemI8U8U8, i8, u8, u8 }
+    impl_qmmp! { QMatMulProblemU8I8U8, u8, i8, u8 }
+    impl_qmmp! { QMatMulProblemU8U8I8, u8, u8, i8 }
+    impl_qmmp! { QMatMulProblemU8U8U8, u8, u8, u8 }
+
+    #[test]
+    fn test_qmmp_i8_i8_i8() {
+        QMatMulProblemI8I8I8 {
+            a: arr2(&[[76, 76, 76], [127, -127, 102]]),
+            b: arr2(&[[25, 51, 76, 102, 127], [-51, -25, 0, 25, 51], [-25, -51, -76, -102, -127]]),
+            bias: tensor0(0i32),
+            a0: 51,
+            b0: 0,
+            c0: -31,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
         }
+        .check(); // c: [[-52, -41, -31, -21, -10], [127, 64, 0, -62, -126]]
+    }
+
+    #[test]
+    fn test_qmmp_i8_i8_u8() {
+        QMatMulProblemI8I8U8 {
+            a: arr2(&[[76, 76, 76], [127, -127, 102]]),
+            b: arr2(&[[25, 51, 76, 102, 127], [-51, -25, 0, 25, 51], [-25, -51, -76, -102, -127]]),
+            bias: tensor0(0i32),
+            a0: 51,
+            b0: 0,
+            c0: 96,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
+        }
+        .check(); // c: [[75, 86, 96, 106, 117], [255, 191, 127, 65, 1]]
+    }
+
+    #[test]
+    fn test_qmmp_i8_u8_i8() {
+        QMatMulProblemI8U8I8 {
+            a: arr2(&[[76, 76, 76], [127, -127, 102]]),
+            b: arr2(&[[152, 178, 203, 229, 254], [76, 102, 127, 152, 178], [102, 76, 51, 25, 0]]),
+            bias: tensor0(0i32),
+            a0: 51,
+            b0: 127,
+            c0: -31,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
+        }
+        .check(); // c: [[-52, -41, -31, -21, -10], [127, 64, 0, -62, -126]]
+    }
+
+    #[test]
+    fn test_qmmp_u8_i8_i8() {
+        QMatMulProblemU8I8I8 {
+            a: arr2(&[[204, 204, 204], [255, 1, 230]]),
+            b: arr2(&[[25, 51, 76, 102, 127], [-51, -25, 0, 25, 51], [-25, -51, -76, -102, -127]]),
+            bias: tensor0(0i32),
+            a0: 179,
+            b0: 0,
+            c0: -31,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
+        }
+        .check(); // c: [[-52, -41, -31, -21, -10], [127, 64, 0, -62, -126]]
+    }
+
+    #[test]
+    fn test_qmmp_i8_u8_u8() {
+        QMatMulProblemI8U8U8 {
+            a: arr2(&[[76, 76, 76], [127, -127, 102]]),
+            b: arr2(&[[152, 178, 203, 229, 254], [76, 102, 127, 152, 178], [102, 76, 51, 25, 0]]),
+            bias: tensor0(0i32),
+            a0: 51,
+            b0: 127,
+            c0: 96,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
+        }
+        .check(); // c: [[75, 86, 96, 106, 117], [255, 191, 127, 65, 1]]
+    }
+
+    #[test]
+    fn test_qmmp_u8_i8_u8() {
+        QMatMulProblemU8I8U8 {
+            a: arr2(&[[204, 204, 204], [255, 1, 230]]),
+            b: arr2(&[[25, 51, 76, 102, 127], [-51, -25, 0, 25, 51], [-25, -51, -76, -102, -127]]),
+            bias: tensor0(0i32),
+            a0: 179,
+            b0: 0,
+            c0: 96,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
+        }
+        .check(); // c: [[75, 86, 96, 106, 117], [255, 191, 127, 65, 1]]
+    }
+
+    #[test]
+    fn test_qmmp_u8_u8_i8() {
+        QMatMulProblemU8U8I8 {
+            a: arr2(&[[204, 204, 204], [255, 1, 230]]),
+            b: arr2(&[[152, 178, 203, 229, 254], [76, 102, 127, 152, 178], [102, 76, 51, 25, 0]]),
+            bias: tensor0(0i32),
+            a0: 179,
+            b0: 127,
+            c0: -31,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
+        }
+        .check(); // c: [[-52, -41, -31, -21, -10], [127, 64, 0, -62, -126]]
+    }
+
+    #[test]
+    fn test_qmmp_u8_u8_u8() {
+        QMatMulProblemU8U8U8 {
+            a: arr2(&[[204, 204, 204], [255, 1, 230]]),
+            b: arr2(&[[152, 178, 203, 229, 254], [76, 102, 127, 152, 178], [102, 76, 51, 25, 0]]),
+            bias: tensor0(0i32),
+            a0: 179,
+            b0: 127,
+            c0: 96,
+            a_scale: 0.039215688,
+            b_scale: 0.039215688,
+            c_scale: 0.09411765,
+        }
+        .check(); // c: [[75, 86, 96, 106, 117], [255, 191, 127, 65, 1]]
     }
 
     fn setup_qparams(inputs: [usize; 6]) -> ([OutletId; 9], MatMulQParams, TypedModel, OutletId) {

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -345,6 +345,20 @@ impl AttrOrInput {
             AttrOrInput::Input(_) => None,
         }
     }
+
+    fn offset_u8_as_i8(&self, model: &TypedModel, inputs: &[OutletId]) -> TractResult<Self> {
+        let tensor = match self {
+            AttrOrInput::Attr(t) => t,
+            AttrOrInput::Input(i) => model.outlet_fact(inputs[*i])?.konst.as_ref().unwrap(),
+        };
+        if let DatumType::U8 = tensor.datum_type().unquantized() {
+            Ok(AttrOrInput::Attr(
+                tensor.to_array_view()?.mapv(quant::offset_u8_as_i8_elementwise).into_arc_tensor(),
+            ))
+        } else {
+            Ok(self.clone())
+        }
+    }
 }
 
 impl From<usize> for AttrOrInput {

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -446,3 +446,18 @@ pub mod scale {
         }
     }
 }
+
+/// Offsets u8 integers as i8 integers.
+pub(crate) fn offset_u8_as_i8_elementwise(x: u8) -> i8 {
+    x.wrapping_sub(128) as i8
+}
+
+element_wise_oop!(
+    /// Offsets nodes of u8 type to i8 type elementwise.
+    offset_u8_as_i8,
+    OffsetU8asI8,
+    [u8] => i8 |_, xs, ys| {
+        xs.iter().zip(ys.iter_mut()).for_each(|(x, y)| *y = offset_u8_as_i8_elementwise(*x));
+        Ok(())
+    }
+);


### PR DESCRIPTION
**Problem**

fixes #413 

**Solution**

`tract-data`:
- add `Tensor::offset_u8_as_i8()` to apply the offsetting to a tensor elementwise

`tract-core`:
- add `ops::quant::OffsetU8asI8` operation to be wired in the quantized matmul
- conditionally wire the offsettings in `QMatMul` and `QMatMulUnary` in the evaluation and decluttering/codegen
- generalize the existing quantized matmul tests with a macro and add new test cases for the various i8-u8 combinations

**Open Questions**

- how to handle the `bias` term is a bit unclear to me. it is always of type `i32` and the way it is used in `wire_matmul_quant()` means that it is only affected by the scales but not the zero points (i would assume that the bias is expected to be given in a scaled form, but this would affect the computation of the scales which i didn't observe, so maybe it is compensated via the `c_scale`). conversely, we probably also don't have to apply `wire_offset_u8_as_i8()` to it, which would also have no effect on it in its current implementation. unfortunatetly, i didn't find any examples in the code except for `None`/`0` `bias`.