### PR TITLE
Fix --assert-op-only lists for SD and SDXL examples

### DIFF
--- a/examples/stable-diffusion-xl/ci-gpu.sh
+++ b/examples/stable-diffusion-xl/ci-gpu.sh
@@ -31,10 +31,10 @@ fi
 
 if nvidia-smi > /dev/null 2>&1; then
     RUNTIME="--cuda"
-    GPU_ASSERT="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source"
+    GPU_ASSERT="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,IsNan,Gather*,Reduce*"
 elif [ "$(uname)" = "Darwin" ] && system_profiler SPDisplaysDataType 2>/dev/null | grep -qi metal; then
     RUNTIME="--metal"
-    GPU_ASSERT="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source"
+    GPU_ASSERT="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,IsNan,Gather*,Reduce*"
 else
     RUNTIME="-O"
     GPU_ASSERT=""

--- a/examples/stable-diffusion/ci-gpu.sh
+++ b/examples/stable-diffusion/ci-gpu.sh
@@ -33,10 +33,10 @@ fi
 
 if nvidia-smi > /dev/null 2>&1; then
     RUNTIME="--cuda"
-    GPU_ASSERT="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source"
+    GPU_ASSERT="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,IsNan,Gather*,Reduce*"
 elif [ "$(uname)" = "Darwin" ] && system_profiler SPDisplaysDataType 2>/dev/null | grep -qi metal; then
     RUNTIME="--metal"
-    GPU_ASSERT="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source"
+    GPU_ASSERT="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,IsNan,Gather*,Reduce*"
 else
     RUNTIME="-O"
     GPU_ASSERT=""


### PR DESCRIPTION
Add IsNan, Gather*, Reduce* to allowed ops. These are CPU fallback ops in the text encoder (IsNan, Gather for embedding, ArgMax) and UNet (GatherNd for timestep embedding).