### PR TITLE
test-onnx-core: default to onnx_1_19_1 test suite

### DIFF
--- a/test-rt/test-onnx-core/Cargo.toml
+++ b/test-rt/test-onnx-core/Cargo.toml
@@ -29,7 +29,7 @@ onnx_1_16_2 = ["suite-onnx/onnx_1_16_2"]
 onnx_1_17_0 = ["suite-onnx/onnx_1_17_0"]
 onnx_1_18_0 = ["suite-onnx/onnx_1_18_0"]
 onnx_1_19_1 = ["suite-onnx/onnx_1_19_1"]
-default = [ "onnx_1_13_0" ]
+default = [ "onnx_1_19_1" ]
 
 [build-dependencies]
 suite-onnx = { path = "../suite-onnx" }


### PR DESCRIPTION
Bumps the default ONNX version exercised by `cargo test -p test-onnx-core` from 1.13.0 (ca. 2023) to 1.19.1. Without any code changes the full suite goes from 1928 passing tests to 3996 passing (0 failing), picking up six years of opset additions.

Motivation: 1.13.0 is stale as a default; CI surface is extended without regressions.