### PR TITLE
Improve Gather: Block Copy

### DIFF
--- a/core/src/ops/array/gather.rs
+++ b/core/src/ops/array/gather.rs
@@ -56,6 +56,8 @@ impl Gather {
 
         if can_block_copy {
             let mut out_offset = 0;
+            let input_slice = data_view.as_slice().unwrap();
+            let output_slice = &mut output_view.as_slice_mut().unwrap();
             for idx_coords in indices.indexed_iter() {
                 let index = *idx_coords.1;
                 let axis_len = data_shape[data_axis] as i64;
@@ -64,11 +66,8 @@ impl Gather {
 
                 let input_offset = resolved_index * block_len;
 
-                let input_slice =
-                    &data_view.as_slice().unwrap()[input_offset..input_offset + block_len];
-                let output_slice =
-                    &mut output_view.as_slice_mut().unwrap()[out_offset..out_offset + block_len];
-                output_slice.copy_from_slice(input_slice);
+                output_slice[out_offset..out_offset + block_len]
+                    .copy_from_slice(&input_slice[input_offset..input_offset + block_len]);
                 out_offset += block_len;
             }
         } else {

--- a/core/src/ops/array/gather.rs
+++ b/core/src/ops/array/gather.rs
@@ -37,24 +37,58 @@ impl Gather {
         Ok(output_shape)
     }
 
-    fn eval_t<T: Datum>(&self, data: TValue, indices: &TValue) -> TractResult<Tensor> {
-        let data_view = unsafe { data.to_array_view_unchecked::<T>() }; // copy only
+    fn eval_t<T: Datum + Copy>(&self, data: TValue, indices: &TValue) -> TractResult<Tensor> {
+        let data_view = unsafe { data.to_array_view_unchecked::<T>() };
         let indices = indices.to_array_view::<i64>()?;
         let output_shape = &*self.compute_output_shape(data.shape(), indices.shape())?;
         let mut output = unsafe { Tensor::uninitialized::<T>(output_shape)? };
         let mut output_view = output.to_array_view_mut::<T>()?;
-        for coords in tract_ndarray::indices(output_shape) {
-            let ocoords = coords.as_array_view();
-            let ocoords = ocoords.as_slice().unwrap();
-            let mut icoords: TVec<usize> = ocoords[0..self.axis].into();
-            let kcoords = &ocoords[self.axis..][..indices.ndim()];
-            let k = indices[kcoords];
-            let k = if k < 0 { k + data_view.shape()[self.axis] as i64 } else { k } as usize;
-            icoords.push(k);
-            icoords.extend(ocoords[self.axis + indices.ndim()..].iter().copied());
-            output_view[ocoords] = data_view.get(&*icoords).context("Invalid gather")?.clone();
+
+        let data_shape = data.shape();
+        let data_axis = self.axis;
+
+        let block_len = data_shape[data_axis + 1..].iter().product::<usize>();
+
+        let can_block_copy = data_shape[..data_axis].iter().all(|&d| d == 1)
+            && output_shape[..data_axis].iter().all(|&d| d == 1)
+            && data_view.is_standard_layout()
+            && output_view.is_standard_layout();
+
+        if can_block_copy {
+            let mut out_offset = 0;
+            for idx_coords in indices.indexed_iter() {
+                let index = *idx_coords.1;
+                let axis_len = data_shape[data_axis] as i64;
+                let resolved_index = if index < 0 { index + axis_len } else { index };
+                let resolved_index = resolved_index as usize;
+
+                let input_offset = resolved_index * block_len;
+
+                let input_slice =
+                    &data_view.as_slice().unwrap()[input_offset..input_offset + block_len];
+                let output_slice =
+                    &mut output_view.as_slice_mut().unwrap()[out_offset..out_offset + block_len];
+                output_slice.copy_from_slice(input_slice);
+                out_offset += block_len;
+            }
+        } else {
+            let ic_len = self.axis + 1 + output_shape.len() - (self.axis + indices.ndim());
+            let mut icoords = vec![0; ic_len];
+            let axis = self.axis;
+            for coords in tract_ndarray::indices(output_shape) {
+                let ocoords = coords.as_array_view();
+                let ocoords = ocoords.as_slice().unwrap();
+
+                let kcoords = &ocoords[self.axis..][..indices.ndim()];
+                let k = indices[kcoords];
+                let k = if k < 0 { k + data_view.shape()[self.axis] as i64 } else { k } as usize;
+                icoords[0..axis].copy_from_slice(&ocoords[..self.axis]);
+                icoords[self.axis] = k;
+                icoords[self.axis + 1..].copy_from_slice(&ocoords[self.axis + indices.ndim()..]);
+                output_view[ocoords] = *data_view.get(&*icoords).context("Invalid gather")?;
+            }
+            unsafe { output.set_datum_type(data.datum_type()) };
         }
-        unsafe { output.set_datum_type(data.datum_type()) };
         Ok(output)
     }
 
@@ -139,20 +173,25 @@ impl TypedOp for Gather {
                 inputs[0].datum_type
             );
         } else {
-            ensure!(!inputs[0].datum_type.is_opaque(),
-                "Gather applied to compressed data requires an explicit datum_type attribute for its output");
+            ensure!(
+                !inputs[0].datum_type.is_opaque(),
+                "Gather applied to compressed data requires an explicit datum_type attribute for its output"
+            );
         }
         ensure!(inputs[1].datum_type == i64::datum_type());
         if inputs[0].datum_type.is_opaque() {
             let data_shape = block_quant_aware_input_shape(inputs[0])?;
-            Ok(tvec!(self
-                .output_type
-                .unwrap()
-                .fact(&*self.compute_output_shape(&data_shape, &inputs[1].shape)?)))
+            Ok(tvec!(
+                self.output_type
+                    .unwrap()
+                    .fact(&*self.compute_output_shape(&data_shape, &inputs[1].shape)?)
+            ))
         } else {
-            Ok(tvec!(inputs[0]
-                .datum_type
-                .fact(&*self.compute_output_shape(&inputs[0].shape, &inputs[1].shape)?)))
+            Ok(tvec!(
+                inputs[0]
+                    .datum_type
+                    .fact(&*self.compute_output_shape(&inputs[0].shape, &inputs[1].shape)?)
+            ))
         }
     }
 
@@ -222,7 +261,7 @@ impl EvalOp for Gather {
                 bail!("Can't use Gather on {:?} input", data);
             }
         } else {
-            dispatch_datum_by_size!(Self::eval_t(data.datum_type())(self, data, &indices))?
+            dispatch_copy!(Self::eval_t(data.datum_type())(self, data, &indices))?
         };
         Ok(tvec!(result.into_tvalue()))
     }


### PR DESCRIPTION
In most cases, data is contiguous and we are copying sub-matrices along the given axis. In this case, doing block copies instead of element by element is significantly faster (for PP512 with Llama-1B-F16 on intel i9: 25ms -> 0.06ms!!).