### PR TITLE
Add NNEF support for `copy` operation

### DIFF
--- a/core/src/ops/math/mod.rs
+++ b/core/src/ops/math/mod.rs
@@ -579,6 +579,11 @@ element_wise!(neg, Neg, [i8, i16, i32, i64, f16, f32, f64, TDim] => |_, xs| {
 };
 q: [i8, u8, i32] => |x: f32| -x);
 
+element_wise!(copy, Copy, [i8, i16, i32, i64, f16, f32, f64, TDim] => |_, _| {
+    Ok(())
+};
+q: [i8, u8, i32] => |x: f32| x);
+
 element_wise!(sign, Sign, [f16, f32, f64] => |_, xs| {
     xs.iter_mut().for_each(|x| *x = if x.is_zero() { *x } else { x.signum() });
     Ok(())

--- a/nnef/src/ops/nnef/mod.rs
+++ b/nnef/src/ops/nnef/mod.rs
@@ -81,6 +81,8 @@ pub fn tract_nnef() -> Registry {
 
     registry.register_unit_element_wise("neg", &ops::math::Neg {});
 
+    registry.register_unit_element_wise("copy", &ops::math::Copy {});
+
     registry.register_element_wise(
         "leaky_relu",
         TypeId::of::<ops::nn::LeakyRelu>(),


### PR DESCRIPTION
For a `.nnef` model such as:

graph.nnef:
```
version 1.0;

graph main(external1) -> (copy1)
{
    external1 = external<scalar>(shape = [1, 28, 28]);
    copy1 = copy(external1);
}
```

graph.quant:
```
"external1": zero_point_linear_quantize(zero_point = 0, scale = 0.003921568859368563, bits = 8, signed = false, symmetric = false);
"copy1": zero_point_linear_quantize(zero_point = -128, scale = 0.003921568859368563, bits = 8, signed = true, symmetric = false);
```

Let me know if I should include a sample .nnef model for testing somewhere?