### PR TITLE
release: include the tract-api base crate in the release loop

### DIFF
--- a/.all_crates.sh
+++ b/.all_crates.sh
@@ -1,2 +1,2 @@
 
-ALL_CRATES_PATH="data linalg core nnef nnef/nnef-resources pulse-opl pulse extra transformers hir tflite tensorflow onnx-opl onnx gpu metal cuda libcli api/rs api/ffi api/proxy/sys api/proxy cli"
+ALL_CRATES_PATH="data linalg core nnef nnef/nnef-resources pulse-opl pulse extra transformers hir tflite tensorflow onnx-opl onnx gpu metal cuda libcli api api/rs api/ffi api/proxy/sys api/proxy cli"


### PR DESCRIPTION
release.sh all $VERSION iterates over .all_crates.sh::ALL_CRATES_PATH, which listed api/rs, api/ffi, api/proxy/sys and api/proxy but not the base api crate (tract-api). As a result tract-api was never bumped along with the rest of the workspace, and the workspace Cargo.toml's ="0.23.0-dev.X" pin for tract-api stayed stale.

That became visible on the dev.5 wheels upload: setup.py derives the Python wheel version from rust-workspace/api/Cargo.toml, which at v0.23.0-dev.5 still read 0.23.0-dev.4. The wheels built as tract-0.23.0.dev4-* and pypi-publish rejected them because PyPI already had the dev.4 files from the actual dev.4 release.

Insert api before api/rs so it ships in dependency order — tract, tract-ffi and tract-proxy all depend on tract-api.