### PR TITLE
 fix: set constant inner tensor values upon "setting" variables 

### DIFF
--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -740,8 +740,7 @@ impl Parameters {
                 for node in m.eval_order()? {
                     let node = m.node_mut(node);
                     if let Some(op) = node.op_as_mut::<Const>() {
-                        match op.0.datum_type() {
-                            DatumType::TDim => {
+                        if op.0.datum_type() == DatumType::TDim { {
                                 // get inner value to Arc<Tensor>
                                 let mut constant = op.0.as_ref().clone();
                                 // Generally a shape or hyperparam
@@ -752,7 +751,6 @@ impl Parameters {
 
                                 op.0 = constant.into_arc_tensor();
                             }
-                            _ => {}
                         }
                     }
                 }

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -740,15 +740,15 @@ impl Parameters {
                 for node in m.eval_order()? {
                     let node = m.node_mut(node);
                     if node.op_is::<Const>() {
-                        // map option to err
+                        // safe to unwrap as we know it is a Const
                         let op = node
                             .op_as_mut::<Const>()
                             .unwrap();
-                        // get inner value to Arc<Tensor>
-                        let mut constant = op.0.as_ref().clone();
 
-                        match constant.datum_type() {
+                        match op.0.datum_type() {
                             DatumType::TDim => {
+                                // get inner value to Arc<Tensor>
+                                let mut constant = op.0.as_ref().clone();
                                 // Generally a shape or hyperparam
                                 constant
                                     .as_slice_mut::<tract_onnx::prelude::TDim>()?

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -739,12 +739,7 @@ impl Parameters {
             stage!("set", typed_model -> typed_model, |mut m: TypedModel| {
                 for node in m.eval_order()? {
                     let node = m.node_mut(node);
-                    if node.op_is::<Const>() {
-                        // safe to unwrap as we know it is a Const
-                        let op = node
-                            .op_as_mut::<Const>()
-                            .unwrap();
-
+                    if let Some(op) = node.op_as_mut::<Const>() {
                         match op.0.datum_type() {
                             DatumType::TDim => {
                                 // get inner value to Arc<Tensor>


### PR DESCRIPTION
Resolves #1279 on the cli by creating a routine within the --set feature of the tract cli which: 

1. Iterates over all constants in the graph 
2. If const's the inner tensor type is of type TDim then: 
    a) extract that tensor
    b) _evaluate_ the inner values using the symbol_values map previously established
3. _then_ concretize_dims for the entire graph 

Have confirmed that this update works on the network file provided in #1279 