### PR TITLE
[Metal] Rewrite rules: Remove MetalSyncToCPU between Const and CPU Operator

### DIFF
--- a/metal/src/ops/sync.rs
+++ b/metal/src/ops/sync.rs
@@ -1,8 +1,8 @@
 use crate::fact::MetalTypedFactExt;
 pub use crate::kernels::BinOps;
-use crate::tensor::MetalTensorExt;
 use crate::ops::MetalEvalOp;
-use crate::{ MetalFact, IntoMetal, MetalContext };
+use crate::tensor::MetalTensorExt;
+use crate::{IntoMetal, MetalContext, MetalFact};
 use derive_new::new;
 use std::fmt;
 use tract_core::internal::*;

--- a/metal/src/rewrite_rules/mod.rs
+++ b/metal/src/rewrite_rules/mod.rs
@@ -12,7 +12,7 @@ use tract_core::ops::konst::Const;
 pub use apply_rope::{as_apply_rope_rule, BasicApplyRope};
 pub use fuse_axis_op::fuse_axis_op;
 pub use new_gelu::{as_new_gelu_rule, BasicNewGelu};
-pub use rewire_metal_sync::rewire_metal_sync;
+pub use rewire_metal_sync::{rewire_metal_sync, rewire_metal_sync_after_const};
 pub use rms_norm::{as_rms_norm_rule, remove_rms_norm_cast, BasicRmsNorm};
 pub use rotate_half::{as_rotate_half_rule, BasicRotateHalf};
 pub use silu::{as_silu_rule, BasicSilu};

--- a/metal/src/rewrite_rules/rewire_metal_sync.rs
+++ b/metal/src/rewrite_rules/rewire_metal_sync.rs
@@ -46,10 +46,8 @@ pub fn rewire_metal_sync_after_const(
     rule_ensure!(sync_cpu_op.kind == MetalSyncKind::ToCpu);
 
     let mut patch = TypedModelPatch::default();
-
-    let konst_input = patch.taps(model, &node.inputs)?;
     let out =
-        patch.wire_node(format!("{node_name}"), Const(cpu_const.into(), None), &konst_input)?;
+        patch.wire_node(format!("{node_name}"), Const(cpu_const.into(), None), &[])?;
     patch.shunt_outside(model, sync_cpu.id.into(), out[0])?;
     Ok(Some(patch))
 }

--- a/metal/src/rewrite_rules/rewire_metal_sync.rs
+++ b/metal/src/rewrite_rules/rewire_metal_sync.rs
@@ -46,8 +46,7 @@ pub fn rewire_metal_sync_after_const(
     rule_ensure!(sync_cpu_op.kind == MetalSyncKind::ToCpu);
 
     let mut patch = TypedModelPatch::default();
-    let out =
-        patch.wire_node(format!("{node_name}"), Const(cpu_const.into(), None), &[])?;
+    let out = patch.wire_node(node_name.to_string(), Const(cpu_const.into(), None), &[])?;
     patch.shunt_outside(model, sync_cpu.id.into(), out[0])?;
     Ok(Some(patch))
 }

--- a/metal/src/rewrite_rules/rewire_metal_sync.rs
+++ b/metal/src/rewrite_rules/rewire_metal_sync.rs
@@ -40,7 +40,7 @@ pub fn rewire_metal_sync_after_const(
     let Some(gpu_const) = op.0.as_metal_tensor() else { return Ok(None) };
     let cpu_const = gpu_const.to_cpu()?;
 
-    // Identify precessor ToCpu
+    // Identify successor ToCpu
     let Some(sync_cpu) = next_node(model, node) else { return Ok(None) };
     let Some(sync_cpu_op) = sync_cpu.op_as::<MetalSync>() else { return Ok(None) };
     rule_ensure!(sync_cpu_op.kind == MetalSyncKind::ToCpu);

--- a/metal/src/rewrite_rules/rewire_metal_sync.rs
+++ b/metal/src/rewrite_rules/rewire_metal_sync.rs
@@ -1,7 +1,9 @@
 use crate::ops::{MetalSync, MetalSyncKind};
-use crate::rewrite_rules::previous_node;
+use crate::rewrite_rules::{next_node, previous_node};
 use crate::rule_ensure;
+use crate::tensor::MetalTensorExt;
 use tract_core::internal::*;
+use tract_core::ops::konst::Const;
 
 pub fn rewire_metal_sync(
     _ctx: &(),
@@ -23,5 +25,31 @@ pub fn rewire_metal_sync(
         TypedModelPatch::rewire(model, &sync_cpu_prec.inputs, &[node.id.into()], &|_p, xs| {
             Ok(xs.into())
         })?;
+    Ok(Some(patch))
+}
+
+pub fn rewire_metal_sync_after_const(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &Const,
+) -> TractResult<Option<TypedModelPatch>> {
+    // Search pattern => Const => ToCPU
+
+    let Some(gpu_const) = op.0.as_metal_tensor() else { return Ok(None) };
+    let cpu_const = gpu_const.to_cpu()?;
+
+    // Identify precessor ToCpu
+    let Some(sync_cpu) = next_node(model, node) else { return Ok(None) };
+    let Some(sync_cpu_op) = sync_cpu.op_as::<MetalSync>() else { return Ok(None) };
+    rule_ensure!(sync_cpu_op.kind == MetalSyncKind::ToCpu);
+
+    let mut patch = TypedModelPatch::default();
+
+    let konst_input = patch.taps(model, &node.inputs)?;
+    let out =
+        patch.wire_node(format!("{node_name}"), Const(cpu_const.into(), None), &konst_input)?;
+    patch.shunt_outside(model, sync_cpu.id.into(), out[0])?;
     Ok(Some(patch))
 }


### PR DESCRIPTION
After making MetalSyncToCpu stateful to avoid PropConst with Metal Op, some MetalSyncToCPUs were reintroduced which slow down the execution. This rewrite rule remove these ones. 