### PR TITLE
Fix three GPU bugs in pulsed streaming models

### DIFF
--- a/gpu/src/device.rs
+++ b/gpu/src/device.rs
@@ -90,7 +90,25 @@ pub trait DeviceContext: Downcast + dyn_clone::DynClone + Send + Sync {
         if byte_len == 0 {
             return Ok(());
         }
-        self.copy_nd(src, src_byte_offset, &[1], dst, dst_byte_offset, &[byte_len], &[1])
+        // copy_nd dispatches a typed kernel (u8/u16/u32/u64 based on datum_type),
+        // so shape and strides are in elements, not bytes.
+        let elem_size = src.datum_type().size_of();
+        ensure!(
+            byte_len % elem_size == 0
+                && src_byte_offset % elem_size == 0
+                && dst_byte_offset % elem_size == 0,
+            "flat_copy: byte_len {byte_len}, src_offset {src_byte_offset}, \
+             dst_offset {dst_byte_offset} not aligned to element size {elem_size}"
+        );
+        self.copy_nd(
+            src,
+            src_byte_offset,
+            &[1],
+            dst,
+            dst_byte_offset,
+            &[byte_len / elem_size],
+            &[1],
+        )
     }
 }
 

--- a/gpu/src/ops/pulse.rs
+++ b/gpu/src/ops/pulse.rs
@@ -39,7 +39,7 @@ impl EvalOp for GpuDelay {
     }
 
     fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        Ok(Some(Box::new(GpuDelayState { node_id, buffer: None })))
+        Ok(Some(Box::new(GpuDelayState { node_id, buffer: None, shift_scratch: None })))
     }
 }
 
@@ -60,6 +60,7 @@ impl TypedOp for GpuDelay {
 pub struct GpuDelayState {
     pub node_id: usize,
     pub buffer: Option<DeviceTensor>,
+    pub shift_scratch: Option<DeviceTensor>,
 }
 
 impl GpuDelayState {
@@ -93,11 +94,15 @@ impl GpuDelayState {
                 op.axis,
             )?;
         } else {
-            // Shift buffer left by input_pulse elements
-            let dt = input.datum_type();
-            let shift_bytes = buffer.strides()[op.axis] as usize * dt.size_of() * input_pulse;
-            let remaining = buffer.len() * dt.size_of() - shift_bytes;
-            ctx.flat_copy(buffer, shift_bytes, buffer, 0, remaining)?;
+            // Shift buffer left by input_pulse elements.
+            // CUDA memcpy is undefined for overlapping regions in the same
+            // buffer (parallel threads), so copy via a scratch buffer.
+            let keep = buffered - input_pulse;
+            let scratch = self.shift_scratch.get_or_insert_with(|| {
+                DeviceTensor::uninitialized_dt(input.datum_type(), buffer.shape()).unwrap()
+            });
+            ctx.assign_slice(scratch, 0..keep, buffer, input_pulse..buffered, op.axis)?;
+            ctx.assign_slice(buffer, 0..keep, scratch, 0..keep, op.axis)?;
             // Copy input to end of buffer
             ctx.assign_slice(
                 buffer,
@@ -132,7 +137,7 @@ impl OpState for GpuDelayState {
             if self.buffer.is_none() {
                 let mut shape = device_input.shape().to_owned();
                 shape[op.axis] = buffered;
-                self.buffer = Some(DeviceTensor::uninitialized_dt(dt, &shape)?);
+                self.buffer = Some(Tensor::zero_dt(dt, &shape)?.into_device()?);
             };
             let mut output = make_tensor_for_node(state, self.node_id, dt, &output_shape)?;
             self.apply_delay_unchecked(&*ctx, op, device_input, &mut output)?;


### PR DESCRIPTION
1. flat_copy byte/element mismatch: flat_copy passed byte_len as the shape to copy_nd, but the CUDA kernel dispatched by datum_type operates on typed elements (u32 for f32). For f32 tensors, the kernel accessed 4x the intended range, corrupting GPU memory. Fix: divide byte_len by element size before passing to copy_nd.

2. GpuDelay uninitialized buffer: CPU Delay uses zero_dt (zero-filled) but GpuDelay used uninitialized_dt. On the first pulse, garbage from uninitialized GPU memory was copied to the output. Fix: initialize with Tensor::zero_dt(...).into_device().

3. GpuDelay overlapping buffer shift: when buffered >= input_pulse, the buffer shift used flat_copy with overlapping source and destination within the same GPU buffer. CUDA memcpy is undefined for overlapping regions (parallel threads write non-deterministically). Fix: copy via a temporary buffer using assign_slice.