### PR TITLE
Remove the unused libc crate from tract-core dependencies

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -18,7 +18,6 @@ derive-new = "0.5.9"
 downcast-rs = "1.2.0"
 dyn-clone = "1.0.4"
 lazy_static = "1.4.0"
-libc = "0.2.100"
 log = "0.4.14"
 num-traits = "0.2.14"
 tract-data = { version = "0.18.1-pre", path = "../data" }

--- a/linalg/src/lib.rs
+++ b/linalg/src/lib.rs
@@ -2,7 +2,6 @@
 #[macro_use]
 extern crate derive_new;
 extern crate lazy_static;
-extern crate libc;
 extern crate log;
 extern crate num_traits;
 #[macro_use]


### PR DESCRIPTION
Hello Mathieu,

It looks like tract-core does not use the `libc` crate, yet it was part of the Cargo.toml and used with an extern crate declaration. I removed it, it still compiles and there is no regression on the test suite.
