### PR TITLE
support serialization for core::array::Range

### DIFF
--- a/nnef/src/ops/core.rs
+++ b/nnef/src/ops/core.rs
@@ -8,6 +8,7 @@ mod gather;
 mod one_hot;
 mod qconv;
 mod qmatmul;
+mod range;
 mod reduce;
 mod scan;
 mod scatter;
@@ -39,4 +40,5 @@ pub fn register(registry: &mut Registry) {
     scatter::register(registry);
     scan::register(registry);
     source::register(registry);
+    range::register(registry);
 }

--- a/nnef/src/ops/core/range.rs
+++ b/nnef/src/ops/core/range.rs
@@ -1,0 +1,37 @@
+use crate::internal::*;
+use crate::ser::*;
+use tract_core::ops::array::Range;
+
+pub fn register(registry: &mut Registry) {
+    registry.register_dumper(TypeId::of::<Range>(), range_dump);
+    registry.register_primitive("tract_core_range", &range_parameters(), range_load);
+}
+
+fn range_parameters() -> Vec<Parameter> {
+    vec![
+        TypeName::Scalar.tensor().named("start"),
+        TypeName::Scalar.tensor().named("end"),
+        TypeName::Scalar.tensor().named("step"),
+    ]
+}
+
+fn range_dump(ast: &mut IntoAst, node: &TypedNode) -> TractResult<Option<Arc<RValue>>> {
+    let op = node.op_as::<Range>().unwrap();
+    let mut inputs = tvec![];
+
+    inputs.push(ast.konst_variable(format!("{}_start", node.name), &Arc::new(op.start.clone()))?);
+    inputs.push(ast.konst_variable(format!("{}_end", node.name), &Arc::new(op.end.clone()))?);
+    inputs.push(ast.konst_variable(format!("{}_step", node.name), &Arc::new(op.step.clone()))?);
+
+    Ok(Some(invocation("tract_core_range", &inputs, &[])))
+}
+
+fn range_load(
+    builder: &mut ModelBuilder,
+    invocation: &ResolvedInvocation,
+) -> TractResult<TVec<OutletId>> {
+    let start: Arc<Tensor> = invocation.named_arg_as(builder, "start")?;
+    let end: Arc<Tensor> = invocation.named_arg_as(builder, "end")?;
+    let step: Arc<Tensor> = invocation.named_arg_as(builder, "step")?;
+    builder.wire(Range::new((*start).clone(), (*end).clone(), (*step).clone()), &[])
+}

--- a/nnef/src/ser.rs
+++ b/nnef/src/ser.rs
@@ -407,7 +407,7 @@ pub fn tdims(shape: &[TDim]) -> RValue {
     RValue::Array(shape.iter().map(|s| tdim(s)).collect())
 }
 
-fn tdim(dim: &TDim) -> RValue {
+pub fn tdim(dim: &TDim) -> RValue {
     match dim {
         TDim::Val(x) => numeric(x),
         TDim::Sym(s) => ident(format!("{}", s.as_char())),


### PR DESCRIPTION
For the second issue from #718.  This is what the graph looks like:

<img width="279" alt="image" src="https://user-images.githubusercontent.com/8234817/173568420-5aaad3c6-86c5-4443-8e1c-41f300d99ea0.png">

This ends up failing with:

```
    Caused by:
        0: Serializing tensor "Range_1523_end.dat": ,TDim N
        1: Undetermined symbol in expression: N
```

I know that the [ONNX spec for Range](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Range) says the start,end,step are scalars, so I'm wondering if rewriting Range to do the same would be prudent? It doesn't seem like I can easily convert the Tensor to another RValue for serialization. 