### PR TITLE
fix: update compatible_with to add a simple possible subtype

### DIFF
--- a/cli/src/tensor.rs
+++ b/cli/src/tensor.rs
@@ -296,7 +296,7 @@ pub fn retrieve_or_make_inputs(
         let name = tract.node_name(input.node);
         let fact = tract.outlet_typedfact(*input)?;
         if let Some(value) = params.input_values.get(name) {
-            if fact.compatible_with(&TypedFact::from(value[0].clone())) {
+            if TypedFact::from(value[0].clone()).compatible_with(&fact) {
                 info!("Using fixed input for input called {} ({} turn(s))", name, value.len());
                 tmp.push(value.iter().map(|t| t.clone().into_tensor()).collect())
             } else if fact.datum_type == f16::datum_type()

--- a/core/src/model/fact.rs
+++ b/core/src/model/fact.rs
@@ -102,6 +102,17 @@ impl ShapeFact {
         }
         Ok(())
     }
+
+    pub fn compatible_with(&self, _other: &ShapeFact) -> bool {
+        if self.rank() == _other.rank() {
+            self.dims
+                .iter()
+                .zip(_other.dims.iter())
+                .all(|(dim, other_dim)| dim.compatible_with(other_dim))
+        } else {
+            false
+        }
+    }
 }
 
 impl std::ops::Deref for ShapeFact {
@@ -128,6 +139,7 @@ pub trait Fact: std::fmt::Debug + Downcast + dyn_clone::DynClone + Send + Sync +
 
     fn same_as(&self, _other: &dyn Fact) -> bool;
 
+    /// Ensure that self is same type as another fact or a subtype
     fn compatible_with(&self, _other: &dyn Fact) -> bool;
 }
 
@@ -293,7 +305,7 @@ impl Fact for TypedFact {
             if cfg!(debug_assertions) {
                 other.consistent().unwrap()
             }
-            self.without_value().same_as(&other.without_value())
+            self.datum_type == other.datum_type && self.shape.compatible_with(&other.shape)
         } else {
             false
         }

--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -459,6 +459,20 @@ impl TDim {
             Div(a, _) => a.symbols(),
         }
     }
+
+    /// Check if a dim is 'compatible with' another, meaning that the current dim
+    /// is a "sub" dimension within or equal to the _other dim
+    pub fn compatible_with(&self, _other: &TDim) -> bool {
+        match (self, _other) {
+            // If we compare a concrete dim to symbol dim we are always
+            // true but the inverse do not hold since we consider in this
+            // implementation that _other should always hold maximal `genericity`
+            // due to `compatible_with` fn name sementics
+            (TDim::Val(_dim), TDim::Sym(_other_dim)) => true,
+            // for all other case equality is required
+            (dim, other_dim) => dim == other_dim,
+        }
+    }
 }
 
 pub(super) fn reduce_ratio(mut p: i64, mut q: i64) -> (i64, u64) {


### PR DESCRIPTION
This solves the case where you provide an `input-bundle` from CLI but have a model with arbitrary number of symbolic dimension tensors.