### PR TITLE
Avoid trying to check /proc/cpuinfo when the system isn't Linux

### DIFF
--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -86,10 +86,13 @@ impl Kind {
                         part
                     );
                     part
-                } else {
+                } else if cfg!(target_os = "linux") {
                     let part = max_cpuid().unwrap_or("0x00".to_string());
                     log::info!("CPU part auto detected: {}", part);
                     part
+                } else {
+                    log::info!("Unknown CPU part");
+                    "0x00".to_string()
                 };
                 match &*part {
                     PART_A53 => Kind::CortexA53,


### PR DESCRIPTION
This is just a quick fix for systems that aren't Linux (e.g. FreeBSD), falling back on /proc/cpuinfo causes trouble.

I think for special platforms, it's probably better to have some form of override available like getrandom does, because unfortunately I'm not aware of any way to pull the target_cpu if it's been specified...

