### PR TITLE
fix: loosen half crate dependency for compatibility with wgpu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ foreign-types = "0.5"
 fs-err = "2"
 fs2 = "0.4.3"
 getrandom = "0.2"
-half = { version="2.4.1", features = [ "std", "num-traits" ] }
+half = { version=">=2.4,<3.0", features = [ "std", "num-traits" ] }
 home = "0.5.9"
 icu_collections = "1.5.1"
 icu_normalizer = "1.5.0"


### PR DESCRIPTION
Thanks for open-sourcing and maintaining such a fast onnx model inference implementation! It's been great for my project https://github.com/jackrr/eymo! Much more performant than when I was using [ort](https://github.com/pykeio/ort) to call out to ONNX runtime.

I've recently run into this minor issue using the crate alongside [wgpu](https://github.com/gfx-rs/wgpu).
wgpu depends on half=^2.5, so is mutually incompatible with tract pinned to half=2.4.1.

I don't know the `tract` implementation details well enough to claim this is a safe change to make, nor do I believe that the integration testing with `half=2.6.0` verified by my project is sufficient enough. But I figured I'd open this up since I'd made the fork to unblock my project.