### PR TITLE
Add freeze_into for zero-copy State freezing, wrap FrozenState in API

### DIFF
--- a/api/ffi/src/lib.rs
+++ b/api/ffi/src/lib.rs
@@ -1137,6 +1137,22 @@ pub unsafe extern "C" fn tract_state_output_count(
     })
 }
 
+/// Clone a State, creating an independent copy.
+///
+/// `clone` will be overwritten with a pointer to the new state. The new state must eventually be
+/// destroyed with `tract_state_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tract_state_clone(
+    state: *const TractState,
+    clone: *mut *mut TractState,
+) -> TRACT_RESULT {
+    wrap(|| unsafe {
+        check_not_null!(state, clone);
+        *clone = Box::into_raw(Box::new(TractState((*state).0.clone())));
+        Ok(())
+    })
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tract_state_destroy(state: *mut *mut TractState) -> TRACT_RESULT {
     release!(state)

--- a/api/proxy/src/lib.rs
+++ b/api/proxy/src/lib.rs
@@ -459,7 +459,34 @@ impl RunnableInterface for Runnable {
 }
 
 // STATE
-wrapper!(State, TractState, tract_state_destroy);
+pub struct State(*mut sys::TractState);
+
+impl Drop for State {
+    fn drop(&mut self) {
+        unsafe {
+            sys::tract_state_destroy(&mut self.0);
+        }
+    }
+}
+
+impl std::fmt::Debug for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "State({:?})", self.0)
+    }
+}
+
+impl Clone for State {
+    fn clone(&self) -> Self {
+        let mut clone = null_mut();
+        unsafe {
+            sys::tract_state_clone(self.0, &mut clone);
+        }
+        State(clone)
+    }
+}
+
+// Safety: the underlying FrozenState is Send
+unsafe impl Send for State {}
 
 impl StateInterface for State {
     type Tensor = Tensor;

--- a/api/proxy/sys/tract.h
+++ b/api/proxy/sys/tract.h
@@ -572,6 +572,14 @@ enum TRACT_RESULT tract_state_input_count(const struct TractState *state, uintpt
  */
 enum TRACT_RESULT tract_state_output_count(const struct TractState *state, uintptr_t *outputs);
 
+/**
+ * Clone a State, creating an independent copy.
+ *
+ * `clone` will be overwritten with a pointer to the new state. The new state must eventually be
+ * destroyed with `tract_state_destroy`.
+ */
+enum TRACT_RESULT tract_state_clone(const struct TractState *state, struct TractState **clone);
+
 enum TRACT_RESULT tract_state_destroy(struct TractState **state);
 
 /**

--- a/api/rs/src/lib.rs
+++ b/api/rs/src/lib.rs
@@ -348,7 +348,8 @@ impl RunnableInterface for Runnable {
     }
 
     fn spawn_state(&self) -> Result<State> {
-        Ok(State(self.0.spawn()?))
+        let state = self.0.spawn()?;
+        Ok(State(Some(state.freeze_into())))
     }
 
     fn input_count(&self) -> Result<usize> {
@@ -419,7 +420,7 @@ impl RunnableInterface for Runnable {
 }
 
 // STATE
-pub struct State(Box<dyn tract_nnef::internal::State>);
+pub struct State(Option<Box<dyn tract_nnef::internal::FrozenState>>);
 
 impl Debug for State {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -427,22 +428,34 @@ impl Debug for State {
     }
 }
 
+impl Clone for State {
+    fn clone(&self) -> Self {
+        State(self.0.as_ref().map(|s| tract_nnef::tract_core::dyn_clone::clone_box(&**s)))
+    }
+}
+
+// Safety: FrozenState is Send
+unsafe impl Send for State {}
+
 impl StateInterface for State {
     type Fact = Fact;
     type Tensor = Tensor;
 
     fn input_count(&self) -> Result<usize> {
-        Ok(self.0.input_count())
+        Ok(self.0.as_ref().context("State has been invalidated")?.input_count())
     }
 
     fn output_count(&self) -> Result<usize> {
-        Ok(self.0.output_count())
+        Ok(self.0.as_ref().context("State has been invalidated")?.output_count())
     }
 
     fn run(&mut self, inputs: impl IntoInputs<Tensor>) -> Result<Vec<Tensor>> {
         let inputs: TVec<TValue> =
             inputs.into_inputs()?.into_iter().map(|v| v.0.into_tvalue()).collect();
-        let outputs = self.0.run(inputs)?;
+        let frozen = self.0.take().context("State has been invalidated")?;
+        let mut state = frozen.unfreeze();
+        let outputs = state.run(inputs)?;
+        self.0 = Some(state.freeze_into());
         Ok(outputs.into_iter().map(|t| Tensor(t.into_arc_tensor())).collect())
     }
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -222,7 +222,7 @@ pub trait RunnableInterface: Debug + Send + Sync {
         IE: Into<anyhow::Error> + Debug;
 }
 
-pub trait StateInterface: Debug {
+pub trait StateInterface: Debug + Clone + Send {
     type Fact: FactInterface;
     type Tensor: TensorInterface;
 

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -90,6 +90,10 @@ pub trait FrozenOpState: fmt::Debug + dyn_clone::DynClone + Send + 'static {
 
 pub trait OpStateFreeze {
     fn freeze(&self) -> Box<dyn FrozenOpState>;
+    /// Consuming freeze: moves data instead of cloning. Default delegates to freeze().
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        self.freeze()
+    }
 }
 
 dyn_clone::clone_trait_object!(FrozenOpState);

--- a/core/src/ops/scan/optimized.rs
+++ b/core/src/ops/scan/optimized.rs
@@ -98,6 +98,15 @@ impl OpStateFreeze for State {
             model_state: self.model_state.freeze(),
         })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenState {
+            op: self.op,
+            position: self.position,
+            hidden_state: self.hidden_state.into_iter().map(|t| t.into_tensor()).collect(),
+            model_state: self.model_state.freeze_into(),
+        })
+    }
 }
 
 impl FrozenOpState for FrozenState {

--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -644,6 +644,30 @@ where
                 .collect(),
         }
     }
+
+    pub fn freeze_into(self) -> FrozenSimpleState<F, O> {
+        let plan = self.plan;
+        let model = &plan.model;
+        FrozenSimpleState {
+            resolved_symbols: self.turn_state.resolved_symbols,
+            scenario: self.turn_state.scenario,
+            states: self.op_states.into_iter().map(|s| s.map(|s| s.freeze_into())).collect(),
+            values: self
+                .turn_state
+                .values
+                .into_iter()
+                .enumerate()
+                .map(|(ix, t)| {
+                    if model.nodes[ix].op_is::<Const>() {
+                        t.map(|t| t.into_iter().map(|t| t.into_tensor()).collect())
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            plan,
+        }
+    }
 }
 
 pub fn eval<F, O>(
@@ -685,6 +709,10 @@ where
     F: Fact + Clone + 'static,
     O: Debug + Display + AsRef<dyn Op> + AsMut<dyn Op> + Clone + 'static,
 {
+    pub fn plan(&self) -> &Arc<SimplePlan<F, O>> {
+        &self.plan
+    }
+
     pub fn unfreeze(&self) -> SimpleState<F, O> {
         SimpleState {
             plan: self.plan.clone(),

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -86,11 +86,17 @@ pub trait State: Any + Downcast + Debug + 'static {
     }
 
     fn freeze(&self) -> Box<dyn FrozenState>;
+    /// Consuming freeze: moves data instead of cloning.
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenState> {
+        self.freeze()
+    }
 }
 impl_downcast!(State);
 
 pub trait FrozenState: Any + Debug + DynClone + Send {
     fn unfreeze(&self) -> Box<dyn State>;
+    fn input_count(&self) -> usize;
+    fn output_count(&self) -> usize;
 }
 dyn_clone::clone_trait_object!(FrozenState);
 
@@ -157,11 +163,23 @@ impl State for TypedSimpleState {
     fn freeze(&self) -> Box<dyn FrozenState> {
         Box::new(TypedSimpleState::freeze(self))
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenState> {
+        Box::new(TypedSimpleState::freeze_into(*self))
+    }
 }
 
 impl FrozenState for TypedFrozenSimpleState {
     fn unfreeze(&self) -> Box<dyn State> {
         Box::new(TypedFrozenSimpleState::unfreeze(self))
+    }
+
+    fn input_count(&self) -> usize {
+        self.plan().model().input_outlets().unwrap().len()
+    }
+
+    fn output_count(&self) -> usize {
+        self.plan().model().output_outlets().unwrap().len()
     }
 }
 

--- a/cuda/src/ops/fused_axis_op.rs
+++ b/cuda/src/ops/fused_axis_op.rs
@@ -112,6 +112,10 @@ impl OpStateFreeze for CudaFusedAxisOpState {
     fn freeze(&self) -> Box<dyn FrozenOpState + 'static> {
         Box::new(FrozenCudaFusedAxisOpState { op_state: self.op_state.freeze() })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenCudaFusedAxisOpState { op_state: self.op_state.freeze_into() })
+    }
 }
 
 impl FrozenOpState for FrozenCudaFusedAxisOpState {

--- a/gpu/src/ops/dyn_kv_cache.rs
+++ b/gpu/src/ops/dyn_kv_cache.rs
@@ -139,6 +139,16 @@ impl OpStateFreeze for GpuDynKVCacheState {
             kv_cache: self.kv_cache.clone().map(|t| t.to_device_tensor().cloned().unwrap()),
         })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenGpuDynKVCacheState {
+            node_id: self.node_id,
+            name: self.name,
+            axis: self.axis,
+            past_sequence_fact: self.past_sequence_fact,
+            kv_cache: self.kv_cache.map(|t| t.to_device_tensor().cloned().unwrap()),
+        })
+    }
 }
 
 impl FrozenOpState for FrozenGpuDynKVCacheState {

--- a/metal/src/ops/fused_axis_op.rs
+++ b/metal/src/ops/fused_axis_op.rs
@@ -112,6 +112,10 @@ impl OpStateFreeze for MetalFusedAxisOpState {
     fn freeze(&self) -> Box<dyn FrozenOpState + 'static> {
         Box::new(FrozenMetalFusedAxisOpState { op_state: self.op_state.freeze() })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenMetalFusedAxisOpState { op_state: self.op_state.freeze_into() })
+    }
 }
 
 impl FrozenOpState for FrozenMetalFusedAxisOpState {

--- a/pulse-opl/src/deconv_delay.rs
+++ b/pulse-opl/src/deconv_delay.rs
@@ -125,6 +125,13 @@ impl OpStateFreeze for DeconvDelayState {
             buffer: self.buffer.as_ref().map(|t| t.clone().into_arc_tensor()),
         })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenDeconvDelayState {
+            valid_inputed: self.valid_inputed,
+            buffer: self.buffer.map(|t| t.into_arc_tensor()),
+        })
+    }
 }
 
 impl FrozenOpState for FrozenDeconvDelayState {

--- a/pulse-opl/src/delay.rs
+++ b/pulse-opl/src/delay.rs
@@ -201,6 +201,10 @@ impl OpStateFreeze for DelayState {
             buffer: self.buffer.as_ref().map(|t| t.clone().into_arc_tensor()),
         })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenDelayState { buffer: self.buffer.map(|t| t.into_arc_tensor()) })
+    }
 }
 
 impl FrozenOpState for FrozenDelayState {

--- a/pulse-opl/src/pad.rs
+++ b/pulse-opl/src/pad.rs
@@ -271,6 +271,13 @@ impl OpStateFreeze for PulsePadOpState {
             last_valid_frame: self.last_valid_frame.as_ref().map(|t| t.clone().into_arc_tensor()),
         })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenPulsePadOpState {
+            current_pos: self.current_pos,
+            last_valid_frame: self.last_valid_frame.map(|t| t.into_arc_tensor()),
+        })
+    }
 }
 
 impl FrozenOpState for FrozenPulsePadOpState {

--- a/transformers/src/ops/dyn_kv_cache.rs
+++ b/transformers/src/ops/dyn_kv_cache.rs
@@ -251,6 +251,15 @@ impl OpStateFreeze for DynKeyValueCacheState {
             kv_cache: self.kv_cache.clone().map(|t| t.into_tensor()),
         })
     }
+
+    fn freeze_into(self: Box<Self>) -> Box<dyn FrozenOpState> {
+        Box::new(FrozenDynKeyValueCacheState {
+            name: self.name,
+            axis: self.axis,
+            past_sequence_fact: self.past_sequence_fact,
+            kv_cache: self.kv_cache.map(|t| t.into_tensor()),
+        })
+    }
 }
 
 impl FrozenOpState for FrozenDynKeyValueCacheState {


### PR DESCRIPTION
Add consuming freeze_into(self: Box<Self>) methods to OpStateFreeze, State, and SimpleState. Moves data instead of cloning — TValue::into_tensor can unwrap Rc without copying when refcount is 1.

Non-cloning freeze_into overrides on all stateful ops:
- DynKeyValueCacheState / GpuDynKVCacheState: move KV cache tensors
- DelayState / PulsePadOpState / DeconvDelayState: move buffer tensors
- Scan State: move hidden state and nested model state
- CudaFusedAxisOpState / MetalFusedAxisOpState: delegate to inner state

Switch public API State to wrap FrozenState instead of State internally. This makes State Clone + Send. On each run(), the frozen state is unfrozen, executed, then freeze_into'd back — zero-copy in the common case where the state is the sole owner.

Add input_count/output_count to FrozenState trait and FrozenSimpleState.