### PR TITLE
Metal: Single Encoder per Cmd Buffer + Disable Profiling

### DIFF
--- a/cli/src/compare.rs
+++ b/cli/src/compare.rs
@@ -195,7 +195,7 @@ pub fn handle_pbdir(
         let tensor = tract_onnx::tensor::proto_from_reader(file)?;
         let name = tensor.name.to_string();
         let value: Tensor = load_tensor(&FopenDataResolver, &tensor, None)?;
-        values.insert(name, vec!(Ok(value.into_tvalue())));
+        values.insert(name, vec![Ok(value.into_tvalue())]);
     }
     dispatch_model_no_pulse!(params.tract_model, |m| compare(
         cumulative,
@@ -358,7 +358,7 @@ where
                     tags.labels.push(Red.paint("Unimplemented").to_string());
                     failing.insert(node.id);
                 } else {
-                    log::info!("{}", format!("Running {node}"));
+                    log::info!("Running {node}");
                     let obtained = tract_core::plan::eval(session_state, state, node, input);
                     match obtained {
                         Err(e) => {

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -128,24 +128,22 @@ pub fn handle(
             .context("Can only profile typed models")?;
         let inputs = retrieve_or_make_inputs(model, &run_params)?;
 
-        // Metal Profiling is broken, just run standard profiling
-
-        //if matches.is_present("metal") {
-        //    #[cfg(any(target_os = "macos", target_os = "ios"))]
-        //    {
-        //        tract_libcli::profile::profile_metal(
-        //            model,
-        //            bench_limits,
-        //            &mut annotations,
-        //            &plan_options,
-        //            &inputs[0],
-        //        )?;
-        //    }
-        //    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-        //    {
-        //        bail!("Metal profiling called on non-Metal device");
-        //    }
-        //} else {
+        if matches.is_present("metal") {
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            {
+                tract_libcli::profile::profile_metal(
+                    model,
+                    bench_limits,
+                    &mut annotations,
+                    &plan_options,
+                    &inputs[0],
+                )?;
+            }
+            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+            {
+                bail!("Metal profiling called on non-Metal device");
+            }
+        } else {
             tract_libcli::profile::profile(
                 model,
                 bench_limits,
@@ -155,7 +153,7 @@ pub fn handle(
                 None,
                 options.folded,
             )?;
-        //}
+        }
     }
 
     if sub_matches.is_present("axes") || sub_matches.is_present("axes-names") {

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -128,22 +128,24 @@ pub fn handle(
             .context("Can only profile typed models")?;
         let inputs = retrieve_or_make_inputs(model, &run_params)?;
 
-        if matches.is_present("metal") {
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
-            {
-                tract_libcli::profile::profile_metal(
-                    model,
-                    bench_limits,
-                    &mut annotations,
-                    &plan_options,
-                    &inputs[0],
-                )?;
-            }
-            #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-            {
-                bail!("Metal profiling called on non-Metal device");
-            }
-        } else {
+        // Metal Profiling is broken, just run standrad profiling
+
+        //if matches.is_present("metal") {
+        //    #[cfg(any(target_os = "macos", target_os = "ios"))]
+        //    {
+        //        tract_libcli::profile::profile_metal(
+        //            model,
+        //            bench_limits,
+        //            &mut annotations,
+        //            &plan_options,
+        //            &inputs[0],
+        //        )?;
+        //    }
+        //    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        //    {
+        //        bail!("Metal profiling called on non-Metal device");
+        //    }
+        //} else {
             tract_libcli::profile::profile(
                 model,
                 bench_limits,
@@ -153,7 +155,7 @@ pub fn handle(
                 None,
                 options.folded,
             )?;
-        }
+        //}
     }
 
     if sub_matches.is_present("axes") || sub_matches.is_present("axes-names") {

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -128,7 +128,7 @@ pub fn handle(
             .context("Can only profile typed models")?;
         let inputs = retrieve_or_make_inputs(model, &run_params)?;
 
-        // Metal Profiling is broken, just run standrad profiling
+        // Metal Profiling is broken, just run standard profiling
 
         //if matches.is_present("metal") {
         //    #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -181,10 +181,11 @@ pub fn handle(
                     .downcast_ref::<TypedModel>()
                     .context("Check memory arena requires a typed model")?,
                 &plan_options_from_subcommand(sub_matches)?,
-                std::path::Path::new(sub_matches
-                    .value_of("memory-arena")
-                    .ok_or(anyhow!("Path to JSON file required"))?)
-                    .to_path_buf(),
+                std::path::Path::new(
+                    sub_matches
+                        .value_of("memory-arena")
+                        .ok_or(anyhow!("Path to JSON file required"))?,
+                ),
             )?;
         }
         #[cfg(not(any(target_os = "macos", target_os = "ios")))]

--- a/cli/src/memory_arena.rs
+++ b/cli/src/memory_arena.rs
@@ -14,12 +14,12 @@ struct MemArenaUsage {
 impl MemArenaUsage {
     pub fn eval_from_schema(
         schema: &MetalMemSchema,
-        symbol_values: &SymbolValues
+        symbol_values: &SymbolValues,
     ) -> TractResult<Self> {
         Ok(Self {
-            arena_memory_size: schema.eval_memory_size(&symbol_values)?,
-            peak_memory_size: schema.eval_peak_memory_size(&symbol_values)?,
-            peak_memory_usage: schema.eval_usage(&symbol_values)?,
+            arena_memory_size: schema.eval_memory_size(symbol_values)?,
+            peak_memory_size: schema.eval_peak_memory_size(symbol_values)?,
+            peak_memory_usage: schema.eval_usage(symbol_values)?,
         })
     }
 }
@@ -60,7 +60,7 @@ impl MemArenaMetrics {
             let symbol_values = SymbolValues::default()
                 .with(&sequence_length, s)
                 .with(&past_sequence_length, 0);
-            let usage = MemArenaUsage::eval_from_schema(&schema, &symbol_values)?;
+            let usage = MemArenaUsage::eval_from_schema(schema, &symbol_values)?;
             max_memory_size = max_memory_size.max(usage.arena_memory_size);
             sum_size += usage.arena_memory_size;
             sum_used += usage.peak_memory_size;
@@ -72,7 +72,7 @@ impl MemArenaMetrics {
             let symbol_values = SymbolValues::default()
                 .with(&sequence_length, 1)
                 .with(&past_sequence_length, p);
-            let usage = MemArenaUsage::eval_from_schema(&schema, &symbol_values)?;
+            let usage = MemArenaUsage::eval_from_schema(schema, &symbol_values)?;
             max_memory_size = max_memory_size.max(usage.arena_memory_size);
             sum_size += usage.arena_memory_size;
             sum_used += usage.peak_memory_size;

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -1125,7 +1125,7 @@ pub fn display_params_from_clap(
         },
         info: matches.is_present("info"),
         json: matches.is_present("json"),
-        mm: matches.is_present("mm")
+        mm: matches.is_present("mm"),
     })
 }
 

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -1125,8 +1125,7 @@ pub fn display_params_from_clap(
         },
         info: matches.is_present("info"),
         json: matches.is_present("json"),
-        mm: matches.is_present("mm"),
-        has_accelerator: root_matches.is_present("metal"),
+        mm: matches.is_present("mm")
     })
 }
 

--- a/libcli/src/display_params.rs
+++ b/libcli/src/display_params.rs
@@ -30,7 +30,6 @@ pub struct DisplayParams {
     pub json: bool,
     pub info: bool,
     pub left_column_width: usize,
-    pub has_accelerator: bool,
     pub mm: bool,
 }
 

--- a/libcli/src/profile.rs
+++ b/libcli/src/profile.rs
@@ -166,12 +166,14 @@ pub fn rec_profiler_metal(
     inputs: &TVec<TValue>,
     prefix: &[(usize, String)],
 ) -> TractResult<(TVec<TValue>, Duration)> {
-    tract_metal::METAL_CONTEXT.with_borrow(|ctxt| {
-        let (mut cpu_start, mut gpu_start): (u64, u64) = (0, 0);
-        ctxt.device().sample_timestamps(&mut cpu_start, &mut gpu_start);
+    // Metal profiler is broken, only profile CPU
 
-        let n_nodes = state.plan().model().nodes_len();
-        let (result, eval_dur, profiler) = ctxt.profile(n_nodes, || {
+    //tract_metal::METAL_CONTEXT.with_borrow(|ctxt| {
+    //    let (mut cpu_start, mut gpu_start): (u64, u64) = (0, 0);
+    //    ctxt.device().sample_timestamps(&mut cpu_start, &mut gpu_start);
+//
+    //    let n_nodes = state.plan().model().nodes_len();
+    //    let (result, eval_dur, profiler) = ctxt.profile(n_nodes, || {
             let profile_start = crate::time::now();
             let r = state.run_plan_with_eval(
                 inputs.clone(),
@@ -193,21 +195,21 @@ pub fn rec_profiler_metal(
             )?;
 
             Ok((r, profile_start.elapsed()))
-        })?;
-
-        let (mut cpu_end, mut gpu_end): (u64, u64) = (0, 0);
-        ctxt.device().sample_timestamps(&mut cpu_end, &mut gpu_end);
-
-        profiler.iter().enumerate().for_each(|(node_id, duration)| {
-            let node_id = NodeQId(prefix.into(), node_id);
-            *dg.node_mut(node_id).accelerator_profile.get_or_insert(Duration::default()) +=
-                Duration::from_nanos(tract_metal::utils::rescale_gpu_duration(
-                    *duration, cpu_start, cpu_end, gpu_start, gpu_end,
-                ));
-        });
-
-        Ok((result, eval_dur))
-    })
+    //    })?;
+//
+    //    let (mut cpu_end, mut gpu_end): (u64, u64) = (0, 0);
+    //    ctxt.device().sample_timestamps(&mut cpu_end, &mut gpu_end);
+//
+    //    profiler.iter().enumerate().for_each(|(node_id, duration)| {
+    //        let node_id = NodeQId(prefix.into(), node_id);
+    //        *dg.node_mut(node_id).accelerator_profile.get_or_insert(Duration::default()) +=
+    //            Duration::from_nanos(tract_metal::utils::rescale_gpu_duration(
+    //                *duration, cpu_start, cpu_end, gpu_start, gpu_end,
+    //            ));
+    //    });
+//
+    //    Ok((result, eval_dur))
+    //})
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/metal/src/command_buffer.rs
+++ b/metal/src/command_buffer.rs
@@ -1,5 +1,6 @@
 use metal::{
-    Buffer, CommandBuffer, ComputeCommandEncoder, ComputeCommandEncoderRef, ComputePassDescriptor, CounterSampleBuffer, CounterSampleBufferDescriptor, Device, MTLResourceOptions, NSRange
+    Buffer, CommandBuffer, ComputeCommandEncoder, ComputeCommandEncoderRef, ComputePassDescriptor,
+    CounterSampleBuffer, CounterSampleBufferDescriptor, Device, MTLResourceOptions, NSRange,
 };
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
@@ -159,7 +160,6 @@ impl TCommandBuffer {
             );
             blit_encoder.end_encoding();
         } else {
-            //let encoder = self.inner.new_compute_command_encoder();
             encode_cb(&self.encoder);
         };
     }

--- a/metal/src/command_buffer.rs
+++ b/metal/src/command_buffer.rs
@@ -1,6 +1,5 @@
 use metal::{
-    Buffer, CommandBuffer, ComputeCommandEncoderRef, ComputePassDescriptor, CounterSampleBuffer,
-    CounterSampleBufferDescriptor, Device, MTLResourceOptions, NSRange,
+    Buffer, CommandBuffer, ComputeCommandEncoder, ComputeCommandEncoderRef, ComputePassDescriptor, CounterSampleBuffer, CounterSampleBufferDescriptor, Device, MTLResourceOptions, NSRange
 };
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
@@ -121,6 +120,7 @@ impl MetalProfiler {
 #[derive(Debug, Clone)]
 pub struct TCommandBuffer {
     inner: CommandBuffer,
+    encoder: ComputeCommandEncoder,
     profiler: Option<Rc<RefCell<MetalProfiler>>>,
 }
 
@@ -129,7 +129,12 @@ impl TCommandBuffer {
         command_buffer: CommandBuffer,
         profiler: Option<Rc<RefCell<MetalProfiler>>>,
     ) -> Self {
-        TCommandBuffer { inner: command_buffer, profiler }
+        let encoder = command_buffer.new_compute_command_encoder().to_owned();
+        TCommandBuffer { inner: command_buffer, encoder, profiler: None }
+    }
+
+    pub fn encoder(&self) -> &ComputeCommandEncoder {
+        &self.encoder
     }
 
     pub fn encode<EncodeCallback>(&self, encode_cb: EncodeCallback)
@@ -154,8 +159,8 @@ impl TCommandBuffer {
             );
             blit_encoder.end_encoding();
         } else {
-            let encoder = self.inner.new_compute_command_encoder();
-            encode_cb(encoder);
+            //let encoder = self.inner.new_compute_command_encoder();
+            encode_cb(&self.encoder);
         };
     }
 }

--- a/metal/src/command_buffer.rs
+++ b/metal/src/command_buffer.rs
@@ -130,7 +130,7 @@ impl TCommandBuffer {
         profiler: Option<Rc<RefCell<MetalProfiler>>>,
     ) -> Self {
         let encoder = command_buffer.new_compute_command_encoder().to_owned();
-        TCommandBuffer { inner: command_buffer, encoder, profiler: None }
+        TCommandBuffer { inner: command_buffer, encoder, profiler }
     }
 
     pub fn encoder(&self) -> &ComputeCommandEncoder {

--- a/metal/src/context.rs
+++ b/metal/src/context.rs
@@ -257,9 +257,9 @@ impl MetalContext {
         }
         let command_buffer_id = self.command_buffer_id.load(Ordering::Relaxed);
         command_buffer.commit();
-        log::info!("Command buffer {:?} commit", command_buffer_id);
+        log::trace!("Command buffer {:?} commit", command_buffer_id);
         command_buffer.wait_until_completed();
-        log::info!("Command buffer {:?} has completed (Blocking call)", command_buffer_id);
+        log::trace!("Command buffer {:?} has completed (Blocking call)", command_buffer_id);
 
         // Clear local retained values used by the command buffer
         self.retained_tensors.borrow_mut().clear();

--- a/metal/src/context.rs
+++ b/metal/src/context.rs
@@ -245,6 +245,8 @@ impl MetalContext {
     pub fn wait_until_completed(&self) -> Result<()> {
         let Some(command_buffer) = self.command_buffer.borrow().to_owned() else { return Ok(()) };
 
+        command_buffer.encoder().end_encoding();
+
         match command_buffer.status() {
             metal::MTLCommandBufferStatus::Committed
             | metal::MTLCommandBufferStatus::Scheduled
@@ -255,9 +257,9 @@ impl MetalContext {
         }
         let command_buffer_id = self.command_buffer_id.load(Ordering::Relaxed);
         command_buffer.commit();
-        log::trace!("Command buffer {:?} commit", command_buffer_id);
+        log::info!("Command buffer {:?} commit", command_buffer_id);
         command_buffer.wait_until_completed();
-        log::trace!("Command buffer {:?} has completed (Blocking call)", command_buffer_id);
+        log::info!("Command buffer {:?} has completed (Blocking call)", command_buffer_id);
 
         // Clear local retained values used by the command buffer
         self.retained_tensors.borrow_mut().clear();

--- a/metal/src/kernels/array/broadcast.rs
+++ b/metal/src/kernels/array/broadcast.rs
@@ -105,7 +105,6 @@ impl MultiBroadcast {
             let group_size = utils::build_metal_size_with_ones();
 
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
         });
         Ok(())
     }

--- a/metal/src/kernels/array/cast.rs
+++ b/metal/src/kernels/array/cast.rs
@@ -86,7 +86,6 @@ impl Cast {
             let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
         });
         Ok(())
     }

--- a/metal/src/kernels/array/concat.rs
+++ b/metal/src/kernels/array/concat.rs
@@ -114,7 +114,6 @@ impl Concat {
                 let grid_size = utils::build_metal_size_for_shape(i_shape);
                 let group_size = utils::build_metal_size_with_ones();
                 encoder.dispatch_thread_groups(grid_size, group_size);
-                encoder.end_encoding();
             });
         }
 

--- a/metal/src/kernels/array/copy.rs
+++ b/metal/src/kernels/array/copy.rs
@@ -71,7 +71,6 @@ impl Memcpy {
             let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/array/copy.rs
+++ b/metal/src/kernels/array/copy.rs
@@ -71,7 +71,7 @@ impl Memcpy {
             let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/array/permute_axes.rs
+++ b/metal/src/kernels/array/permute_axes.rs
@@ -123,7 +123,7 @@ impl PermuteAxes {
             let group_size = utils::build_metal_size_with_ones();
 
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/array/permute_axes.rs
+++ b/metal/src/kernels/array/permute_axes.rs
@@ -123,7 +123,6 @@ impl PermuteAxes {
             let group_size = utils::build_metal_size_with_ones();
 
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/array/rotate_half.rs
+++ b/metal/src/kernels/array/rotate_half.rs
@@ -76,7 +76,6 @@ impl RotateHalf {
             let group_size = utils::build_metal_size_with_ones();
 
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/array/rotate_half.rs
+++ b/metal/src/kernels/array/rotate_half.rs
@@ -76,7 +76,7 @@ impl RotateHalf {
             let group_size = utils::build_metal_size_with_ones();
 
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/bin_ops.rs
+++ b/metal/src/kernels/bin_ops.rs
@@ -204,7 +204,6 @@ impl BinOps {
                         MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
                     let group_size = MTLSize { width: 1, height: 1, depth: 1 };
                     encoder.dispatch_thread_groups(grid_size, group_size);
-                    encoder.end_encoding();
                 });
             }
             BroadcastKind::Nd1 | BroadcastKind::Nd6 => {
@@ -242,7 +241,7 @@ impl BinOps {
 
                     let group_size = MTLSize { width: 1, height: 1, depth: 1 };
                     encoder.dispatch_thread_groups(grid_size, group_size);
-                    encoder.end_encoding();
+                    
                 });
             }
         }

--- a/metal/src/kernels/bin_ops.rs
+++ b/metal/src/kernels/bin_ops.rs
@@ -241,7 +241,6 @@ impl BinOps {
 
                     let group_size = MTLSize { width: 1, height: 1, depth: 1 };
                     encoder.dispatch_thread_groups(grid_size, group_size);
-                    
                 });
             }
         }

--- a/metal/src/kernels/element_wise.rs
+++ b/metal/src/kernels/element_wise.rs
@@ -201,7 +201,6 @@ impl ElementWiseOps {
             let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
         });
         Ok(())
     }

--- a/metal/src/kernels/matmul/basic/mod.rs
+++ b/metal/src/kernels/matmul/basic/mod.rs
@@ -140,7 +140,7 @@ impl BasicMatMul {
             encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
             encoder.use_resource(output, metal::MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }
@@ -187,7 +187,7 @@ impl BasicMatMul {
             encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
             encoder.use_resource(output, metal::MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/matmul/basic/mod.rs
+++ b/metal/src/kernels/matmul/basic/mod.rs
@@ -140,7 +140,6 @@ impl BasicMatMul {
             encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
             encoder.use_resource(output, metal::MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }
@@ -187,7 +186,6 @@ impl BasicMatMul {
             encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
             encoder.use_resource(output, metal::MTLResourceUsage::Write);
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/matmul/ggml_gemm/mod.rs
+++ b/metal/src/kernels/matmul/ggml_gemm/mod.rs
@@ -263,7 +263,6 @@ fn dispatch_metal_ggml_gemv(
         let group_size = MTLSize { width: nth0, height: nth1, depth: 1 };
 
         encoder.dispatch_thread_groups(grid_size, group_size);
-        encoder.end_encoding();
     });
 
     Ok(())
@@ -315,7 +314,6 @@ fn dispatch_metal_ggml_gemm(
 
         encoder.set_threadgroup_memory_length(0, 8192);
         encoder.dispatch_thread_groups(grid_size, group_size);
-        encoder.end_encoding();
     });
 
     Ok(())

--- a/metal/src/kernels/matmul/mfa/mod.rs
+++ b/metal/src/kernels/matmul/mfa/mod.rs
@@ -242,7 +242,6 @@ pub fn dispatch_metal_mfa_gemm(
         encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
         encoder.use_resource(output, metal::MTLResourceUsage::Write);
         encoder.dispatch_thread_groups(grid_size, group_size);
-        
     });
     Ok(())
 }

--- a/metal/src/kernels/matmul/mfa/mod.rs
+++ b/metal/src/kernels/matmul/mfa/mod.rs
@@ -242,7 +242,7 @@ pub fn dispatch_metal_mfa_gemm(
         encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
         encoder.use_resource(output, metal::MTLResourceUsage::Write);
         encoder.dispatch_thread_groups(grid_size, group_size);
-        encoder.end_encoding();
+        
     });
     Ok(())
 }

--- a/metal/src/kernels/matmul/mlx_gemm/mod.rs
+++ b/metal/src/kernels/matmul/mlx_gemm/mod.rs
@@ -260,7 +260,6 @@ pub fn dispatch_metal_mlx_gemv(
         encoder.use_resource(b_buffer, metal::MTLResourceUsage::Read);
         encoder.use_resource(output, metal::MTLResourceUsage::Write);
         encoder.dispatch_thread_groups(grid_size, group_size);
-        
     });
     Ok(())
 }
@@ -409,7 +408,6 @@ pub fn dispatch_metal_mlx_gemm(
         encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
         encoder.use_resource(output, metal::MTLResourceUsage::Write);
         encoder.dispatch_thread_groups(grid_size, group_size);
-        
     });
     if debug {
         context.wait_until_completed()?;

--- a/metal/src/kernels/matmul/mlx_gemm/mod.rs
+++ b/metal/src/kernels/matmul/mlx_gemm/mod.rs
@@ -260,7 +260,7 @@ pub fn dispatch_metal_mlx_gemv(
         encoder.use_resource(b_buffer, metal::MTLResourceUsage::Read);
         encoder.use_resource(output, metal::MTLResourceUsage::Write);
         encoder.dispatch_thread_groups(grid_size, group_size);
-        encoder.end_encoding();
+        
     });
     Ok(())
 }
@@ -409,7 +409,7 @@ pub fn dispatch_metal_mlx_gemm(
         encoder.use_resource(rhs_buffer, metal::MTLResourceUsage::Read);
         encoder.use_resource(output, metal::MTLResourceUsage::Write);
         encoder.dispatch_thread_groups(grid_size, group_size);
-        encoder.end_encoding();
+        
     });
     if debug {
         context.wait_until_completed()?;

--- a/metal/src/kernels/matmul/mmm_tile_8x8.rs
+++ b/metal/src/kernels/matmul/mmm_tile_8x8.rs
@@ -67,7 +67,7 @@ pub fn metal_mmm_tile_8x8(
         };
         let group_size = MTLSize { width: 32, height: 2, depth: 1 };
         encoder.dispatch_thread_groups(grid_size, group_size);
-        encoder.end_encoding();
+        
     });
     Ok(())
 }

--- a/metal/src/kernels/matmul/mmm_tile_8x8.rs
+++ b/metal/src/kernels/matmul/mmm_tile_8x8.rs
@@ -67,7 +67,6 @@ pub fn metal_mmm_tile_8x8(
         };
         let group_size = MTLSize { width: 32, height: 2, depth: 1 };
         encoder.dispatch_thread_groups(grid_size, group_size);
-        
     });
     Ok(())
 }

--- a/metal/src/kernels/nn/apply_rope.rs
+++ b/metal/src/kernels/nn/apply_rope.rs
@@ -91,7 +91,6 @@ impl ApplyRope {
 
             let group_size = metal::MTLSize { width: 32 as _, height: 32 as _, depth: 1 as _ };
             encoder.dispatch_threads(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/apply_rope.rs
+++ b/metal/src/kernels/nn/apply_rope.rs
@@ -91,7 +91,7 @@ impl ApplyRope {
 
             let group_size = metal::MTLSize { width: 32 as _, height: 32 as _, depth: 1 as _ };
             encoder.dispatch_threads(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/new_gelu.rs
+++ b/metal/src/kernels/nn/new_gelu.rs
@@ -62,7 +62,7 @@ impl NewGelu {
             let grid_size = MTLSize { width: output.len() as _, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/new_gelu.rs
+++ b/metal/src/kernels/nn/new_gelu.rs
@@ -62,7 +62,6 @@ impl NewGelu {
             let grid_size = MTLSize { width: output.len() as _, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/reduce.rs
+++ b/metal/src/kernels/nn/reduce.rs
@@ -84,7 +84,7 @@ impl Reducer {
             let group_size =
                 MTLSize { width: usize::min(32, input_shape_nd3[1]) as _, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/reduce.rs
+++ b/metal/src/kernels/nn/reduce.rs
@@ -84,7 +84,6 @@ impl Reducer {
             let group_size =
                 MTLSize { width: usize::min(32, input_shape_nd3[1]) as _, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/rms_norm.rs
+++ b/metal/src/kernels/nn/rms_norm.rs
@@ -68,7 +68,7 @@ impl RmsNorm {
                 MTLSize { width: usize::min(32, shape_nd3[1]) as _, height: 1, depth: 1 };
 
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/rms_norm.rs
+++ b/metal/src/kernels/nn/rms_norm.rs
@@ -68,7 +68,6 @@ impl RmsNorm {
                 MTLSize { width: usize::min(32, shape_nd3[1]) as _, height: 1, depth: 1 };
 
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/scaled_masked_softmax.rs
+++ b/metal/src/kernels/nn/scaled_masked_softmax.rs
@@ -73,7 +73,7 @@ impl ScaledMaskedSoftmax {
             let grid_size = MTLSize { width: 1 as _, height: shape[1] as _, depth: shape[0] as _ };
             let group_size = MTLSize { width: usize::min(32, shape[2]) as _, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/scaled_masked_softmax.rs
+++ b/metal/src/kernels/nn/scaled_masked_softmax.rs
@@ -73,7 +73,6 @@ impl ScaledMaskedSoftmax {
             let grid_size = MTLSize { width: 1 as _, height: shape[1] as _, depth: shape[0] as _ };
             let group_size = MTLSize { width: usize::min(32, shape[2]) as _, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/silu.rs
+++ b/metal/src/kernels/nn/silu.rs
@@ -49,7 +49,7 @@ impl Silu {
             let grid_size = MTLSize { width: output.len() as _, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/silu.rs
+++ b/metal/src/kernels/nn/silu.rs
@@ -49,7 +49,6 @@ impl Silu {
             let grid_size = MTLSize { width: output.len() as _, height: 1, depth: 1 };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/softmax.rs
+++ b/metal/src/kernels/nn/softmax.rs
@@ -64,7 +64,7 @@ impl Softmax {
             let group_size =
                 MTLSize { width: usize::min(32, shape_nd3[1]) as _, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            encoder.end_encoding();
+            
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/softmax.rs
+++ b/metal/src/kernels/nn/softmax.rs
@@ -64,7 +64,6 @@ impl Softmax {
             let group_size =
                 MTLSize { width: usize::min(32, shape_nd3[1]) as _, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
-            
         });
         Ok(())
     }

--- a/metal/src/rewrite_rules/fuse_axis_op.rs
+++ b/metal/src/rewrite_rules/fuse_axis_op.rs
@@ -122,7 +122,7 @@ pub fn fuse_axis_op(
 
     // Handle AxisOp::Move operator.
     if let Some(op) = node.op_as::<crate::ops::MetalAxisOp>() {
-        // Early quit if MoveAxis will be fused in next calls to rule 
+        // Early quit if MoveAxis will be fused in next calls to rule
         if matches!(op.0, AxisOp::Move(..))
             && (!grouped_axis_ops[0].is_empty() && !can_fuse_move(model, node))
         {


### PR DESCRIPTION
Metal API for profiling GPU ops is not working on most Apple's GPUs. It is more reliable to record GPU trace and analyze it with Xcode. 

I disabled Metal GPU profiling but kept most of the code for potential re-use with CUDA integration. I also create a single encoder per Metal Command Buffer so the GPU trace is way easier to analyze in Xcode (no impact on compute observed doing so)