### PR TITLE
Feat: tract core shape of

### DIFF
--- a/nnef/src/deser.rs
+++ b/nnef/src/deser.rs
@@ -75,8 +75,7 @@ impl<'mb> ModelBuilder<'mb> {
             .results
             .iter()
             .map(|s| {
-                vars
-                    .get(s)
+                vars.get(s)
                     .with_context(|| format!("Could not find variable for output named `{}'", s))
             })
             .collect::<TractResult<TVec<&Value>>>()?;
@@ -566,7 +565,9 @@ impl CoerceFrom<Value> for TDim {
         match from {
             Value::Dim(d) => Ok(d.clone()),
             Value::Tensor(t) => Ok(t.to_scalar::<TDim>()?.clone()),
-            Value::Wire(_) => Ok(from.to::<Arc<Tensor>>(builder)?.to_scalar::<TDim>()?.clone()),
+            Value::Wire(_) => {
+                Ok(from.to::<Arc<Tensor>>(builder)?.cast_to::<TDim>()?.to_scalar::<TDim>()?.clone())
+            }
             _ => bail!("Can not build a TDim from {:?}", from),
         }
     }

--- a/nnef/src/ops/core.rs
+++ b/nnef/src/ops/core.rs
@@ -12,6 +12,7 @@ mod range;
 mod reduce;
 mod scan;
 mod scatter;
+mod shape_of;
 mod source;
 
 pub fn register(registry: &mut Registry) {
@@ -39,6 +40,7 @@ pub fn register(registry: &mut Registry) {
     reduce::register(registry);
     scatter::register(registry);
     scan::register(registry);
+    shape_of::register(registry);
     source::register(registry);
     range::register(registry);
 }

--- a/nnef/src/ops/core/shape_of.rs
+++ b/nnef/src/ops/core/shape_of.rs
@@ -1,5 +1,4 @@
 use crate::internal::*;
-use crate::ser::*;
 
 pub fn register(registry: &mut Registry) {
     // No serialization is done since: operation follow ONNX design:

--- a/nnef/src/ops/core/shape_of.rs
+++ b/nnef/src/ops/core/shape_of.rs
@@ -1,0 +1,23 @@
+use crate::internal::*;
+use crate::ser::*;
+
+pub fn register(registry: &mut Registry) {
+    // No serialization is done since: operation follow ONNX design:
+    // At deserialization we wire it to a constant used by tract.
+    // This make the operation serialization/deserialization non-symmetric
+    registry.register_primitive(
+        "tract_core_shape_of",
+        &[TypeName::Scalar.tensor().named("input")],
+        de_shape_of,
+    );
+}
+
+fn de_shape_of(
+    builder: &mut ModelBuilder,
+    invocation: &ResolvedInvocation,
+) -> TractResult<TVec<OutletId>> {
+    let input = invocation.named_arg_as(builder, "input")?;
+    let shape = tensor1(&builder.model.outlet_fact(input)?.shape.to_tvec());
+    let wire = builder.model.add_const("shape", shape)?;
+    Ok(tvec!(wire))
+}

--- a/nnef/src/ops/nnef/deser.rs
+++ b/nnef/src/ops/nnef/deser.rs
@@ -498,7 +498,12 @@ pub fn reduce(
     let fact = builder.model.outlet_fact(wire[0])?.clone();
     let input_shape = &builder.model.outlet_fact(input)?.shape;
     let cardinality: TDim = axes.iter().map(|ax| &input_shape[*ax]).product();
-    let cardinality = builder.wire(ops::konst::Const::new(tensor0(cardinality).broadcast_into_rank(fact.rank())?.into_arc_tensor()), &[])?;
+    let cardinality = builder.wire(
+        ops::konst::Const::new(
+            tensor0(cardinality).broadcast_into_rank(fact.rank())?.into_arc_tensor(),
+        ),
+        &[],
+    )?;
     let cardinality = builder.wire(ops::cast::Cast::new(fact.datum_type), &cardinality)?;
     dbg!(&cardinality);
     builder.wire(ops::math::div::bin_typed(), &[wire[0], cardinality[0]])


### PR DESCRIPTION
Allow to build NNEF models that propagate symbolic values like streaming dimension though the graph (beyond input and output current limitation).

This feature goes explicitly against NNEF spec that deprecated the practice, but is needed given the objective of `tract-nnef`.
Indeed, in our case, we want to express symbolic dimension such as streaming within the dumped graph (`graph.nnef` file).
This need arise since concretization of those symbols may be done only at inference time.

For example, in an internal case : using `tile` with a number of repeats being the number of frames in time dimension (so sample dependant).

Here are a few toy examples of working behaviours:
```
version 1.0;

extension tract_registry tract_core;
extension tract_pulse_streaming_symbol;


graph net_basic(input_0) -> (output_0)
{
    input_0 = external<scalar>(shape = [5, 10, S]);
    shape = tract_core_shape_of(input_0); # at this stage shape contains type DatumType::TDim
    output_0 = tract_core_cast(shape, to = 'i32');
}
```
and
```
version 1.0;

extension tract_registry tract_core;
extension tract_pulse_streaming_symbol;

extension KHR_enable_fragment_definitions;
extension KHR_enable_operator_expressions;

fragment trunc( x: tensor<scalar> ) -> ( y: tensor<scalar> )
{
    y = select(x < 0.0, ceil(x), floor(x));
}

graph net_2022_08_10T15_27_49(input_0) -> (output_0)
{
    input_0 = external<scalar>(shape = [5, 10, S]);
    v5_shape = tract_core_shape_of(input_0);
    v5 = slice(v5_shape, axes = [0], begin = [0], end = [1], stride = [1]);
    v4 = mul(v5, 2.0);
    v8_shape = tract_core_shape_of(input_0);
    v8 = slice(v8_shape, axes = [0], begin = [1], end = [2], stride = [1]);
    v7_casted = tract_core_cast(v8, to = 'f32');
    v7_div = div(v7_casted, 2.0);
    v7_trunc = trunc(v7_div);
    v7 = tract_core_cast(v7_trunc, to = 'i32');
    v6_shape = tract_core_shape_of(input_0);
    v6 = slice(v6_shape, axes = [0], begin = [2], end = [3], stride = [1]);
    output_0 = reshape(input_0, shape = [v4, v7, v6]);
}
```