### PR TITLE
Fix downsample node name duplication

### DIFF
--- a/core/src/ops/downsample/mod.rs
+++ b/core/src/ops/downsample/mod.rs
@@ -131,7 +131,7 @@ fn pull_downsample_up(
                 let source = patch.tap_model(model, oo)?;
                 let mut op = down_op.clone();
                 op.axis = above_axis;
-                let ds = patch.wire_node(format!("{}-{}", prec.name, ix), op, [source].as_ref())?;
+                let ds = patch.wire_node(format!("{}.{}-{}", down_node.name, prec.name, ix), op, [source].as_ref())?;
                 inputs.push(ds[0]);
             }
             let other = patch.wire_node(&*prec.name, prec.op.clone(), &*inputs)?;


### PR DESCRIPTION
I add a proptest failing because of a node name duplication error when decluttering a model:
```
    0 |                   -> >1/0              | Source                    a                                                  [] => [1,1,S,F32]
    1 | 0/0>              -> >2/0              | Downsample                conv0.downsample                                   [1,1,S,F32] => [1,1,(S+1)/2,F32]
    2 | 1/0>              -> >3/0              | Downsample                conv0.matmul-0                                     [1,1,(S+1)/2,F32] => [1,1,(S+3)/4,F32]
    3 | 2/0>              -> >4/0              | Downsample                conv0.matmul-0                                     [1,1,(S+3)/4,F32] => [1,1,(S+7)/8,F32]
    4 | 3/0>              -> >5/0              | MatMulUnary               conv0.matmul                                       [1,1,(S+7)/8,F32] => [1,1,(S+7)/8,F32]
    5 | 4/0>              -> >6/0              | Downsample                conv1.matmul-0                                     [1,1,(S+7)/8,F32] => [1,1,(S+15)/16,F32]
    6 | 5/0>              -> >7/0              | MatMulUnary               conv1.matmul                                       [1,1,(S+15)/16,F32] => [1,1,(S+15)/16,F32]
    7 | 6/0>              -> >8/0              | MatMulUnary               conv2.matmul                                       [1,1,(S+15)/16,F32] => [1,1,(S+15)/16,F32]
    8 | 7/0>              ->                   | ConvUnary                 conv3                                              [1,1,(S+15)/16,F32] => [1,1,-1+(S+15)/16,F32]
outputs: 8/0>

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: after pass declutter

Caused by:
    0: after graph compaction
    1: duplicate name conv0.matmul-0', openvx-tract-client/tests/test_hybrid_runner.rs:157:45
```

The issue is fixed with this change.