### PR TITLE
Add ONNX Multinomial Operator

### DIFF
--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -195,7 +195,7 @@ case "$PLATFORM" in
 
     "wasm32-unknown-unknown")
         rustup target add wasm32-unknown-unknown
-        cargo check --target wasm32-unknown-unknown -p tract-onnx -p tract-tensorflow
+        cargo check --target wasm32-unknown-unknown --features getrandom-js -p tract-onnx -p tract-tensorflow
         ;;
     *)
         echo "Don't know what to do for platform: $PLATFORM"

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -305,7 +305,12 @@ impl Parameters {
                 let graph = onnx.proto_model_for_read(&mut *location.read()?)?;
                 info_usage("proto model loaded", probe);
                 let path = &location.path().clone();
-                let parsed = onnx.parse(&graph, path.to_str())?;
+                let mut parsed = onnx.parse(&graph, path.to_str())?;
+
+                if matches.is_present("determinize") {
+                    tract_onnx::Onnx::determinize(&mut parsed.model)?;
+                }
+
                 if need_graph {
                     (
                         SomeGraphDef::Onnx(graph, parsed.clone()),

--- a/hir/src/ops/expandable.rs
+++ b/hir/src/ops/expandable.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use crate::internal::*;
 use tract_core::internal::*;
 
@@ -12,6 +14,7 @@ pub trait Expansion:
     + Sync
     + tract_core::downcast_rs::Downcast
     + tract_core::internal::DynHash
+    + Any
 {
     fn name(&self) -> Cow<str>;
     fn op_families(&self) -> &'static [&'static str];

--- a/onnx-opl/Cargo.toml
+++ b/onnx-opl/Cargo.toml
@@ -17,3 +17,8 @@ maintenance = { status = "actively-developed" }
 tract-nnef = { version = "0.17.4-pre", path = "../nnef" }
 educe = "0.4.18"
 rand = { version = "0.8.4", features = ["small_rng"] }
+getrandom = "0.2"
+
+[features]
+default = []
+getrandom-js = ["getrandom/js"]

--- a/onnx-opl/Cargo.toml
+++ b/onnx-opl/Cargo.toml
@@ -16,3 +16,4 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 tract-nnef = { version = "0.17.4-pre", path = "../nnef" }
 educe = "0.4.18"
+rand = { version = "0.8.4", features = ["small_rng"] }

--- a/onnx-opl/src/lib.rs
+++ b/onnx-opl/src/lib.rs
@@ -13,6 +13,7 @@ pub mod is_nan;
 pub mod lrn;
 pub mod ml;
 pub mod non_max_suppression;
+pub mod multinomial;
 
 pub trait WithOnnx {
     fn with_onnx(self) -> Self;
@@ -30,6 +31,7 @@ fn onnx_opl_registry() -> Registry {
     let mut registry: Registry = Registry::new("tract_onnx");
     ml::register(&mut registry);
     non_max_suppression::register(&mut registry);
+    multinomial::register(&mut registry);
     registry.register_unit_element_wise("tract_onnx_erf", &erf::Erf {});
     registry.register_element_wise(
         "tract_onnx_isinf",

--- a/onnx-opl/src/multinomial.rs
+++ b/onnx-opl/src/multinomial.rs
@@ -1,0 +1,189 @@
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+use tract_nnef::internal::*;
+use tract_nnef::tract_ndarray::s;
+use tract_nnef::tract_num_traits::{AsPrimitive, Float, Zero};
+
+pub fn register(registry: &mut Registry) {
+    registry.register_primitive("tract_onnx_multinomial", &parameters(), load);
+    registry.register_dumper(TypeId::of::<Multinomial>(), dump);
+}
+
+/// https://github.com/onnx/onnx/blob/main/docs/Operators.md#Multinomial
+#[derive(Clone, Debug, Educe)]
+#[educe(Hash)]
+pub struct Multinomial {
+    pub dtype: DatumType,
+    pub sample_size: i32,
+    #[educe(Hash(method = "hash_opt_f32"))]
+    pub seed: Option<f32>,
+}
+
+impl_dyn_hash!(Multinomial);
+
+impl Multinomial {
+    fn eval_t0<T1>(&self, input: Arc<Tensor>) -> TractResult<Arc<Tensor>>
+    where
+        T1: Datum + std::ops::SubAssign + Float + std::iter::Sum,
+        Standard: Distribution<T1>,
+    {
+        match self.dtype {
+            DatumType::I32 => self.eval_t::<T1, i32>(input),
+            DatumType::I64 => self.eval_t::<T1, i64>(input),
+            dt => bail!("Unsupported output datum type for Multinomial: {:?}", dt),
+        }
+    }
+    fn eval_t<T1, T2>(&self, input: Arc<Tensor>) -> TractResult<Arc<Tensor>>
+    where
+        T1: Datum + std::ops::SubAssign + Float + std::iter::Sum,
+        Standard: Distribution<T1>,
+        T2: Datum + Zero + Copy,
+        usize: AsPrimitive<T2>,
+    {
+        let batch_size = input.shape()[0];
+        let class_size = input.shape()[1];
+
+        let mut rng = self.seed.map_or_else(
+            || SmallRng::from_entropy(),
+            |seed| SmallRng::seed_from_u64(seed.to_bits() as _),
+        );
+
+        // shape: [batch_size, class_size]
+        let input = input.to_array_view::<T1>()?;
+
+        // ONNX Multinomial inputs are "unnormalized log probabilities".
+        // This means that we need to compute the maximum for each batch beforehand,
+        //  and we also need to exp every value.
+
+        let maximums: TVec<_> =
+            input.rows().into_iter().map(|r| r.iter().map(|e| e.exp()).sum::<T1>()).collect();
+
+        // shape: [batch_size, sample_size]
+        let out_shape: &[_] = &[batch_size, self.sample_size as usize];
+        let output = tract_ndarray::ArrayD::from_shape_fn(out_shape, |co_o| -> T2 {
+            let batch = co_o[0];
+
+            let mut rand = rng.gen::<T1>() * maximums[batch];
+            let mut ret: T2 = usize::as_(class_size - 1);
+
+            for (i, prob) in input.slice(s![batch, ..]).iter().enumerate() {
+                let prob = prob.exp();
+                if rand < prob {
+                    ret = usize::as_(i);
+                    break;
+                }
+                rand -= prob;
+            }
+
+            ret
+        });
+
+        Ok(output.into_arc_tensor())
+    }
+}
+
+impl Op for Multinomial {
+    fn name(&self) -> Cow<str> {
+        "Multinomial".into()
+    }
+
+    fn op_families(&self) -> &'static [&'static str] {
+        &["onnx"]
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for Multinomial {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, mut inputs: TVec<Arc<Tensor>>) -> TractResult<TVec<Arc<Tensor>>> {
+        let input = args_1!(inputs);
+
+        let output = match input.datum_type() {
+            // DatumType::F16 => self.eval_t0::<f16>(input), // TODO: implement random for f16
+            DatumType::F32 => self.eval_t0::<f32>(input),
+            DatumType::F64 => self.eval_t0::<f64>(input),
+            dt => bail!("Unsupported input datum type for Multinomial: {:?}", dt),
+        }?;
+
+        Ok(tvec![output])
+    }
+}
+
+impl TypedOp for Multinomial {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        let input_shape = if let Some(s) = inputs[0].shape.as_concrete() {
+            s
+        } else {
+            bail!("Only constant input shape are supported in Multinomial")
+        };
+
+        let batch_size = input_shape[0];
+        Ok(tvec!(self.dtype.fact(&[batch_size, self.sample_size as usize])))
+    }
+
+    as_op!();
+}
+
+fn parameters() -> Vec<Parameter> {
+    vec![
+        TypeName::Integer.tensor().named("input"),
+        TypeName::Integer.named("dtype").default(6),
+        TypeName::Integer.named("sample_size").default(1),
+        TypeName::Integer.named("seed"),
+    ]
+}
+
+fn dump(ast: &mut IntoAst, node: &TypedNode) -> TractResult<Option<Arc<RValue>>> {
+    let op = node.op_as::<Multinomial>().context("wrong op")?;
+    let input = ast.mapping[&node.inputs[0]].clone();
+
+    let dtype = match op.dtype {
+        DatumType::I32 => 6,
+        DatumType::I64 => 7,
+        dt => bail!("Unsupported datum type {:?} for ONNX Multinomial", dt),
+    };
+
+    let inv = if let Some(seed) = op.seed {
+        invocation(
+            "tract_onnx_multinomial",
+            &[input],
+            &[
+                ("dtype", numeric(dtype)),
+                ("sample_size", numeric(op.sample_size)),
+                ("seed", numeric(seed)),
+            ],
+        )
+    } else {
+        invocation(
+            "tract_onnx_multinomial",
+            &[input],
+            &[("dtype", numeric(dtype)), ("sample_size", numeric(op.sample_size))],
+        )
+    };
+
+    Ok(Some(inv))
+}
+
+fn load(
+    builder: &mut ModelBuilder,
+    invocation: &ResolvedInvocation,
+) -> TractResult<TVec<OutletId>> {
+    let input = invocation.named_arg_as(builder, "input")?;
+    let dtype = match invocation.named_arg_as::<i64>(builder, "dtype")? {
+        6 => DatumType::I32,
+        7 => DatumType::I64,
+        i => bail!("Unsupported datum type {} for ONNX Multinomial", i),
+    };
+    let sample_size = invocation.named_arg_as::<i64>(builder, "sample_size")? as _;
+    let seed = invocation.named_arg_as(builder, "seed").ok();
+
+    let op = Multinomial { dtype, sample_size, seed };
+    builder.wire(op, &[input])
+}

--- a/onnx/Cargo.toml
+++ b/onnx/Cargo.toml
@@ -31,3 +31,7 @@ mapr = "0.8.0"
 
 [build-dependencies]
 prost-build = "0.10.0"
+
+[features]
+default = []
+getrandom-js = ["tract-onnx-opl/getrandom-js"]

--- a/onnx/Cargo.toml
+++ b/onnx/Cargo.toml
@@ -25,7 +25,6 @@ smallvec = "1.6.1"
 tract-hir = { version = "0.17.4-pre", path = "../hir" }
 tract-nnef = { version = "0.17.4-pre", path = "../nnef" }
 tract-onnx-opl = { version = "0.17.4-pre", path = "../onnx-opl" }
-rand = "0.8.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 mapr = "0.8.0"

--- a/onnx/Cargo.toml
+++ b/onnx/Cargo.toml
@@ -25,6 +25,7 @@ smallvec = "1.6.1"
 tract-hir = { version = "0.17.4-pre", path = "../hir" }
 tract-nnef = { version = "0.17.4-pre", path = "../nnef" }
 tract-onnx-opl = { version = "0.17.4-pre", path = "../onnx-opl" }
+rand = "0.8.4"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 mapr = "0.8.0"

--- a/onnx/src/ops/mod.rs
+++ b/onnx/src/ops/mod.rs
@@ -24,6 +24,7 @@ mod quant;
 pub mod rec;
 mod resize;
 mod non_max_suppression;
+mod multinomial;
 mod s2d;
 
 pub fn register_all_ops(reg: &mut OnnxOpRegister) {
@@ -33,6 +34,7 @@ pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("Identity", |_, _| Ok((Box::new(ops::identity::Identity::default()), vec![])));
     reg.insert("Resize", resize::resize);
     reg.insert("NonMaxSuppression", non_max_suppression::non_max_suppression);
+    reg.insert("Multinomial", multinomial::multinomial);
     array::register_all_ops(reg);
     cumsum::register_all_ops(reg);
     d2s::register_all_ops(reg);

--- a/onnx/src/ops/mod.rs
+++ b/onnx/src/ops/mod.rs
@@ -24,7 +24,7 @@ mod quant;
 pub mod rec;
 mod resize;
 mod non_max_suppression;
-mod multinomial;
+pub mod multinomial;
 mod s2d;
 
 pub fn register_all_ops(reg: &mut OnnxOpRegister) {

--- a/onnx/src/ops/multinomial.rs
+++ b/onnx/src/ops/multinomial.rs
@@ -1,0 +1,158 @@
+use crate::model::ParsingContext;
+use crate::pb::*;
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+use tract_hir::internal::*;
+use tract_hir::tract_ndarray::s;
+use tract_hir::tract_num_traits::{AsPrimitive, Zero, Float};
+
+pub fn multinomial(
+    _ctx: &ParsingContext,
+    node: &NodeProto,
+) -> TractResult<(Box<dyn InferenceOp>, Vec<String>)> {
+    let dtype = match node.get_attr_opt("dtype")?.unwrap_or(6) {
+        6 => DatumType::I32,
+        7 => DatumType::I64,
+        i => bail!("Unsupported datum type {} for ONNX Multinomial", i),
+    };
+    let sample_size = node.get_attr_opt("sample_size")?.unwrap_or(1);
+    let seed = node.get_attr_opt("seed")?.unwrap_or(0.0f32);
+
+    Ok((Box::new(Multinomial { dtype, sample_size, seed }), vec![]))
+}
+
+/// https://github.com/onnx/onnx/blob/main/docs/Operators.md#Multinomial
+#[derive(Clone, new, Debug, Educe)]
+#[educe(Hash)]
+struct Multinomial {
+    dtype: DatumType,
+    sample_size: i32,
+    #[educe(Hash(method = "hash_f32"))]
+    seed: f32,
+}
+
+impl Multinomial {
+    fn eval_t0<T1>(&self, input: Arc<Tensor>) -> TractResult<Arc<Tensor>>
+    where
+        T1: Datum + std::ops::SubAssign + Float,
+        Standard: Distribution<T1>,
+    {
+        match self.dtype {
+            DatumType::I32 => self.eval_t::<T1, i32>(input),
+            DatumType::I64 => self.eval_t::<T1, i64>(input),
+            dt => bail!("Unsupported output datum type for Multinomial: {:?}", dt),
+        }
+    }
+    fn eval_t<T1, T2>(&self, input: Arc<Tensor>) -> TractResult<Arc<Tensor>>
+    where
+        T1: Datum + std::ops::SubAssign + Float,
+        Standard: Distribution<T1>,
+        T2: Datum + Zero + Copy,
+        usize: AsPrimitive<T2>,
+    {
+        let batch_size = input.shape()[0];
+        let class_size = input.shape()[1];
+        let out_shape: &[_] = &[batch_size, self.sample_size as usize];
+
+        let input = input.to_array_view::<T1>()?;
+
+        let output = tract_ndarray::ArrayD::from_shape_fn(out_shape, |co_o| -> T2 {
+            let batch = co_o[0];
+
+            let mut rand: T1 = rand::random();
+            let mut ret: T2 = usize::as_(class_size - 1);
+
+            for (i, prob) in input.slice(s![batch, ..]).iter().enumerate() {
+                let prob = prob.exp();
+                if rand < prob {
+                    ret = usize::as_(i);
+                    break;
+                }
+                rand -= prob;
+            }
+
+            ret
+        });
+
+        Ok(output.into_arc_tensor())
+    }
+}
+
+impl_dyn_hash!(Multinomial);
+
+impl Op for Multinomial {
+    fn name(&self) -> Cow<str> {
+        "Multinomial".into()
+    }
+
+    op_onnx!();
+    op_as_typed_op!();
+}
+
+impl EvalOp for Multinomial {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, mut inputs: TVec<Arc<Tensor>>) -> TractResult<TVec<Arc<Tensor>>> {
+        let input = args_1!(inputs);
+
+        let output = match input.datum_type() {
+            // DatumType::F16 => self.eval_t0::<f16>(input),
+            DatumType::F32 => self.eval_t0::<f32>(input),
+            DatumType::F64 => self.eval_t0::<f64>(input),
+            dt => bail!("Unsupported input datum type for Multinomial: {:?}", dt),
+        }?;
+
+        Ok(tvec![output])
+    }
+}
+
+impl InferenceRulesOp for Multinomial {
+    fn rules<'r, 'p: 'r, 's: 'r>(
+        &'s self,
+        s: &mut Solver<'r>,
+        inputs: &'p [TensorProxy],
+        outputs: &'p [TensorProxy],
+    ) -> InferenceResult {
+        check_output_arity(&outputs, 1)?;
+        check_input_arity(&inputs, 1)?;
+
+        // inputs[0]: tensor(float16), tensor(float), tensor(double) ; [batch_size, class_size]
+        // outputs[0]: tensor(int32), tensor(int64) {depending on self.datum_type} ; [batch_size, sample_size]
+
+        s.equals(&inputs[0].rank, 2)?;
+        s.equals(&outputs[0].rank, 2)?;
+        s.equals(&outputs[0].datum_type, self.dtype)?;
+        s.equals(&inputs[0].shape[0], &outputs[0].shape[0])?; // batch_size
+        s.equals(&outputs[0].shape[1], self.sample_size.to_dim())?; // sample_size
+
+        Ok(())
+    }
+
+    as_op!();
+    to_typed!();
+}
+
+impl TypedOp for Multinomial {
+    as_op!();
+
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        let input_shape = if let Some(s) = inputs[0].shape.as_concrete() {
+            s
+        } else {
+            bail!("Only constant input shape are supported in Multinomial")
+        };
+
+        let batch_size = input_shape[0];
+        Ok(tvec!(self.dtype.fact(&[batch_size, self.sample_size as usize])))
+    }
+
+    fn declutter(
+        &self,
+        _model: &TypedModel,
+        _node: &TypedNode,
+    ) -> TractResult<Option<TypedModelPatch>> {
+        Ok(None)
+    }
+}

--- a/onnx/src/ops/multinomial.rs
+++ b/onnx/src/ops/multinomial.rs
@@ -23,7 +23,7 @@ pub struct Multinomial {
     dtype: DatumType,
     sample_size: i32,
     #[educe(Hash(method = "hash_opt_f32"))]
-    seed: Option<f32>,
+    pub seed: Option<f32>,
 }
 
 impl_dyn_hash!(Multinomial);


### PR DESCRIPTION
Add [ONNX Multinomial Operator](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Multinomial).

> Generate a tensor of samples from a multinomial distribution according to the probabilities of each of the possible outcomes.

This is useful for GPT-like models, as a source of randomness for text generation.

There are no harness tests for this operator, because the outputs are random, and even though you can seed this random on the operator ; i would guess that the ONNX runtimes are not expected to output the same results.

This makes it difficult to test this operator.
What do you think? Should I add a bare minimal CI test that only checks if the eval functions doesnt crash, without checking any output?