### PR TITLE
Fix symbolic dimensions considered as None in ensure_mkn

### DIFF
--- a/core/src/ops/einsum/optimize.rs
+++ b/core/src/ops/einsum/optimize.rs
@@ -359,14 +359,15 @@ pub(crate) fn ensure_mkn_axes<'a>(
                     || (input_shapes[0][a.inputs[0][0]].is_one() && a.inputs[1].is_empty()))
         })
         .collect();
-    
+
     // Prioritize obvious m-axes
     if possible_m_axes.iter().any(|a| !a.outputs[0].is_empty()) {
         possible_m_axes.retain(|a| !a.outputs[0].is_empty());
     }
 
-    let m_axis =
-        possible_m_axes.into_iter().max_by_key(|a| input_shapes[0][a.inputs[0][0]].as_i64());
+    let m_axis = possible_m_axes
+        .into_iter()
+        .max_by_key(|a| input_shapes[0][a.inputs[0][0]].as_i64().unwrap_or(i64::MAX));
 
     let Some(m_axis) = m_axis else {
         return Ok(AxesOrPatch::Patch(inject_m_or_n_axis(op, model, node, false)?));

--- a/metal/src/rewrite_rules/remove_matmul_broadcast.rs
+++ b/metal/src/rewrite_rules/remove_matmul_broadcast.rs
@@ -47,15 +47,16 @@ pub fn remove_ggml_broadcast_pre_matmul(
         axis_op_chain.push(node.op_as::<AxisOp>().unwrap());
         running_node = node;
     }
-    
+
     rule_ensure!(next_node(model, running_node).is_some_and(|node| node.op_is::<BasicMatMul>()));
 
     if let Some(mm_node) = next_node(model, running_node) {
         let mut new_mm_input = inputs[0];
-        if (axis_op_chain == tvec![&AxisOp::Move(0,1)] && reshape_out_shape[0] == TDim::Val(1)) || 
-            axis_op_chain == tvec![&AxisOp::Rm(0), &AxisOp::Add(1)] {
-                new_mm_input =
-                    patch.wire_node(format!("{node_name}.reshape"), AxisOp::Move(0, 1), &inputs)?[0];
+        if (axis_op_chain == tvec![&AxisOp::Move(0, 1)] && reshape_out_shape[0] == TDim::Val(1))
+            || axis_op_chain == tvec![&AxisOp::Rm(0), &AxisOp::Add(1)]
+        {
+            new_mm_input =
+                patch.wire_node(format!("{node_name}.reshape"), AxisOp::Move(0, 1), &inputs)?[0];
         }
 
         // Only Ggml kernels have internal broadcasting. If no kernel impl is specified,
@@ -76,7 +77,7 @@ pub fn remove_ggml_broadcast_pre_matmul(
 
         let out = patch.wire_node(&mm_node.name, &mm_node.op, &matmul_inputs)?;
         patch.shunt_outside(model, mm_node.id.into(), out[0])?;
-        return Ok(Some(patch))
+        return Ok(Some(patch));
     }
     Ok(None)
 }

--- a/metal/src/rewrite_rules/remove_matmul_broadcast.rs
+++ b/metal/src/rewrite_rules/remove_matmul_broadcast.rs
@@ -40,37 +40,43 @@ pub fn remove_ggml_broadcast_pre_matmul(
 
     // Check if optional Move before matmul is present
     let reshape_out_shape = reshape_node.outputs[0].fact.shape.dims();
-    let (mm_node, new_mm_input, prev_node_id) = match next_node(model, reshape_node) {
-        Some(n) if n.op_is::<BasicMatMul>() => (n, inputs[0], reshape_node.id),
-        Some(n)
-            if n.op_as::<AxisOp>() == Some(&AxisOp::Move(0, 1))
-                && reshape_out_shape[0] == TDim::Val(1)
-                && next_node(model, n).is_some_and(|m| m.op_is::<BasicMatMul>()) =>
+
+    let mut axis_op_chain: TVec<&AxisOp> = tvec![];
+    let mut running_node = reshape_node;
+    while let Some(node) = next_node(model, running_node).filter(|n| n.op_is::<AxisOp>()) {
+        axis_op_chain.push(node.op_as::<AxisOp>().unwrap());
+        running_node = node;
+    }
+    
+    rule_ensure!(next_node(model, running_node).is_some_and(|node| node.op_is::<BasicMatMul>()));
+
+    if let Some(mm_node) = next_node(model, running_node) {
+        let mut new_mm_input = inputs[0];
+        if (axis_op_chain == tvec![&AxisOp::Move(0,1)] && reshape_out_shape[0] == TDim::Val(1)) || 
+            axis_op_chain == tvec![&AxisOp::Rm(0), &AxisOp::Add(1)] {
+                new_mm_input =
+                    patch.wire_node(format!("{node_name}.reshape"), AxisOp::Move(0, 1), &inputs)?[0];
+        }
+
+        // Only Ggml kernels have internal broadcasting. If no kernel impl is specified,
+        // Ggml kernels will be used if and only activations are F32
+        let in_facts = model.node_input_facts(mm_node.id)?;
+        if ctx.gemm_impl != Some(MetalGemmImplKind::Ggml)
+            && (ctx.gemm_impl.is_some() || in_facts[0].datum_type != DatumType::F32)
         {
-            let swap_input =
-                patch.wire_node(format!("{node_name}.reshape"), AxisOp::Move(0, 1), &inputs)?[0];
-            (next_node(model, n).unwrap(), swap_input, n.id)
+            return Ok(None);
         }
-        _ => return Ok(None),
-    };
 
-    // Only Ggml kernels have internal broadcasting. If no kernel impl is specified,
-    // Ggml kernels will be used if and only activations are F32
-    let in_facts = model.node_input_facts(mm_node.id)?;
-    if ctx.gemm_impl != Some(MetalGemmImplKind::Ggml)
-        && (ctx.gemm_impl.is_some() || in_facts[0].datum_type != DatumType::F32)
-    {
-        return Ok(None);
-    }
-
-    let mut matmul_inputs = patch.taps(model, &mm_node.inputs)?;
-    for (idx, o) in mm_node.inputs.iter().enumerate() {
-        if o.node == prev_node_id {
-            matmul_inputs[idx] = new_mm_input;
+        let mut matmul_inputs = patch.taps(model, &mm_node.inputs)?;
+        for (idx, o) in mm_node.inputs.iter().enumerate() {
+            if o.node == running_node.id {
+                matmul_inputs[idx] = new_mm_input;
+            }
         }
-    }
 
-    let out = patch.wire_node(&mm_node.name, &mm_node.op, &matmul_inputs)?;
-    patch.shunt_outside(model, mm_node.id.into(), out[0])?;
-    Ok(Some(patch))
+        let out = patch.wire_node(&mm_node.name, &mm_node.op, &matmul_inputs)?;
+        patch.shunt_outside(model, mm_node.id.into(), out[0])?;
+        return Ok(Some(patch))
+    }
+    Ok(None)
 }

--- a/metal/src/transform.rs
+++ b/metal/src/transform.rs
@@ -361,17 +361,11 @@ fn check_matmul_in_dts(in_facts: &[TypedFact]) -> bool {
 }
 
 fn is_input_broadcast(facts: TVec<&TypedFact>) -> bool {
-    let b_batch_size = if as_q40_fact(facts[1]).is_some() {
-        facts[1].shape.iter().product::<TDim>()
-    } else {
-        let rank = facts[1].rank();
-        facts[1].shape[..rank - 2].iter().product::<TDim>()
-    };
+    let b_shape = as_q40_fact(facts[1])
+        .map(|fact| fact.shape()[0])
+        .unwrap_or(facts[1].shape[0].to_i64().unwrap_or(0) as usize);
 
-    let a_rank = facts[0].rank();
-    let a_batch_size = facts[0].shape[..(a_rank - 2)].iter().product::<TDim>();
-
-    (a_batch_size.gcd() % b_batch_size.gcd()) == 0
+    b_shape != facts[0].shape[0].to_i64().unwrap_or(0) as usize
 }
 
 pub fn resolve_gemm_impl(

--- a/metal/src/transform.rs
+++ b/metal/src/transform.rs
@@ -365,7 +365,7 @@ fn is_input_broadcast(facts: TVec<&TypedFact>) -> bool {
         facts[1].shape.iter().product::<TDim>()
     } else {
         let rank = facts[1].rank();
-        facts[1].shape[.. rank - 2].iter().product::<TDim>()
+        facts[1].shape[..rank - 2].iter().product::<TDim>()
     };
 
     let a_rank = facts[0].rank();


### PR DESCRIPTION
[Previous PR](https://github.com/sonos/tract/pull/1700) was missing to unwrap Symbolic dimensions to i64::Max so they were never considered. This PR fixes it

The PR also changed the rule to detect an alternative pattern to the Move(0,1) before the Matmul which can be in some models Rm(0), Add(1)