### PR TITLE
Precompute more metadata during plan

### DIFF
--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -76,10 +76,17 @@ where
     M: Borrow<Graph<F, O>>,
 {
     model: M,
+    inputs: Vec<OutletId>,
+    input_facts: Vec<Option<TypedFact>>,
     outputs: Vec<OutletId>,
+    output_facts: Vec<Vec<Option<TypedFact>>>,
     order: Vec<usize>,
     flush_lists: Vec<TVec<usize>>,
     has_unresolved_symbols: bool,
+    node_has_symbolic_output: Vec<bool>,
+    single_symbolic_output_syms: Vec<Vec<Vec<Option<Symbol>>>>,
+    symbols: Vec<Symbol>,
+    symbolic_output_dims: Vec<Vec<Vec<usize>>>,
     executor: Option<Executor>,
     session_handler: Option<Arc<dyn SessionStateHandler + 'static>>,
     _casper: PhantomData<(F, O)>,
@@ -151,19 +158,83 @@ where
 
         #[allow(clippy::mutable_key_type)]
         let mut symbols: std::collections::HashSet<Symbol> = Default::default();
+        let node_count = model.borrow().nodes.len();
+        let mut symbolic_output_dims: Vec<Vec<Vec<usize>>> = vec![vec![]; node_count];
+        let mut node_has_symbolic_output: Vec<bool> = vec![false; node_count];
+        let mut output_facts: Vec<Vec<Option<TypedFact>>> =
+            vec![vec![]; model.borrow().nodes.len()];
+        let mut single_symbolic_output_syms: Vec<Vec<Vec<Option<Symbol>>>> =
+            vec![vec![]; model.borrow().nodes.len()];
+
         for node in &model.borrow().nodes {
+            let mut node_outputs: Vec<Vec<usize>> = Vec::with_capacity(node.outputs.len());
+            let mut node_typed_facts: Vec<Option<TypedFact>> =
+                Vec::with_capacity(node.outputs.len());
+            let mut node_single_syms: Vec<Vec<Option<Symbol>>> =
+                Vec::with_capacity(node.outputs.len());
             for output in &node.outputs {
                 if let Ok(fact) = output.fact.to_typed_fact() {
-                    symbols.extend(fact.shape.iter().flat_map(|d| d.symbols()))
+                    symbols.extend(fact.shape.iter().flat_map(|d| d.symbols()));
+
+                    let dims_with_symbols = fact
+                        .shape
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(ix, d)| if d.symbols().len() > 0 { Some(ix) } else { None })
+                        .collect::<Vec<_>>();
+                    node_outputs.push(dims_with_symbols);
+
+                    let mut per_dim_syms: Vec<Option<Symbol>> =
+                        Vec::with_capacity(fact.shape.iter().count());
+                    for d in fact.shape.iter() {
+                        let syms = d.symbols();
+                        if syms.len() == 1 {
+                            let s = syms.iter().next().unwrap().clone();
+                            per_dim_syms.push(Some(s));
+                        } else {
+                            per_dim_syms.push(None);
+                        }
+                    }
+                    node_single_syms.push(per_dim_syms);
+                    node_typed_facts.push(Some(fact.into_owned()));
+                } else {
+                    node_outputs.push(Vec::new());
+                    node_single_syms.push(Vec::new());
+                    node_typed_facts.push(None);
                 }
             }
+            let any_symbolic = node_outputs.iter().any(|v| !v.is_empty());
+            output_facts[node.id] = node_typed_facts;
+            node_has_symbolic_output[node.id] = any_symbolic;
+            symbolic_output_dims[node.id] = node_outputs;
+            single_symbolic_output_syms[node.id] = node_single_syms;
         }
+
+        let inputs = model.borrow().input_outlets()?.to_vec();
+        let input_facts: Vec<Option<TypedFact>> = inputs
+            .iter()
+            .map(|outlet| {
+                model
+                    .borrow()
+                    .outlet_fact(*outlet)
+                    .ok()
+                    .and_then(|f| f.to_typed_fact().ok().map(|f| f.into_owned()))
+            })
+            .collect();
+
         Ok(SimplePlan {
             model,
             order,
             flush_lists,
+            inputs,
+            input_facts,
             outputs: outputs.to_vec(),
+            output_facts,
             has_unresolved_symbols: !symbols.is_empty(),
+            node_has_symbolic_output,
+            single_symbolic_output_syms,
+            symbols: symbols.into_iter().collect(),
+            symbolic_output_dims,
             _casper: PhantomData,
             executor: options.executor.clone(),
             session_handler: None,
@@ -351,14 +422,19 @@ where
                 .map(|it| it.before_plan_eval(&mut self.session_state))
                 .transpose()?;
 
-            for (step, n) in plan.order.iter().enumerate() {
-                let node = model.node(*n);
+            let mut syms_done = !plan.has_unresolved_symbols
+                || plan
+                    .symbols
+                    .iter()
+                    .all(|s| self.session_state.resolved_symbols.get(s).is_some());
+            for (step, &n) in plan.order.iter().enumerate() {
+                let node = model.node(n);
                 trace!("Running step {step}, node {node}");
-                let mut inputs: TVec<TValue> = tvec![];
+                let mut inputs: TVec<TValue> = TVec::with_capacity(node.inputs.len());
                 for i in &node.inputs {
                     trace!("  use input {i:?}");
-                    let prec_node = model.node(i.node);
                     let prec = self.values[i.node].as_ref().ok_or_else(|| {
+                        let prec_node = model.node(i.node);
                         format_err!("Computing {}, precursor {} not done:", node, prec_node)
                     })?;
                     inputs.push(prec[i.slot].clone())
@@ -379,8 +455,9 @@ where
                             inputs.len()
                         );
                     }
+                    let syms = &self.session_state.resolved_symbols;
                     for (ix, (v, f)) in inputs.iter().zip(facts.iter()).enumerate() {
-                        if !f.matches(v, Some(&self.session_state.resolved_symbols))? {
+                        if !f.matches(v, Some(syms))? {
                             bail!(
                                 "Evaluating {}: input {:?}, expected {:?}, got {:?}",
                                 node,
@@ -400,17 +477,70 @@ where
                 )
                 .map_err(|e| e.into())?;
 
-                if plan.has_unresolved_symbols {
-                    for (o, v) in node.outputs.iter().zip(vs.iter()) {
-                        if let Ok(f) = o.fact.to_typed_fact() {
-                            for (dim_abstract, dim_concrete) in f.shape.iter().zip(v.shape()) {
-                                Self::resolve(
-                                    &mut self.session_state,
-                                    dim_abstract,
-                                    *dim_concrete as i64,
-                                )?;
+                if !syms_done
+                    && plan.has_unresolved_symbols
+                    && unsafe { *plan.node_has_symbolic_output.get_unchecked(node.id) }
+                {
+                    let symbolic = unsafe { plan.symbolic_output_dims.get_unchecked(node.id) };
+                    let single_syms =
+                        unsafe { plan.single_symbolic_output_syms.get_unchecked(node.id) };
+                    let typed_facts = unsafe { plan.output_facts.get_unchecked(node.id) };
+                    for out_ix in 0..node.outputs.len() {
+                        let dims = unsafe { symbolic.get_unchecked(out_ix) };
+                        if dims.is_empty() {
+                            continue;
+                        }
+                        if let Some(f) = unsafe { typed_facts.get_unchecked(out_ix) }.as_ref() {
+                            let vshape = unsafe { vs.get_unchecked(out_ix) }.shape();
+                            let syms_per_dim = unsafe { single_syms.get_unchecked(out_ix) };
+                            for &ix in dims {
+                                let dim_abstract = unsafe { f.shape.get_unchecked(ix) };
+                                let dim_concrete = unsafe { *vshape.get_unchecked(ix) } as i64;
+
+                                if let Some(sym) =
+                                    unsafe { syms_per_dim.get_unchecked(ix) }.as_ref()
+                                {
+                                    if self.session_state.resolved_symbols.get(sym).is_none() {
+                                        let expected =
+                                            dim_abstract.eval(&self.session_state.resolved_symbols);
+                                        if let Some(v) =
+                                            solve_for(sym, &expected, &dim_concrete.to_dim())
+                                        {
+                                            let val = v.to_i64()?;
+                                            self.session_state.resolved_symbols.set(sym, val);
+                                            if self.session_state.scenario.is_none() {
+                                                let scope = sym.scope().with_context(|| format!(
+                                                    "Symbol {sym:?} points to an invalid (dead ?) SymbolScope. Make sure to create symbols using the model-managed SymbolScope."
+                                                ))?;
+                                                self.session_state.scenario = scope
+                                                    .guess_scenario(
+                                                        &self.session_state.resolved_symbols,
+                                                    )?;
+                                            }
+                                        } else {
+                                            Self::resolve(
+                                                &mut self.session_state,
+                                                dim_abstract,
+                                                dim_concrete,
+                                            )?;
+                                        }
+                                    }
+                                } else {
+                                    Self::resolve(
+                                        &mut self.session_state,
+                                        dim_abstract,
+                                        dim_concrete,
+                                    )?;
+                                }
                             }
                         }
+                    }
+                    if plan
+                        .symbols
+                        .iter()
+                        .all(|s| self.session_state.resolved_symbols.get(s).is_some())
+                    {
+                        syms_done = true;
                     }
                 }
                 if cfg!(debug_assertions) {
@@ -423,11 +553,12 @@ where
                             vs.len()
                         );
                     }
+                    let syms = &self.session_state.resolved_symbols;
                     for (ix, (v, f)) in vs.iter().zip(facts.iter()).enumerate() {
-                        if node.outputs[ix].successors.len() == 0 {
+                        if node.outputs[ix].successors.is_empty() {
                             continue;
                         }
-                        if !f.matches(v, Some(&self.session_state.resolved_symbols))? {
+                        if !f.matches(v, Some(syms))? {
                             bail!(
                                 "Evaluating {}: output {:?}, expected {:?}, got {:?}",
                                 node,
@@ -450,10 +581,11 @@ where
     }
 
     pub fn set_inputs(&mut self, inputs: TVec<TValue>) -> TractResult<()> {
+        let expected_count = self.plan.borrow().inputs.len();
         ensure!(
-            inputs.len() == self.model().inputs.len(),
+            inputs.len() == expected_count,
             "Wrong number of inputs for model. Expected {} got {}",
-            self.model().inputs.len(),
+            expected_count,
             inputs.len()
         );
 
@@ -464,47 +596,107 @@ where
     }
 
     fn resolve(state: &mut SessionState, expression: &TDim, provided: i64) -> TractResult<()> {
-        let expected = expression.eval(&state.resolved_symbols);
-        if let Ok(x) = expected.to_i64() {
-            if x != provided {
-                bail!(
-                    "Clashing resolution for expression. {expression}={x} != {provided}. ({state:?})"
-                )
+        {
+            use crate::internal::TDim::*;
+            if let Sym(sym) = expression {
+                if state.resolved_symbols.get(sym).is_none() {
+                    state.resolved_symbols.set(sym, provided);
+                    if state.scenario.is_none() {
+                        let scope = sym.scope().with_context(|| format!(
+                            "Symbol {sym:?} points to an invalid (dead ?) SymbolScope. Make sure to create symbols using the model-managed SymbolScope."
+                        ))?;
+                        state.scenario = scope.guess_scenario(&state.resolved_symbols)?;
+                    }
+                    return Ok(());
+                }
             }
         }
-        if expected.symbols().len() == 1 {
-            let sym = expected.symbols().into_iter().next().unwrap();
+
+        if let Ok(x) = expression.eval_to_i64(&state.resolved_symbols) {
+            ensure!(
+                x == provided,
+                "Clashing resolution for expression. {expression}={x} != {provided}. ({state:?})"
+            );
+            return Ok(());
+        }
+
+        fn single_unresolved_symbol(expr: &TDim, values: &SymbolValues) -> Option<Symbol> {
+            use crate::internal::TDim::*;
+            fn walk(e: &TDim, values: &SymbolValues, acc: &mut Option<Symbol>) -> bool {
+                match e {
+                    Val(_) => true,
+                    Sym(s) => {
+                        if values.get(s).is_some() {
+                            true
+                        } else {
+                            match acc {
+                                None => {
+                                    *acc = Some(s.clone());
+                                    true
+                                }
+                                Some(seen) if seen == s => true,
+                                Some(_) => false,
+                            }
+                        }
+                    }
+                    Add(ts) | Mul(ts) | Broadcast(ts) | Min(ts) | Max(ts) => {
+                        for t in ts {
+                            if !walk(t, values, acc) {
+                                return false;
+                            }
+                        }
+                        true
+                    }
+                    MulInt(_, a) => walk(a, values, acc),
+                    Div(a, _) => walk(a, values, acc),
+                }
+            }
+            let mut only: Option<Symbol> = None;
+            if walk(expr, values, &mut only) { only } else { None }
+        }
+
+        if let Some(sym) = single_unresolved_symbol(expression, &state.resolved_symbols) {
+            let expected = expression.eval(&state.resolved_symbols);
             if let Some(v) = solve_for(&sym, &expected, &provided.to_dim()) {
                 debug!("Determined symbol {sym}={v}");
-                state.resolved_symbols.set(&sym, v.to_i64().unwrap());
-            }
-            if state.scenario.is_none() {
-                let scope = sym
-                    .scope()
-                    .with_context(|| format!("Symbol {sym:?} points to an invalid (dead ?) SymbolScope. Make sure to create symbols using the model-managed SymbolScope."))?;
-                state.scenario = scope.guess_scenario(&state.resolved_symbols)?;
+                let val = v.to_i64()?;
+                state.resolved_symbols.set(&sym, val);
+                if state.scenario.is_none() {
+                    let scope = sym.scope().with_context(|| format!(
+                        "Symbol {sym:?} points to an invalid (dead ?) SymbolScope. Make sure to create symbols using the model-managed SymbolScope."
+                    ))?;
+                    state.scenario = scope.guess_scenario(&state.resolved_symbols)?;
+                }
             }
         }
         Ok(())
     }
 
     pub fn set_input(&mut self, input: usize, t: TValue) -> TractResult<()> {
-        let outlet: OutletId = *self
-            .model()
-            .input_outlets()?
-            .get(input)
-            .with_context(|| format!("Invalid input id for model ({input})."))?;
-        if let Ok(fact) = self.plan.borrow().model().outlet_fact(outlet)?.to_typed_fact() {
-            for (expected, provided) in fact.shape.iter().zip(t.shape()) {
-                Self::resolve(&mut self.session_state, expected, *provided as i64)?;
+        let plan = self.plan.borrow();
+
+        if input >= plan.inputs.len() {
+            bail!("Invalid input id for model ({input}).");
+        }
+
+        let outlet = unsafe { *plan.inputs.get_unchecked(input) };
+
+        if let Some(fact) = unsafe { plan.input_facts.get_unchecked(input) }.as_ref() {
+            let t_shape = t.shape();
+            if fact.shape.iter().count() == t_shape.len() {
+                for (expected, &provided) in fact.shape.iter().zip(t_shape.iter()) {
+                    Self::resolve(&mut self.session_state, expected, provided as i64)?;
+                }
             }
         }
+
         let fact = self.plan.borrow().model().outlet_fact(outlet)?;
         ensure!(
             fact.matches(&t, Some(&self.session_state.resolved_symbols))
                 .with_context(|| format!("Setting input {input}"))?,
             "Input at index {input} has incorrect dtype or shape (got {t:?}, expected to match fact {fact:?})",
         );
+
         self.session_state.inputs.insert(outlet.node, t);
         Ok(())
     }
@@ -557,7 +749,7 @@ where
         let plan = plan.borrow();
         let nodes = plan.model().nodes();
         let node = &nodes[node];
-        let mut inputs: TVec<TValue> = tvec![];
+        let mut inputs: TVec<TValue> = TVec::with_capacity(node.inputs.len());
         for i in &node.inputs {
             let prec_node = &nodes[i.node];
             let prec = values[i.node].as_ref().ok_or_else(|| {
@@ -603,7 +795,8 @@ where
                     let _ = self.compute_recursively(i)?;
                 }
             }
-            let mut inputs: TVec<TValue> = tvec![];
+            let mut inputs: TVec<TValue> =
+                TVec::with_capacity(self.model().nodes()[node].inputs.len());
             {
                 let node = &self.model().nodes()[node];
                 for i in &node.inputs {
@@ -636,10 +829,12 @@ where
             .collect())
     }
 
+    #[inline]
     pub fn plan(&self) -> &SimplePlan<F, O, M> {
         self.plan.borrow()
     }
 
+    #[inline]
     pub fn model(&self) -> &Graph<F, O> {
         self.plan().model()
     }


### PR DESCRIPTION
For our use case we are executing basic ONNX models e.g. LinearClassifier millions of times.
And so the overhead of Tract is our biggest performance impact.

This PR aims to "front-load" more work during the plan stage.

Based on benchmarks we see a ~3x performance improvement. 