### PR TITLE
ArrayFeatureExtractor: Use rank check from gather, don't assume indices of rank 1

### DIFF
--- a/hir/src/ops/array/array_feature_extractor.rs
+++ b/hir/src/ops/array/array_feature_extractor.rs
@@ -31,7 +31,7 @@ impl Expansion for ArrayFeatureExtractor {
         inputs: &'p [TensorProxy],
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
-        // Expect two inputs:
+        // Expect two inputs:   
         // - X: data to be selected
         // - Y: the indices that'll be applied to the last axis
         check_input_arity(&inputs, 2)?;
@@ -44,15 +44,14 @@ impl Expansion for ArrayFeatureExtractor {
         s.equals(&inputs[1].datum_type, i64::datum_type())?;
 
         // Check ranks
-        s.equals(inputs[0].rank.bex(), outputs[0].rank.bex())?;
-        s.equals(inputs[1].rank.bex(), 1)?;
+        s.equals(inputs[0].rank.bex() - 1 + inputs[1].rank.bex(), outputs[0].rank.bex())?;
 
         // Check shapes
         s.given_2(&inputs[0].shape, &inputs[1].shape, move |s, input_shape, indices_shape| {
             let input_rank = input_shape.len();
             let mut output_shape = tvec![];
-            output_shape.extend(input_shape[..input_rank].iter().cloned());
-            output_shape.push(indices_shape[0].clone());
+            output_shape.extend(input_shape.iter().cloned().take(input_rank - 1));
+            output_shape.extend(indices_shape.iter().cloned());
             s.equals(&outputs[0].shape, output_shape)?;
             Ok(())
         })?;


### PR DESCRIPTION
I am terribly sorry, but I seems I previously misunderstood the operators description with regards to the possible ranks and dimensions of the indices tensor.
This MR thus fixes the rank check for the output tensor, no longer assumes the indices to be of rank 1 and correctly calculates the outputs dimensions.