### PR TITLE
Split --input-bundle into --input-facts-from-bundle and --input-from-bundle

### DIFF
--- a/.travis/bundle-entrypoint.sh
+++ b/.travis/bundle-entrypoint.sh
@@ -54,11 +54,11 @@ net_bench() {
     pb=$2
     shift 2
 
-    $TRACT "$@" --machine-friendly -O --allow-random-input bench $BENCH_OPTS > tract.out
+    $TRACT "$@" --machine-friendly -O bench --allow-random-input $BENCH_OPTS > tract.out
     v=`cat tract.out | grep real | cut -f 2 -d ' ' | sed 's/\([0-9]\{9,9\}\)[0-9]*/\1/'`
     echo net.$net.evaltime.$pb $v >> metrics
 
-    $TRACT "$@" --readings --readings-heartbeat 1000 --machine-friendly --allow-random-input -O bench $BENCH_OPTS > tract.out
+    $TRACT "$@" --readings --readings-heartbeat 1000 --machine-friendly -O bench --allow-random-input $BENCH_OPTS > tract.out
 
     for stage in model_ready before_optimize
     do

--- a/.travis/cli-tests.sh
+++ b/.travis/cli-tests.sh
@@ -91,44 +91,51 @@ cd $CACHEDIR
 )
 
 $TRACT_RUN $CACHEDIR/squeezenet.onnx \
+    run -q \
     --allow-random-input \
-    run -q --assert-output-fact 1,1000,1,1,f32
+    --assert-output-fact 1,1000,1,1,f32
 
 $TRACT_RUN \
     $CACHEDIR/inception_v3_2016_08_28_frozen.pb \
-    --allow-random-input \
     -i 1,299,299,3,f32 \
-    run -q --assert-output-fact 1,1001,f32
+    run -q \
+    --allow-random-input \
+    --assert-output-fact 1,1001,f32
 
 $TRACT_RUN \
     $CACHEDIR/inception_v3_2016_08_28_frozen.pb \
-    --allow-random-input \
     -i 1,299,299,3,f32 -O \
-    run -q --assert-output-fact 1,1001,f32
+    run -q \
+    --allow-random-input \
+    --assert-output-fact 1,1001,f32
 
 $TRACT_RUN $CACHEDIR/ARM-ML-KWS-CNN-M.pb \
-    --allow-random-input \
     -O -i 49,10,f32 --partial \
-    --input-node Mfcc run -q
-
+    --input-node Mfcc \
+    run -q \
+    --allow-random-input
+    
 $TRACT_RUN $CACHEDIR/mdl-en-2019-Q3-librispeech.onnx \
-    --allow-random-input \
     -O -i S,40,f32 --output-node output --pulse 24 \
-    run -q
-
+    run -q \
+    --allow-random-input
+    
 $TRACT_RUN $CACHEDIR/mobilenet_v1_1.0_224_frozen.pb \
-    --allow-random-input \
     -O -i 1,224,224,3,f32 \
-    run -q --assert-output-fact 1,1001,f32
+    run -q \
+    --allow-random-input \
+    --assert-output-fact 1,1001,f32
 
 $TRACT_RUN $CACHEDIR/mobilenet_v2_1.4_224_frozen.pb \
-    --allow-random-input \
     -O -i 1,224,224,3,f32 \
-    run -q --assert-output-fact 1,1001,f32
+    run -q \
+    --allow-random-input \
+    --assert-output-fact 1,1001,f32
 
 $TRACT_RUN $CACHEDIR/GRU128KeywordSpotter-v2-10epochs.onnx \
+    -O run -q \
     --allow-random-input \
-    -O run -q --assert-output-fact 1,3,f32
+    --assert-output-fact 1,3,f32
 
 $TRACT_RUN $CACHEDIR/hey_snips_v4_model17.pb \
     -i S,20,f32 --pulse 8 dump --cost -q \
@@ -141,33 +148,37 @@ $TRACT_RUN $CACHEDIR/hey_snips_v4_model17.pb -i S,20,f32 \
 $TRACT_RUN $CACHEDIR/en_libri_real/model.raw.txt \
     -f kaldi --output-node output \
     --kaldi-downsample 3 --kaldi-left-context 5 --kaldi-right-context 15 --kaldi-adjust-final-offset -5 \
-    --input-bundle $CACHEDIR/en_libri_real/io.npz \
-    --allow-random-input \
+    --input-facts-from-bundle $CACHEDIR/en_libri_real/io.npz \
     run \
+    --input-from-bundle $CACHEDIR/en_libri_real/io.npz \
+    --allow-random-input \
     --assert-output-bundle $CACHEDIR/en_libri_real/io.npz
 
 $TRACT_RUN $CACHEDIR/en_libri_real/model.raw \
     -f kaldi --output-node output \
     --kaldi-downsample 3 --kaldi-left-context 5 --kaldi-right-context 15 --kaldi-adjust-final-offset -5 \
-    --input-bundle $CACHEDIR/en_libri_real/io.npz \
-    --allow-random-input \
+    --input-facts-from-bundle $CACHEDIR/en_libri_real/io.npz \
     run \
+    --input-from-bundle $CACHEDIR/en_libri_real/io.npz \
+    --allow-random-input \
     --assert-output-bundle $CACHEDIR/en_libri_real/io.npz
 
 $TRACT_RUN $CACHEDIR/en_libri_real/model.onnx \
     --output-node output \
     --kaldi-left-context 5 --kaldi-right-context 15 --kaldi-adjust-final-offset -5 \
-    --input-bundle $CACHEDIR/en_libri_real/io.npz \
-    --allow-random-input \
+    --input-facts-from-bundle $CACHEDIR/en_libri_real/io.npz \
     run \
+    --input-from-bundle $CACHEDIR/en_libri_real/io.npz \
+    --allow-random-input \
     --assert-output-bundle $CACHEDIR/en_libri_real/io.npz
 
 $TRACT_RUN $CACHEDIR/inceptionv1_quant.nnef.tar.gz \
     --nnef-tract-core \
-    --input-bundle $CACHEDIR/inceptionv1_quant.io.npz \
-    --allow-random-input \
+    --input-facts-from-bundle $CACHEDIR/inceptionv1_quant.io.npz \
     run \
-    --assert-output-bundle $CACHEDIR/inceptionv1_quant.io.npz \
+    --input-from-bundle $CACHEDIR/inceptionv1_quant.io.npz \
+    --allow-random-input \
+    --assert-output-bundle $CACHEDIR/inceptionv1_quant.io.npz
 
 for t in harness/pre-optimized-graphes/*
 do

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -1,5 +1,6 @@
 use crate::annotations::*;
 use crate::display_params::*;
+use crate::tensor::RunParams;
 use crate::terminal;
 use crate::CliResult;
 use crate::{BenchLimits, Parameters};
@@ -19,11 +20,12 @@ pub fn handle(
         annotations.extract_costs(model)?;
     }
     if options.profile {
+        let run_params = RunParams::from_subcommand(params, sub_matches)?;
         let model = params
             .tract_model
             .downcast_ref::<TypedModel>()
             .context("Can only profile typed models")?;
-        crate::profile::profile(model, bench_limits, &mut annotations, params)?;
+        crate::profile::profile(model, bench_limits, &mut annotations, &run_params)?;
     }
 
     if let Some(asserts) = &params.assertions.assert_output_facts {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -88,7 +88,8 @@ fn main() -> tract_core::anyhow::Result<()> {
                   "Set input shape and type (@file.pb or @file.npz:thing.npy or 3x4xi32)."))
 
         .arg(arg!(--"const-input" [const_input] ... "Treat input as a Const (by name), retaining its value."))
-        .arg(arg!(--"input-bundle" [input_bundle] "Path to an input container (.npz)"))
+        .arg(arg!(--"input-bundle" [input_bundle] "Path to an input container (.npz). This sets input facts and tensor values.").hide(true))
+        .arg(arg!(--"input-facts-from-bundle" [input_bundle] "Path to an input container (.npz). This only sets input facts."))
         .arg(arg!(--"allow-random-input" "WIll use random generated input"))
 
         .arg(arg!(--"kaldi-adjust-final-offset" [frames] "Adjust value of final offset in network (for reproducibility)"))
@@ -207,6 +208,12 @@ fn main() -> tract_core::anyhow::Result<()> {
                 .long("save-steps")
                 .takes_value(true)
                 .help("Save intermediary values as a npz file"),
+        )
+        .arg(
+            Arg::new("input-from-bundle")
+                .long("input-from-bundle")
+                .takes_value(true)
+                .help("Path to an input container (.npz). This sets tensor values."),
         )
         .arg(
             Arg::new("assert-sane-floats")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> tract_core::anyhow::Result<()> {
         .arg(arg!(--"onnx-test-data-set" [data_set] "Use onnx-test data-set as input (expect test_data_set_N dir with input_X.pb, etc. inside)"))
         .arg(arg!(--"onnx-ignore-output-shapes" "Ignore output shapes from model (workaround for pytorch export bug with mask axes)"))
 
-        .arg(arg!(--"input-node" [node] ... "Oveide input nodes names (auto-detects otherwise)."))
+        .arg(arg!(--"input-node" [node] ... "Override input nodes names (auto-detects otherwise)."))
         .arg(arg!(--"output-node" [node] ... "Override output nodes name (auto-detects otherwise)."))
         .arg(arg!(--"label-wires" "Propagate node labels to wires"))
 

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -145,11 +145,13 @@ impl TensorsValues {
                 tensor = other_tensor.name.as_deref().and_then(|ix| self.by_name_mut(ix))
             }
 
-            let tensor = tensor.with_context(|| anyhow!("Unmatched tensor values: {:?}", other_tensor))?;
-
-            if tensor.values.is_none() {
-                tensor.values = other_tensor.values.clone();
-            }
+            if let Some(tensor) = tensor {
+                if tensor.values.is_none() {
+                    tensor.values = other_tensor.values.clone();
+                }
+            } else {
+                self.0.push(other_tensor.clone());
+            };
         }
         Ok(())
     }
@@ -872,7 +874,13 @@ impl Parameters {
         }
 
         let allow_random_input: bool = matches.is_present("allow-random-input");
+        if allow_random_input {
+            warn!("Argument --allow-random-input as global argument is deprecated and may be removed in a future release. Please move this argument to the right of the subcommand.");
+        }
         let allow_float_casts = matches.is_present("allow-float-casts");
+        if allow_float_casts {
+            warn!("Argument --allow-float-casts as global argument is deprecated and may be removed in a future release. Please move this argument to the right of the subcommand.");
+        }
 
         Self::pipeline(matches, probe, raw_model, tf_model_extensions, need_reference_model).map(
             |(tract_model, pulsed_model, reference_model)| {

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -137,29 +137,23 @@ impl TensorsValues {
     }
     */
 
-    pub fn set_tensor_values(&mut self, other: &TensorsValues) -> CliResult<()> {
-        for other_tensor in other.0.iter() {
-            let mut tensor = other_tensor.input_index.and_then(|ix| self.by_input_ix_mut(ix));
+    pub fn add(&mut self, other: TensorValues) {
+        let mut tensor = other.input_index.and_then(|ix| self.by_input_ix_mut(ix));
 
-            if tensor.is_none() {
-                tensor = other_tensor.name.as_deref().and_then(|ix| self.by_name_mut(ix))
+        if tensor.is_none() {
+            tensor = other.name.as_deref().and_then(|ix| self.by_name_mut(ix))
+        }
+
+        if let Some(tensor) = tensor {
+            if tensor.fact.is_none() {
+                tensor.fact = other.fact;
             }
-
-            if let Some(tensor) = tensor {
-                if tensor.values.is_none() {
-                    tensor.values = other_tensor.values.clone();
-                }
-            } else {
-                self.0.push(other_tensor.clone());
-            };
-        }
-        Ok(())
-    }
-
-    pub fn add(&mut self, tv: TensorValues) {
-        if !self.0.contains(&tv) {
-            self.0.push(tv)
-        }
+            if tensor.values.is_none() {
+                tensor.values = other.values;
+            }
+        } else {
+            self.0.push(other.clone());
+        };
     }
 }
 

--- a/cli/src/profile.rs
+++ b/cli/src/profile.rs
@@ -2,9 +2,9 @@ use tract_core::internal::*;
 
 use crate::annotations::*;
 use crate::model::Model;
+use crate::tensor::RunParams;
 use crate::BenchLimits;
 use crate::CliResult;
-use crate::Parameters;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone)]
@@ -19,7 +19,7 @@ pub fn profile(
     model: &TypedModel,
     bench_limits: &BenchLimits,
     dg: &mut Annotations,
-    params: &Parameters,
+    run_params: &RunParams,
 ) -> CliResult<()> {
     info!("Running entire network");
     let plan = SimplePlan::new(model)?;
@@ -27,7 +27,7 @@ pub fn profile(
     let mut iters = 0usize;
     let start = Instant::now();
     while iters < bench_limits.max_iters && start.elapsed() < bench_limits.max_time {
-        let input = crate::tensor::retrieve_or_make_inputs(model, params)?;
+        let input = crate::tensor::retrieve_or_make_inputs(model, run_params)?;
         let _ =
             state.run_plan_with_eval(input[0].clone(), |session_state, state, node, input| {
                 let start = Instant::now();

--- a/cli/src/tensor.rs
+++ b/cli/src/tensor.rs
@@ -295,16 +295,14 @@ pub struct RunParams {
 }
 
 impl RunParams {
-    pub fn from_subcommand(
-        params: &Parameters,
-        sub_matches: &clap::ArgMatches,
-    ) -> CliResult<Self> {
+    pub fn from_subcommand(params: &Parameters, sub_matches: &clap::ArgMatches) -> CliResult<Self> {
         let mut tv = params.tensors_values.clone();
 
         if let Some(bundle) = sub_matches.values_of("input-from-bundle") {
             for input in bundle {
-                let tensor_values = TensorsValues(Parameters::parse_npz(input, true, false)?);
-                tv.set_tensor_values(&tensor_values)?;
+                for tensor in Parameters::parse_npz(input, true, false)? {
+                    tv.add(tensor);
+                }
             }
         }
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -14,6 +14,8 @@ pub fn check_outputs(got: &[Arc<Tensor>], params: &Parameters) -> CliResult<()> 
             params.tract_model.node_name(output.node)
         };
         // pick expected tensor values for this output
+        println!("{:?}, ", params
+        .tensors_values);
         let exp = params
             .tensors_values
             .by_name(name)

--- a/doc/cli-recipe.md
+++ b/doc/cli-recipe.md
@@ -115,24 +115,28 @@ but it's less susceptible to changes.
 `tract` command line can also be use to build test-case, either for non-regression insurance
 of debugging purposes.
 
-`--input-bundle` takes a `.npz` file, and tries to match its tensors with the input names in
-the network. This will also supersede the `-i` option: we will take the input shapes and tensor
+`--input-facts-from-bundle` takes a `.npz` file, and will set the input facts (dtype, shape) according to the tensors
+in the npz file. This is useful when your model does not have any input type information embedded within it.
+
+The `run` subcommand accepts an `--input-from-bundle` that also takes a `.npz` file, but it
+will not set any input fact, it will only take the tensor values.
+This will also supersede the `-i` option: we will take the input shapes and tensor
 from the input itself.
 
-The `run` subcommand accepts an `--assert-output-bundle`. This time, the tensors names are
+The `run` subcommand also accepts an `--assert-output-bundle`. This time, the tensors names are
 matched with the model output names. `tract` will run over the input and check that its finding
 are the same to the expected output (with some leeway for rounding differences).
 
 [Example here](/onnx/test_cases/qtanh_1) for a quantized tanh in onnx.
 
-```
-tract --input-bundle io.npz model.onnx -O run --assert-output-bundle io.npz
+```sh
+tract model.onnx -O run --input-from-bundle io.npz --assert-output-bundle io.npz
 ```
 
 If we want to make sure we actually check something, `-v` can help:
 
 ```
-tract -v --input-bundle io.npz model.onnx -O run --assert-output-bundle io.npz
+tract -v model.onnx -O run --input-from-bundle io.npz --assert-output-bundle io.npz
 ```
 
 The log displays "Checked output #0, ok." (among other information).

--- a/harness/nnef-test-cases/conv-with-batch/runme.sh
+++ b/harness/nnef-test-cases/conv-with-batch/runme.sh
@@ -5,4 +5,4 @@ set -x
 
 : ${TRACT_RUN:=cargo run -p tract $CARGO_OPTS --}
 
-$TRACT_RUN -O --allow-random-input . compare --stage declutter
+$TRACT_RUN -O . compare --allow-random-input --stage declutter

--- a/kaldi/test_cases/run_all.sh
+++ b/kaldi/test_cases/run_all.sh
@@ -30,13 +30,14 @@ do
         cmd="$TRACT_RUN \
             -f kaldi $tc/model.raw$suffix \
             --output-node output \
-            --input-bundle $tc/io.npz \
+            --input-facts-from-bundle $tc/io.npz \
             --kaldi-downsample $subsampling \
             --kaldi-left-context $left_context \
             --kaldi-right-context $right_context \
             --kaldi-adjust-final-offset $adjust_final_offset \
             $opti \
             run \
+            --input-from-bundle $tc/io.npz \
             --assert-output-bundle $tc/io.npz"
 
         # echo $cmd

--- a/onnx/test_cases/run_all.sh
+++ b/onnx/test_cases/run_all.sh
@@ -62,10 +62,11 @@ do
         fi
         cmd="$TRACT_RUN \
             $MODEL \
-            --input-bundle $tc/io.npz \
+            --input-facts-from-bundle $tc/io.npz \
             $options \
             $opti \
             run \
+            --input-from-bundle $tc/io.npz \
             --assert-output-bundle $tc/io.npz"
 
         if $($cmd 2> /dev/null > /dev/null)


### PR DESCRIPTION
Motivation #797

I did not change the CI (yet?)
Not sure this is the cleanest

I only changed the `run` command for `--input-from-bundle`. You were talking about `dump` / `compare` too but i'm not sure I understand: dump does not run the model, compare only uses random input, right?