### PR TITLE
Fix `CoordTransformer::HalfPixel` formula

### DIFF
--- a/onnx/src/ops/resize.rs
+++ b/onnx/src/ops/resize.rs
@@ -46,7 +46,7 @@ enum CoordTransformer {
 impl CoordTransformer {
     fn transform(&self, x_out: usize, scale: f32, len_in: usize, len_out: usize) -> f32 {
         match self {
-            CoordTransformer::HalfPixel => (x_out as f32 + 0.5) * scale - 0.5,
+            CoordTransformer::HalfPixel => (x_out as f32 + 0.5) / scale - 0.5,
             CoordTransformer::AlignCorners => {
                 (x_out as f32 * (len_in as f32 - 1.0)) / (len_out as f32 - 1.0)
             }


### PR DESCRIPTION
I was getting incorrect results from some MediaPipe models that use `Resize` nodes (after TFLite->ONNX conversion). This PR fixes at least one of the issues.