### PR TITLE
Resolve Resize eval for opset 11 models with empty scales tensor

### DIFF
--- a/onnx-opl/src/resize.rs
+++ b/onnx-opl/src/resize.rs
@@ -227,7 +227,8 @@ impl EvalOp for Resize {
             scales.map(|t| &**t),
             sizes.map(|t| &**t),
         )?;
-        let scales: TVec<f32> = if let Some(scales) = scales {
+        let scales: TVec<f32> = if let Some(scales) = scales.filter(|s| s.len() == inputs[0].rank())
+        {
             scales.try_as_plain()?.as_slice::<f32>()?.into()
         } else {
             output_shape.iter().zip(inputs[0].shape()).map(|(o, i)| *o as f32 / *i as f32).collect()


### PR DESCRIPTION
Fixes #2130.

ONNX opset 11 Resize models express sizes-based resize by providing an empty scales tensor (shape=(0,)) alongside a non-empty sizes input. The current eval code treats any `Some(scales)` as a usable scale vector and iterates over it, producing no axes to resize — the output equals the input.

Eval now guards on `scales.len() == inputs[0].rank()` and falls back to computing scale factors from `output_shape / input_shape` when the scales tensor is absent or empty, matching the pre-existing guard in `compute_output_shape`.

The four tests flagged in #2130 now pass:
- \`default::node::v1_6_0::test_resize_downsample_sizes_cubic\`
- \`default::node::v1_6_0::test_resize_upsample_sizes_cubic\`
- \`unoptimized::node::v1_6_0::test_resize_downsample_sizes_cubic\`
- \`unoptimized::node::v1_6_0::test_resize_upsample_sizes_cubic\`

All existing resize tests continue to pass across default, unoptimized, nnef_cycle, and nnef_predump runtimes for both opset 11 (v1.6.0) and opset 18 (v1.13.0).