### PR TITLE
Ensure callee saved registered are properly restored

### DIFF
--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_12x8_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_12x8_core.tmpl
@@ -1,6 +1,9 @@
 // vim: ft=arm
 
-// C tile regs: d8..d16 to preserve, v16 to v31, no need to preserve
+// C tile regs: 
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
 //
 // v8  v11 v14 v17 v20 v23 v26 v29
 // v9  v12 v15 v18 v21 v24 v27 v30
@@ -17,12 +20,10 @@
 .global {{G}}arm64simd_mmm_f32_12x8_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_12x8_{{core}}_{{suffix}}:
 
-    stp         x19, x20, [sp, #-16]!
-    stp         x21, x22, [sp, #-16]!
-    stp         x23, x24, [sp, #-16]!
-    stp         x25, x26, [sp, #-16]!
-    stp         x27, x28, [sp, #-16]!
-    stp         x29, x30, [sp, #-16]!
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -152,12 +153,10 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x29, x30, [sp], #16
-    ldp         x27, x28, [sp], #16
-    ldp         x25, x26, [sp], #16
-    ldp         x23, x24, [sp], #16
-    ldp         x21, x22, [sp], #16
-    ldp         x19, x20, [sp], #16
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_12x8_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_12x8_core.tmpl
@@ -17,10 +17,12 @@
 .global {{G}}arm64simd_mmm_f32_12x8_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_12x8_{{core}}_{{suffix}}:
 
-    stp         x20, x21, [sp, #-16]!
-    stp         x22, x23, [sp, #-16]!
-    stp         x24, x25, [sp, #-16]!
-    stp         x26, x27, [sp, #-16]!
+    stp         x19, x20, [sp, #-16]!
+    stp         x21, x22, [sp, #-16]!
+    stp         x23, x24, [sp, #-16]!
+    stp         x25, x26, [sp, #-16]!
+    stp         x27, x28, [sp, #-16]!
+    stp         x29, x30, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -150,10 +152,12 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x26, x27, [sp], #16
-    ldp         x24, x25, [sp], #16
-    ldp         x22, x23, [sp], #16
-    ldp         x20, x21, [sp], #16
+    ldp         x29, x30, [sp], #16
+    ldp         x27, x28, [sp], #16
+    ldp         x25, x26, [sp], #16
+    ldp         x23, x24, [sp], #16
+    ldp         x21, x22, [sp], #16
+    ldp         x19, x20, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_16x4_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_16x4_core.tmpl
@@ -16,12 +16,17 @@
 .global {{G}}arm64simd_mmm_f32_16x4_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_16x4_{{core}}_{{suffix}}:
 
-    stp         x20, x21, [sp, #-16]!
-    stp         x22, x23, [sp, #-16]!
-    stp         x24, x25, [sp, #-16]!
-    stp         x26, x27, [sp, #-16]!
+    stp         x19, x20, [sp, #-16]!
+    stp         x21, x22, [sp, #-16]!
+    stp         x23, x24, [sp, #-16]!
+    stp         x25, x26, [sp, #-16]!
+    stp         x27, x28, [sp, #-16]!
+    stp         x29, x30, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
+    stp         d10, d11, [sp, #-16]!
+    stp         d12, d13, [sp, #-16]!
+    stp         d14, d15, [sp, #-16]!
 
 {% include "dispatcher.tmpliq" %}
 
@@ -155,12 +160,17 @@
     b           .non_linear_loop
 
 .return:
+    ldp         d14, d15, [sp], #16
+    ldp         d12, d13, [sp], #16
+    ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x26, x27, [sp], #16
-    ldp         x24, x25, [sp], #16
-    ldp         x22, x23, [sp], #16
-    ldp         x20, x21, [sp], #16
+    ldp         x29, x30, [sp], #16
+    ldp         x27, x28, [sp], #16
+    ldp         x25, x26, [sp], #16
+    ldp         x23, x24, [sp], #16
+    ldp         x21, x22, [sp], #16
+    ldp         x19, x20, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_16x4_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_16x4_core.tmpl
@@ -1,8 +1,9 @@
 // vim: ft=arm
 
-// x20..x27 are used, callee-preserved
-
 // C tile regs: v16 to v31, (scratch)
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
 
 // v8 is used, d8 (lower half) must preserved
 // v0-v7 (scratch registers)
@@ -16,12 +17,10 @@
 .global {{G}}arm64simd_mmm_f32_16x4_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_16x4_{{core}}_{{suffix}}:
 
-    stp         x19, x20, [sp, #-16]!
-    stp         x21, x22, [sp, #-16]!
-    stp         x23, x24, [sp, #-16]!
-    stp         x25, x26, [sp, #-16]!
-    stp         x27, x28, [sp, #-16]!
-    stp         x29, x30, [sp, #-16]!
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -165,12 +164,10 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x29, x30, [sp], #16
-    ldp         x27, x28, [sp], #16
-    ldp         x25, x26, [sp], #16
-    ldp         x23, x24, [sp], #16
-    ldp         x21, x22, [sp], #16
-    ldp         x19, x20, [sp], #16
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_24x4_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_24x4_core.tmpl
@@ -16,10 +16,12 @@
 .global {{G}}arm64simd_mmm_f32_24x4_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_24x4_{{core}}_{{suffix}}:
 
-    stp         x20, x21, [sp, #-16]!
-    stp         x22, x23, [sp, #-16]!
-    stp         x24, x25, [sp, #-16]!
-    stp         x26, x27, [sp, #-16]!
+    stp         x19, x20, [sp, #-16]!
+    stp         x21, x22, [sp, #-16]!
+    stp         x23, x24, [sp, #-16]!
+    stp         x25, x26, [sp, #-16]!
+    stp         x27, x28, [sp, #-16]!
+    stp         x29, x30, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -172,10 +174,12 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x26, x27, [sp], #16
-    ldp         x24, x25, [sp], #16
-    ldp         x22, x23, [sp], #16
-    ldp         x20, x21, [sp], #16
+    ldp         x29, x30, [sp], #16
+    ldp         x27, x28, [sp], #16
+    ldp         x25, x26, [sp], #16
+    ldp         x23, x24, [sp], #16
+    ldp         x21, x22, [sp], #16
+    ldp         x19, x20, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_24x4_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_24x4_core.tmpl
@@ -3,6 +3,9 @@
 // x20..x27 are used, callee-preserved
 
 // C tile regs: v8 to v31, (scratch)
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
 
 // v8 is used, d8 (lower half) must preserved
 // v0-v7 (scratch registers)
@@ -16,12 +19,10 @@
 .global {{G}}arm64simd_mmm_f32_24x4_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_24x4_{{core}}_{{suffix}}:
 
-    stp         x19, x20, [sp, #-16]!
-    stp         x21, x22, [sp, #-16]!
-    stp         x23, x24, [sp, #-16]!
-    stp         x25, x26, [sp, #-16]!
-    stp         x27, x28, [sp, #-16]!
-    stp         x29, x30, [sp, #-16]!
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -174,12 +175,10 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x29, x30, [sp], #16
-    ldp         x27, x28, [sp], #16
-    ldp         x25, x26, [sp], #16
-    ldp         x23, x24, [sp], #16
-    ldp         x21, x22, [sp], #16
-    ldp         x19, x20, [sp], #16
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_64x1_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_64x1_core.tmpl
@@ -24,9 +24,12 @@
 .global {{G}}arm64simd_mmm_f32_64x1_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_64x1_{{core}}_{{suffix}}:
 
-    stp         x20, x21, [sp, #-16]!
-    stp         x22, x23, [sp, #-16]!
-    stp         x24, x25, [sp, #-16]!
+    stp         x19, x20, [sp, #-16]!
+    stp         x21, x22, [sp, #-16]!
+    stp         x23, x24, [sp, #-16]!
+    stp         x25, x26, [sp, #-16]!
+    stp         x27, x28, [sp, #-16]!
+    stp         x29, x30, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -213,9 +216,12 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x24, x25, [sp], #16
-    ldp         x22, x23, [sp], #16
-    ldp         x20, x21, [sp], #16
+    ldp         x29, x30, [sp], #16
+    ldp         x27, x28, [sp], #16
+    ldp         x25, x26, [sp], #16
+    ldp         x23, x24, [sp], #16
+    ldp         x21, x22, [sp], #16
+    ldp         x19, x20, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_64x1_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_64x1_core.tmpl
@@ -1,6 +1,9 @@
 // vim: ft=arm
 
-// C tile regs: v16 to v31, no need to preserve
+// C tile regs:
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
 // 
 //      v16[0] v18[0] v20[0] v22[0] v24[0] v26[0] v28[0] v30[0]
 //      v16[1] v18[1] 
@@ -12,8 +15,6 @@
 //      v17[2] v19[2] 
 //      v17[3] v19[3] 
 
-// no preservation either for v0-v7...
-// v8..v15 are callee-preserved
 // packed A buffering (2x8 values): alternating v0, v1 with v2, v3
 // packed B buffering (2x8 values): alternating v4, v5 with v6, v7
 
@@ -24,12 +25,10 @@
 .global {{G}}arm64simd_mmm_f32_64x1_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_64x1_{{core}}_{{suffix}}:
 
-    stp         x19, x20, [sp, #-16]!
-    stp         x21, x22, [sp, #-16]!
-    stp         x23, x24, [sp, #-16]!
-    stp         x25, x26, [sp, #-16]!
-    stp         x27, x28, [sp, #-16]!
-    stp         x29, x30, [sp, #-16]!
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -216,12 +215,10 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x29, x30, [sp], #16
-    ldp         x27, x28, [sp], #16
-    ldp         x25, x26, [sp], #16
-    ldp         x23, x24, [sp], #16
-    ldp         x21, x22, [sp], #16
-    ldp         x19, x20, [sp], #16
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_8x8_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_8x8_core.tmpl
@@ -1,8 +1,9 @@
 // vim: ft=arm
 
-// x20..x27 are used, callee-preserved
-
 // C tile regs: v16 to v31, (scratch)
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
 // 
 //      v16[0] v18[0] v20[0] v22[0] v24[0] v26[0] v28[0] v30[0]
 //      v16[1] v18[1] 
@@ -14,7 +15,6 @@
 //      v17[2] v19[2] 
 //      v17[3] v19[3] 
 
-// v8 is used, d8 (lower half) must preserved
 // v0-v7 (scratch registers)
 //  packed A buffering (2x8 values): alternating v0, v1 with v2, v3
 //  packed B buffering (2x8 values): alternating v4, v5 with v6, v7
@@ -26,13 +26,11 @@
 .global {{G}}arm64simd_mmm_f32_8x8_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_8x8_{{core}}_{{suffix}}:
 
-    stp         x19, x20, [sp, #-16]!
-    stp         x21, x22, [sp, #-16]!
-    stp         x23, x24, [sp, #-16]!
-    stp         x25, x26, [sp, #-16]!
-    stp         x27, x28, [sp, #-16]!
-    stp         x29, x30, [sp, #-16]!
-
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
+    
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
     stp         d12, d13, [sp, #-16]!
@@ -175,11 +173,9 @@
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x29, x30, [sp], #16
-    ldp         x27, x28, [sp], #16
-    ldp         x25, x26, [sp], #16
-    ldp         x23, x24, [sp], #16
-    ldp         x21, x22, [sp], #16
-    ldp         x19, x20, [sp], #16
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
 
     ret

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_8x8_core.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_8x8_core.tmpl
@@ -26,12 +26,17 @@
 .global {{G}}arm64simd_mmm_f32_8x8_{{core}}_{{suffix}}
 {{G}}arm64simd_mmm_f32_8x8_{{core}}_{{suffix}}:
 
-    stp         x20, x21, [sp, #-16]!
-    stp         x22, x23, [sp, #-16]!
-    stp         x24, x25, [sp, #-16]!
-    stp         x26, x27, [sp, #-16]!
+    stp         x19, x20, [sp, #-16]!
+    stp         x21, x22, [sp, #-16]!
+    stp         x23, x24, [sp, #-16]!
+    stp         x25, x26, [sp, #-16]!
+    stp         x27, x28, [sp, #-16]!
+    stp         x29, x30, [sp, #-16]!
 
-    str         q8, [sp, #-16]!
+    stp         d8, d9, [sp, #-16]!
+    stp         d10, d11, [sp, #-16]!
+    stp         d12, d13, [sp, #-16]!
+    stp         d14, d15, [sp, #-16]!
 
 {% include "dispatcher.tmpliq" %}
 
@@ -165,11 +170,16 @@
     b           .non_linear_loop
 
 .return:
-    ldr         q8, [sp], #16
+    ldp         d14, d15, [sp], #16
+    ldp         d12, d13, [sp], #16
+    ldp         d10, d11, [sp], #16
+    ldp         d8, d9, [sp], #16
 
-    ldp         x26, x27, [sp], #16
-    ldp         x24, x25, [sp], #16
-    ldp         x22, x23, [sp], #16
-    ldp         x20, x21, [sp], #16
+    ldp         x29, x30, [sp], #16
+    ldp         x27, x28, [sp], #16
+    ldp         x25, x26, [sp], #16
+    ldp         x23, x24, [sp], #16
+    ldp         x21, x22, [sp], #16
+    ldp         x19, x20, [sp], #16
 
     ret

--- a/linalg/arm64/arm64simd/arm64simd_mmm_i32_64x1.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_i32_64x1.tmpl
@@ -17,11 +17,17 @@
     prfm        pldl1keep, [x1]
     prfm        pldl1keep, [x2]
 */
+    stp         x19, x20, [sp, #-16]!
+    stp         x21, x22, [sp, #-16]!
+    stp         x23, x24, [sp, #-16]!
+    stp         x25, x26, [sp, #-16]!
+    stp         x27, x28, [sp, #-16]!
+    stp         x29, x30, [sp, #-16]!
 
-    stp         x20, x21, [sp, #-16]!
-    stp         x22, x23, [sp, #-16]!
-    stp         x24, x25, [sp, #-16]!
-    stp         x26, x27, [sp, #-16]!
+    stp         d8, d9, [sp, #-16]!
+    stp         d10, d11, [sp, #-16]!
+    stp         d12, d13, [sp, #-16]!
+    stp         d14, d15, [sp, #-16]!
 
 {% include "dispatcher.tmpliq" %}
 
@@ -133,10 +139,17 @@ non_linear_addc_i32:
     b   .non_linear_loop
 
 .return:
-    ldp         x26, x27, [sp], #16
-    ldp         x24, x25, [sp], #16
-    ldp         x22, x23, [sp], #16
-    ldp         x20, x21, [sp], #16
+    ldp         d14, d15, [sp], #16
+    ldp         d12, d13, [sp], #16
+    ldp         d10, d11, [sp], #16
+    ldp         d8, d9, [sp], #16
+    
+    ldp         x29, x30, [sp], #16
+    ldp         x27, x28, [sp], #16
+    ldp         x25, x26, [sp], #16
+    ldp         x23, x24, [sp], #16
+    ldp         x21, x22, [sp], #16
+    ldp         x19, x20, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_i32_64x1.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_i32_64x1.tmpl
@@ -1,6 +1,9 @@
 // vim: ft=arm
 
-// C tile regs: v16 to v31, no need to preserve
+// C tile regs: 
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
 
 // no preservation either for v0-v7...
 // packed A buffering (2x8 values): alternating v0, v1 with v2, v3
@@ -17,12 +20,10 @@
     prfm        pldl1keep, [x1]
     prfm        pldl1keep, [x2]
 */
-    stp         x19, x20, [sp, #-16]!
-    stp         x21, x22, [sp, #-16]!
-    stp         x23, x24, [sp, #-16]!
-    stp         x25, x26, [sp, #-16]!
-    stp         x27, x28, [sp, #-16]!
-    stp         x29, x30, [sp, #-16]!
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -144,12 +145,10 @@ non_linear_addc_i32:
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
     
-    ldp         x29, x30, [sp], #16
-    ldp         x27, x28, [sp], #16
-    ldp         x25, x26, [sp], #16
-    ldp         x23, x24, [sp], #16
-    ldp         x21, x22, [sp], #16
-    ldp         x19, x20, [sp], #16
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_i32_8x8.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_i32_8x8.tmpl
@@ -27,11 +27,17 @@
     prfm        pldl1keep, [x1]
     prfm        pldl1keep, [x2]
 */
+    stp         x19, x20, [sp, #-16]!
+    stp         x21, x22, [sp, #-16]!
+    stp         x23, x24, [sp, #-16]!
+    stp         x25, x26, [sp, #-16]!
+    stp         x27, x28, [sp, #-16]!
+    stp         x29, x30, [sp, #-16]!
 
-    stp         x20, x21, [sp, #-16]!
-    stp         x22, x23, [sp, #-16]!
-    stp         x24, x25, [sp, #-16]!
-    stp         x26, x27, [sp, #-16]!
+    stp         d8, d9, [sp, #-16]!
+    stp         d10, d11, [sp, #-16]!
+    stp         d12, d13, [sp, #-16]!
+    stp         d14, d15, [sp, #-16]!
 
 {% include "dispatcher.tmpliq" %}
 
@@ -179,10 +185,17 @@ non_linear_addc_i32:
     b           .non_linear_loop
 
 .return:
-    ldp         x26, x27, [sp], #16
-    ldp         x24, x25, [sp], #16
-    ldp         x22, x23, [sp], #16
-    ldp         x20, x21, [sp], #16
+    ldp         d14, d15, [sp], #16
+    ldp         d12, d13, [sp], #16
+    ldp         d10, d11, [sp], #16
+    ldp         d8, d9, [sp], #16
+
+    ldp         x29, x30, [sp], #16
+    ldp         x27, x28, [sp], #16
+    ldp         x25, x26, [sp], #16
+    ldp         x23, x24, [sp], #16
+    ldp         x21, x22, [sp], #16
+    ldp         x19, x20, [sp], #16
 
     ret
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_i32_8x8.tmpl
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_i32_8x8.tmpl
@@ -1,6 +1,9 @@
 // vim: ft=arm
 
-// C tile regs: v16 to v31, no need to preserve
+// C tile regs:
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
 // 
 //      v16[0] v18[0] v20[0] v22[0] v24[0] v26[0] v28[0] v30[0]
 //      v16[1] v18[1] 
@@ -27,12 +30,10 @@
     prfm        pldl1keep, [x1]
     prfm        pldl1keep, [x2]
 */
-    stp         x19, x20, [sp, #-16]!
-    stp         x21, x22, [sp, #-16]!
-    stp         x23, x24, [sp, #-16]!
-    stp         x25, x26, [sp, #-16]!
-    stp         x27, x28, [sp, #-16]!
-    stp         x29, x30, [sp, #-16]!
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
 
     stp         d8, d9, [sp, #-16]!
     stp         d10, d11, [sp, #-16]!
@@ -190,12 +191,10 @@ non_linear_addc_i32:
     ldp         d10, d11, [sp], #16
     ldp         d8, d9, [sp], #16
 
-    ldp         x29, x30, [sp], #16
-    ldp         x27, x28, [sp], #16
-    ldp         x25, x26, [sp], #16
-    ldp         x23, x24, [sp], #16
-    ldp         x21, x22, [sp], #16
-    ldp         x19, x20, [sp], #16
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
 
     ret
 


### PR DESCRIPTION
According to ARM documentation:
- x19-x29 needs to be callee preserved
- v8-v15 needs to be callee preserved

I might have been a bit too exhaustive (some registers might not be altered during the subroutine processing but I took the choice to persist all the resisters that needs to be persisted anyway in that first version of the PR). For sure it's a tradeoff between minimising load/stores instructions from the stack and ensuring the code is safe without having to look into the subroutine code.

Let's discuss that here