### PR TITLE
cuda: surface setup dependencies and diagnostics

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -70,6 +70,20 @@ jobs:
     - name: Cargo test
       run: cargo test -p tract-cuda -p test-cuda
 
+  cuda-minimum-deploy:
+    # Validates the BOM documented in cuda/src/context.rs. Builds tract-cli
+    # on the runner (full toolkit available) then runs it against a tiny
+    # model inside a container that only has the minimum runtime packages
+    # pinned in harness/cuda-minimum-deploy/Dockerfile.
+    runs-on: cuda-lovelace
+    needs: prepare-matrix
+    env:
+      RUSTUP_TOOLCHAIN: "1.91.0"
+    steps:
+    - uses: actions/checkout@v6
+    - name: Minimum-BOM GPU smoke
+      run: harness/cuda-minimum-deploy/gpu-ci.sh
+
   metal:
     runs-on: macOS
     needs: prepare-matrix

--- a/cuda/src/context.rs
+++ b/cuda/src/context.rs
@@ -65,6 +65,27 @@ impl TractCudaContext {
             CudaContext::new(0).with_context(|| "Could not find system default CUDA device")?;
 
         let prop = get_device_prop(0)?;
+
+        // Log device identity so users diagnosing a bad deploy can tell what their code actually
+        // found. cudaDeviceProp::name is a C char array; be defensive about odd bytes.
+        let name_bytes: Vec<u8> =
+            prop.name.iter().take_while(|c| **c != 0).map(|c| *c as u8).collect();
+        let device_name = String::from_utf8_lossy(&name_bytes);
+        log::info!(
+            "tract-cuda: device 0 = {:?}, compute capability {}.{}, {} MiB global mem",
+            device_name,
+            prop.major,
+            prop.minor,
+            prop.totalGlobalMem / (1024 * 1024),
+        );
+
+        if let Ok(rt) = cudarc::runtime::result::version::get_runtime_version() {
+            let (ma, mi) = (rt / 1000, (rt % 1000) / 10);
+            log::info!("tract-cuda: CUDA runtime (cudart) version {ma}.{mi}");
+        } else {
+            log::warn!("tract-cuda: cudaRuntimeGetVersion failed");
+        }
+
         let ctxt = Self {
             inner: context,
             device_properties: prop,
@@ -142,37 +163,43 @@ impl TractCudaContext {
         Ok(())
     }
 
-    /// Build NVRTC options: include paths + GPU arch.
+    /// Build NVRTC options: GPU arch + include paths for the CUDA toolkit's host/device
+    /// headers and the CCCL (libcudacxx) tree. Both are required because NVRTC in
+    /// CUDA 13 does not intercept `<cuda_fp16.h>`, `<math_constants.h>`, or any of
+    /// the libcudacxx headers — they have to be reachable on disk via `-I`. On
+    /// Debian/Ubuntu the matching packages are `cuda-cccl-<ver>` and
+    /// `cuda-cudart-dev-<ver>`.
     fn build_nvrtc_opts(&self) -> TractResult<Vec<String>> {
-        let cuda_home = std::env::var_os("CUDA_HOME")
-            .map(PathBuf::from)
-            .or_else(|| std::env::var_os("CUDA_PATH").map(PathBuf::from)) // Windows
-            .or_else(|| {
-                let p = Path::new("/usr/local/cuda");
-                if p.exists() { Some(p.to_path_buf()) } else { None }
-            })
-            .or_else(|| {
-                // Last resort: infer from nvcc location
-                 std::process::Command::new("which").arg("nvcc").output().ok()
-                    .and_then(|nvcc| Path::new(&String::from_utf8(nvcc.stdout).unwrap()).parent().and_then(|bin| bin.parent()).map(|p| p.to_path_buf()))
-            });
-
-        let cuda_inc = cuda_home.unwrap().join("include");
-        if !cuda_inc.exists() {
-            return Err(anyhow!("CUDA include dir not found at {:?}", cuda_inc));
-        }
-
         let arch = format!(
             "--gpu-architecture=sm_{}{}",
             self.device_properties.major, self.device_properties.minor
         );
+        log::info!("tract-cuda: NVRTC target architecture {arch}");
 
-        let mut opts = vec!["--std=c++17".into(), arch, format!("-I{}", cuda_inc.display())];
-        // CUDA 13 moved libcudacxx (`cuda/std/*`) under `include/cccl/`.
-        let cccl_inc = cuda_inc.join("cccl");
-        if cccl_inc.exists() {
-            opts.push(format!("-I{}", cccl_inc.display()));
+        let cuda_inc = resolve_toolkit_include_dir()?;
+        log::info!("tract-cuda: toolkit include dir {}", cuda_inc.display());
+
+        let cccl_root = find_cccl_root(&cuda_inc)?;
+        log::info!("tract-cuda: CCCL root {}", cccl_root.display());
+
+        // `cuda_fp16.h` is already checked as the sentinel in resolve_toolkit_include_dir.
+        // Check the other non-CCCL header we rely on for the same fail-fast reason.
+        let math_hdr = cuda_inc.join("math_constants.h");
+        if !math_hdr.exists() {
+            bail!(
+                "Required header {} not found. Install cuda-cudart-dev-{}.",
+                math_hdr.display(),
+                cuda_pkg_suffix(),
+            );
         }
+
+        let opts = vec![
+            "--std=c++17".into(),
+            arch,
+            format!("-I{}", cuda_inc.display()),
+            format!("-I{}", cccl_root.display()),
+        ];
+        log::info!("tract-cuda: NVRTC opts = {opts:?}");
         Ok(opts)
     }
 
@@ -342,8 +369,18 @@ pub struct TractCudaStream {
 impl TractCudaStream {
     fn new() -> TractResult<TractCudaStream> {
         let stream = cuda_context().default_stream();
-        let cublas = CudaBlas::new(stream.clone())?;
-        let cudnn = Cudnn::new(stream.clone())?;
+        let cublas = CudaBlas::new(stream.clone()).context(
+            "CudaBlas::new failed: libcublas loaded but the handle could not be created",
+        )?;
+        let cudnn = Cudnn::new(stream.clone()).context(
+            "Cudnn::new failed: libcudnn loaded but the handle could not be created. \
+             Version mismatch between libcudnn and the CUDA runtime is the most common cause.",
+        )?;
+
+        // Log once per stream — typically one per thread. Debug-level because the first stream's
+        // INFO-level summary already captured the versions via info_once below.
+        log_library_versions_once();
+
         Ok(TractCudaStream {
             inner: stream,
             cublas,
@@ -411,4 +448,150 @@ impl Deref for TractCudaStream {
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
+}
+
+/// Resolve a CUDA toolkit root containing an `include/` directory, if any is available.
+/// Returns `None` on runtime-only deploys where the toolkit isn't installed — callers are
+/// expected to rely on NVRTC's built-in headers in that case and may still succeed.
+fn resolve_cuda_home() -> Option<(&'static str, PathBuf)> {
+    if let Some(v) = std::env::var_os("CUDA_HOME") {
+        let p = PathBuf::from(v);
+        log::debug!("tract-cuda: CUDA_HOME env var set, using {}", p.display());
+        return Some(("CUDA_HOME env", p));
+    }
+    if let Some(v) = std::env::var_os("CUDA_PATH") {
+        let p = PathBuf::from(v);
+        log::debug!("tract-cuda: CUDA_PATH env var set, using {}", p.display());
+        return Some(("CUDA_PATH env", p));
+    }
+    let default = Path::new("/usr/local/cuda");
+    if default.exists() {
+        log::debug!("tract-cuda: /usr/local/cuda exists, using that as CUDA_HOME");
+        return Some(("default /usr/local/cuda", default.to_path_buf()));
+    }
+    if let Ok(nvcc) = std::process::Command::new("which").arg("nvcc").output()
+        && nvcc.status.success()
+    {
+        let stdout = String::from_utf8_lossy(&nvcc.stdout);
+        let p = Path::new(stdout.trim());
+        if let Some(root) = p.parent().and_then(|bin| bin.parent()) {
+            log::debug!(
+                "tract-cuda: inferred CUDA_HOME {} from nvcc at {}",
+                root.display(),
+                p.display()
+            );
+            return Some(("inferred from `which nvcc`", root.to_path_buf()));
+        }
+    }
+    log::debug!(
+        "tract-cuda: no CUDA_HOME found (env vars unset, /usr/local/cuda absent, nvcc not in PATH)"
+    );
+    None
+}
+
+/// Resolve the toolkit include dir — the directory that holds `cuda_fp16.h`. CUDA 13
+/// ships headers under `<root>/targets/<arch>-<os>/include/` and usually symlinks
+/// `<root>/include/` to it, but minimal installs can skip that symlink; probe both.
+fn resolve_toolkit_include_dir() -> TractResult<PathBuf> {
+    let Some((_, cuda_home)) = resolve_cuda_home() else {
+        let ver = cuda_pkg_suffix();
+        bail!(
+            "No CUDA toolkit root found. Tract's NVRTC kernels need the toolkit's \
+             host/device headers (apt: cuda-cudart-dev-{ver}) plus CCCL (apt: \
+             cuda-cccl-{ver}). Set CUDA_HOME if the toolkit is installed somewhere \
+             other than /usr/local/cuda."
+        );
+    };
+
+    let sentinel = "cuda_fp16.h";
+    let mut candidates = vec![cuda_home.join("include")];
+    let targets = cuda_home.join("targets");
+    if targets.exists() {
+        if let Ok(entries) = std::fs::read_dir(&targets) {
+            for entry in entries.flatten() {
+                candidates.push(entry.path().join("include"));
+            }
+        }
+    }
+
+    let mut tried: Vec<PathBuf> = Vec::new();
+    for cand in &candidates {
+        let probe = cand.join(sentinel);
+        let found = probe.exists();
+        log::debug!("tract-cuda: toolkit-inc probe {} exists={found}", probe.display());
+        tried.push(probe);
+        if found {
+            return Ok(cand.clone());
+        }
+    }
+
+    bail!(
+        "Could not find a toolkit include dir containing {sentinel}. Tried:\n  - {}\nInstall \
+         cuda-cudart-dev-{}.",
+        tried.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join("\n  - "),
+        cuda_pkg_suffix(),
+    )
+}
+
+/// Locate the CCCL (libcudacxx) include root that contains `cuda/std/cstdint`. Probes
+/// under the given toolkit include dir: `cccl/`, `libcudacxx/include/`, then the dir
+/// itself (pre-13 layout).
+fn find_cccl_root(cuda_inc: &Path) -> TractResult<PathBuf> {
+    let sentinel = Path::new("cuda").join("std").join("cstdint");
+    let mut tried: Vec<PathBuf> = Vec::new();
+
+    for cand in
+        [cuda_inc.join("cccl"), cuda_inc.join("libcudacxx").join("include"), cuda_inc.to_path_buf()]
+    {
+        let probe_path = cand.join(&sentinel);
+        let found = probe_path.exists();
+        log::debug!("tract-cuda: CCCL probe {} exists={found}", probe_path.display());
+        tried.push(probe_path);
+        if found {
+            return Ok(cand);
+        }
+    }
+
+    bail!(
+        "CCCL/libcudacxx headers not found. Tract's NVRTC kernels need <cuda/std/cstdint> and \
+         <cuda/std/type_traits>. Tried:\n  - {}\nInstall the CCCL headers (apt: cuda-cccl-{}).",
+        tried.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join("\n  - "),
+        cuda_pkg_suffix(),
+    )
+}
+
+/// Package suffix used by the NVIDIA apt repo, e.g. `13-0` for cudart 13.0. We prefer the
+/// runtime's actual cudart version when it's already loaded (via cudarc) — that aligns with
+/// whatever is installed on this host — and fall back to the feature-gated minimum
+/// (`REQUIRED_CUDA_API`) otherwise.
+fn cuda_pkg_suffix() -> String {
+    let v = cudarc::runtime::result::version::get_runtime_version()
+        .unwrap_or(crate::utils::REQUIRED_CUDA_API);
+    format!("{}-{}", v / 1000, (v % 1000) / 10)
+}
+
+/// Log cuBLAS / cuDNN / cudart versions and device property summary at INFO level, exactly once
+/// per process. Called from every `TractCudaStream::new`, but the `OnceLock` guard ensures we
+/// don't spam the log when user code creates one stream per thread.
+fn log_library_versions_once() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let cudnn_v = cudarc::cudnn::result::get_version();
+        log::info!(
+            "tract-cuda: cuDNN version {}.{}.{} (raw {cudnn_v})",
+            cudnn_v / 1000,
+            (cudnn_v % 1000) / 100,
+            cudnn_v % 100,
+        );
+
+        // cuBLAS exposes cublasGetVersion_v2(handle, *int). We don't plumb a handle here, but
+        // cublasGetCudartVersion is no-arg and reports the cudart version cuBLAS was built
+        // against — which is the interesting diagnostic when debugging a cuBLAS/cudart mismatch.
+        let cublas_cudart = unsafe { cudarc::cublas::sys::cublasGetCudartVersion() };
+        log::info!(
+            "tract-cuda: cuBLAS was built against cudart {}.{}",
+            cublas_cudart / 1000,
+            (cublas_cudart % 1000) / 10,
+        );
+    });
 }

--- a/cuda/src/utils.rs
+++ b/cuda/src/utils.rs
@@ -11,7 +11,8 @@ use tract_gpu::tensor::DeviceTensor;
 use crate::Q40_ROW_PADDING;
 use crate::ops::GgmlQuantQ81Fact;
 
-static CULIBS_PRESENT: OnceLock<bool> = OnceLock::new();
+static CULIBS_MISSING: OnceLock<Option<&'static str>> = OnceLock::new();
+static DEPENDENCIES_OK: OnceLock<()> = OnceLock::new();
 
 // Ensure exactly cuda-13000 is enabled.
 // Prevent accidental change of feature gate without
@@ -43,10 +44,14 @@ fn format_cuda_version(v: i32) -> (i32, i32) {
     (v / 1000, (v % 1000) / 10)
 }
 
-fn load_first_found_cuda_lib() -> TractResult<Library> {
+fn load_first_found_cuda_lib() -> TractResult<(&'static str, Library)> {
     for name in CUDA_DRIVER_LIB_CANDIDATES {
-        if let Ok(lib) = unsafe { Library::new(name) } {
-            return Ok(lib);
+        match unsafe { Library::new(name) } {
+            Ok(lib) => {
+                log::debug!("tract-cuda: driver candidate {name:?} loaded");
+                return Ok((name, lib));
+            }
+            Err(e) => log::debug!("tract-cuda: driver candidate {name:?} not loadable: {e}"),
         }
     }
 
@@ -64,13 +69,14 @@ fn load_first_found_cuda_lib() -> TractResult<Library> {
 /// otherwise cudarc may panic while eagerly binding symbols.
 fn ensure_cuda_driver_compatible() -> TractResult<()> {
     // Load driver library without involving cudarc.
-    let lib = load_first_found_cuda_lib()?;
+    let (lib_name, lib) = load_first_found_cuda_lib()?;
+    let (req_major, req_minor) = format_cuda_version(REQUIRED_CUDA_API);
 
     unsafe {
         // Resolve symbols we need. If these are missing, the driver install is broken or not NVIDIA.
         let cu_init: Symbol<CuInitFn> = lib.get(b"cuInit\0").map_err(|e| {
             format_err!(
-                "CUDA driver library loaded, but symbol cuInit is missing. \
+                "CUDA driver library loaded ({lib_name}), but symbol cuInit is missing. \
                  This does not look like a functional NVIDIA driver installation. Details: {e}"
             )
         })?;
@@ -78,7 +84,7 @@ fn ensure_cuda_driver_compatible() -> TractResult<()> {
         let cu_driver_get_version: Symbol<CuDriverGetVersionFn> =
             lib.get(b"cuDriverGetVersion\0").map_err(|e| {
                 format_err!(
-                    "CUDA driver library loaded, but symbol cuDriverGetVersion is missing. \
+                    "CUDA driver library loaded ({lib_name}), but symbol cuDriverGetVersion is missing. \
                      Driver is too old or installation is corrupted. Details: {e}"
                 )
             })?;
@@ -88,7 +94,7 @@ fn ensure_cuda_driver_compatible() -> TractResult<()> {
         if init_res != 0 {
             // Don't assume specific numeric codes here; just report the CUresult.
             bail!(
-                "CUDA driver initialization failed (cuInit returned {}). \
+                "CUDA driver initialization failed (cuInit returned {}, via {lib_name}). \
                  Possible causes: no CUDA-capable device exposed to this process, \
                  missing /dev/nvidia* nodes (container), insufficient permissions, \
                  or a broken driver install.",
@@ -101,19 +107,19 @@ fn ensure_cuda_driver_compatible() -> TractResult<()> {
         let ver_res = cu_driver_get_version(&mut version as *mut _);
         if ver_res != 0 {
             bail!(
-                "cuDriverGetVersion failed (returned {}). \
+                "cuDriverGetVersion failed (returned {}, via {lib_name}). \
                  NVIDIA driver may be corrupted or not functioning properly.",
                 ver_res
             );
         }
 
+        let (found_major, found_minor) = format_cuda_version(version);
+
         // Compare against required API based on feature gate.
         if version < REQUIRED_CUDA_API {
-            let (req_major, req_minor) = format_cuda_version(REQUIRED_CUDA_API);
-            let (found_major, found_minor) = format_cuda_version(version);
-
             bail!(
                 "CUDA driver too old.\n\
+                 Driver library: {lib_name}\n\
                  Built with cudarc feature cuda-{} (requires driver API >= {}.{}).\n\
                  Found driver API {}.{}.\n\
                  Fix: upgrade the NVIDIA driver, or rebuild tract-cuda with a lower cuda-XXXXX gate.",
@@ -124,31 +130,67 @@ fn ensure_cuda_driver_compatible() -> TractResult<()> {
                 found_minor
             );
         }
+
+        log::info!(
+            "tract-cuda: CUDA driver {lib_name} OK; API version {found_major}.{found_minor} (built for >= {req_major}.{req_minor})"
+        );
     }
 
     Ok(())
 }
 
-fn are_cudarc_required_culibs_present() -> bool {
-    *CULIBS_PRESENT.get_or_init(|| unsafe {
-        cudarc::driver::sys::is_culib_present()
-            && cudarc::runtime::sys::is_culib_present()
-            && cudarc::nvrtc::sys::is_culib_present()
-            && cudarc::cublas::sys::is_culib_present()
+/// Probe each cudarc-backed sub-library we rely on and return the name of the first one
+/// that fails to load, or `None` if all are present. Cached across calls.
+fn first_missing_cudarc_culib() -> Option<&'static str> {
+    *CULIBS_MISSING.get_or_init(|| {
+        // Names match the short labels cudarc uses in its dynamic-loading candidates.
+        // SAFETY: cudarc's `is_culib_present` functions are documented dlopen probes with no
+        // side effects beyond the library handle cache.
+        let probe = |name: &'static str, ok: bool| -> Option<&'static str> {
+            if ok {
+                log::debug!("tract-cuda: cudarc probe for {name:?} succeeded");
+                None
+            } else {
+                log::debug!("tract-cuda: cudarc probe for {name:?} failed");
+                Some(name)
+            }
+        };
+        probe("cuda (driver)", unsafe { cudarc::driver::sys::is_culib_present() })
+            .or_else(|| {
+                probe("cudart (runtime)", unsafe { cudarc::runtime::sys::is_culib_present() })
+            })
+            .or_else(|| probe("nvrtc", unsafe { cudarc::nvrtc::sys::is_culib_present() }))
+            .or_else(|| probe("cublas", unsafe { cudarc::cublas::sys::is_culib_present() }))
+            .or_else(|| probe("cudnn", unsafe { cudarc::cudnn::sys::is_culib_present() }))
     })
 }
 
 pub fn ensure_cuda_runtime_dependencies(context_msg: &'static str) -> TractResult<()> {
+    // Fast path: if a previous call already validated the full chain, skip the whole probe.
+    // CudaRuntime wires this into both `check()` and `prepare_with_options()`, so the second
+    // caller would otherwise re-dlopen libcuda and re-log the init narrative.
+    if DEPENDENCIES_OK.get().is_some() {
+        return Ok(());
+    }
+
     ensure_cuda_driver_compatible()
         .context("CUDA driver validation failed")
         .context(context_msg)?;
 
-    ensure!(
-        are_cudarc_required_culibs_present(),
-        "{}: CUDA runtime sub-libraries missing/missaligned with cudarc (nvrtc,cublas,cudart).",
-        context_msg
+    if let Some(missing) = first_missing_cudarc_culib() {
+        bail!(
+            "{context_msg}: CUDA runtime sub-library {missing:?} could not be dlopen'd. \
+             cudarc searches standard library names derived from the build-time CUDA \
+             version; install the matching package or set LD_LIBRARY_PATH so the \
+             loader can find it. Enable RUST_LOG=tract_cuda=debug to see each probe."
+        );
+    }
+
+    log::info!(
+        "tract-cuda: all required cudarc sub-libraries present (driver, cudart, nvrtc, cublas, cudnn)"
     );
 
+    let _ = DEPENDENCIES_OK.set(());
     Ok(())
 }
 

--- a/harness/cuda-minimum-deploy/Dockerfile
+++ b/harness/cuda-minimum-deploy/Dockerfile
@@ -1,0 +1,19 @@
+# Minimum runtime image for tract-cuda — validates the BOM documented
+# in cuda/src/context.rs. If this image doesn't have what
+# `ensure_cuda_runtime_dependencies` + `build_nvrtc_opts` expect, the CI
+# job using it will fail, and the BOM has drifted.
+#
+# Intentionally lean: no nvcc, no cuda-toolkit meta-package, no profiler.
+# The nvidia/cuda -runtime- base already ships the runtime libs we need
+# (libcudart, libcublas, libnvrtc) held at specific versions. We only
+# install the delta: CCCL headers, cudart-dev headers (for cuda_fp16.h
+# and math_constants.h), and cuDNN. --allow-change-held-packages lets
+# apt bump transitive pins the base image set.
+FROM nvidia/cuda:13.0.0-runtime-ubuntu24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      --allow-change-held-packages \
+      cuda-cccl-13-0 \
+      cuda-cudart-dev-13-0 \
+      libcudnn9-cuda-13 \
+ && rm -rf /var/lib/apt/lists/*

--- a/harness/cuda-minimum-deploy/gpu-ci.sh
+++ b/harness/cuda-minimum-deploy/gpu-ci.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Runs tract-cli against a tiny NNEF model inside a Docker container that
+# has only the minimum CUDA runtime packages installed — the BOM spelled
+# out in cuda/src/context.rs and pinned in the sibling Dockerfile.
+#
+# Intended to be runnable locally on a GPU workstation so you can catch
+# BOM drift without pushing to CI and waiting. The matching CI job is
+# `cuda-minimum-deploy` in .github/workflows/crates.yml.
+#
+# Requirements on the host:
+#   - docker + nvidia-container-toolkit
+#   - an NVIDIA GPU accessible via --gpus all
+#   - a full CUDA toolkit (for building tract-cli — NOT for running)
+#
+# Usage: harness/cuda-minimum-deploy/gpu-ci.sh
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+HERE="harness/cuda-minimum-deploy"
+IMAGE_TAG="tract-cuda-minimal:13-0"
+MODEL_DIR="harness/nnef-test-cases/conv-q40/conv_base_kernel1"
+
+echo "==> Building tract-cli (release) on the host"
+cargo build --release -p tract-cli
+
+echo "==> Building minimum-BOM runtime image"
+docker build -t "$IMAGE_TAG" "$HERE"
+
+echo "==> Running tract inside minimum-BOM container"
+docker run --rm --gpus all \
+    -v "$PWD/target/release/tract:/usr/local/bin/tract:ro" \
+    -v "$PWD/$MODEL_DIR:/model:ro" \
+    -w /model \
+    -e RUST_LOG="${RUST_LOG:-tract_cuda=info}" \
+    "$IMAGE_TAG" \
+    tract --nnef-tract-core model.nnef.tgz -O -r cuda run \
+        --approx very --input-from-bundle io.npz --assert-output-bundle io.npz
+
+echo "==> OK: tract ran end-to-end inside the minimum-BOM container"


### PR DESCRIPTION
Tract's CUDA runtime previously failed with cryptic NVRTC/cudarc errors when the toolkit libs/headers weren't on the host. This adds info-level logging across the setup path and fail-fast preflights with actionable messages.

- log driver lib + resolved API version, device properties, cudart / cuBLAS / cuDNN versions, the resolved CUDA_HOME / CCCL root, and the exact NVRTC opts we hand to cudarc
- per-lib cudarc probe that names the missing sub-library (driver, cudart, nvrtc, cublas, cudnn) rather than the previous generic blurb, and covers cuDNN which was previously deferred
- cache the full dependency check so Runtime::check() + prepare() don't re-run the probe every time
- probe <cuda_home>/targets/<arch>-<os>/include/ for the toolkit headers, so CUDA 13 installs without the legacy include/ symlink still resolve
- error messages name the matching NVIDIA apt package at the host's actual runtime version (cuda-cccl-13-0, cuda-cudart-dev-13-0, ...)