### PR TITLE
Fix `x86_64-apple-darwin` cross compilation

### DIFF
--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -80,88 +80,53 @@ fn main() {
         "x86_64" => {
             let files = preprocess_files("x86_64/fma", &[], &suffix, false);
 
-            match os.as_ref() {
-                "windows" => {
-                    if use_masm() {
-                        let mut lib_exe = cc::windows_registry::find(&target, "lib.exe")
-                            .expect("Could not find lib.exe");
-                        lib_exe.arg(format!(
-                            "/out:{}",
-                            out_dir.join("x86_64_fma.lib").to_str().unwrap()
-                        ));
-                        for f in files {
-                            let mut obj = f.clone();
-                            obj.set_extension("o");
-                            let mut ml_exe = cc::windows_registry::find(&target, "ml64.exe")
-                                .expect("Could not find ml64.exe");
-                            if !ml_exe
-                                .arg("/Fo")
-                                .arg(&obj)
-                                .arg("/c")
-                                .arg(&f)
-                                .status()
-                                .unwrap()
-                                .success()
-                            {
-                                for (i, l) in
-                                    std::fs::read_to_string(&f).unwrap().lines().enumerate()
-                                {
-                                    println!("{:8} {}", i, l);
-                                }
-                                panic!();
-                            }
-                            lib_exe.arg(obj);
-                        }
-                        assert!(lib_exe.status().unwrap().success());
-                        println!("cargo:rustc-link-search=native={}", out_dir.to_str().unwrap());
-                        println!("cargo:rustc-link-lib=static=x86_64_fma");
-                    } else {
-                        cc::Build::new()
-                            .files(files)
-                            .flag("-mfma")
-                            .static_flag(true)
-                            .compile("x86_64_fma");
-
-                        // clang at least (dunno about gcc) outputs .asm files in the
-                        // root directory that we need to clean up so we don't pollute
-                        // the build output/working directory
-                        let _ = fs::remove_file("fma_mmm_f32_16x6.asm");
-                        let _ = fs::remove_file("fma_mmm_i32_8x8.asm");
-                        let _ = fs::remove_file("fma_sigmoid_f32.asm");
-                        let _ = fs::remove_file("fma_tanh_f32.asm");
-                    }
-                }
-                "macos" => {
-                    let lib = out_dir.join("libx86_64_fma.a");
-                    if lib.exists() {
-                        std::fs::remove_file(lib).unwrap();
-                    }
-                    let mut lib = std::process::Command::new("xcrun");
-                    lib.args(["ar", "-rv"]).arg(out_dir.join("libx86_64_fma.a"));
+            if os == "windows" {
+                if use_masm() {
+                    let mut lib_exe = cc::windows_registry::find(&target, "lib.exe")
+                        .expect("Could not find lib.exe");
+                    lib_exe
+                        .arg(format!("/out:{}", out_dir.join("x86_64_fma.lib").to_str().unwrap()));
                     for f in files {
                         let mut obj = f.clone();
                         obj.set_extension("o");
-                        assert!(std::process::Command::new("cc")
-                            .args(["-arch", "x86_64"])
-                            .args(["-c", "-o"])
+                        let mut ml_exe = cc::windows_registry::find(&target, "ml64.exe")
+                            .expect("Could not find ml64.exe");
+                        if !ml_exe
+                            .arg("/Fo")
                             .arg(&obj)
+                            .arg("/c")
                             .arg(&f)
                             .status()
                             .unwrap()
-                            .success());
-                        lib.arg(obj);
+                            .success()
+                        {
+                            for (i, l) in std::fs::read_to_string(&f).unwrap().lines().enumerate() {
+                                println!("{:8} {}", i, l);
+                            }
+                            panic!();
+                        }
+                        lib_exe.arg(obj);
                     }
-                    assert!(lib.status().unwrap().success());
+                    assert!(lib_exe.status().unwrap().success());
                     println!("cargo:rustc-link-search=native={}", out_dir.to_str().unwrap());
                     println!("cargo:rustc-link-lib=static=x86_64_fma");
-                }
-                _ => {
+                } else {
                     cc::Build::new()
                         .files(files)
                         .flag("-mfma")
                         .static_flag(true)
                         .compile("x86_64_fma");
+
+                    // clang at least (dunno about gcc) outputs .asm files in the
+                    // root directory that we need to clean up so we don't pollute
+                    // the build output/working directory
+                    let _ = fs::remove_file("fma_mmm_f32_16x6.asm");
+                    let _ = fs::remove_file("fma_mmm_i32_8x8.asm");
+                    let _ = fs::remove_file("fma_sigmoid_f32.asm");
+                    let _ = fs::remove_file("fma_tanh_f32.asm");
                 }
+            } else {
+                cc::Build::new().files(files).flag("-mfma").static_flag(true).compile("x86_64_fma");
             }
         }
         "arm" | "armv7" => {


### PR DESCRIPTION
This fixes an issue where targeting `x86_64-apple-darwin` would unconditionally invoke `xcrun` to get `ar`, which won't work on non-macos hosts (usually). Initially I made it respect the `AR/_<cfg>` etc environment variables, but then realized the code could just, be the default, and I'm unsure why it was explicitly assembling each file and manually adding them to the archive? This method works on a linux host at least, so if CI works on a normal macos host I think it should be fine.