### PR TITLE
feat: add missing types conversion between NNEF 1.0.5 and tract 

### DIFF
--- a/nnef/src/tensors.rs
+++ b/nnef/src/tensors.rs
@@ -36,7 +36,19 @@ pub fn read_tensor<R: std::io::Read>(mut reader: R) -> TractResult<Tensor> {
         let shape: TVec<usize> =
             header.dims[0..header.rank as usize].iter().map(|d| *d as _).collect();
         let len = shape.iter().product::<usize>();
-        if header.bits_per_item != 0xFFFFFFFF
+
+        if header.item_type == 5 {
+            let expected_bit_size = len * header.bits_per_item as usize;
+            let real_bit_size = header.data_size_bytes as usize * 8;
+            if !(real_bit_size - 8 <= expected_bit_size && expected_bit_size <= real_bit_size) {
+                bail!(
+                    "Shape and len mismatch: shape:{:?}, bits_per_item:{}, bytes:{} ",
+                    shape,
+                    header.bits_per_item,
+                    header.data_size_bytes
+                );
+            }
+        } else if header.bits_per_item != 0xFFFFFFFF
             && len * (header.bits_per_item as usize / 8) != header.data_size_bytes as usize
         {
             bail!(
@@ -49,18 +61,45 @@ pub fn read_tensor<R: std::io::Read>(mut reader: R) -> TractResult<Tensor> {
         if header.item_type_vendor != 0 && header.item_type_vendor != TRACT_ITEM_TYPE_VENDOR {
             bail!("Unknownn item type vendor {}", header.item_type_vendor);
         }
+
+        // last checked with spec 1.0.5: https://registry.khronos.org/NNEF/specs/1.0/nnef-1.0.5.html
+        //
+        // Quantized types are not instanciated as DatumType::Q* here since
+        // quant infos are joined later from .quant file (
+        //  see: ops/nnef/deser.rs
+        // )
         let dt = match (header.item_type_vendor, header.item_type, header.bits_per_item) {
+            // 0 - 0b0000 - float values in IEEE format, valid bits per item is 16, 32, 64
             (0, 0, 16) => DatumType::F16,
             (0, 0, 32) => DatumType::F32,
             (0, 0, 64) => DatumType::F64,
+
+            // 1 - 0b0001 - unsigned integer values, maximum bits per item is 64.
             (0, 1, 8) => DatumType::U8,
             (0, 1, 16) => DatumType::U16,
             (0, 1, 32) => DatumType::U32,
             (0, 1, 64) => DatumType::U64,
+
+            // 2 - 0b0010 - quantized unsigned integer values, maximum bits per item is 64.
+            (0, 2, 8) => DatumType::U8,
+            (0, 2, 16) => DatumType::U16,
+            (0, 2, 32) => DatumType::U32,
+            (0, 2, 64) => DatumType::U64,
+
+            // 3 - 0b0011 - quantized signed integer values, maximum bits per item is 64.
+            (0, 3, 8) => DatumType::I8,
+            (0, 3, 16) => DatumType::I16,
+            (0, 3, 32) => DatumType::I32,
+            (0, 3, 64) => DatumType::I64,
+
+            // 4 - 0b0100 - signed integer values, maximum bits per item is 64.
             (0, 4, 8) => DatumType::I8,
             (0, 4, 16) => DatumType::I16,
             (0, 4, 32) => DatumType::I32,
             (0, 4, 64) => DatumType::I64,
+
+            // 5 - 0b0101 - bool values, 1 bit or 8 bits (0 means false, non-zero means true)
+            (0, 5, 1) => DatumType::Bool,
             (TRACT_ITEM_TYPE_VENDOR, 0x1000, 0xFFFF) => DatumType::String,
             (TRACT_ITEM_TYPE_VENDOR, 0, 32) => DatumType::ComplexF16,
             (TRACT_ITEM_TYPE_VENDOR, 0, 64) => DatumType::ComplexF32,
@@ -76,7 +115,20 @@ pub fn read_tensor<R: std::io::Read>(mut reader: R) -> TractResult<Tensor> {
         };
         if dt.is_copy() {
             let mut tensor = Tensor::uninitialized_dt(dt, &shape)?;
-            reader.read_exact(tensor.as_bytes_mut())?;
+            if dt == DatumType::Bool && header.bits_per_item == 1 {
+                let buf = tensor.as_slice_mut::<bool>()?;
+
+                let mut current_byte = 0;
+                for (ix, value) in buf.iter_mut().enumerate() {
+                    let bit_ix = ix % 8;
+                    if bit_ix == 0 {
+                        current_byte = reader.read_u8()?;
+                    }
+                    *value = ((current_byte >> (7 - bit_ix)) & 0x1) != 0;
+                }
+            } else {
+                reader.read_exact(tensor.as_bytes_mut())?;
+            }
             Ok(tensor)
         } else if dt == DatumType::String {
             let mut tensor = Tensor::zero_dt(dt, &shape)?;


### PR DESCRIPTION
- add NNEF bool tensor deserialization
- add NNEF quantized "types" mapping to tract types