### PR TITLE
onnx resize: add pytorch_half_pixel coordinate transformer

### DIFF
--- a/onnx-opl/src/resize.rs
+++ b/onnx-opl/src/resize.rs
@@ -5,10 +5,11 @@ pub enum CoordTransformer {
     HalfPixel,
     AlignCorners,
     Asymmetric,
+    PytorchHalfPixel,
 }
 
 impl CoordTransformer {
-    pub fn transform(&self, x_out: usize, scale: f32, len_in: usize, _len_out: usize) -> f32 {
+    pub fn transform(&self, x_out: usize, scale: f32, len_in: usize, len_out: usize) -> f32 {
         match self {
             CoordTransformer::HalfPixel => (x_out as f32 + 0.5) / scale - 0.5,
             CoordTransformer::AlignCorners => {
@@ -20,6 +21,13 @@ impl CoordTransformer {
                 }
             }
             CoordTransformer::Asymmetric => (x_out as f32) / scale,
+            CoordTransformer::PytorchHalfPixel => {
+                if len_out > 1 {
+                    (x_out as f32 + 0.5) / scale - 0.5
+                } else {
+                    0.0
+                }
+            }
         }
     }
 
@@ -28,6 +36,7 @@ impl CoordTransformer {
             CoordTransformer::HalfPixel => "half_pixel",
             CoordTransformer::AlignCorners => "align_corners",
             CoordTransformer::Asymmetric => "asymmetric",
+            CoordTransformer::PytorchHalfPixel => "pytorch_half_pixel",
         }
     }
 
@@ -36,6 +45,7 @@ impl CoordTransformer {
             "half_pixel" => CoordTransformer::HalfPixel,
             "align_corners" => CoordTransformer::AlignCorners,
             "asymmetric" => CoordTransformer::Asymmetric,
+            "pytorch_half_pixel" => CoordTransformer::PytorchHalfPixel,
             s => bail!("coordinate_transformation_mode: {s}"),
         })
     }

--- a/test-rt/suite-onnx/node.txt
+++ b/test-rt/suite-onnx/node.txt
@@ -490,6 +490,7 @@ test_resize_downsample_scales_cubic_align_corners                               
 test_resize_downsample_scales_cubic_A_n0p5_exclude_outside                          input:X
 test_resize_downsample_scales_linear                                                input:X
 test_resize_downsample_sizes_cubic                                                  input:X
+test_resize_downsample_sizes_linear_pytorch_half_pixel                              input:X
 test_resize_upsample_scales_cubic                                                   input:X
 test_resize_upsample_scales_cubic_align_corners                                     input:X
 test_resize_upsample_scales_cubic_asymmetric                                        input:X


### PR DESCRIPTION
PyTorch's "half_pixel" variant is a recognized ONNX coordinate_transformation_mode that tract did not implement. Formula matches the ONNX spec:

    if len_out > 1 { (x_out + 0.5) / scale - 0.5 } else { 0.0 }

i.e. identical to HalfPixel for multi-pixel outputs, collapses to 0.0 for a single output pixel (avoids the half-pixel center offset in the degenerate case).

Enables test_resize_downsample_sizes_linear_pytorch_half_pixel in the ONNX node-test suite (4 variants: default/unoptimized x v1_13_0/v1_19_1).