### PR TITLE
[WIP] fix: allow to load tract_core in nnef if specified

### DIFF
--- a/nnef/src/deser.rs
+++ b/nnef/src/deser.rs
@@ -29,7 +29,16 @@ impl<'mb> ModelBuilder<'mb> {
                     if self.framework.registries.iter().any(|reg| reg.id == ext[1]) {
                         self.registries.push(ext[1].to_string())
                     } else {
-                        bail!("Registry not found {}", &ext[1])
+                        bail!(
+                            "Registry not found {} among [{:?}]",
+                            &ext[1],
+                            self.framework
+                                .registries
+                                .iter()
+                                .map(|reg| reg.id.to_string())
+                                .reduce(|cur_id, nxt| cur_id + ", " + &nxt)
+                                .unwrap()
+                        )
                     }
                 }
                 _ => warn!("Ignore unknown extension {}", ext.join(" ")),

--- a/nnef/src/lib.rs
+++ b/nnef/src/lib.rs
@@ -33,5 +33,5 @@ pub mod internal {
 }
 
 pub fn nnef() -> framework::Nnef {
-    framework::Nnef::new()
+    framework::Nnef::new().with_tract_core()
 }


### PR DESCRIPTION
- show available registries when incorrect key is set
- add availability for tract_core operator