### PR TITLE
Upgrade `prost` 0.9 -> 0.10

### DIFF
--- a/harness/onnx-test-suite/Cargo.toml
+++ b/harness/onnx-test-suite/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 bytes = "1.0.1"
 fs2 = "0.4.3"
 log = "0.4.14"
-prost = "0.9.0"
+prost = "0.10.0"
 tract-core = { path = "../../core", features = [ "paranoid_assertions" ] }
 tract-nnef = { path = "../../nnef" }
 tract-onnx = { path = "../../onnx" }

--- a/onnx/Cargo.toml
+++ b/onnx/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 license = "MIT/Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
-keywords = ["TensorFlow", "NeuralNetworks", "ONNX"]
-categories = ["science"]
+keywords = [ "TensorFlow", "NeuralNetworks", "ONNX" ]
+categories = [ "science" ]
 autobenches = false
 edition = "2018"
-exclude = ["test_cases"]
+exclude = [ "test_cases" ]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/onnx/Cargo.toml
+++ b/onnx/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 license = "MIT/Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
-keywords = [ "TensorFlow", "NeuralNetworks", "ONNX" ]
-categories = [ "science" ]
+keywords = ["TensorFlow", "NeuralNetworks", "ONNX"]
+categories = ["science"]
 autobenches = false
 edition = "2018"
-exclude = [ "test_cases" ]
+exclude = ["test_cases"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -20,7 +20,7 @@ derive-new = "0.5.9"
 educe = "0.4.18"
 log = "0.4.14"
 num-integer = "0.1.44"
-prost = "0.9.0"
+prost = "0.10.0"
 smallvec = "1.6.1"
 tract-hir = { path = "../hir" }
 tract-nnef = { path = "../nnef" }
@@ -30,4 +30,4 @@ tract-onnx-opl = { path = "../onnx-opl" }
 mapr = "0.8.0"
 
 [build-dependencies]
-prost-build = "0.9.0"
+prost-build = "0.10.0"

--- a/tensorflow/Cargo.toml
+++ b/tensorflow/Cargo.toml
@@ -18,8 +18,8 @@ bytes = "1.0.1"
 derive-new = "0.5.9"
 educe = "0.4.18"
 log = "0.4.14"
-prost = "0.9.0"
-prost-types = "0.9.0"
+prost = "0.10.0"
+prost-types = "0.10.0"
 tensorflow = { version = "0.17.0", optional = true }
 tract-hir = { path = "../hir" }
 tract-pulse = { path = "../pulse" }
@@ -28,7 +28,7 @@ tract-pulse = { path = "../pulse" }
 mapr = "0.8.0"
 
 [build-dependencies]
-prost-build = "0.9.0"
+prost-build = "0.10.0"
 
 [features]
 conform = [ "tensorflow" ]

--- a/tensorflow/src/lib.rs
+++ b/tensorflow/src/lib.rs
@@ -14,7 +14,7 @@
 //! let mut model = tf.model_for_path("tests/models/plus3.pb").unwrap();
 //!
 //! // set input input type and shape, then optimize the network.
-//! model.set_input_fact(0, f32::fact(&[3]).into())).unwrap();
+//! model.set_input_fact(0, f32::fact(&[3]).into()).unwrap();
 //! let model = model.into_optimized().unwrap();
 //!
 //! // we build an execution plan. default input and output are inferred from


### PR DESCRIPTION
This upgrades prost to 0.10 in tract-onnx and tract-tensorflow.

Also fixes a small bug in a doctest that failed `cargo test` from the root.