### PR TITLE
Update cargo-deny skip for hashbrown 0.17

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,7 @@ deny = [
 
 # Skip some multiple-versions checks, until they can be fixed.
 skip = [
-    { name = "hashbrown", version="<0.16" },
+    { name = "hashbrown", version="<0.17" },
     { name = "foldhash", version="<0.2" },
     { name = "cpufeatures", version="<0.3" },
     { name = "cfg-if", version="<1" },


### PR DESCRIPTION
indexmap 2.14 pulled in hashbrown 0.17 while safetensors still uses 0.16. Widen the skip from <0.16 to <0.17.