### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/cli/src/tensor.rs
+++ b/cli/src/tensor.rs
@@ -40,7 +40,9 @@ pub fn parse_coma_spec(size: &str) -> CliResult<InferenceFact> {
     let splits = size.split(",").collect::<Vec<_>>();
 
     if splits.len() < 1 {
-        bail!("The <size> argument should be formatted as {size},{...},{type}.");
+        // Hide '{' in this error message from the formatting machinery in bail macro
+        let msg = "The <size> argument should be formatted as {size},{...},{type}.";
+        bail!(msg);
     }
 
     let last = splits.last().unwrap();
@@ -95,7 +97,9 @@ pub fn parse_x_spec(size: &str) -> CliResult<InferenceFact> {
     let splits = size.split("x").collect::<Vec<_>>();
 
     if splits.len() < 1 {
-        bail!("The <size> argument should be formatted as {size},{...},{type}.");
+        // Hide '{' in this error message from the formatting machinery in bail macro
+        let msg = "The <size> argument should be formatted as {size},{...},{type}.";
+        bail!(msg);
     }
 
     let last = splits.last().unwrap();

--- a/onnx/src/ops/resize.rs
+++ b/onnx/src/ops/resize.rs
@@ -114,7 +114,10 @@ impl Resize {
                 return Ok(size.as_slice::<i64>()?.iter().map(|i| *i as usize).collect());
             }
         }
-        bail!("Neither shape not scale makes sense: input_shape: {:?}, scale: {:?}, sizes: {:?}")
+        bail!(
+            "Neither shape not scale makes sense: input_shape: {:?}, scale: {:?}, sizes: {:?}",
+            input_shape, input_scale, input_sizes,
+        );
     }
 }
 


### PR DESCRIPTION
- The first commit fills in several missing arguments to `{:?}` in tract-onnx. Without this, the error message would literally be "Neither shape not scale makes sense: input_shape: {:?}, scale: {:?}, sizes: {:?}" with curly braces in it instead of the intended variables.

- The second commit is added for future compatibility with https://rust-lang.github.io/rfcs/2795-format-args-implicit-identifiers.html &mdash; if `{size}` and `{type}` in a format string without arguments were to start trying to interpolate a variable called `size` and `type`, the original code would be problematic.