### PR TITLE
Try to coerce f32 value from Dim (i64)

### DIFF
--- a/nnef/src/deser.rs
+++ b/nnef/src/deser.rs
@@ -750,6 +750,7 @@ impl CoerceFrom<Value> for f32 {
     fn coerce(builder: &mut ModelBuilder, from: &Value) -> TractResult<Self> {
         match from {
             Value::Scalar(f) => Ok(*f),
+            Value::Dim(d) => Ok(d.to_i64()? as f32),
             Value::Tensor(t) => Ok(*t.to_scalar::<f32>()?),
             Value::Wire(_) => {
                 Ok(*from.to::<Arc<Tensor>>(builder)?.cast_to::<f32>()?.to_scalar::<f32>()?)


### PR DESCRIPTION
NNEF deserialization can fail if a floating-point whole number is expressed as an integer. For example "1" instead of "1.0" results in `Can not build a f32 from Dim(Val(1))`

If `Dim.to_i64` is successful, then the result can be cast to `f32`.