### PR TITLE
Fix double-free in tract-proxy wrapper Clone impls

### DIFF
--- a/.travis/asan.sh
+++ b/.travis/asan.sh
@@ -37,3 +37,13 @@ then
 fi
 ./.travis/cli-tests.sh
 
+if [ -n "$CI" ]
+then
+    cargo clean
+fi
+
+# Build libtract.so with asan, then run proxy tests against it
+cargo build -p tract-ffi $CARGO_EXTRA
+LIBTRACT_DIR=$(dirname $(find target -name 'libtract.so' | head -1))
+TRACT_DYLIB_SEARCH_PATH=$LIBTRACT_DIR LD_LIBRARY_PATH=$LIBTRACT_DIR cargo -q test -q -p tract-proxy $CARGO_EXTRA
+

--- a/api/ffi/src/lib.rs
+++ b/api/ffi/src/lib.rs
@@ -1051,6 +1051,21 @@ pub unsafe extern "C" fn tract_tensor_convert_to(
 }
 
 /// Destroy a tensor.
+/// Clone a Tensor, creating an independent copy.
+///
+/// The returned tensor must be destroyed by `tract_tensor_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tract_tensor_clone(
+    tensor: *const TractTensor,
+    clone: *mut *mut TractTensor,
+) -> TRACT_RESULT {
+    wrap(|| unsafe {
+        check_not_null!(tensor, clone);
+        *clone = Box::into_raw(Box::new(TractTensor((*tensor).0.clone())));
+        Ok(())
+    })
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tract_tensor_destroy(tensor: *mut *mut TractTensor) -> TRACT_RESULT {
     release!(tensor)
@@ -1214,6 +1229,21 @@ pub unsafe extern "C" fn tract_fact_dump(
     })
 }
 
+/// Clone a Fact, creating an independent copy.
+///
+/// The returned fact must be destroyed by `tract_fact_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tract_fact_clone(
+    fact: *const TractFact,
+    clone: *mut *mut TractFact,
+) -> TRACT_RESULT {
+    wrap(|| unsafe {
+        check_not_null!(fact, clone);
+        *clone = Box::into_raw(Box::new(TractFact((*fact).0.clone())));
+        Ok(())
+    })
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tract_fact_destroy(fact: *mut *mut TractFact) -> TRACT_RESULT {
     release!(fact)
@@ -1265,6 +1295,21 @@ pub unsafe extern "C" fn tract_inference_fact_dump(
     wrap(|| unsafe {
         check_not_null!(fact, spec);
         *spec = CString::new(format!("{}", (*fact).0))?.into_raw();
+        Ok(())
+    })
+}
+
+/// Clone an InferenceFact, creating an independent copy.
+///
+/// The returned fact must be destroyed by `tract_inference_fact_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tract_inference_fact_clone(
+    fact: *const TractInferenceFact,
+    clone: *mut *mut TractInferenceFact,
+) -> TRACT_RESULT {
+    wrap(|| unsafe {
+        check_not_null!(fact, clone);
+        *clone = Box::into_raw(Box::new(TractInferenceFact((*fact).0.clone())));
         Ok(())
     })
 }
@@ -1330,6 +1375,21 @@ pub unsafe extern "C" fn tract_dim_dump(
     wrap(|| unsafe {
         check_not_null!(dim, spec);
         *spec = CString::new((*dim).0.to_string())?.into_raw();
+        Ok(())
+    })
+}
+
+/// Clone a Dim, creating an independent copy.
+///
+/// The returned dim must be destroyed by `tract_dim_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tract_dim_clone(
+    dim: *const TractDim,
+    clone: *mut *mut TractDim,
+) -> TRACT_RESULT {
+    wrap(|| unsafe {
+        check_not_null!(dim, clone);
+        *clone = Box::into_raw(Box::new(TractDim((*dim).0.clone())));
         Ok(())
     })
 }

--- a/api/proxy/src/lib.rs
+++ b/api/proxy/src/lib.rs
@@ -23,7 +23,7 @@ macro_rules! check {
 
 macro_rules! wrapper {
     ($new_type:ident, $c_type:ident, $dest:ident $(, $typ:ty )*) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug)]
         pub struct $new_type(*mut sys::$c_type $(, $typ)*);
 
         impl Drop for $new_type {
@@ -31,6 +31,20 @@ macro_rules! wrapper {
                 unsafe {
                     sys::$dest(&mut self.0);
                 }
+            }
+        }
+    };
+}
+
+macro_rules! wrapper_clone {
+    ($new_type:ident, $clone_fn:ident) => {
+        impl Clone for $new_type {
+            fn clone(&self) -> Self {
+                let mut clone = null_mut();
+                unsafe {
+                    sys::$clone_fn(self.0, &mut clone);
+                }
+                $new_type(clone)
             }
         }
     };
@@ -516,6 +530,7 @@ impl StateInterface for State {
 
 // TENSOR
 wrapper!(Tensor, TractTensor, tract_tensor_destroy);
+wrapper_clone!(Tensor, tract_tensor_clone);
 unsafe impl Send for Tensor {}
 unsafe impl Sync for Tensor {}
 
@@ -582,6 +597,7 @@ tensor_from_to_ndarray!();
 
 // FACT
 wrapper!(Fact, TractFact, tract_fact_destroy);
+wrapper_clone!(Fact, tract_fact_clone);
 
 impl Fact {
     fn new(model: &Model, spec: impl ToString) -> Result<Fact> {
@@ -635,6 +651,7 @@ impl std::fmt::Display for Fact {
 
 // INFERENCE FACT
 wrapper!(InferenceFact, TractInferenceFact, tract_inference_fact_destroy);
+wrapper_clone!(InferenceFact, tract_inference_fact_clone);
 
 impl InferenceFact {
     fn new(model: &InferenceModel, spec: impl ToString) -> Result<InferenceFact> {
@@ -683,6 +700,7 @@ as_fact_impl!(Model, Fact);
 
 // Dim
 wrapper!(Dim, TractDim, tract_dim_destroy);
+wrapper_clone!(Dim, tract_dim_clone);
 
 impl Dim {
     fn dump(&self) -> Result<String> {
@@ -720,5 +738,17 @@ impl std::fmt::Display for Dim {
             Ok(s) => f.write_str(&s),
             Err(_) => Err(std::fmt::Error),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_tensor_no_double_free() {
+        let t = Tensor::from_slice::<f32>(&[2, 2], &[1.0, 2.0, 3.0, 4.0]).unwrap();
+        let clone = t.clone();
+        assert_eq!(t, clone);
     }
 }

--- a/api/proxy/sys/tract.h
+++ b/api/proxy/sys/tract.h
@@ -508,10 +508,10 @@ enum TRACT_RESULT tract_runnable_release(struct TractRunnable **runnable);
  * The returned tensor must be destroyed by `tract_tensor_destroy`.
  */
 enum TRACT_RESULT tract_tensor_from_bytes(DatumType datum_type,
-                                         uintptr_t rank,
-                                         const uintptr_t *shape,
-                                         void *data,
-                                         struct TractTensor **tensor);
+                                          uintptr_t rank,
+                                          const uintptr_t *shape,
+                                          void *data,
+                                          struct TractTensor **tensor);
 
 /**
  * Write a tensor as a debug string
@@ -524,18 +524,23 @@ enum TRACT_RESULT tract_tensor_dump(const struct TractTensor *tensor, char **spe
  * Convert a tensor to a new datum type.
  *
  * This function will perform a cheap shallow clone if the destination type is
- * the same as the current type, otherwise it returns a newly allocated tensor instead.
+ * the same as the current type, otherwise it returns a newly allocated Tensor instead.
  *
  * In both cases, the returned tensor must be destroyed by `tract_tensor_destroy`.
  * The input tensor is not consumed, it still need to be destroyed.
  */
 enum TRACT_RESULT tract_tensor_convert_to(const struct TractTensor *input,
-                                         DatumType datum_type,
-                                         struct TractTensor **output);
+                                          DatumType datum_type,
+                                          struct TractTensor **output);
 
 /**
  * Destroy a tensor.
+ * Clone a Tensor, creating an independent copy.
+ *
+ * The returned tensor must be destroyed by `tract_tensor_destroy`.
  */
+enum TRACT_RESULT tract_tensor_clone(const struct TractTensor *tensor, struct TractTensor **clone);
+
 enum TRACT_RESULT tract_tensor_destroy(struct TractTensor **tensor);
 
 /**
@@ -543,10 +548,10 @@ enum TRACT_RESULT tract_tensor_destroy(struct TractTensor **tensor);
  * are required.
  */
 enum TRACT_RESULT tract_tensor_as_bytes(struct TractTensor *tensor,
-                                       DatumType *datum_type,
-                                       uintptr_t *rank,
-                                       const uintptr_t **shape,
-                                       const void **data);
+                                        DatumType *datum_type,
+                                        uintptr_t *rank,
+                                        const uintptr_t **shape,
+                                        const void **data);
 
 /**
  * Run a turn on a model state
@@ -606,6 +611,13 @@ enum TRACT_RESULT tract_fact_dim(const struct TractFact *fact,
  */
 enum TRACT_RESULT tract_fact_dump(const struct TractFact *fact, char **spec);
 
+/**
+ * Clone a Fact, creating an independent copy.
+ *
+ * The returned fact must be destroyed by `tract_fact_destroy`.
+ */
+enum TRACT_RESULT tract_fact_clone(const struct TractFact *fact, struct TractFact **clone);
+
 enum TRACT_RESULT tract_fact_destroy(struct TractFact **fact);
 
 /**
@@ -630,6 +642,14 @@ enum TRACT_RESULT tract_inference_fact_empty(struct TractInferenceFact **fact);
  * The returned string must be freed by the caller using tract_free_cstring.
  */
 enum TRACT_RESULT tract_inference_fact_dump(const struct TractInferenceFact *fact, char **spec);
+
+/**
+ * Clone an InferenceFact, creating an independent copy.
+ *
+ * The returned fact must be destroyed by `tract_inference_fact_destroy`.
+ */
+enum TRACT_RESULT tract_inference_fact_clone(const struct TractInferenceFact *fact,
+                                             struct TractInferenceFact **clone);
 
 /**
  * Destroy a fact.
@@ -658,6 +678,13 @@ enum TRACT_RESULT tract_dim_to_int64(const struct TractDim *fact, int64_t *i);
  * The returned string must be freed by the caller using tract_free_cstring.
  */
 enum TRACT_RESULT tract_dim_dump(const struct TractDim *dim, char **spec);
+
+/**
+ * Clone a Dim, creating an independent copy.
+ *
+ * The returned dim must be destroyed by `tract_dim_destroy`.
+ */
+enum TRACT_RESULT tract_dim_clone(const struct TractDim *dim, struct TractDim **clone);
 
 /**
  * Destroy a dim.


### PR DESCRIPTION
The wrapper! macro derived Clone on raw-pointer-wrapping structs, causing double-free when a clone and its original were both dropped.

Add clone FFI functions (tract_tensor_clone, tract_fact_clone, tract_inference_fact_clone, tract_dim_clone) that perform deep copies, and use them in manual Clone impls instead of the derived bitwise copy. Remove Clone from wrapper types that have no clone support (Nnef, Onnx, Model, InferenceModel, Runnable, Runtime).

Also add proxy crate to the ASan CI test script.

Fixes #2135