### PR TITLE
Metal Ops Pre-SyncToCPU outputs owned tensor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ liquid-core = "0.26"
 log = "0.4.14"
 maplit = "1.0.2"
 memmap2 = "0.9"
-metal = { version = "0.27.0", features = ["mps"] }
+metal = { version = "0.30.0", features = ["mps"] }
 ndarray = "0.16"
 ndarray-npy = { version = "0.9.1", features = [ "compressed_npz" ] }
 nom = "7.0.0"

--- a/metal/src/memory/schema.rs
+++ b/metal/src/memory/schema.rs
@@ -1,5 +1,5 @@
 use crate::fact::MetalTypedFactExt;
-use crate::ops::{MetalSync, MetalSyncKind};
+use crate::ops::MetalSyncKind;
 use std::fmt;
 use std::fmt::Debug;
 use tract_core::internal::*;
@@ -37,7 +37,7 @@ impl Lifetime {
 }
 
 fn next_nodes<'a>(model: &'a TypedModel, node: &TypedNode) -> Option<TVec<&'a TypedNode>> {
-    if node.outputs.len() == 0 { return None };
+    if node.outputs.is_empty() { return None };
 
     Some(node.outputs.iter().map(|o| {
         o.successors.iter().map(|succ| {


### PR DESCRIPTION
Some time is wasted in SyncToCPU ops as the inputs are in most cases ArenaView tensors we need to copy to an Owned tensor. This PR makes those outputs "Owned" so SyncToCpu only clone the reference. On OpenELM f16 the gain is of ~2%


