### PR TITLE
pytorch_half_pixel coordinate transform mode

### DIFF
--- a/onnx/src/ops/resize.rs
+++ b/onnx/src/ops/resize.rs
@@ -11,6 +11,7 @@ pub fn resize(
         match node.get_attr_opt("coordinate_transformation_mode")?.unwrap_or("half_pixel") {
             "align_corners" => CoordTransformer::AlignCorners,
             "half_pixel" => CoordTransformer::HalfPixel,
+            "pytorch_half_pixel" => CoordTransformer::HalfPixel,
             s => todo!("coordinate_transformation_mode: {}", s),
         };
     let interpolator = match node.get_attr("mode")? {


### PR DESCRIPTION
I hit a todo when trying to run an onnx model that was created by `pytorch`. The coordinate transform for `"pytorch_half_pixel"` was not implemented. I think we can just use the `"half_pixel"` implementation for `"pytorch_half_pixel"`.