### PR TITLE
Fix CUDA uninitialized allocations

### DIFF
--- a/cuda/src/context.rs
+++ b/cuda/src/context.rs
@@ -132,8 +132,8 @@ impl DeviceContext for TractCudaContext {
         Ok(Box::new(CudaTensor::from_tensor(tensor.view().tensor)))
     }
 
-    fn mem_pool_create(&self, size: usize) -> TractResult<Box<dyn OwnedDeviceTensor>> {
-        Ok(Box::new(CudaTensor::uninitialized(size)))
+    fn uninitialized_device_tensor(&self, shape: &[usize], dt: DatumType) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+        Ok(Box::new(CudaTensor::uninitialized_dt(shape, dt)))
     }
 }
 

--- a/cuda/src/context.rs
+++ b/cuda/src/context.rs
@@ -132,7 +132,11 @@ impl DeviceContext for TractCudaContext {
         Ok(Box::new(CudaTensor::from_tensor(tensor.view().tensor)))
     }
 
-    fn uninitialized_device_tensor(&self, shape: &[usize], dt: DatumType) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+    fn uninitialized_device_tensor(
+        &self,
+        shape: &[usize],
+        dt: DatumType,
+    ) -> TractResult<Box<dyn OwnedDeviceTensor>> {
         Ok(Box::new(CudaTensor::uninitialized_dt(shape, dt)))
     }
 }

--- a/gpu/src/device.rs
+++ b/gpu/src/device.rs
@@ -4,14 +4,14 @@ use std::sync::Mutex;
 use anyhow::{anyhow, bail};
 use downcast_rs::{Downcast, impl_downcast};
 use tract_core::dyn_clone;
-use tract_core::prelude::TractResult;
+use tract_core::prelude::{DatumType, TractResult};
 use tract_core::value::TValue;
 
 use crate::tensor::OwnedDeviceTensor;
 
 pub trait DeviceContext: Downcast + dyn_clone::DynClone + Send + Sync {
     fn tensor_to_device(&self, tensor: TValue) -> TractResult<Box<dyn OwnedDeviceTensor>>;
-    fn mem_pool_create(&self, size: usize) -> TractResult<Box<dyn OwnedDeviceTensor>>;
+    fn uninitialized_device_tensor(&self, shape: &[usize], dt: DatumType) -> TractResult<Box<dyn OwnedDeviceTensor>>;
     fn synchronize(&self) -> TractResult<()>;
 }
 

--- a/gpu/src/device.rs
+++ b/gpu/src/device.rs
@@ -11,7 +11,11 @@ use crate::tensor::OwnedDeviceTensor;
 
 pub trait DeviceContext: Downcast + dyn_clone::DynClone + Send + Sync {
     fn tensor_to_device(&self, tensor: TValue) -> TractResult<Box<dyn OwnedDeviceTensor>>;
-    fn uninitialized_device_tensor(&self, shape: &[usize], dt: DatumType) -> TractResult<Box<dyn OwnedDeviceTensor>>;
+    fn uninitialized_device_tensor(
+        &self,
+        shape: &[usize],
+        dt: DatumType,
+    ) -> TractResult<Box<dyn OwnedDeviceTensor>>;
     fn synchronize(&self) -> TractResult<()>;
 }
 

--- a/gpu/src/memory/pool.rs
+++ b/gpu/src/memory/pool.rs
@@ -18,7 +18,10 @@ pub struct DeviceMemoryPool {
 impl DeviceMemoryPool {
     pub fn from_schema(resolved_schema: DeviceResolvedMemSchema) -> TractResult<Self> {
         Ok(Self {
-            storage: Arc::new(get_context()?.uninitialized_device_tensor(&[resolved_schema.memory_size], DatumType::U8)?),
+            storage: Arc::new(
+                get_context()?
+                    .uninitialized_device_tensor(&[resolved_schema.memory_size], DatumType::U8)?,
+            ),
             resolved_schema,
             node_seen: RefCell::new(HashSet::new()),
         })

--- a/gpu/src/memory/pool.rs
+++ b/gpu/src/memory/pool.rs
@@ -2,7 +2,6 @@ use crate::device::get_context;
 use crate::memory::DeviceResolvedMemSchema;
 use crate::tensor::DeviceArenaView;
 use crate::tensor::DeviceTensor;
-use crate::tensor::IntoDevice;
 use crate::tensor::OwnedDeviceTensor;
 
 use std::cell::RefCell;
@@ -19,7 +18,7 @@ pub struct DeviceMemoryPool {
 impl DeviceMemoryPool {
     pub fn from_schema(resolved_schema: DeviceResolvedMemSchema) -> TractResult<Self> {
         Ok(Self {
-            storage: Arc::new(get_context()?.mem_pool_create(resolved_schema.memory_size)?),
+            storage: Arc::new(get_context()?.uninitialized_device_tensor(&[resolved_schema.memory_size], DatumType::U8)?),
             resolved_schema,
             node_seen: RefCell::new(HashSet::new()),
         })
@@ -48,7 +47,7 @@ impl DeviceMemoryPool {
                 }
                 .into())
             })
-            .unwrap_or_else(|| unsafe { Tensor::uninitialized_dt(dt, shape)?.into_device() })
+            .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
     }
 
     pub fn reset(&self) {

--- a/gpu/src/session_handler.rs
+++ b/gpu/src/session_handler.rs
@@ -50,5 +50,5 @@ pub fn make_tensor_for_node(
         .scratch_extensions
         .get::<DeviceMemoryPool>()
         .map(|mem| mem.tensor_for_node(node_id, dt, shape))
-        .unwrap_or_else(|| unsafe { DeviceTensor::uninitialized_dt(dt, shape) })
+        .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
 }

--- a/gpu/src/tensor/mod.rs
+++ b/gpu/src/tensor/mod.rs
@@ -58,12 +58,12 @@ impl DeviceTensor {
     }
 
     /// Create an uninitialized DeviceTensor
-    pub unsafe fn uninitialized_dt(dt: DatumType, shape: &[usize]) -> TractResult<DeviceTensor> {
-        unsafe { Tensor::uninitialized_dt(dt, shape) }?.into_device()
+    pub fn uninitialized_dt(dt: DatumType, shape: &[usize]) -> TractResult<DeviceTensor> {
+        Ok(DeviceTensor::Owned(get_context()?.uninitialized_device_tensor(shape, dt)?))
     }
 
-    pub unsafe fn uninitialized<T: Datum>(shape: &[usize]) -> TractResult<DeviceTensor> {
-        unsafe { Self::uninitialized_dt(T::datum_type(), shape) }
+    pub fn uninitialized<T: Datum>(shape: &[usize]) -> TractResult<DeviceTensor> {
+        Self::uninitialized_dt(T::datum_type(), shape)
     }
 
     // Create a device tensor with a given shape and a slice of elements. The data is copied and aligned to size of T.

--- a/metal/src/context.rs
+++ b/metal/src/context.rs
@@ -198,10 +198,15 @@ impl DeviceContext for MetalContext {
         }))
     }
 
-    fn uninitialized_device_tensor(&self, shape: &[usize], dt: DatumType) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+    fn uninitialized_device_tensor(
+        &self,
+        shape: &[usize],
+        dt: DatumType,
+    ) -> TractResult<Box<dyn OwnedDeviceTensor>> {
         let tensor = unsafe {
-            Tensor::uninitialized_dt(dt, shape)
-                .with_context(|| format!("Error while allocating a {dt:?} tensor of shape {shape:?}"))?
+            Tensor::uninitialized_dt(dt, shape).with_context(|| {
+                format!("Error while allocating a {dt:?} tensor of shape {shape:?}")
+            })?
         };
         self.tensor_to_device(tensor.into())
     }

--- a/metal/src/context.rs
+++ b/metal/src/context.rs
@@ -198,10 +198,10 @@ impl DeviceContext for MetalContext {
         }))
     }
 
-    fn mem_pool_create(&self, size: usize) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+    fn uninitialized_device_tensor(&self, shape: &[usize], dt: DatumType) -> TractResult<Box<dyn OwnedDeviceTensor>> {
         let tensor = unsafe {
-            Tensor::uninitialized_dt(DatumType::U8, &[size])
-                .with_context(|| format!("Error while allocating a tensor of {:?} bytes", size))?
+            Tensor::uninitialized_dt(dt, shape)
+                .with_context(|| format!("Error while allocating a {dt:?} tensor of shape {shape:?}"))?
         };
         self.tensor_to_device(tensor.into())
     }


### PR DESCRIPTION
Directly doing an allocation on the Device side instead of creating an uninitialized Tensor on Host and copying it to Device.
This changes nothing for Metal since we are using shared memory anyway.