### PR TITLE
Add support for GPU inference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "onnx",
     "kaldi",
     "cli",
+    "gpu",
     "examples/tensorflow-mobilenet-v2",
     "examples/jupyter-keras-tract-tf1",
     "examples/jupyter-keras-tract-tf2",
@@ -29,6 +30,7 @@ members = [
     "harness/tf-mobilenet-v2",
     "harness/tf-moz-deepspeech",
 ]
+resolver = "2"
 
 [profile.release]
 lto = true

--- a/examples/tensorflow-mobilenet-v2/src/main.rs
+++ b/examples/tensorflow-mobilenet-v2/src/main.rs
@@ -6,10 +6,12 @@ fn main() -> TractResult<()> {
         .model_for_path("mobilenet_v2_1.4_224_frozen.pb")?
         // specify input type and shape
         .with_input_fact(0, InferenceFact::dt_shape(f32::datum_type(), tvec!(1, 224, 224, 3)))?
-        // optimize the model
-        .into_optimized()?
-        // make the model runnable and fix its inputs and outputs
-        .into_runnable()?;
+        // declutter the model
+        .into_typed()?
+        .into_decluttered()?;
+
+    // GPU state
+    println!("{:#?}", SimplePlan::new(model.clone())?);
 
     // open image, resize it and make a Tensor out of it
     let image = image::open("grace_hopper.jpg").unwrap().to_rgb8();
@@ -21,7 +23,7 @@ fn main() -> TractResult<()> {
     .into();
 
     // run the model on the input
-    let result = model.run(tvec!(image))?;
+    let result = model.into_runnable()?.run(tvec!(image))?;
 
     // find and display the max value with its index
     let best = result[0]

--- a/gpu/Cargo.toml
+++ b/gpu/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "tract-gpu"
+version = "0.16.5-pre"
+license = "MIT/Apache-2.0"
+authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
+description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
+repository = "https://github.com/snipsco/tract"
+keywords = ["TensorFlow", "NeuralNetworks"]
+categories = ["science"]
+autobenches = false
+edition = "2018"
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+derive-new = "0.5.9"
+downcast-rs = "1.2.0"
+dyn-clone = "1.0.4"
+educe = "0.4.18"
+lazy_static = "1.4.0"
+libc = "0.2.100"
+log = "0.4.14"
+num-traits = "0.2.14"
+tract-data = { path = "../data" }
+tract-core = { path = "../core" }
+tract-hir = { path = "../hir" }
+paste = "1.0.5"
+scan_fmt = "0.2.6"
+wgpu = "0.12"
+futures = "0.3"
+bytemuck = "1.9"
+
+[build-dependencies]
+cc = "1.0.69"
+liquid = "0.24"
+unicode-normalization = "0.1.19"
+smallvec = "1.6.1"
+walkdir = "2.3.2"
+
+[dev-dependencies]
+criterion = "0.3.5"
+proptest = "1.0.0"

--- a/gpu/examples/a.rs
+++ b/gpu/examples/a.rs
@@ -1,0 +1,20 @@
+use futures::executor::block_on;
+use tract_core::prelude::{DatumType, Tensor};
+use tract_data::tvec;
+use tract_gpu::GpuAccel;
+
+fn main() {
+    let gpu = block_on(GpuAccel::default()).unwrap();
+
+    let inp = gpu.import_tensor(
+        "inp".to_string(),
+        &Tensor::from_shape(&tvec![2, 2], &vec![1.0f32, 2.0f32, 3.0f32, 4.0f32]).unwrap(),
+    );
+    let a = gpu.create_storage_tensor("a".to_string(), DatumType::F32, tvec![2, 2]);
+    let out = gpu.create_out_tensor("out".to_string(), DatumType::F32, tvec![2, 2]);
+
+    gpu.tanh(&inp, &a);
+    gpu.sigmoid(&a, &out);
+
+    println!("{:#?}", block_on(gpu.tensor_move_out(out)));
+}

--- a/gpu/shaders/sigmoid.wgsl
+++ b/gpu/shaders/sigmoid.wgsl
@@ -1,0 +1,14 @@
+struct Buffer {
+    data: [[stride(4)]] array<f32>; // 4 represents 4 bytes per value
+};
+
+[[group(0), binding(0)]]
+var<storage, read> in: Buffer;
+
+[[group(0), binding(1)]]
+var<storage, write> out: Buffer;
+
+[[stage(compute), workgroup_size(1)]]
+fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+    out.data[global_id.x] = 1.0 / (1.0 + exp(-1.0 * in.data[global_id.x]));
+}

--- a/gpu/shaders/tanh.wgsl
+++ b/gpu/shaders/tanh.wgsl
@@ -1,0 +1,14 @@
+struct Buffer {
+    data: [[stride(4)]] array<f32>; // 4 represents 4 bytes per value
+};
+
+[[group(0), binding(0)]]
+var<storage, read> in: Buffer;
+
+[[group(0), binding(1)]]
+var<storage, write> out: Buffer;
+
+[[stage(compute), workgroup_size(1)]]
+fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+    out.data[global_id.x] = tanh(in.data[global_id.x]);
+}

--- a/gpu/src/lib.rs
+++ b/gpu/src/lib.rs
@@ -1,0 +1,231 @@
+use std::borrow::Cow;
+use std::fmt::Debug;
+use tract_core::prelude::{natural_strides, DatumType, Tensor};
+use tract_data::TVec;
+use wgpu::{
+    util::{BufferInitDescriptor, DeviceExt},
+    BindGroupDescriptor, BindGroupEntry, Buffer, BufferUsages, CommandEncoderDescriptor,
+    ComputePassDescriptor, ComputePipelineDescriptor, Device, DeviceDescriptor, Instance, Queue,
+    ShaderModule, ShaderModuleDescriptor, ShaderSource,
+};
+
+pub struct GPUTensor {
+    dt: DatumType,
+    shape: TVec<usize>,
+    strides: TVec<isize>,
+    len: usize,
+    buffer: Buffer,
+}
+
+#[derive(Debug)]
+pub struct GpuAccel {
+    device: Device,
+    queue: Queue,
+    sigmoid_shader: ShaderModule,
+    tanh_shader: ShaderModule,
+}
+
+impl GpuAccel {
+    pub async fn default() -> Option<GpuAccel> {
+        let instance = Instance::new(wgpu::Backends::all());
+        let adapter = match wgpu::util::initialize_adapter_from_env_or_default(
+            &instance,
+            wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
+            None,
+        )
+        .await
+        {
+            Some(a) => a,
+            None => return None,
+        };
+
+        let (device, queue) =
+            match adapter.request_device(&DeviceDescriptor::default(), None).await.ok() {
+                Some((d, q)) => (d, q),
+                None => return None,
+            };
+
+        println!("{:#?}", adapter.get_info());
+
+        let sigmoid_shader = device.create_shader_module(&ShaderModuleDescriptor {
+            label: None,
+            source: ShaderSource::Wgsl(Cow::Borrowed(include_str!("../shaders/sigmoid.wgsl"))),
+        });
+
+        let tanh_shader = device.create_shader_module(&ShaderModuleDescriptor {
+            label: None,
+            source: ShaderSource::Wgsl(Cow::Borrowed(include_str!("../shaders/tanh.wgsl"))),
+        });
+
+        Some(GpuAccel { device, queue, sigmoid_shader, tanh_shader })
+    }
+
+    pub fn alloc_in_buffer<T: bytemuck::NoUninit>(&self, label: String, bytes: &Vec<T>) -> Buffer {
+        self.device.create_buffer_init(&BufferInitDescriptor {
+            label: Some(&label),
+            contents: bytemuck::cast_slice(bytes),
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+        })
+    }
+
+    pub fn import_tensor(&self, label: String, t: &Tensor) -> GPUTensor {
+        GPUTensor {
+            dt: t.datum_type(),
+            shape: t.shape().into(),
+            strides: t.strides().into(),
+            len: t.len(),
+            // TODO: proper type
+            buffer: self.alloc_in_buffer(label, &Vec::from(t.as_slice::<f32>().unwrap())),
+        }
+    }
+
+    pub fn alloc_storage_buffer(&self, label: String, size: u64, output: bool) -> Buffer {
+        self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(&label),
+            size,
+            usage: if output {
+                BufferUsages::STORAGE | BufferUsages::MAP_READ | BufferUsages::COPY_SRC
+            } else {
+                BufferUsages::STORAGE
+            },
+            mapped_at_creation: false,
+        })
+    }
+
+    fn create_generic_storage_tensor(
+        &self,
+        label: String,
+        dt: DatumType,
+        shape: TVec<usize>,
+        output: bool,
+    ) -> GPUTensor {
+        let strides = natural_strides(&shape);
+        let len = if shape.len() == 0 {
+            1
+        } else {
+            *strides.get(0).unwrap() as usize * shape.get(0).unwrap()
+        };
+
+        GPUTensor {
+            dt,
+            shape,
+            strides,
+            len,
+            buffer: self.alloc_storage_buffer(label, len as u64 * dt.size_of() as u64, output),
+        }
+    }
+
+    pub fn create_storage_tensor(
+        &self,
+        label: String,
+        dt: DatumType,
+        shape: TVec<usize>,
+    ) -> GPUTensor {
+        self.create_generic_storage_tensor(label, dt, shape, false)
+    }
+
+    pub fn create_out_tensor(&self, label: String, dt: DatumType, shape: TVec<usize>) -> GPUTensor {
+        self.create_generic_storage_tensor(label, dt, shape, true)
+    }
+
+    pub async fn buffer_move_out<T: bytemuck::Pod>(&self, buf: Buffer) -> Vec<T> {
+        let buffer_slice = buf.slice(..);
+        let buffer_future = buffer_slice.map_async(wgpu::MapMode::Read);
+
+        self.device.poll(wgpu::Maintain::Wait);
+
+        if let Ok(()) = buffer_future.await {
+            let data = buffer_slice.get_mapped_range();
+            let result = bytemuck::cast_slice(&data).to_vec();
+
+            drop(data);
+            buf.unmap();
+
+            println!("Moved buffer {:?} out from GPU memory", buf);
+
+            return result;
+        } else {
+            panic!("Failed to move buffer {:?} out from GPU memory", buf);
+        }
+    }
+
+    pub async fn tensor_move_out(&self, t: GPUTensor) -> Tensor {
+        unsafe {
+            Tensor::from_raw_dt(t.dt, &t.shape, &self.buffer_move_out::<u8>(t.buffer).await)
+                .unwrap()
+        }
+    }
+
+    pub fn sigmoid(&self, in_tensor: &GPUTensor, out_tensor: &GPUTensor) {
+        let bind_group = vec![
+            BindGroupEntry { binding: 0, resource: in_tensor.buffer.as_entire_binding() },
+            BindGroupEntry { binding: 1, resource: out_tensor.buffer.as_entire_binding() },
+        ];
+
+        self.execute_shader(
+            &"sigmoid".to_string(),
+            &self.sigmoid_shader,
+            bind_group,
+            out_tensor.len as u32,
+            1,
+            1,
+        );
+    }
+
+    pub fn tanh(&self, in_tensor: &GPUTensor, out_tensor: &GPUTensor) {
+        let bind_group = vec![
+            BindGroupEntry { binding: 0, resource: in_tensor.buffer.as_entire_binding() },
+            BindGroupEntry { binding: 1, resource: out_tensor.buffer.as_entire_binding() },
+        ];
+
+        self.execute_shader(
+            &"tanh".to_string(),
+            &self.tanh_shader,
+            bind_group,
+            out_tensor.len as u32,
+            1,
+            1,
+        );
+    }
+
+    pub fn execute_shader(
+        &self,
+        label: &String,
+        shader: &ShaderModule,
+        bind_group_entries: Vec<BindGroupEntry<'_>>,
+        wg_x: u32,
+        wg_y: u32,
+        wg_z: u32,
+    ) {
+        let compute_pipeline = self.device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some(&(label.clone() + "_pipeline")),
+            layout: None,
+            module: shader,
+            entry_point: "main",
+        });
+
+        let bind_group_layout = compute_pipeline.get_bind_group_layout(0);
+        let bind_group = self.device.create_bind_group(&BindGroupDescriptor {
+            label: Some(&(label.clone() + "_bind_group")),
+            layout: &bind_group_layout,
+            entries: &bind_group_entries,
+        });
+
+        let mut encoder = self.device.create_command_encoder(&CommandEncoderDescriptor {
+            label: Some(&(label.clone() + "_encoder")),
+        });
+        {
+            let mut cpass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: Some(&(label.clone() + "_compute_pass")),
+            });
+            cpass.set_pipeline(&compute_pipeline);
+            cpass.set_bind_group(0, &bind_group, &[]);
+            // Number of cells to run, the (x,y,z) size of item being processed
+            cpass.dispatch(wg_x, wg_y, wg_z);
+        }
+
+        self.queue.submit(Some(encoder.finish()));
+
+        self.device.poll(wgpu::Maintain::Wait);
+    }
+}


### PR DESCRIPTION
Address #688 .

Tasks:
- [x] `GPUTensor`
  - [x] Import
  - [x] Export
  - [x] Intermediate data in GPU memory
- [ ] Ops
  - [ ] Convolution
  - [ ] Activations
    - [x] tanh
    - [x] sigmoid
    - [ ] relu
  - [ ] Fully-connected
  - [ ] Pooling
  - [ ] Softmax
- [ ] Runner for models
  - [ ] Managing GPU memory
    - [ ] Free buffers no longer in use to allow for models larger than GPU memory
- [ ] Examples working
  - [ ] `tensorflow-mobilenet-v2`