### PR TITLE
Fix facts inference on example pytorch-albert-v2

### DIFF
--- a/examples/pytorch-albert-v2/src/main.rs
+++ b/examples/pytorch-albert-v2/src/main.rs
@@ -22,9 +22,6 @@ fn main() -> Result<()> {
 
     let model = tract_onnx::onnx()
         .model_for_path(Path::join(&model_dir, "model.onnx"))?
-        .with_input_fact(0, i64::fact(&[1, length]).into())?
-        .with_input_fact(1, i64::fact(&[1, length]).into())?
-        .with_input_fact(2, i64::fact(&[1, length]).into())?
         .into_optimized()?
         .into_runnable()?;
 


### PR DESCRIPTION
Hi there,

I found a bug while running the example `pytorch-albert-v2`. It gives the following error:

```
Error: Failed analyse for node #1470 "Add_1433" Add

Caused by:
    0: Infering facts
    1: Applying rule outputs[0].shape == 1,9,30000
    2: Unifying shapes b,s,30000 and 1,9,30000
    3: Impossible to unify Sym(Symbol('b', 0)) with Val(1).
```

After a short discussion with @cchudant, he told me calls to the function `with_input_fact` were not required anymore.
Removing them fixes the problem