### PR TITLE
Add test case for pulsed einsum

### DIFF
--- a/core/src/ops/matmul/mir_unary.rs
+++ b/core/src/ops/matmul/mir_unary.rs
@@ -402,7 +402,9 @@ pub(super) fn mir_unary_change_axes(
     if let Ok((axes, change_a, change_b, change_c)) = result {
         let mut new_a = old_a.clone();
         if let Some(change_a) = change_a {
-            change_a.change_tensor(&mut new_a, false)?;
+            if let Err(_) = change_a.change_tensor(&mut new_a, false) {
+                return Ok(None) // can not apply change to A (Rm on non-trivial axis ?)
+            }
         }
         let mut wires = tvec!();
         if let Some(change_b) = change_b {

--- a/harness/core-proptest-pulse/Cargo.toml
+++ b/harness/core-proptest-pulse/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 tract-pulse = { path = "../../pulse" }
 tract-hir = { path = "../../hir" }
+tract-onnx-opl = { path = "../../onnx-opl/" }
 
 [dev-dependencies]
 log = "0.4.14"

--- a/harness/core-proptest-pulse/src/einsum.rs
+++ b/harness/core-proptest-pulse/src/einsum.rs
@@ -1,0 +1,42 @@
+use tract_hir::internal::*;
+use tract_onnx_opl::einsum::*;
+
+use super::*;
+
+#[test]
+fn einsum_bmm() {
+    let mut model = TypedModel::default();
+    let s = 5;
+    let x = model.add_source("x", f32::fact(dims!(s, 8, 2))).unwrap();
+    let w = model.add_const("w", Tensor::zero::<f32>(&[8, 2, 4]).unwrap()).unwrap();
+
+    let expr = "sij,ijk->sik".parse::<Expr>().unwrap();
+    let einsum = EinSum { expr };
+
+    let einsum = model.wire_node("einsum", einsum, &[x, w]).unwrap();
+    model.set_output_outlets(&einsum).unwrap();
+    model.declutter().unwrap();
+
+    let mut input = Tensor::zero::<f32>(&[5, 8, 2]).unwrap();
+    input.as_slice_mut::<f32>().unwrap().iter_mut().enumerate().for_each(|(ix, x)| *x = ix as f32);
+    proptest_regular_against_pulse(model, 1, input.into_array().unwrap(), 0).unwrap()
+}
+
+#[test]
+fn einsum_pulsedmm() {
+    let mut model = TypedModel::default();
+    let s = stream_symbol();
+    let x = model.add_source("x", f32::fact(dims!(s, 8, 2))).unwrap();
+    let w = model.add_const("w", Tensor::zero::<f32>(&[8, 2, 4]).unwrap()).unwrap();
+
+    let expr = "sij,ijk->sik".parse::<Expr>().unwrap();
+    let einsum = EinSum { expr };
+
+    let einsum = model.wire_node("einsum", einsum, &[x, w]).unwrap();
+    model.set_output_outlets(&einsum).unwrap();
+    model.declutter().unwrap();
+
+    let mut input = Tensor::zero::<f32>(&[5, 8, 2]).unwrap();
+    input.as_slice_mut::<f32>().unwrap().iter_mut().enumerate().for_each(|(ix, x)| *x = ix as f32);
+    proptest_regular_against_pulse(model, 1, input.into_array().unwrap(), 0).unwrap()
+}

--- a/harness/core-proptest-pulse/src/einsum.rs
+++ b/harness/core-proptest-pulse/src/einsum.rs
@@ -4,25 +4,6 @@ use tract_onnx_opl::einsum::*;
 use super::*;
 
 #[test]
-fn einsum_bmm() {
-    let mut model = TypedModel::default();
-    let s = 5;
-    let x = model.add_source("x", f32::fact(dims!(s, 8, 2))).unwrap();
-    let w = model.add_const("w", Tensor::zero::<f32>(&[8, 2, 4]).unwrap()).unwrap();
-
-    let expr = "sij,ijk->sik".parse::<Expr>().unwrap();
-    let einsum = EinSum { expr };
-
-    let einsum = model.wire_node("einsum", einsum, &[x, w]).unwrap();
-    model.set_output_outlets(&einsum).unwrap();
-    model.declutter().unwrap();
-
-    let mut input = Tensor::zero::<f32>(&[5, 8, 2]).unwrap();
-    input.as_slice_mut::<f32>().unwrap().iter_mut().enumerate().for_each(|(ix, x)| *x = ix as f32);
-    proptest_regular_against_pulse(model, 1, input.into_array().unwrap(), 0).unwrap()
-}
-
-#[test]
 fn einsum_pulsedmm() {
     let mut model = TypedModel::default();
     let s = stream_symbol();

--- a/harness/core-proptest-pulse/src/lib.rs
+++ b/harness/core-proptest-pulse/src/lib.rs
@@ -16,6 +16,7 @@ mod conv_plus_conv;
 mod deconv;
 mod delay_plus_pool;
 mod pad_plus_conv;
+mod einsum;
 
 #[allow(dead_code)]
 fn setup_test_logger() {

--- a/onnx-opl/src/einsum/expr.rs
+++ b/onnx-opl/src/einsum/expr.rs
@@ -313,4 +313,31 @@ mod test {
     fn test_display_expr() {
         assert_eq!("pqrs,tuqvr->pstuv".parse::<Expr>().unwrap().to_string(), "pqrs,tuqvr->pstuv");
     }
+
+    #[test]
+    fn test_parse_pulsed_matmul() {
+        assert_eq!(
+            "sij,ijk->sik".parse::<Expr>().unwrap(),
+            Expr::from(tvec![
+                AxisSym::new('i').result(1).input(0, 1).input(1, 0),
+                AxisSym::new('k').result(2).input(1, 2),
+                AxisSym::new('s').result(0).input(0, 0),
+                AxisSym::new('j').input(0, 2).input(1, 1),
+            ])
+        )
+    }
+
+    #[test]
+    fn test_parse_pulsed_batch_matmul() {
+        assert_eq!(
+            "bsij,ijk->bsik".parse::<Expr>().unwrap(),
+            Expr::from(tvec![
+                AxisSym::new('b').result(0).input(0, 0),
+                AxisSym::new('i').result(2).input(0, 2).input(1, 0),
+                AxisSym::new('k').result(3).input(1, 2),
+                AxisSym::new('s').result(1).input(0, 1),
+                AxisSym::new('j').input(0, 3).input(1, 1),
+            ])
+        )
+    }
 }


### PR DESCRIPTION
See #792
Not sure if I implemented the test correctly. Currently, also the first test without pulse is failing:
```
---- einsum::einsum_bmm stdout ----
thread 'einsum::einsum_bmm' panicked at 'called `Result::unwrap()` on an `Err` value: running pass ChangeAxes

Caused by:
    0: Making patch for AxisChange { outlet: 1/0>, op: Rm(3) } from #1 "einsum.add_m_axis" AddAxis
    1: Propagating AxisChange { outlet: 1/0>, op: Rm(3) } to node #2 "einsum.mm" MatMulUnary
    2: Remove a non-1 axis: axis 1 in 1,8,2,4,F32 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0...', harness/core-proptest-pulse/src/einsum.rs:18:23
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
   2: core::result::unwrap_failed
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/result.rs:1805:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/result.rs:1098:23
   4: core_proptest_pulse::einsum::einsum_bmm
             at ./src/einsum.rs:18:5
   5: core_proptest_pulse::einsum::einsum_bmm::{{closure}}
             at ./src/einsum.rs:7:1
   6: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```