### PR TITLE
Consider using easyfft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ rand_distr = "0.4"
 readings-probe = "0.1.3"
 regex = "1.5.4"
 reqwest = { version = "0.11.4", features = [ "blocking", "rustls" ], default-features = false }
-rustfft = { version = "6.1", features = [ "neon" ] }
+easyfft = "0.3.5"
 rustls = "0.20.4"
 smallvec = "1.6.1"
 scan_fmt = "0.2.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ maplit.workspace = true
 ndarray.workspace = true
 num-integer.workspace = true
 num-traits.workspace = true
-rustfft.workspace = true
+easyfft.workspace = true
 smallvec.workspace = true
 tract-linalg = { version = "=0.19.1-pre", path = "../linalg" }
 tract-data = { version = "=0.19.1-pre", path = "../data" }

--- a/onnx-opl/Cargo.toml
+++ b/onnx-opl/Cargo.toml
@@ -19,7 +19,6 @@ getrandom.workspace = true
 log.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
-rustfft.workspace = true
 tract-nnef = { version = "=0.19.1-pre", path = "../nnef" }
 
 [dev-dependencies]


### PR DESCRIPTION
`easyfft` is a wrapper that uses `rustfft` internally. It makes it harder to make mistakes and manages boilerplate for you.

```
commit edfd69987535e98e36ec5f24a768076c1eb5795c
Author: Walter Smuts <smuts.walter@gmail.com>
Date:   Sun Jan 15 08:54:20 2023 +0200

    Replace rustfft with easyfft

    This avoids re-generating the Planner struct each time the `eval_t`
    method is invoked. As a bonus it also handles initialization and sizing
    calculations for you, resulting in less boilerplate.

commit 0484590e18d269adf293f729a7c8c3da9961b931
Author: Walter Smuts <smuts.walter@gmail.com>
Date:   Sun Jan 15 08:53:03 2023 +0200

    Remove rustfft from onnx-opl module

    The module has it declared as a dependency but it's unused.
````