### PR TITLE
Add interpolator nearest for the Resize onnx op

### DIFF
--- a/harness/onnx-test-suite/node-1.6.0.txt
+++ b/harness/onnx-test-suite/node-1.6.0.txt
@@ -390,6 +390,8 @@ test_reshape_reordered_last_dims input:data
 test_reshape_zero_and_negative_dim input:data
 test_reshape_zero_dim input:data
 test_resize_upsample_scales_linear_align_corners                                    input:X not-nnef
+test_resize_upsample_scales_nearest not-nnef not-typable
+test_resize_upsample_sizes_nearest not-nnef not-typable
 test_rnn_seq_length
 test_round
 test_scan9_sum

--- a/harness/onnx-test-suite/node-1.7.0.txt
+++ b/harness/onnx-test-suite/node-1.7.0.txt
@@ -477,6 +477,10 @@ test_reshape_reordered_last_dims input:data
 test_reshape_zero_and_negative_dim input:data
 test_reshape_zero_dim input:data
 test_resize_upsample_scales_linear_align_corners                                    input:X not-nnef
+test_resize_upsample_scales_nearest not-nnef not-typable
+test_resize_upsample_sizes_nearest not-nnef not-typable
+test_resize_upsample_sizes_nearest_floor_align_corners not-nnef not-typable
+test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric not-nnef not-typable
 test_rnn_seq_length
 test_round
 test_scan9_sum

--- a/harness/onnx-test-suite/node-1.8.1.txt
+++ b/harness/onnx-test-suite/node-1.8.1.txt
@@ -503,6 +503,7 @@ test_reshape_reordered_last_dims input:data
 test_reshape_zero_and_negative_dim input:data
 test_reshape_zero_dim input:data
 test_resize_upsample_scales_linear_align_corners                                    input:X not-nnef
+test_resize_upsample_scales_nearest not-nnef not-typable
 test_rnn_seq_length
 test_round
 test_scan9_sum

--- a/harness/onnx-test-suite/node-1.9.0.txt
+++ b/harness/onnx-test-suite/node-1.9.0.txt
@@ -509,6 +509,7 @@ test_reshape_reordered_last_dims input:data
 test_reshape_zero_and_negative_dim input:data
 test_reshape_zero_dim input:data
 test_resize_upsample_scales_linear_align_corners                                    input:X not-nnef
+test_resize_upsample_scales_nearest not-nnef not-typable
 test_rnn_seq_length
 test_round
 test_scan9_sum


### PR DESCRIPTION
This PR implements the `nearest` mode for the Resize onnx op.

This is following the description in the ONNX docs (which isn't super clear but I think my implementation is right): https://github.com/onnx/onnx/blob/main/docs/Operators.md#Resize 

I have tested it by comparing the results of a [YoloV5 model](https://github.com/ultralytics/yolov5), using tract and onnxruntime. YoloV5 uses the `nearest` mode in the Resize ONNX op.

Do I have to add a unit test somewhere?