### PR TITLE
Translate symbols shapes in ONNX file loading

### DIFF
--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -14,8 +14,6 @@ pub fn check_outputs(got: &[Arc<Tensor>], params: &Parameters) -> CliResult<()> 
             params.tract_model.node_name(output.node)
         };
         // pick expected tensor values for this output
-        println!("{:?}, ", params
-        .tensors_values);
         let exp = params
             .tensors_values
             .by_name(name)

--- a/hir/src/infer/fact.rs
+++ b/hir/src/infer/fact.rs
@@ -121,8 +121,12 @@ impl Fact for InferenceFact {
         Ok(Cow::Owned(TypedFact::try_from(self)?))
     }
 
-    fn matches(&self, t: &Tensor, _symbols: Option<&SymbolValues>) -> TractResult<bool> {
-        Ok(self.unify(&InferenceFact::from(t)).is_ok())
+    fn matches(&self, t: &Tensor, symbols: Option<&SymbolValues>) -> TractResult<bool> {
+        let other = InferenceFact::from(t);
+
+        Ok(self.datum_type.unify(&other.datum_type).is_ok()
+            && self.value.unify(&other.value).is_ok()
+            && self.shape.matches(t, symbols).is_ok())
     }
 
     fn same_as(&self, other: &dyn Fact) -> bool {

--- a/onnx/test_cases/run_all.sh
+++ b/onnx/test_cases/run_all.sh
@@ -63,6 +63,7 @@ do
         cmd="$TRACT_RUN \
             $MODEL \
             --input-facts-from-bundle $tc/io.npz \
+            --onnx-ignore-output-shapes \
             $options \
             $opti \
             run \

--- a/tensorflow/src/ops/array/mod.rs
+++ b/tensorflow/src/ops/array/mod.rs
@@ -22,9 +22,9 @@ pub fn register_all_ops(reg: &mut TfOpRegister) {
     reg.insert("GatherV2", gather_v2::gather_v2);
     reg.insert("Pack", pack::pack);
     reg.insert("Pad", pad::pad);
-    reg.insert("Range", | _, _ | Ok(expand(tract_hir::ops::array::Range::default())));
+    reg.insert("Range", |_, _| Ok(expand(tract_hir::ops::array::Range::default())));
     reg.insert("Reshape", |_, _| Ok(expand(tract_hir::ops::array::Reshape::new())));
-    reg.insert("Shape", |_, _| Ok(expand(tract_hir::ops::array::Shape::new(DatumType::I32))));
+    reg.insert("Shape", |_, _| Ok(expand(tract_hir::ops::array::Shape::new(DatumType::TDim))));
     reg.insert("Slice", slice);
     reg.insert("Squeeze", squeeze::squeeze);
     reg.insert("StridedSlice", strided_slice);


### PR DESCRIPTION
Some ONNX models have symbols in their type info,

Resnet18 v2-7 example: `float32[N,3,224,224]` where N is the batch size.
Right now, we have to add the input facts ourselves in this case, otherwise it'll error. This PR fixes that :)
