### PR TITLE
Feat: elmwise unary ops quant unaligned zp scale

### DIFF
--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -572,10 +572,10 @@ macro_rules! bin_to_super_type {
                             let mut c = Tensor::zero_dt(*c_dt, &c_shape)?;
                             let view = c.to_array_view_mut::<u8>()?;
                             $crate::ndarray::Zip::from(view).and_broadcast(a).and_broadcast(b).for_each(|c, a, b| {
-                                *c = (($q_op_on_f32(
-                                            scale_by((*a as i32 - a_zp as i32) as f32, a_scale),
-                                            scale_by((*b as i32 - b_zp as i32) as f32, b_scale),
-                                ) * c_inv_scale) as i32
+                                *c = (scale_by($q_op_on_f32(
+                                            ((*a as i32 - a_zp as i32) as f32 * a_scale),
+                                            ((*b as i32 - b_zp as i32) as f32 * b_scale),
+                                ), c_inv_scale) as i32
                                     + *c_zp as i32)
                                     .clamp_cast()
                             });

--- a/core/src/ops/element_wise.rs
+++ b/core/src/ops/element_wise.rs
@@ -197,7 +197,7 @@ macro_rules! element_wise {
                 $(
                     $(
                        $(
-                        let input_dt = t.datum_type();
+                        let mut input_dt = t.datum_type();
                         let sout_dt = out_dt.unwrap_or(input_dt);
                         if sout_dt.unquantized() == <$typ_dt>::datum_type().unquantized() {
                            if input_dt.unquantized() != sout_dt.unquantized() {
@@ -207,6 +207,7 @@ macro_rules! element_wise {
                                    DatumType::I8 => t.clone().into_arc_tensor().offset_i8_as_u8(),
                                    unknown_dt => bail!("unexpected quantization input dt {:?}", unknown_dt)
                                }.into_tensor();
+                               input_dt = t.datum_type(); // because zero_point change
                            }
                            unsafe { t.set_datum_type(sout_dt) } // force cast
                            let t: &mut[$typ_dt] = t.as_slice_mut::<$typ_dt>()?;

--- a/core/src/ops/logic.rs
+++ b/core/src/ops/logic.rs
@@ -80,7 +80,7 @@ fn codegen_compare_to_zero(
                 model,
                 node,
                 &[uniform.var],
-                ElementWiseOp(mapped()),
+                ElementWiseOp(mapped(), None),
             )?));
         }
     }

--- a/core/src/ops/nn/mod.rs
+++ b/core/src/ops/nn/mod.rs
@@ -8,9 +8,12 @@ pub use self::softmax::{Softmax, SoftmaxExp};
 
 pub use crate::internal::*;
 
+use tract_num_traits::AsPrimitive;
+
 element_wise!(sigmoid, Sigmoid,
  [f16] => |_, xs| { (tract_linalg::ops().sigmoid_f16)().run(xs) },
  [f32] => |_, xs| { (tract_linalg::ops().sigmoid_f32)().run(xs) };
+ q: [i8, u8, i32, i32] => |x: f32| 1.0 / (1.0+(-x).exp());
  cost: |dt| {tvec!((Cost::FMA(dt), 11), (Cost::Div(dt), 1))}
 );
 

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -366,7 +366,7 @@ impl crate::ops::binary::BinMiniOp for Scale {
                 let factor = a.cast_to_scalar::<f32>()?;
                 let scaler = Scaler::new(factor, RoundingPolicy::Even);
 
-                let op = ElementWiseOp(Box::new(QScale { scaler }));
+                let op = ElementWiseOp(Box::new(QScale { scaler }), None);
                 let patch =
                     TypedModelPatch::replace_single_op(model, node, &node.inputs[1..2], op)?;
 
@@ -411,8 +411,8 @@ impl ElementWiseMiniOp for OffsetI8asU8 {
             input_type
         })
     }
-    fn eval_out_of_place(&self, t: &Tensor) -> TractResult<Tensor> {
-        let output_type = self.output_type(t.datum_type()).unwrap();
+    fn eval_out_of_place(&self, t: &Tensor, out_dt: Option<DatumType>) -> TractResult<Tensor> {
+        let output_type = out_dt.unwrap_or(self.output_type(t.datum_type()).unwrap());
         let mut dst = unsafe { Tensor::uninitialized_dt(output_type, t.shape())? };
         if t.datum_type().unquantized() == i8::datum_type() {
             t.as_slice::<i8>()?
@@ -427,7 +427,7 @@ impl ElementWiseMiniOp for OffsetI8asU8 {
 }
 
 pub fn offset_i8_as_u8() -> ElementWiseOp {
-    ElementWiseOp(Box::new(OffsetI8asU8 {}))
+    ElementWiseOp(Box::new(OffsetI8asU8 {}), None)
 }
 
 /// Offsets u8 integers as i8 integers.
@@ -451,8 +451,8 @@ impl ElementWiseMiniOp for OffsetU8asI8 {
             input_type
         })
     }
-    fn eval_out_of_place(&self, t: &Tensor) -> TractResult<Tensor> {
-        let output_type = self.output_type(t.datum_type()).unwrap();
+    fn eval_out_of_place(&self, t: &Tensor, out_dt: Option<DatumType>) -> TractResult<Tensor> {
+        let output_type = out_dt.unwrap_or(self.output_type(t.datum_type()).unwrap());
         let mut dst = unsafe { Tensor::uninitialized_dt(output_type, t.shape())? };
         if t.datum_type().unquantized() == u8::datum_type() {
             t.as_slice::<u8>()?
@@ -466,7 +466,7 @@ impl ElementWiseMiniOp for OffsetU8asI8 {
     }
 }
 pub fn offset_u8_as_i8() -> ElementWiseOp {
-    ElementWiseOp(Box::new(OffsetU8asI8 {}))
+    ElementWiseOp(Box::new(OffsetU8asI8 {}), None)
 }
 
 #[cfg(test)]

--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -1470,7 +1470,7 @@ impl Tensor {
         t.into_arc_tensor()
     }
 
-    /// Offsets the tensor as an u8 type if it's an u8 type, otherwise passes it unchanged.
+    /// Offsets the tensor as an u8 type if it's an i8 type, otherwise passes it unchanged.
     pub fn offset_i8_as_u8(self: &Arc<Self>) -> Arc<Self> {
         let mut t = if let DatumType::I8 = self.dt.unquantized() {
             self.to_array_view::<i8>().unwrap().mapv(|v| (v as u8).wrapping_add(128)).into_tensor()

--- a/hir/src/ops/element_wise.rs
+++ b/hir/src/ops/element_wise.rs
@@ -22,7 +22,7 @@ impl Expansion for ElementWiseOp {
         let wires = wire_cast(prefix, target, inputs, operating_datum_type)?;
         target.wire_node(
             prefix,
-            tract_core::ops::element_wise::ElementWiseOp(self.0.clone()),
+            tract_core::ops::element_wise::ElementWiseOp(self.0.clone(), None),
             &wires,
         )
     }

--- a/nnef/src/registry.rs
+++ b/nnef/src/registry.rs
@@ -190,11 +190,11 @@ impl Registry {
                 tract_core::ops::element_wise::ElementWiseOp(ew.1.clone(), c_dt),
                 &[input],
             )?;
-            if let Some(Some(assumed_out_dt)) = dt.first() {
+            if let Some(assumed_out_dt) = c_dt {
                 let out_dt = builder.model.outlet_fact(outlet[0])?.datum_type;
-                if out_dt != *assumed_out_dt {
+                if out_dt != assumed_out_dt {
                     return Ok(Some(
-                        builder.wire(tract_core::ops::cast::cast(*assumed_out_dt), &outlet)?,
+                        builder.wire(tract_core::ops::cast::cast(assumed_out_dt), &outlet)?,
                     ));
                 }
             }

--- a/nnef/src/registry.rs
+++ b/nnef/src/registry.rs
@@ -182,11 +182,12 @@ impl Registry {
                 .with_context(|| format!("Deserializing op `{}'", invocation.id.0))?;
             return Ok(Some(out_value));
         }
+        let c_dt: Option<DatumType> = dt.first().cloned().and_then(|dt| dt);
         if let Some(ew) = self.unit_element_wise_ops.iter().find(|ew| ew.0 == invocation.id) {
             let input =
                 invocation.arguments[0].rvalue.resolve(builder, &[])?.to::<OutletId>(builder)?;
             let outlet = builder.wire_as_outlets(
-                tract_core::ops::element_wise::ElementWiseOp(ew.1.clone()),
+                tract_core::ops::element_wise::ElementWiseOp(ew.1.clone(), c_dt),
                 &[input],
             )?;
             if let Some(Some(assumed_out_dt)) = dt.first() {

--- a/onnx-opl/src/is_inf.rs
+++ b/onnx-opl/src/is_inf.rs
@@ -38,13 +38,10 @@ pub fn dump(ast: &mut IntoAst, node: &TypedNode) -> TractResult<Option<Arc<RValu
     )))
 }
 
-pub fn load(
-    builder: &mut ModelBuilder,
-    invocation: &ResolvedInvocation,
-) -> TractResult<Value> {
+pub fn load(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> TractResult<Value> {
     let input = invocation.named_arg_as(builder, "input")?;
     let detect_positive = invocation.named_arg_as(builder, "detect_positive")?;
     let detect_negative = invocation.named_arg_as(builder, "detect_negative")?;
     let op = IsInf { detect_negative, detect_positive };
-    builder.wire(ElementWiseOp(Box::new(op)), &[input])
+    builder.wire(ElementWiseOp(Box::new(op), None), &[input])
 }

--- a/onnx/src/ops/cast.rs
+++ b/onnx/src/ops/cast.rs
@@ -17,7 +17,7 @@ fn cast(
     if to == i64::datum_type() {
         to = TDim::datum_type();
     }
-    Ok((ElementWiseOp(Box::new(Cast::new(to))).into_hir(), vec![]))
+    Ok((ElementWiseOp(Box::new(Cast::new(to)), None).into_hir(), vec![]))
 }
 
 #[derive(Debug, Clone, new, Hash)]
@@ -34,7 +34,7 @@ impl ElementWiseMiniOp for Cast {
         Some(self.to)
     }
 
-    fn eval_out_of_place(&self, t: &Tensor) -> TractResult<Tensor> {
+    fn eval_out_of_place(&self, t: &Tensor, _out_dt: Option<DatumType>) -> TractResult<Tensor> {
         if t.datum_type() == String::datum_type() && self.to == f32::datum_type() {
             unsafe {
                 let mut output = Tensor::uninitialized::<f32>(t.shape())?;

--- a/test-rt/suite-unit/src/conv_q.rs
+++ b/test-rt/suite-unit/src/conv_q.rs
@@ -12,6 +12,7 @@ use tract_itertools::izip;
 use tract_ndarray::*;
 
 use crate::conv_f32::ConvProblemParams;
+use crate::q_helpers::qtensor;
 
 /* https://www.tensorflow.org/lite/performance/quantization_spec
 CONV_2D
@@ -34,23 +35,6 @@ data_type  : int8
 range      : [-128, 127]
 granularity: per-tensor
 */
-
-pub fn qtensor(shape: Vec<usize>, dt: DatumType) -> BoxedStrategy<Tensor> {
-    assert!(dt.unquantized() == dt);
-    let len = shape.iter().product::<usize>();
-    let range = if dt.is_signed() { -100..100i32 } else { 0..100i32 };
-    vec(range, len..=len)
-        .prop_map(move |v| {
-            ArrayD::from_shape_vec(shape.clone(), v)
-                .unwrap()
-                .into_tensor()
-                .cast_to_dt(dt.unquantized())
-                .unwrap()
-                .into_owned()
-        })
-        .boxed()
-}
-
 #[allow(clippy::arc_with_non_send_sync)]
 pub fn q_params(
     params: &QConvProblemParams,

--- a/test-rt/suite-unit/src/lib.rs
+++ b/test-rt/suite-unit/src/lib.rs
@@ -11,7 +11,9 @@ pub mod conv_q;
 pub mod deconv;
 pub mod downsample;
 pub mod q_binary;
+pub mod q_elmwise;
 pub mod q_flavours;
+pub mod q_helpers;
 pub mod slice;
 
 pub fn suite() -> TractResult<TestSuite> {
@@ -23,6 +25,7 @@ pub fn suite() -> TractResult<TestSuite> {
     suite.add("q_flavours", q_flavours::suite()?);
     suite.add("slice", slice::suite()?);
     suite.add("q_binary", q_binary::suite()?);
+    suite.add("q_elmwise", q_elmwise::suite()?);
     Ok(suite)
 }
 

--- a/test-rt/suite-unit/src/q_binary.rs
+++ b/test-rt/suite-unit/src/q_binary.rs
@@ -2,7 +2,7 @@ use infra::{Test, TestSuite};
 use proptest::prelude::*;
 use tract_core::internal::*;
 
-use crate::conv_q::qtensor;
+use crate::q_helpers::*;
 
 #[derive(Debug, Clone)]
 struct QBinaryOpProblem {
@@ -24,24 +24,6 @@ impl Default for QBinaryOpProblem {
 }
 
 impl QBinaryOpProblem {
-    fn pick_signed_datum(signed: bool) -> DatumType {
-        if signed {
-            DatumType::I8
-        } else {
-            DatumType::U8
-        }
-    }
-
-    fn get_qtensor(values: Tensor, dt: DatumType, zp: Tensor, scale: f32) -> Tensor {
-        let mut values = values;
-        let zp = zp.cast_to_scalar::<i32>().unwrap();
-        let dt = dt.quantize(QParams::ZpScale { zero_point: zp, scale });
-        unsafe {
-            values.set_datum_type(dt);
-        }
-        values
-    }
-
     fn reference_float_ops(&self) -> TractResult<Tensor> {
         let a = self.tensor_a.cast_to::<f32>()?.clone().into_owned();
         let b = self.tensor_b.cast_to::<f32>()?.clone().into_owned();
@@ -73,9 +55,9 @@ impl Arbitrary for QBinaryOpProblem {
             tested_operators,
         )
             .prop_flat_map(|(len, a_signed, b_signed, c_signed, a_scale, b_scale, c_scale, op)| {
-                let a_dt = Self::pick_signed_datum(a_signed);
-                let b_dt = Self::pick_signed_datum(b_signed);
-                let c_dt = Self::pick_signed_datum(c_signed);
+                let a_dt = pick_signed_datum(a_signed);
+                let b_dt = pick_signed_datum(b_signed);
+                let c_dt = pick_signed_datum(c_signed);
                 fn just_scale(scale: usize) -> Just<f32> {
                     Just(scale as f32 * 0.5)
                 }
@@ -112,18 +94,10 @@ impl Arbitrary for QBinaryOpProblem {
                     c_scale,
                     op,
                 )| {
-                    let tensor_a = Self::get_qtensor(
-                        a_values.into_tensor(),
-                        a_dt,
-                        a_zp.into_tensor(),
-                        a_scale,
-                    );
-                    let tensor_b = Self::get_qtensor(
-                        b_values.into_tensor(),
-                        b_dt,
-                        b_zp.into_tensor(),
-                        b_scale,
-                    );
+                    let tensor_a =
+                        build_qtensor(a_values.into_tensor(), a_dt, a_zp.into_tensor(), a_scale);
+                    let tensor_b =
+                        build_qtensor(b_values.into_tensor(), b_dt, b_zp.into_tensor(), b_scale);
                     let c_dt = c_dt.quantize(QParams::ZpScale {
                         zero_point: c_zp.into_tensor().cast_to_scalar::<i32>().unwrap(),
                         scale: c_scale,
@@ -211,23 +185,6 @@ impl Test for QBinaryOpProblem {
 pub fn suite() -> TractResult<TestSuite> {
     let mut suite = TestSuite::default();
     suite.add_arbitrary::<QBinaryOpProblem>("proptest", ());
-
-    fn qu8_dt(zp: i32, scale: f32) -> DatumType {
-        u8::datum_type().quantize(QParams::ZpScale { zero_point: zp, scale })
-    }
-
-    fn qu8_tensor(tensor: Tensor, zp: i32, scale: f32) -> TractResult<Tensor> {
-        Ok(tensor.cast_to_dt(qu8_dt(zp, scale))?.into_owned())
-    }
-
-    fn qu8_tensor0(value: u8, zp: i32, scale: f32) -> TractResult<Tensor> {
-        qu8_tensor(tensor0(value), zp, scale)
-    }
-
-    fn qu8_tensor1(values: &[u8], zp: i32, scale: f32) -> TractResult<Tensor> {
-        qu8_tensor(tensor1(values), zp, scale)
-    }
-
     // simplification 0 at declutter constant
     suite.add(
         "trivial_mul_0_case",

--- a/test-rt/suite-unit/src/q_elmwise.rs
+++ b/test-rt/suite-unit/src/q_elmwise.rs
@@ -109,5 +109,13 @@ pub fn suite() -> TractResult<TestSuite> {
         },
     );
 
+    suite.add(
+        "cos_switch_qi8_to_qu8_case",
+        QElmWiseOpProblem {
+            operator: tract_core::ops::math::cos(),
+            tensor_input: qi8_tensor1(&[-16], 39, 0.5)?,
+            out_dt: qu8_dt(2, 0.5),
+        },
+    );
     Ok(suite)
 }

--- a/test-rt/suite-unit/src/q_elmwise.rs
+++ b/test-rt/suite-unit/src/q_elmwise.rs
@@ -1,0 +1,141 @@
+use infra::{Test, TestSuite};
+use proptest::prelude::*;
+use tract_core::internal::*;
+
+use crate::q_helpers::*;
+
+#[derive(Debug, Clone)]
+struct QElmWiseOpProblem {
+    operator: tract_core::ops::element_wise::ElementWiseOp,
+    tensor_input: Tensor,
+    out_dt: DatumType,
+}
+
+impl QElmWiseOpProblem {
+    fn reference_float_ops(&self) -> TractResult<Tensor> {
+        let inp = self.tensor_input.cast_to::<f32>()?.clone().into_owned();
+        Ok(self.operator.eval(tvec![inp.into_tvalue()])?.remove(0).into_tensor())
+    }
+}
+
+impl Arbitrary for QElmWiseOpProblem {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<QElmWiseOpProblem>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        let tested_operators =
+            prop_oneof![Just(tract_core::ops::math::cos()), Just(tract_core::ops::math::tanh()),];
+        ((1..20usize), any::<bool>(), any::<bool>(), (1..4usize), (1..4usize), tested_operators)
+            .prop_flat_map(|(len, inp_signed, out_signed, inp_scale, out_scale, op)| {
+                let inp_dt = pick_signed_datum(inp_signed);
+                let out_dt = pick_signed_datum(out_signed);
+                fn just_scale(scale: usize) -> Just<f32> {
+                    Just(scale as f32 * 0.5)
+                }
+                (
+                    // tensor a
+                    Just(inp_dt),
+                    qtensor(vec![1], inp_dt),
+                    just_scale(inp_scale),
+                    qtensor(vec![len], inp_dt),
+                    // dt of c
+                    Just(out_dt),
+                    qtensor(vec![1], out_dt),
+                    just_scale(out_scale),
+                    Just(op),
+                )
+            })
+            .prop_map(|(inp_dt, inp_zp, inp_scale, inp_values, out_dt, out_zp, out_scale, op)| {
+                let tensor_input = build_qtensor(
+                    inp_values.into_tensor(),
+                    inp_dt,
+                    inp_zp.into_tensor(),
+                    inp_scale,
+                );
+                let out_dt = out_dt.quantize(QParams::ZpScale {
+                    zero_point: out_zp.into_tensor().cast_to_scalar::<i32>().unwrap(),
+                    scale: out_scale,
+                });
+                QElmWiseOpProblem { operator: op.to_owned(), tensor_input, out_dt }
+            })
+            .boxed()
+    }
+}
+
+impl Test for QElmWiseOpProblem {
+    fn run_with_approx(
+        &self,
+        _suite: &str,
+        id: &str,
+        runtime: &dyn Runtime,
+        approx: Approximation,
+    ) -> infra::TestResult {
+        let mut model = TypedModel::default();
+        model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));
+
+        let inp = model.add_source(
+            "inp",
+            TypedFact::dt_shape(self.tensor_input.datum_type(), self.tensor_input.shape()),
+        )?;
+        // we need to wire correctly output to the provided operator {
+        let mut op = self.operator.clone();
+        op.1 = Some(self.out_dt);
+        // }
+        let out = model.wire_node("out", op, &[inp])?[0];
+        model.set_output_outlets(&[out])?;
+
+        let result = runtime
+            .prepare(model)?
+            .run(tvec![self.tensor_input.clone().into_tvalue()])?
+            .remove(0)
+            .into_tensor();
+        let mut reference = self.reference_float_ops()?;
+
+        let (zero_point, scale) = self.out_dt.zp_scale();
+        let min_repr_val = (self.out_dt.unquantized().min_value().cast_to_scalar::<f32>()?
+            - zero_point as f32)
+            * scale;
+        let max_repr_val = (self.out_dt.unquantized().max_value().cast_to_scalar::<f32>()?
+            - zero_point as f32)
+            * scale;
+
+        reference
+            .to_array_view_mut()?
+            .iter_mut()
+            .for_each(|x: &mut f32| *x = (*x).clamp(min_repr_val, max_repr_val));
+
+        let mut diff = result.cast_to::<f32>()?.into_owned();
+
+        let acceptable_scale_error_ratio = match approx {
+            Approximation::Exact => 0.,
+            Approximation::Approximate => 1.,
+            _ => 2.,
+        };
+        tract_core::ndarray::Zip::from(diff.to_array_view_mut()?)
+            .and(reference.to_array_view()?)
+            .for_each(|x: &mut f32, xref: &f32| {
+                dbg!(&x);
+                let closest_x = (*x).clamp(min_repr_val, max_repr_val);
+                // core maximal accepted distance by default
+                assert!((xref - closest_x).abs() <= scale * acceptable_scale_error_ratio)
+            });
+        Ok(())
+    }
+}
+
+pub fn suite() -> TractResult<TestSuite> {
+    let mut suite = TestSuite::default();
+    suite.add_arbitrary::<QElmWiseOpProblem>("proptest", ());
+
+    // simplification 0 at declutter constant
+    suite.add(
+        "trivial_tanh_0_case",
+        QElmWiseOpProblem {
+            operator: tract_core::ops::math::tanh(),
+            tensor_input: qu8_tensor0(0u8, 0, 1.)?,
+            out_dt: qu8_dt(0, 1.),
+        },
+    );
+
+    Ok(suite)
+}

--- a/test-rt/suite-unit/src/q_elmwise.rs
+++ b/test-rt/suite-unit/src/q_elmwise.rs
@@ -101,11 +101,11 @@ pub fn suite() -> TractResult<TestSuite> {
     suite.add_arbitrary::<QElmWiseOpProblem>("proptest", ());
 
     suite.add(
-        "trivial_tanh_0_case",
+        "tanh_sweep_case",
         QElmWiseOpProblem {
             operator: tract_core::ops::math::tanh(),
-            tensor_input: qu8_tensor0(0u8, 0, 1.)?,
-            out_dt: qu8_dt(0, 1.),
+            tensor_input: qu8_tensor1(&(0u8..=100).collect::<Box<[u8]>>(), 50, 0.05)?,
+            out_dt: qu8_dt(127, 0.001),
         },
     );
 

--- a/test-rt/suite-unit/src/q_flavours.rs
+++ b/test-rt/suite-unit/src/q_flavours.rs
@@ -3,7 +3,7 @@ use proptest::prelude::*;
 use tract_core::internal::*;
 use tract_core::ops::quant::{offset_i8_as_u8, offset_u8_as_i8};
 
-use crate::conv_q::qtensor;
+use crate::q_helpers::qtensor;
 
 #[derive(Debug, Clone, Default)]
 struct QFlavoursProblem {

--- a/test-rt/suite-unit/src/q_helpers.rs
+++ b/test-rt/suite-unit/src/q_helpers.rs
@@ -1,0 +1,54 @@
+use proptest::collection::vec;
+use proptest::prelude::*;
+use tract_core::internal::*;
+use tract_ndarray::*;
+
+pub fn qtensor(shape: Vec<usize>, dt: DatumType) -> BoxedStrategy<Tensor> {
+    assert!(dt.unquantized() == dt);
+    let len = shape.iter().product::<usize>();
+    let range = if dt.is_signed() { -100..100i32 } else { 0..100i32 };
+    vec(range, len..=len)
+        .prop_map(move |v| {
+            ArrayD::from_shape_vec(shape.clone(), v)
+                .unwrap()
+                .into_tensor()
+                .cast_to_dt(dt.unquantized())
+                .unwrap()
+                .into_owned()
+        })
+        .boxed()
+}
+
+pub fn build_qtensor(values: Tensor, dt: DatumType, zp: Tensor, scale: f32) -> Tensor {
+    let mut values = values;
+    let zp = zp.cast_to_scalar::<i32>().unwrap();
+    let dt = dt.quantize(QParams::ZpScale { zero_point: zp, scale });
+    unsafe {
+        values.set_datum_type(dt);
+    }
+    values
+}
+
+pub fn pick_signed_datum(signed: bool) -> DatumType {
+    if signed {
+        DatumType::I8
+    } else {
+        DatumType::U8
+    }
+}
+
+pub fn qu8_dt(zp: i32, scale: f32) -> DatumType {
+    u8::datum_type().quantize(QParams::ZpScale { zero_point: zp, scale })
+}
+
+pub fn qu8_tensor(tensor: Tensor, zp: i32, scale: f32) -> TractResult<Tensor> {
+    Ok(tensor.cast_to_dt(qu8_dt(zp, scale))?.into_owned())
+}
+
+pub fn qu8_tensor0(value: u8, zp: i32, scale: f32) -> TractResult<Tensor> {
+    qu8_tensor(tensor0(value), zp, scale)
+}
+
+pub fn qu8_tensor1(values: &[u8], zp: i32, scale: f32) -> TractResult<Tensor> {
+    qu8_tensor(tensor1(values), zp, scale)
+}

--- a/test-rt/suite-unit/src/q_helpers.rs
+++ b/test-rt/suite-unit/src/q_helpers.rs
@@ -52,3 +52,38 @@ pub fn qu8_tensor0(value: u8, zp: i32, scale: f32) -> TractResult<Tensor> {
 pub fn qu8_tensor1(values: &[u8], zp: i32, scale: f32) -> TractResult<Tensor> {
     qu8_tensor(tensor1(values), zp, scale)
 }
+
+pub trait QOpProblem {
+    fn reference_float_ops(&self) -> TractResult<Tensor>;
+
+    fn check_ref_with_approx(&self, result: Tensor, approx: Approximation) -> infra::TestResult {
+        let mut reference = self.reference_float_ops()?;
+        let out_dt = result.datum_type();
+        let (zero_point, scale) = out_dt.zp_scale();
+        let min_repr_val =
+            (out_dt.unquantized().min_value().cast_to_scalar::<f32>()? - zero_point as f32) * scale;
+        let max_repr_val =
+            (out_dt.unquantized().max_value().cast_to_scalar::<f32>()? - zero_point as f32) * scale;
+
+        reference
+            .to_array_view_mut()?
+            .iter_mut()
+            .for_each(|x: &mut f32| *x = (*x).clamp(min_repr_val, max_repr_val));
+
+        let mut fp_results = result.cast_to::<f32>()?.into_owned();
+
+        let acceptable_scale_error_ratio = match approx {
+            Approximation::Exact => 0.,
+            Approximation::Approximate => 2.,
+            _ => 3.,
+        };
+        assert!(tract_core::ndarray::Zip::from(fp_results.to_array_view_mut()?)
+            .and(reference.to_array_view()?)
+            .all(|x: &mut f32, xref: &f32| {
+                let closest_x = (*x).clamp(min_repr_val, max_repr_val);
+                // core maximal accepted distance by default
+                (xref - closest_x).abs() <= scale * acceptable_scale_error_ratio
+            }));
+        Ok(())
+    }
+}

--- a/test-rt/suite-unit/src/q_helpers.rs
+++ b/test-rt/suite-unit/src/q_helpers.rs
@@ -38,7 +38,7 @@ pub fn pick_signed_datum(signed: bool) -> DatumType {
 }
 
 pub fn qu8_dt(zp: i32, scale: f32) -> DatumType {
-    u8::datum_type().quantize(QParams::ZpScale { zero_point: zp, scale })
+    u8::datum_type().with_zp_scale(zp, scale)
 }
 
 pub fn qu8_tensor(tensor: Tensor, zp: i32, scale: f32) -> TractResult<Tensor> {

--- a/test-rt/suite-unit/src/q_helpers.rs
+++ b/test-rt/suite-unit/src/q_helpers.rs
@@ -41,8 +41,16 @@ pub fn qu8_dt(zp: i32, scale: f32) -> DatumType {
     u8::datum_type().with_zp_scale(zp, scale)
 }
 
+pub fn qi8_dt(zp: i32, scale: f32) -> DatumType {
+    i8::datum_type().with_zp_scale(zp, scale)
+}
+
 pub fn qu8_tensor(tensor: Tensor, zp: i32, scale: f32) -> TractResult<Tensor> {
     Ok(tensor.cast_to_dt(qu8_dt(zp, scale))?.into_owned())
+}
+
+pub fn qi8_tensor(tensor: Tensor, zp: i32, scale: f32) -> TractResult<Tensor> {
+    Ok(tensor.cast_to_dt(qi8_dt(zp, scale))?.into_owned())
 }
 
 pub fn qu8_tensor0(value: u8, zp: i32, scale: f32) -> TractResult<Tensor> {
@@ -51,6 +59,10 @@ pub fn qu8_tensor0(value: u8, zp: i32, scale: f32) -> TractResult<Tensor> {
 
 pub fn qu8_tensor1(values: &[u8], zp: i32, scale: f32) -> TractResult<Tensor> {
     qu8_tensor(tensor1(values), zp, scale)
+}
+
+pub fn qi8_tensor1(values: &[i8], zp: i32, scale: f32) -> TractResult<Tensor> {
+    qi8_tensor(tensor1(values), zp, scale)
 }
 
 pub trait QOpProblem {

--- a/test-rt/test-tflite/suite.rs
+++ b/test-rt/test-tflite/suite.rs
@@ -138,7 +138,7 @@ fn ignore_unit(t: &[String], case: &dyn Test) -> bool {
         }
     }
     let [section, _unit] = t else { return false };
-    ["deconv", "q_flavours", "q_binary"].contains(&&**section)
+    ["deconv", "q_flavours", "q_binary", "q_elmwise"].contains(&&**section)
 }
 
 fn compatible_conv_f32(qcp: &ConvProblem) -> bool {


### PR DESCRIPTION
This PR is a follow-up of binary op quantization for unary ops (like activations).

- increase precision of q for binary by removing unnecessary `scale_by`
- add output datatype for all unary operations from NNEF
- use this output datatype for the dequant->f32 op->requant default ops
- add prop-test problem for unary (refactor joint with binary)
- add sigmoid default basic q implementation
