### PR TITLE
Fix Einsum rule

### DIFF
--- a/core/src/ops/einsum/optimize.rs
+++ b/core/src/ops/einsum/optimize.rs
@@ -51,10 +51,10 @@ impl EinSumAnnotatedAsMatMul<'_> {
         self.n_axis.inputs[1][0]
     }
     pub fn c_m(&self) -> usize {
-        self.m_axis.outputs[0].get(0).unwrap_or(&self.a_m()).clone()
+        *self.m_axis.outputs[0].first().unwrap_or(&self.a_m())
     }
     pub fn c_n(&self) -> usize {
-        self.n_axis.outputs[0].get(0).unwrap_or(&self.b_n()).clone()
+        *self.n_axis.outputs[0].first().unwrap_or(&self.b_n())
     }
 }
 

--- a/test-rt/suite-unit/src/bin_einsum.rs
+++ b/test-rt/suite-unit/src/bin_einsum.rs
@@ -383,6 +383,18 @@ pub fn suite() -> TractResult<TestSuite> {
         },
     );
 
+    suite.add(
+        "supp_axis_bug_0",
+        BinEinsumProblem {
+            expr: "bmk, abkn->bn".parse().unwrap(),
+            a: Tensor::zero::<f32>(&[32, 1, 25]).unwrap(),
+            b: Tensor::zero::<f32>(&[1, 32, 25, 64]).unwrap(),
+            a_constant: false,
+            b_constant: false,
+            unicast_add_constant: None,
+        },
+    );
+
     // TODO: fix ensure_mkn() to handle multiple n axes
     //suite.add(
     //    "multiple_n_axes",


### PR DESCRIPTION
Einsum_as_matmul rule is adding unecessary axes to A and B when m axis is not present in the output (m dimension is necessarily 1 in those cases).
The PR makes the rule more flexible to this