### PR TITLE
ArrayFeatureExtractor: Fix rank check for second input

### DIFF
--- a/hir/src/ops/array/array_feature_extractor.rs
+++ b/hir/src/ops/array/array_feature_extractor.rs
@@ -45,7 +45,7 @@ impl Expansion for ArrayFeatureExtractor {
 
         // Check ranks
         s.equals(inputs[0].rank.bex(), outputs[0].rank.bex())?;
-        s.equals(inputs[0].rank.bex(), 1)?;
+        s.equals(inputs[1].rank.bex(), 1)?;
 
         // Check shapes
         s.given_2(&inputs[0].shape, &inputs[1].shape, move |s, input_shape, indices_shape| {


### PR DESCRIPTION
This MR fixes an error introduced in #581 by properly checking the second input's rank.