### PR TITLE
substiture constants as soon as wire_node (#965)

### DIFF
--- a/core/src/model/graph.rs
+++ b/core/src/model/graph.rs
@@ -696,12 +696,11 @@ where
 
     pub fn compact(&mut self) -> TractResult<()> {
         use crate::model::translator::Translate;
-        let mut result = crate::model::translator::IntoTranslator.translate_model(self)?;
+        *self = crate::model::translator::IntoTranslator.translate_model(self)?;
         #[cfg(debug_assertions)]
         {
-            result.check_compact().context("after graph compaction")?;
+            self.check_compact().context("after graph compaction")?;
         }
-        std::mem::swap(self, &mut result);
         Ok(())
     }
 

--- a/hir/src/ops/cnn/conv.rs
+++ b/hir/src/ops/cnn/conv.rs
@@ -342,7 +342,7 @@ mod test {
         let k = tensor4(&[[[[0.0f32], [0.0]], [[1.0], [0.0]]]]);
         let e = tensor4(&[[[[1.0f32], [0.0]]]]);
         let res = op.eval(tvec!(i.into(), k.into())).unwrap();
-        assert_eq!(res, tvec!(e.into()));
+        res[0].close_enough(&e, Approximation::Approximate).unwrap();
     }
 
     #[test]
@@ -352,7 +352,7 @@ mod test {
         let i = tensor4(&[[[[0.0f32, 1.0], [2.0, 3.0]], [[10.0, 11.0], [12.0, 13.0]]]]);
         let k = tensor4(&[[[[1.0f32, 0.0], [0.0, 1.0]]]]);
         let res = op.eval(tvec!(i.clone().into(), k.into())).unwrap();
-        assert_eq!(res, tvec!(i.into()));
+        res[0].close_enough(&i, Approximation::Approximate).unwrap()
     }
 
     #[test]
@@ -365,7 +365,7 @@ mod test {
                 tensor4(&[[[[1.0f32]]]]).into()
             ))
             .unwrap();
-        assert_eq!(result, tvec!(tensor4(&[[[[2.0f32]]], [[[0.0f32]]]]).into()));
+        result[0].close_enough(&tensor4(&[[[[2.0f32]]], [[[0.0f32]]]]), Approximation::Approximate).unwrap();
     }
 
     #[test]
@@ -384,7 +384,7 @@ mod test {
         let result = op
             .eval(tvec!(tensor3(&[[[2.0f32], [0.0f32]]]).into(), tensor3(&[[[1.0f32]]]).into()))
             .unwrap();
-        assert_eq!(result, tvec!(tensor3(&[[[2.0f32], [0.0f32]]]).into()));
+        result[0].close_enough(&tensor3(&[[[2.0f32], [0.0f32]]]), Approximation::Approximate).unwrap();
     }
 
     #[test]
@@ -403,7 +403,7 @@ mod test {
         let result = op
             .eval(tvec!(tensor3(&[[[2.0f32]], [[0.0f32]]]).into(), tensor3(&[[[1.0f32]]]).into()))
             .unwrap();
-        assert_eq!(result, tvec!(tensor3(&[[[2.0f32]], [[0.0f32]]]).into()));
+        result[0].close_enough(&tensor3(&[[[2.0f32]], [[0.0f32]]]), Approximation::Approximate).unwrap();
     }
 
     #[test]
@@ -425,6 +425,6 @@ mod test {
                 tensor3(&[[[1.0f32], [0.0f32]]]).into()
             ))
             .unwrap();
-        assert_eq!(result, tvec!(tensor3(&[[[2.0f32]]]).into()));
+        result[0].close_enough(&tensor3(&[[[2.0f32]]]), Approximation::Approximate).unwrap();
     }
 }

--- a/tensorflow/src/ops/nn/conv2d.rs
+++ b/tensorflow/src/ops/nn/conv2d.rs
@@ -136,8 +136,8 @@ mod tests {
         let filter = tensor4(&[[[[0.0f32]]], [[[1.0]]], [[[0.0]]]]);
         let exp = tensor4(&[[[[1f32]]]]);
 
-        let result = conv.eval(tvec![data.into(), filter.into()]).unwrap().remove(0);
-        assert_eq!(exp.into_tvalue(), result);
+        let result = conv.eval(tvec![data.into(), filter.into()]).unwrap();
+        result[0].close_enough(&exp, Approximation::Approximate).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
* substiture constants as soon as wire_node

* paranoid assert should not be set by default (#963)

* semi-adhox fix for slice of broadcasted dim