### PR TITLE
Update `itertools` from `0.10.1` to `0.12.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ fs2 = "0.4.3"
 getrandom = "0.2"
 half = { version="2.2.1", features = [ "std", "num-traits" ] }
 image = "0.24.1"
-itertools = "0.10.1"
+itertools = "0.12.1"
 home = "0.5.5"
 lazy_static = "1.4.0"
 liquid = "0.26"


### PR DESCRIPTION
Just a minor bump to reduce duplicated crates in the dependency tree of consumers.