### PR TITLE
Add einsum test case that currently fails

### DIFF
--- a/onnx-opl/src/einsum.rs
+++ b/onnx-opl/src/einsum.rs
@@ -363,6 +363,17 @@ mod test {
     fn test_parse_inner_product_implicit() {
         assert_eq!("i,i".parse::<Expr>().unwrap(), "i,i->".parse::<Expr>().unwrap(),)
     }
+    
+    #[test]
+    fn test_parse_inner_product2() {
+        assert_eq!(
+            dbg!("i,ij->j".parse::<Expr>().unwrap()),
+            Expr::from(tvec![
+                AxisSym::new('i').input(0, 0).input(1, 0),
+                AxisSym::new('j').result(0).input(1, 1)
+            ]),
+        )
+    }
 
     #[test]
     fn test_parse_batch_matmul() {
@@ -428,5 +439,16 @@ mod test {
     #[test]
     fn test_display_expr() {
         assert_eq!("pqrs,tuqvr->pstuv".parse::<Expr>().unwrap().to_string(), "pqrs,tuqvr->pstuv");
+    }
+    
+    #[test]
+    fn test_output_shape_inner_product2() {
+        let op = EinSum{
+            expr:"i,ij->j".parse::<Expr>().unwrap()
+        };
+        let i = Tensor::from_shape(&[10], &vec![1.; 10]).unwrap();
+        let j = Tensor::from_shape(&[5], &vec![2.; 5]).unwrap();
+        let shapes = TVec::from_vec(vec![i.shape(), j.shape()]);
+        dbg!(op.output_shape(&shapes));
     }
 }

--- a/onnx-opl/src/einsum.rs
+++ b/onnx-opl/src/einsum.rs
@@ -440,15 +440,14 @@ mod test {
     fn test_display_expr() {
         assert_eq!("pqrs,tuqvr->pstuv".parse::<Expr>().unwrap().to_string(), "pqrs,tuqvr->pstuv");
     }
-    
+
     #[test]
     fn test_output_shape_inner_product2() {
-        let op = EinSum{
-            expr:"i,ij->j".parse::<Expr>().unwrap()
-        };
-        let i = Tensor::from_shape(&[10], &vec![1.; 10]).unwrap();
-        let j = Tensor::from_shape(&[5], &vec![2.; 5]).unwrap();
-        let shapes = TVec::from_vec(vec![i.shape(), j.shape()]);
-        dbg!(op.output_shape(&shapes));
+        let op = EinSum { expr: "i,ij->j".parse::<Expr>().unwrap() };
+        let a = Tensor::from_shape(&[3], &vec![1.; 3]).unwrap();
+        let b = Tensor::from_shape(&[3, 4], &vec![2.; 3 * 4]).unwrap();
+        let in_shapes = TVec::from_vec(vec![a.shape(), b.shape()]);
+        let out_shape = tvec![4];
+        assert_eq!(op.output_shape(&in_shapes), out_shape);
     }
 }

--- a/onnx-opl/src/einsum.rs
+++ b/onnx-opl/src/einsum.rs
@@ -450,4 +450,15 @@ mod test {
         let out_shape = tvec![4];
         assert_eq!(op.output_shape(&in_shapes), out_shape);
     }
+    
+    #[test]
+    fn test_output_shape_unkown_dims() {
+        // Test "abci,acij->abcj"; the second input is missing the `b` dimension.
+        let op = EinSum { expr: "*i,*ij->*j".parse::<Expr>().unwrap() };  // need resolve_ellipsis that considers input shapes
+        let a = vec![1, 2, 3, 4];
+        let b = vec![1, 3, 4, 5];
+        let in_shapes = tvec![a.as_slice(), b.as_slice()];
+        let out_shape = tvec![1, 2, 3, 5];
+        assert_eq!(op.output_shape(&in_shapes), out_shape);  // This failes 
+    }
 }


### PR DESCRIPTION
`test_output_shape_inner_product2` currently fails with index out of bounce:

```
running 1 test
thread 'einsum::test::test_output_shape_inner_product2' panicked at 'index out of bounds: the len is 1 but the index is 1', onnx-opl/src/einsum.rs:198:34
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
   2: core::panicking::panic_bounds_check
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:84:5
   3: tract_onnx_opl::einsum::EinSum::output_shape::{{closure}}::{{closure}}
             at ./src/einsum.rs:198:34
   4: core::iter::traits::iterator::Iterator::find_map::check::{{closure}}
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:2688:32
   5: <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::try_fold::enumerate::{{closure}}
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/adapters/enumerate.rs:85:27
   6: core::iter::traits::iterator::Iterator::try_fold
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:2194:21
   7: <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::try_fold
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/adapters/enumerate.rs:91:9
   8: core::iter::traits::iterator::Iterator::find_map
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:2694:9
   9: tract_onnx_opl::einsum::EinSum::output_shape::{{closure}}
             at ./src/einsum.rs:193:17
  10: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:301:13
  11: core::option::Option<T>::map
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/option.rs:929:29
  12: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/adapters/map.rs:103:9
  13: <smallvec::SmallVec<A> as core::iter::traits::collect::Extend<<A as smallvec::Array>::Item>>::extend
             at /home/hendrik/.cargo/registry/src/github.com-1ecc6299db9ec823/smallvec-1.9.0/src/lib.rs:1764:36
  14: <smallvec::SmallVec<A> as core::iter::traits::collect::FromIterator<<A as smallvec::Array>::Item>>::from_iter
             at /home/hendrik/.cargo/registry/src/github.com-1ecc6299db9ec823/smallvec-1.9.0/src/lib.rs:1749:9
  15: core::iter::traits::iterator::Iterator::collect
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/iter/traits/iterator.rs:1792:9
  16: tract_onnx_opl::einsum::EinSum::output_shape
             at ./src/einsum.rs:188:9
  17: tract_onnx_opl::einsum::test::test_output_shape_inner_product2
             at ./src/einsum.rs:386:14
  18: tract_onnx_opl::einsum::test::test_output_shape_inner_product2::{{closure}}
             at ./src/einsum.rs:379:5
  19: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
  20: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test einsum::test::test_output_shape_inner_product2 ... FAILED

failures:

failures:
    einsum::test::test_output_shape_inner_product2

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.04s

error: test failed, to rerun pass '-p tract-onnx-opl --lib'
```