### PR TITLE
Improve if op

### DIFF
--- a/core/src/ops/logic.rs
+++ b/core/src/ops/logic.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::bool_comparison)]
 #![allow(clippy::unnecessary_cast)]
 
+mod ite;
+pub use ite::IfThenElse;
+
 use ndarray::*;
 
 use crate::broadcast::multi_broadcast;

--- a/core/src/ops/logic/ite.rs
+++ b/core/src/ops/logic/ite.rs
@@ -1,0 +1,93 @@
+use crate::internal::*;
+
+#[derive(Debug, Clone, Default)]
+pub struct IfThenElse {
+    pub then_body: TypedModel,
+    pub then_input_mapping: Vec<usize>,
+    pub else_body: TypedModel,
+    pub else_input_mapping: Vec<usize>,
+}
+
+impl Op for IfThenElse {
+    fn name(&self) -> Cow<str> {
+        "IfThenElse".into()
+    }
+
+    op_as_typed_op!();
+}
+
+impl TypedOp for IfThenElse {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        ensure!(inputs[0].datum_type == bool::datum_type());
+        ensure!(inputs[0].shape.volume() == 1.to_dim());
+        ensure!(self.then_body.inputs.len() == self.then_input_mapping.len());
+        ensure!(self.else_body.inputs.len() == self.else_input_mapping.len());
+        let mut facts = tvec!();
+        for i in 0..self.then_body.outputs.len() {
+            ensure!(
+                self.then_body.output_fact(i)?.without_value()
+                    == self.else_body.output_fact(i)?.without_value()
+            );
+            facts.push(self.then_body.output_fact(i)?.clone());
+        }
+        Ok(facts)
+    }
+
+    fn declutter(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TypedModelPatch>> {
+        if let Some(cond) = &model.outlet_fact(node.inputs[0])?.konst {
+            let cond = cond.cast_to_scalar::<bool>()?;
+            let (body, input_mapping) = if cond {
+                (&self.then_body, &self.then_input_mapping)
+            } else {
+                (&self.else_body, &self.else_input_mapping)
+            };
+            let mut inner_mapping: HashMap<OutletId, OutletId> = HashMap::default();
+            let mut patch = TypedModelPatch::default();
+            for (input_ix, outlet) in tract_itertools::izip!(input_mapping, body.input_outlets()?) {
+                let tap = patch.tap_model(model, node.inputs[*input_ix])?;
+                inner_mapping.insert(*outlet, tap);
+            }
+            for node in body.eval_order()? {
+                if Graph::is_source(&body.node(node).op) {
+                    continue;
+                }
+                let node_inputs =
+                    body.node(node).inputs.iter().map(|o| inner_mapping[o]).collect::<TVec<_>>();
+                let node_outputs =
+                    patch.wire_node(&body.node(node).name, &body.node(node).op, &node_inputs)?;
+                for (slot_ix, outlet) in node_outputs.iter().enumerate() {
+                    inner_mapping.insert((node, slot_ix).into(), *outlet);
+                }
+            }
+            for (ix, output) in body.outputs.iter().enumerate() {
+                patch.shunt_outside(model, OutletId::new(node.id, ix), inner_mapping[output])?;
+            }
+            Ok(Some(patch))
+        } else {
+            Ok(None)
+        }
+    }
+
+    as_op!();
+}
+
+impl EvalOp for IfThenElse {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let cond = inputs[0].cast_to_scalar::<bool>()?;
+        let (input_mapping, body) = if cond {
+            (&self.then_input_mapping, &self.then_body)
+        } else {
+            (&self.else_input_mapping, &self.else_body)
+        };
+        let inputs: TVec<TValue> = input_mapping.iter().map(|&ix| inputs[ix].clone()).collect();
+        body.clone().into_runnable()?.run(inputs)
+    }
+}

--- a/hir/src/infer/model.rs
+++ b/hir/src/infer/model.rs
@@ -120,8 +120,7 @@ impl InferenceModelExt for InferenceModel {
                 } else {
                     let outputs = node
                         .op
-                        .to_typed(source, node, target, mapping)
-                        .with_context(|| format!("translating op {:?}", node.op))?;
+                        .to_typed(source, node, target, mapping)?;
                     for output in &outputs {
                         let fact = target.outlet_fact(*output)?;
                         fact.consistent().with_context(|| {

--- a/onnx/src/ops/logic.rs
+++ b/onnx/src/ops/logic.rs
@@ -120,6 +120,12 @@ impl InferenceOp for If {
                     changed =
                         changed || body.output_fact_mut(oix)?.unify_with_mut(&mut outputs[oix])?;
                 }
+            } else {
+                for ix in 0..self.nboutputs()? {
+                    changed = changed
+                        || self.then_body.output_fact_mut(ix)?.unify_with_mut(&mut outputs[ix])?
+                        || self.else_body.output_fact_mut(ix)?.unify_with_mut(&mut outputs[ix])?;
+                }
             }
             changed = changed || self.then_body.analyse(false)?;
             changed = changed || self.else_body.analyse(false)?;


### PR DESCRIPTION
ONNX If only works has a loading macro expansion: the condition must be known and fixed at loading time, the right branch is substituted in the type phase. This blocks Silero VAD v4 (see #1029).

* [x] make analyse work when input is dynamic
* [x] implement an If operator in core and translate ONNX op into it
* [ ] find out how to encode this in NNEF
* [ ] into_optimized as in Scan
* [ ] declutter as in Scan