### PR TITLE
Simplified Tensor drop

### DIFF
--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -144,8 +144,8 @@ impl Drop for Tensor {
             ($t: ty) => {
                 if self.dt == <$t>::datum_type() {
                     unsafe {
-                      let slice = self.as_slice_mut::<$t>().unwrap();
-                      std::ptr::drop_in_place(slice as *mut [$t]);
+                        let slice = self.as_slice_mut::<$t>().unwrap();
+                        std::ptr::drop_in_place(slice as *mut [$t]);
                     }
                 }
             };


### PR DESCRIPTION
In benchmark testing we see a small performance improvement:

LinearClassifier - 535.98 µs -> 541.75 µs
LinearClassifier - 2.2194 s -> 2.1692 s

LinearRegressor - 544.21 µs -> 533.79 µs
LinearRegressor - 2.2033 s -> 2.1418 s
