### PR TITLE
Update compiler flags for aarch64-unknown-linux-gnu

### DIFF
--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_128x1_core.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_128x1_core.tmpl
@@ -20,7 +20,7 @@
 .text
 .align 4
 
-{% if clang == false %}
+{% if needs_pragma == false %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_mmm_f16_128x1_{{core}}_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_128x1_core.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_128x1_core.tmpl
@@ -20,7 +20,7 @@
 .text
 .align 4
 
-{% if needs_pragma == false %}
+{% if needs_pragma == true %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_mmm_f16_128x1_{{core}}_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_16x8_core.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_16x8_core.tmpl
@@ -22,7 +22,7 @@
 .text
 .align 4
 
-{% if clang == false %}
+{% if needs_pragma == false %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_mmm_f16_16x8_{{core}}_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_16x8_core.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_16x8_core.tmpl
@@ -22,7 +22,7 @@
 .text
 .align 4
 
-{% if needs_pragma == false %}
+{% if needs_pragma == true %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_mmm_f16_16x8_{{core}}_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_32x4_core.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_32x4_core.tmpl
@@ -12,7 +12,7 @@
 .text
 .align 4
 
-{% if needs_pragma == false %}
+{% if needs_pragma == true %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_mmm_f16_32x4_{{core}}_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_32x4_core.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_32x4_core.tmpl
@@ -12,7 +12,7 @@
 .text
 .align 4
 
-{% if clang == false %}
+{% if needs_pragma == false %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_mmm_f16_32x4_{{core}}_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_sigmoid_f16_8n.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_sigmoid_f16_8n.tmpl
@@ -5,7 +5,7 @@
 .text
 .align 4
 
-{% if clang == false %}
+{% if needs_pragma == false %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_sigmoid_f16_8n_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_sigmoid_f16_8n.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_sigmoid_f16_8n.tmpl
@@ -5,7 +5,7 @@
 .text
 .align 4
 
-{% if needs_pragma == false %}
+{% if needs_pragma == true %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_sigmoid_f16_8n_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_tanh_f16_8n.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_tanh_f16_8n.tmpl
@@ -5,7 +5,7 @@
 .text
 .align 4
 
-{% if clang == false %}
+{% if needs_pragma == false %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_tanh_f16_8n_{{suffix}}

--- a/linalg/arm64/arm64fp16/arm64fp16_tanh_f16_8n.tmpl
+++ b/linalg/arm64/arm64fp16/arm64fp16_tanh_f16_8n.tmpl
@@ -5,7 +5,7 @@
 .text
 .align 4
 
-{% if needs_pragma == false %}
+{% if needs_pragma == true %}
 .cpu generic+fp+simd+fp16
 {% endif %}
 .global {{G}}arm64fp16_tanh_f16_8n_{{suffix}}

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -13,7 +13,10 @@ fn use_masm() -> bool {
 }
 
 fn use_clang() -> bool {
-    var("TARGET").contains("-android") || var("TARGET").contains("-ios") || var("TARGET").contains("-darwin")
+    var("TARGET").contains("-android")
+        || var("TARGET").contains("-ios")
+        || var("TARGET").contains("-darwin")
+        || var("TARGET") == "aarch64-unknown-linux-gnu"
 }
 
 fn jump_table() -> Vec<String> {
@@ -27,7 +30,6 @@ fn jump_table() -> Vec<String> {
 }
 
 fn main() {
-
     let target = var("TARGET");
     let arch = var("CARGO_CFG_TARGET_ARCH");
     let os = var("CARGO_CFG_TARGET_OS");
@@ -319,8 +321,12 @@ pub struct F16;
 struct F16Filter;
 
 impl Filter for F16Filter {
-    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> liquid_core::Result<Value> {
-        let input:f32 = input.as_scalar().unwrap().to_float().unwrap() as f32;
+    fn evaluate(
+        &self,
+        input: &dyn ValueView,
+        _runtime: &dyn Runtime,
+    ) -> liquid_core::Result<Value> {
+        let input: f32 = input.as_scalar().unwrap().to_float().unwrap() as f32;
         let value = half::f16::from_f32(input);
         let bits = value.to_bits();
         Ok(format!(".short {bits}").to_value())

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -13,10 +13,9 @@ fn use_masm() -> bool {
 }
 
 fn needs_pragma() -> bool {
-    // This will add the following to the asm templates:
+    // This will add the following to the asm templates if true:
     // .cpu generic+fp+simd+fp16
-    // for non clang compilers
-   cc::Build::new().get_compiler().is_like_clang() || cc::Build::new().get_compiler().is_like_gnu()
+   !cc::Build::new().get_compiler().is_like_clang() && !cc::Build::new().get_compiler().is_like_gnu()
 }
 
 fn jump_table() -> Vec<String> {

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -13,10 +13,11 @@ fn use_masm() -> bool {
 }
 
 fn use_clang() -> bool {
-    var("TARGET").contains("-android")
-        || var("TARGET").contains("-ios")
-        || var("TARGET").contains("-darwin")
-        || var("TARGET") == "aarch64-unknown-linux-gnu"
+    // This will fail to compile aarch64 with gcc thanks to the 
+    // asm templates adding:
+    // .cpu generic+fp+simd+fp16
+    // for non clang compilers
+   cc::Build::new().get_compiler().is_like_clang()
 }
 
 fn jump_table() -> Vec<String> {
@@ -156,9 +157,8 @@ fn main() {
             let files =
                 preprocess_files("arm64/arm64fp16", &[("core", vec!["a55", "gen"])], &suffix);
             let mut cc = cc::Build::new();
-            if use_clang() {
-                cc.flag("-mcpu=cortex-a55");
-            }
+            // Adds support for fp16 instruction extension if cpu supports it
+            cc.flag("-mcpu=native");
             cc.files(files).static_flag(true).compile("arm64fp16");
         }
         _ => {}


### PR DESCRIPTION
Fixes compilation issues on the target by ensuring `-mcpu=cortex-a55` is added as a compiler flag. Before this you would end up with the error posted below. Let me know if you want a different approach (perhaps unconditionally add the flag for aarch64?)

Tested on physical Ampere Altra Arm64 machine. Issue could be seen in qemu builds as well.

```
  cargo:warning=/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_sigmoid_f16_8n.S:103:5: error: instruction requires: fullfp16
  cargo:warning=    fmla v28.8h, v20.8h, v0.h[2]
  cargo:warning=    ^
  cargo:warning=/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_sigmoid_f16_8n.S:105:5: error: instruction requires: fullfp16
  cargo:warning=    fmla v24.8h, v20.8h, v28.8h
  cargo:warning=    ^
  cargo:warning=/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_sigmoid_f16_8n.S:106:5: error: instruction requires: fullfp16
  cargo:warning=    fmul v16.8h, v16.8h, v24.8h
  cargo:warning=    ^
  cargo:warning=/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_sigmoid_f16_8n.S:109:5: error: instruction requires: fullfp16
  cargo:warning=    fmla v24.8h, v20.8h, v0.h[5]
  cargo:warning=    ^
  cargo:warning=/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_sigmoid_f16_8n.S:111:5: error: instruction requires: fullfp16
  cargo:warning=    fdiv v16.8h, v16.8h, v24.8h
  cargo:warning=    ^
  cargo:warning=/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_sigmoid_f16_8n.S:112:5: error: instruction requires: fullfp16
  cargo:warning=    fadd v16.8h, v16.8h, v7.8h
  cargo:warning=    ^
  exit status: 1

  --- stderr


  error occurred: Command "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-static" "-Wall" "-Wextra" "-o" "/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_mmm_f16_128x1_a55.o" "-c" "/mnt/disks/storage_disk/ark/target/debug/build/tract-linalg-de04fa2611fd2023/out/arm64fp16_mmm_f16_128x1_a55.S" with args "cc" did not execute successfully (status code exit status: 1).
```