### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tract"
 version = "0.20.7-pre"
 authors = [ "Romain Liautaud <romain.liautaud@snips.ai>", "Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
 keywords = [ "TensorFlow", "NeuralNetworks" ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-core"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-data"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/examples/jupyter-keras-tract-tf1/Cargo.toml
+++ b/examples/jupyter-keras-tract-tf1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jupyter-keras-tract-tf1"
 version = "0.20.7-pre"
 authors = ["Matthew Alhonte <mattalhonte@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/jupyter-keras-tract-tf2/Cargo.toml
+++ b/examples/jupyter-keras-tract-tf2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jupyter-keras-tract-tf2"
 version = "0.20.7-pre"
 authors = ["Matthew Alhonte <mattalhonte@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/nnef-dump-mobilenet-v2/Cargo.toml
+++ b/examples/nnef-dump-mobilenet-v2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-dump-nnef-mobilenet-v2"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/nnef-mobilenet-v2/Cargo.toml
+++ b/examples/nnef-mobilenet-v2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-nnef-mobilenet-v2"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/onnx-mobilenet-v2/Cargo.toml
+++ b/examples/onnx-mobilenet-v2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-onnx-mobilenet-v2"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/pytorch-resnet/Cargo.toml
+++ b/examples/pytorch-resnet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-pytorch-resnet"
 version = "0.20.7-pre"
 authors = ["Teddy Koker <teddy.koker@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/tensorflow-mobilenet-v2/Cargo.toml
+++ b/examples/tensorflow-mobilenet-v2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-tensorflow-mobilenet-v2"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/examples/tflite-mobilenet-v3/Cargo.toml
+++ b/examples/tflite-mobilenet-v3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-tflite-mobilenet-v3"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-ffi"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/harness/core-proptest-pulse/Cargo.toml
+++ b/harness/core-proptest-pulse/Cargo.toml
@@ -2,7 +2,7 @@
 name = "core-proptest-pulse"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/harness/lstm-proptest-onnx-vs-tf/Cargo.toml
+++ b/harness/lstm-proptest-onnx-vs-tf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lstm-proptest-onnx-vs-tf"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/harness/nnef-inceptionv3/Cargo.toml
+++ b/harness/nnef-inceptionv3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nnef-inceptionv3"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/harness/tf-inceptionv3/Cargo.toml
+++ b/harness/tf-inceptionv3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tf-inceptionv3"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 image.workspace = true

--- a/harness/tf-mobilenet-v2/Cargo.toml
+++ b/harness/tf-mobilenet-v2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tf-mobilenet-v2"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 image.workspace = true

--- a/harness/tf-moz-deepspeech/Cargo.toml
+++ b/harness/tf-moz-deepspeech/Cargo.toml
@@ -3,7 +3,7 @@ name = "tf-moz-deepspeech"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 edition = "2021"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 log.workspace = true

--- a/hir/Cargo.toml
+++ b/hir/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-hir"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/libcli/Cargo.toml
+++ b/libcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-libcli"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-linalg"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/nnef/Cargo.toml
+++ b/nnef/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tract-nnef"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
 keywords = [ "NeuralNetworks", "NNEF" ]

--- a/nnef/nnef-resources/Cargo.toml
+++ b/nnef/nnef-resources/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
 	"Mathieu Poumeyrol <kali@zoy.org>",
 	"Hubert de La Jonquière <hubert.delajonquiere@sonos.com>"
 ]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
 keywords = [ "NeuralNetworks", "NNEF" ]

--- a/onnx-opl/Cargo.toml
+++ b/onnx-opl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tract-onnx-opl"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
 keywords = [ "TensorFlow", "NeuralNetworks", "ONNX" ]

--- a/onnx/Cargo.toml
+++ b/onnx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tract-onnx"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
 keywords = [ "TensorFlow", "NeuralNetworks", "ONNX" ]

--- a/pulse-opl/Cargo.toml
+++ b/pulse-opl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-pulse-opl"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/pulse/Cargo.toml
+++ b/pulse/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tract-pulse"
 version = "0.20.7-pre"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"

--- a/tensorflow/Cargo.toml
+++ b/tensorflow/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tract-tensorflow"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
 keywords = [ "TensorFlow", "NeuralNetworks", "ONNX" ]

--- a/test-rt/test-onnx-core/Cargo.toml
+++ b/test-rt/test-onnx-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-onnx-core"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]

--- a/tflite/Cargo.toml
+++ b/tflite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tract-tflite"
 version = "0.20.7-pre"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
 repository = "https://github.com/snipsco/tract"
 edition = "2021"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields