### PR TITLE
Bump liquid to 0.24

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -5,8 +5,8 @@ license = "MIT/Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
-keywords = [ "TensorFlow", "NeuralNetworks" ]
-categories = [ "science" ]
+keywords = ["TensorFlow", "NeuralNetworks"]
+categories = ["science"]
 autobenches = false
 edition = "2018"
 
@@ -28,7 +28,7 @@ scan_fmt = "0.2.6"
 
 [build-dependencies]
 cc = "1.0.69"
-liquid = "0.23"
+liquid = "0.24"
 unicode-normalization = "0.1.19"
 smallvec = "1.6.1"
 walkdir = "2.3.2"


### PR DESCRIPTION
Liquid 0.24 includes https://github.com/cobalt-org/liquid-rust/pull/460 which removes `chrono`, this gets rid of two CVEs

- https://rustsec.org/advisories/RUSTSEC-2020-0159.html
- https://rustsec.org/advisories/RUSTSEC-2020-0071.html

Neither of these CVEs affected tract, but this means users won't get spurious errors if they use eg [cargo-audit](https://github.com/rustsec/rustsec) or [cargo-deny](https://github.com/EmbarkStudios/cargo-deny)