### PR TITLE
Change m0 precision in qconv

### DIFF
--- a/cli/src/tensor.rs
+++ b/cli/src/tensor.rs
@@ -10,64 +10,6 @@ use crate::{CliResult, Parameters};
 use tract_hir::internal::*;
 
 fn parse_dt(dt: &str) -> CliResult<DatumType> {
-//<<<<<<< Updated upstream
-//=======
-//    if dt.contains("q") {
-//        parse_quant_dt(dt)
-//    } else {
-//        parse_non_quant_dt(dt)
-//    }
-//}
-//
-//fn parse_float(i: &str) -> IResult<&str, f32> {
-//    map_res(recognize(tuple((digit1, tuple((tag("."), digit1))))), |f| FromStr::from_str(f))(i)
-//}
-//
-//fn parse_int(i: &str) -> IResult<&str, i32> {
-//    map_res(recognize(digit1), |f| FromStr::from_str(f))(i)
-//}
-//
-//fn parse_min_max(i: &str) -> IResult<&str, QParams> {
-//    map(separated_pair(preceded(tag("min"), parse_float), tag(";"), preceded(tag("max"),parse_float)), |(min, max)| QParams::MinMax {
-//        min,
-//        max,
-//    })(i)
-//}
-//
-//fn parse_zp_scale(i: &str) -> IResult<&str, QParams> {
-//    dbg!(i);
-//    map(separated_pair(preceded(tag("zp"), parse_int), tag(";"), preceded(tag("scale"), parse_float)), |(zero_point, scale)| QParams::ZpScale {
-//        zero_point,
-//        scale,
-//    })(i)
-//}
-//
-//// QParams are in the form of {(int|float)-float}
-//// {int, float} -> QParams::ZpScale
-//// {float, float} -> QParams::MinMax
-//fn parse_qparams(i: &str) -> IResult<&str, QParams> {
-//    delimited(tag("("), alt((parse_zp_scale, parse_min_max)), tag(")"))(i)
-//}
-//
-//// Quantized datum are in the form (qu8|qi8|qi32){(int|float)-float}
-//fn parse_quant_dt(dt: &str) -> CliResult<DatumType> {
-//    dbg!(dt);
-//    let res: IResult<&str, DatumType> = alt((
-//        map(preceded(tag("qi32"), parse_qparams), |qp| -> DatumType {
-//            DatumType::QI32(qp)
-//        }),
-//        map(preceded(tag("qi8"), parse_qparams), |qp| -> DatumType {
-//            DatumType::QI8(qp)
-//        }),
-//        map(preceded(tag("qu8"), parse_qparams), |qp| -> DatumType {
-//            DatumType::QU8(qp)
-//        }),
-//    ))(dt);
-//
-//    Ok(res.unwrap().1)
-//}
-//
-//fn parse_non_quant_dt(dt: &str) -> CliResult<DatumType> {
     Ok(match dt.to_lowercase().as_ref() {
         "f16" => DatumType::F16,
         "f32" => DatumType::F32,

--- a/cli/src/tensor.rs
+++ b/cli/src/tensor.rs
@@ -10,6 +10,64 @@ use crate::{CliResult, Parameters};
 use tract_hir::internal::*;
 
 fn parse_dt(dt: &str) -> CliResult<DatumType> {
+//<<<<<<< Updated upstream
+//=======
+//    if dt.contains("q") {
+//        parse_quant_dt(dt)
+//    } else {
+//        parse_non_quant_dt(dt)
+//    }
+//}
+//
+//fn parse_float(i: &str) -> IResult<&str, f32> {
+//    map_res(recognize(tuple((digit1, tuple((tag("."), digit1))))), |f| FromStr::from_str(f))(i)
+//}
+//
+//fn parse_int(i: &str) -> IResult<&str, i32> {
+//    map_res(recognize(digit1), |f| FromStr::from_str(f))(i)
+//}
+//
+//fn parse_min_max(i: &str) -> IResult<&str, QParams> {
+//    map(separated_pair(preceded(tag("min"), parse_float), tag(";"), preceded(tag("max"),parse_float)), |(min, max)| QParams::MinMax {
+//        min,
+//        max,
+//    })(i)
+//}
+//
+//fn parse_zp_scale(i: &str) -> IResult<&str, QParams> {
+//    dbg!(i);
+//    map(separated_pair(preceded(tag("zp"), parse_int), tag(";"), preceded(tag("scale"), parse_float)), |(zero_point, scale)| QParams::ZpScale {
+//        zero_point,
+//        scale,
+//    })(i)
+//}
+//
+//// QParams are in the form of {(int|float)-float}
+//// {int, float} -> QParams::ZpScale
+//// {float, float} -> QParams::MinMax
+//fn parse_qparams(i: &str) -> IResult<&str, QParams> {
+//    delimited(tag("("), alt((parse_zp_scale, parse_min_max)), tag(")"))(i)
+//}
+//
+//// Quantized datum are in the form (qu8|qi8|qi32){(int|float)-float}
+//fn parse_quant_dt(dt: &str) -> CliResult<DatumType> {
+//    dbg!(dt);
+//    let res: IResult<&str, DatumType> = alt((
+//        map(preceded(tag("qi32"), parse_qparams), |qp| -> DatumType {
+//            DatumType::QI32(qp)
+//        }),
+//        map(preceded(tag("qi8"), parse_qparams), |qp| -> DatumType {
+//            DatumType::QI8(qp)
+//        }),
+//        map(preceded(tag("qu8"), parse_qparams), |qp| -> DatumType {
+//            DatumType::QU8(qp)
+//        }),
+//    ))(dt);
+//
+//    Ok(res.unwrap().1)
+//}
+//
+//fn parse_non_quant_dt(dt: &str) -> CliResult<DatumType> {
     Ok(match dt.to_lowercase().as_ref() {
         "f16" => DatumType::F16,
         "f32" => DatumType::F32,

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -363,13 +363,12 @@ where
 {
     let b = b.as_();
     let scaler = Scaler::new(a, RoundingPolicy::Even);
-    let real_product = b * scaler;
-    if (real_product - real_product.round()).abs() == 0.5 {
-        dbg!("rounding ambiguity, scale is rounded to pow2");
-        round_ties_to_even(2f32.powi(a.log2().round() as i32) * b).as_()
-    } else {
-        round_ties_to_even(real_product).as_()
-    }
+    let new_product = scaler.mult.map(|it| (it >> 16) as f32 * 2f32.powi(-15)).unwrap_or(1.0)
+        * 2f32.powi(-scaler.shift as i32)
+        * b;
+    let real_product = b * a;
+    println!("real: {}, new: {}, a: {}, scale: {}", real_product, new_product, b, a);
+    round_ties_to_even(new_product).as_()
 }
 
 pub mod scale {

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -363,12 +363,7 @@ where
 {
     let b = b.as_();
     let scaler = Scaler::new(a, RoundingPolicy::Even);
-
-    // This new product interprets the multiplier with 16bits precision
-    let new_product = scaler.mult.map(|it| (it >> 15) as f32 * 2f32.powi(-16)).unwrap_or(1.0)
-        * 2f32.powi(-scaler.shift as i32)
-        * b;
-    round_ties_to_even(new_product).as_()
+    (b * scaler).as_()
 }
 
 pub mod scale {

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -366,8 +366,6 @@ where
     let new_product = scaler.mult.map(|it| (it >> 16) as f32 * 2f32.powi(-15)).unwrap_or(1.0)
         * 2f32.powi(-scaler.shift as i32)
         * b;
-    let real_product = b * a;
-    println!("real: {}, new: {}, a: {}, scale: {}", real_product, new_product, b, a);
     round_ties_to_even(new_product).as_()
 }
 

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -363,7 +363,9 @@ where
 {
     let b = b.as_();
     let scaler = Scaler::new(a, RoundingPolicy::Even);
-    let new_product = scaler.mult.map(|it| (it >> 16) as f32 * 2f32.powi(-15)).unwrap_or(1.0)
+
+    // This new product interprets the multiplier with 16bits precision
+    let new_product = scaler.mult.map(|it| (it >> 15) as f32 * 2f32.powi(-16)).unwrap_or(1.0)
         * 2f32.powi(-scaler.shift as i32)
         * b;
     round_ties_to_even(new_product).as_()

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -362,7 +362,14 @@ where
     f32: AsPrimitive<T>,
 {
     let b = b.as_();
-    (round_ties_to_even(b.abs() * a) * b.signum()).as_()
+    let scaler = Scaler::new(a, RoundingPolicy::Even);
+    let real_product = b * scaler;
+    if (real_product - real_product.round()).abs() == 0.5 {
+        dbg!("rounding ambiguity, scale is rounded to pow2");
+        round_ties_to_even(2f32.powi(a.log2().round() as i32) * b).as_()
+    } else {
+        round_ties_to_even(real_product).as_()
+    }
 }
 
 pub mod scale {

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -6,8 +6,6 @@ use tract_linalg::lut::Lut;
 use tract_linalg::mmm::RoundingPolicy;
 use tract_linalg::Scaler;
 
-use super::math::round_ties_to_even;
-
 pub fn quantize_linear_f32_u8(x: f32, scale: f32, zero_point: i32) -> u8 {
     (((x * scale).round() as i32) + zero_point as i32)
         .max(u8::min_value() as i32)
@@ -290,9 +288,9 @@ impl crate::ops::binary::BinMiniOp for Scale {
 
     fn eval_uniform_in_place(&self, a: &Tensor, b: &mut Tensor) -> TractResult<()> {
         let a = a.to_scalar::<f32>()?;
-        unsafe fn eval_in_place_t<T: Datum + AsPrimitive<f32>>(a: f32, b: &mut Tensor)
+        unsafe fn eval_in_place_t<T: Datum + AsPrimitive<i32>>(a: f32, b: &mut Tensor)
         where
-            f32: AsPrimitive<T>,
+            i32: AsPrimitive<T>,
         {
             b.as_slice_mut_unchecked::<T>().iter_mut().for_each(|x| *x = scale_by(*x, a));
         }
@@ -302,11 +300,11 @@ impl crate::ops::binary::BinMiniOp for Scale {
 
     fn eval_unicast_in_place(&self, a: &Tensor, b: &mut Tensor) -> TractResult<()> {
         let a = a.to_array_view::<f32>()?;
-        unsafe fn eval_in_place_t<T: Datum + AsPrimitive<f32>>(
+        unsafe fn eval_in_place_t<T: Datum + AsPrimitive<i32>>(
             a: &ndarray::ArrayViewD<f32>,
             b: &mut Tensor,
         ) where
-            f32: AsPrimitive<T>,
+            i32: AsPrimitive<T>,
         {
             let mut b = b.to_array_view_mut_unchecked::<T>();
             ndarray::Zip::from(&mut b).and_broadcast(a).for_each(|b, a| *b = scale_by(*b, *a))
@@ -317,12 +315,12 @@ impl crate::ops::binary::BinMiniOp for Scale {
 
     fn eval_out_of_place(&self, c: &mut Tensor, a: &Tensor, b: &Tensor) -> TractResult<()> {
         let a = a.to_array_view::<f32>()?;
-        unsafe fn eval_out_of_place_t<T: Datum + AsPrimitive<f32>>(
+        unsafe fn eval_out_of_place_t<T: Datum + AsPrimitive<i32>>(
             c: &mut Tensor,
             a: &ndarray::ArrayViewD<f32>,
             b: &Tensor,
         ) where
-            f32: AsPrimitive<T>,
+            i32: AsPrimitive<T>,
         {
             let b = b.to_array_view_unchecked::<T>();
             let mut c = c.to_array_view_mut_unchecked::<T>();
@@ -357,9 +355,9 @@ impl crate::ops::binary::BinMiniOp for Scale {
 }
 
 #[inline]
-pub(crate) fn scale_by<T: Datum + AsPrimitive<f32>>(b: T, a: f32) -> T
+pub(crate) fn scale_by<T: Datum + AsPrimitive<i32>>(b: T, a: f32) -> T
 where
-    f32: AsPrimitive<T>,
+    i32: AsPrimitive<T>,
 {
     let b = b.as_();
     let scaler = Scaler::new(a, RoundingPolicy::Even);

--- a/linalg/arm32/armv7neon/armv7neon_mmm_i32_scale_q8_q15.tmpliq
+++ b/linalg/arm32/armv7neon/armv7neon_mmm_i32_scale_q8_q15.tmpliq
@@ -8,9 +8,9 @@
     vdup.s32    q1, r3                      // q1 <- ones
     vmovl.s32   q1, d2
 
-    add         r5, #32
+    add         r5, #17
     neg         r5, r5
-    vdup.s32    q2, r5                      // q2 <- -(shift + 32)
+    vdup.s32    q2, r5                      // q2 <- -(shift + 16 + 1)
     vmovl.s32   q2, d4
 
     cmp     r6, #1

--- a/linalg/arm64/arm64simd/arm64simd_mmm_i32_scale_q16_q31.tmpliq
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_i32_scale_q16_q31.tmpliq
@@ -10,10 +10,10 @@
     ins     v4.d[0], x3
     dup     v4.2d, v4.d[0]              // v4.2d <- 1
 
-    add     x5, x5, #32                 // add 32 to shift
+    add     x5, x5, #17                 // add 17 to shift
     neg     x5, x5                      // broadcast shift
     ins     v1.d[0], x5
-    dup     v1.2d, v1.d[0]              // v1.2s <- -(shift + 32)
+    dup     v1.2d, v1.d[0]              // v1.2s <- -(shift + 16 + 1)
 
     cmp     x6, 1
     beq     .q_scale_rounding_zero

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -153,6 +153,7 @@ fn main() {
                 &suffix,
             );
             cc::Build::new().files(files).static_flag(true).compile("arm64simd");
+
             if std::env::var("CARGO_FEATURE_NO_FP16").is_err() {
                 let files =
                     preprocess_files("arm64/arm64fp16", &[("core", vec!["a55", "gen"])], &suffix);

--- a/linalg/src/frame/mmm/fuse.rs
+++ b/linalg/src/frame/mmm/fuse.rs
@@ -43,7 +43,7 @@ pub enum FusedSpec<'t> {
     BinPerCol(&'t Tensor, BinOp),
     AddRowColProducts(&'t Tensor, &'t Tensor),
     AddUnicast(OutputStore),
-    QScale(isize, RoundingPolicy, i32),
+    QScale(isize, RoundingPolicy, i32), // TODO:Change this to u16 (u16 not working as expected in assembly)
     RoundingShiftRight(usize, RoundingPolicy),
     ShiftLeft(usize),
     Store(OutputStore),

--- a/linalg/src/generic/rounding.rs
+++ b/linalg/src/generic/rounding.rs
@@ -6,13 +6,12 @@ use tract_data::prelude::f16;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Scaler {
     scale: f32,
-    mult: Option<i32>,
-    shift: isize,
+    pub mult: Option<i32>,
+    pub shift: isize,
     policy: RoundingPolicy,
 }
 
-impl Eq for Scaler {
-}
+impl Eq for Scaler {}
 
 #[allow(clippy::derive_hash_xor_eq)]
 impl Hash for Scaler {

--- a/linalg/x86_64/fma/avx2_mmm_i32_8x8.tmpl
+++ b/linalg/x86_64/fma/avx2_mmm_i32_8x8.tmpl
@@ -264,15 +264,15 @@ i128_shuffle dd              0, 4
     movq            xmm9, rax
     vpbroadcastq    ymm9, xmm9              // ymm9 <- 1
 
-    mov             rax, [ rdi + 8 ]        // xmm10 <- shift + 31
-    add             rax, 31
+    mov             rax, [ rdi + 8 ]        // xmm10 <- shift + 16
+    add             rax, 16
     movq            xmm10, rax
     vpbroadcastq    ymm10, xmm10
 
     mov             rax, 1
     movq            xmm11, rax
-    vpsubq          ymm12, ymm10, ymm9      // shift+31 - 1
-    vpsllq          ymm11, ymm9, xmm12      // ymm11 <- 1 << (shift + 31 - 1)
+    vpsubq          ymm12, ymm10, ymm9      // shift+16 - 1
+    vpsllq          ymm11, ymm9, xmm12      // ymm11 <- 1 << (shift + 16 - 1)
 
     cmp     r8, 1
     je      {{L}}q_scale_rounding_zero


### PR DESCRIPTION
This PR changes the precision of the M0 value in the convolution scale factor.
It was previously computed in Q0_31 and stored as a `i32`. It is now computed in Q0_16 an stored as a `u16`.