### PR TITLE
Fix PropagateRoi infinite loop on SD UNet

### DIFF
--- a/core/src/ops/array/broadcast.rs
+++ b/core/src/ops/array/broadcast.rs
@@ -38,6 +38,14 @@ impl TypedOp for MultiBroadcastTo {
         Ok(tvec!(fact))
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn concretize_dims(
         &self,
         _source: &TypedModel,

--- a/core/src/ops/cast.rs
+++ b/core/src/ops/cast.rs
@@ -81,6 +81,14 @@ impl TypedOp for Cast {
         Ok(tvec!(fact))
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn declutter(
         &self,
         model: &TypedModel,

--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -730,6 +730,14 @@ impl TypedOp for AxisOp {
         Ok(tvec!(fact))
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn axes_mapping(
         &self,
         inputs: &[&TypedFact],

--- a/core/src/ops/einsum/mod.rs
+++ b/core/src/ops/einsum/mod.rs
@@ -218,6 +218,14 @@ impl TypedOp for EinSum {
         }
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn axes_mapping(
         &self,
         inputs: &[&TypedFact],

--- a/core/src/ops/element_wise.rs
+++ b/core/src/ops/element_wise.rs
@@ -140,6 +140,14 @@ impl TypedOp for ElementWiseOp {
         Ok(tvec!(fact))
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn change_axes(
         &self,
         model: &TypedModel,

--- a/core/src/ops/identity.rs
+++ b/core/src/ops/identity.rs
@@ -27,6 +27,14 @@ impl TypedOp for Identity {
         Ok(tvec!(inputs[0].clone()))
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn declutter(
         &self,
         model: &TypedModel,

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -229,16 +229,15 @@ pub trait TypedOp:
     }
 
     /// Derive ROI (region of interest) expressions for this node's inputs.
-    /// Called by the PropagateRoi pass. The default implementation uses
-    /// axes_mapping to bubble output ROI to inputs with coordinate remapping.
-    /// Override for ops that introduce ROIs (e.g. Iff, masked softmax) or
-    /// that need arithmetic coordinate transforms (e.g. Slice, Pad).
+    /// Called by the PropagateRoi pass. Default returns None (no propagation).
+    /// Override to introduce ROIs or bubble them through.
+    #[allow(unused_variables)]
     fn input_roi(
         &self,
         model: &TypedModel,
         node: &TypedNode,
     ) -> TractResult<Option<TVec<Option<TDim>>>> {
-        crate::optim::propagate_roi::bubble_roi(model, node)
+        Ok(None)
     }
 
     #[allow(unused_variables)]

--- a/core/src/ops/nn/reduce.rs
+++ b/core/src/ops/nn/reduce.rs
@@ -371,6 +371,14 @@ impl EvalOp for Reduce {
 }
 
 impl TypedOp for Reduce {
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
         ensure!(self.axes.iter().tuple_windows().all(|(a, b)| a < b));
         if inputs[0].datum_type == TDim::datum_type() {

--- a/core/src/ops/nn/rms_norm.rs
+++ b/core/src/ops/nn/rms_norm.rs
@@ -52,6 +52,14 @@ impl TypedOp for RmsNorm {
         Ok(tvec!(fact))
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn axes_mapping(
         &self,
         inputs: &[&TypedFact],

--- a/core/src/ops/nn/softmax/mod.rs
+++ b/core/src/ops/nn/softmax/mod.rs
@@ -86,6 +86,14 @@ impl TypedOp for Softmax {
         Ok(tvec!(fact))
     }
 
+    fn input_roi(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TVec<Option<TDim>>>> {
+        crate::optim::propagate_roi::bubble_roi(model, node)
+    }
+
     fn axes_mapping(
         &self,
         inputs: &[&TypedFact],

--- a/core/src/optim/propagate_roi.rs
+++ b/core/src/optim/propagate_roi.rs
@@ -85,52 +85,45 @@ impl super::TypedPass for PropagateRoi {
     }
 
     fn run_direct(&mut self, model: &mut TypedModel) -> TractResult<bool> {
-        let mut any_changed = false;
-        loop {
-            let order = model.eval_order()?;
-            let mut changed = false;
+        let order = model.eval_order()?;
+        let mut changed = false;
 
-            // Collect ROI demands from all nodes.
-            let mut demands: HashMap<OutletId, Option<TDim>> = HashMap::new();
+        // Collect ROI demands from all nodes.
+        let mut demands: HashMap<OutletId, Option<TDim>> = HashMap::new();
 
-            for &node_id in &order {
-                let node = &model.nodes()[node_id];
-                let Some(input_rois) = node.op.as_typed().unwrap().input_roi(model, node)? else {
-                    continue;
-                };
-                for (ix, roi) in input_rois.into_iter().enumerate() {
-                    let outlet = node.inputs[ix];
-                    match (demands.get(&outlet), &roi) {
-                        (_, None) => {
-                            demands.insert(outlet, None);
-                        }
-                        (Option::None, Some(roi)) => {
-                            demands.insert(outlet, Some(roi.clone()));
-                        }
-                        (Some(None), Some(_)) => {}
-                        (Some(Some(existing)), Some(new)) => {
-                            demands.insert(outlet, Some(roi_union(existing, new)));
-                        }
+        for &node_id in &order {
+            let node = &model.nodes()[node_id];
+            let Some(input_rois) = node.op.as_typed().unwrap().input_roi(model, node)? else {
+                continue;
+            };
+            for (ix, roi) in input_rois.into_iter().enumerate() {
+                let outlet = node.inputs[ix];
+                match (demands.get(&outlet), &roi) {
+                    (_, None) => {
+                        demands.insert(outlet, None);
+                    }
+                    (Option::None, Some(roi)) => {
+                        demands.insert(outlet, Some(roi.clone()));
+                    }
+                    (Some(None), Some(_)) => {}
+                    (Some(Some(existing)), Some(new)) => {
+                        demands.insert(outlet, Some(roi_union(existing, new)));
                     }
                 }
-            }
-
-            // Apply demands to model facts.
-            for (outlet, demand) in demands {
-                if let Some(roi) = demand {
-                    let fact = &mut model.nodes_mut()[outlet.node].outputs[outlet.slot].fact;
-                    if fact.region_of_interest.as_ref() != Some(&roi) {
-                        fact.region_of_interest = Some(roi);
-                        changed = true;
-                    }
-                }
-            }
-
-            any_changed |= changed;
-            if !changed {
-                break;
             }
         }
-        Ok(any_changed)
+
+        // Apply demands to model facts.
+        for (outlet, demand) in demands {
+            if let Some(roi) = demand {
+                let fact = &mut model.nodes_mut()[outlet.node].outputs[outlet.slot].fact;
+                if fact.region_of_interest.as_ref() != Some(&roi) {
+                    fact.region_of_interest = Some(roi);
+                    changed = true;
+                }
+            }
+        }
+
+        Ok(changed)
     }
 }


### PR DESCRIPTION
The fixpoint loop in PropagateRoi produced ever-growing ROI expressions via De Morgan OR merge, causing an infinite loop on large models.

Fix: single pass instead of fixpoint (introductions + bubbling in one traversal). Revert default input_roi to None — only explicitly opted-in ops participate, preventing ROI from leaking through Conv/Scan/etc.