### PR TITLE
Parsing for quantized datum in CLI inputs

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ flate2 = "1.0.20"
 lazy_static = "1.4.0"
 log = "0.4.14"
 ndarray-npy = { version = "0.8.0", features = [ "compressed_npz" ] }
+nom = "7.0"
 py_literal = "0.4.0"
 rand = "0.8.4"
 readings-probe = "0.1.3"


### PR DESCRIPTION
Add the ability to specify a quantized datum (`QI8`, `QU8`, `QI32`) type when specifying input facts.
It can be specified with the following pattern:
- QI8 with zp scale (zp: 95, scale: 0.036406454) -> `qi8{95-0.036406454}`
- QI8 with min max (min: 0.125, max: 0.525) -> `qi8{0.125-0.525}`