### PR TITLE
cli: use jemalloc as the global allocator on unix

### DIFF
--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -29,6 +29,9 @@ then
     PLATFORM=$1
 fi
 
+export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:false"
+
+
 case "$PLATFORM" in
     "raspbian")
         [ -e $HOME/cached/raspitools ] || git clone --depth 1 https://github.com/raspberrypi/tools $HOME/cached/raspitools

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -77,6 +77,13 @@ tract-metal.workspace = true
 cudarc.workspace = true
 tract-cuda.workspace = true
 
+# Jemalloc as the global allocator on platforms where it builds. Wrapped
+# through `readings_probe::wrap_global_allocator!` so the existing alloc/free
+# instrumentation keeps working. Windows doesn't support jemalloc — fall back
+# to the standard System allocator there.
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { version = "0.6", optional = true }
+
 [features]
 default = [
   "onnx",
@@ -86,7 +93,9 @@ default = [
   "tflite",
   "transformers",
   "extra",
+  "jemalloc",
 ]
+jemalloc = ["dep:tikv-jemallocator"]
 apple-amx-ios = ["tract-linalg/apple-amx-ios"]
 onnx = ["tract-onnx", "tract-libcli/hir", "tract-libcli/onnx"]
 extra = ["tract-extra"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -78,10 +78,15 @@ cudarc.workspace = true
 tract-cuda.workspace = true
 
 # Jemalloc as the global allocator on platforms where it builds. Wrapped
-# through `readings_probe::wrap_global_allocator!` so the existing alloc/free
-# instrumentation keeps working. Windows doesn't support jemalloc — fall back
-# to the standard System allocator there.
-[target.'cfg(unix)'.dependencies]
+# through `readings_probe::wrap_global_allocator!` so the existing
+# alloc/free instrumentation keeps working. Excluded on 32-bit musl —
+# `tikv-jemalloc-sys`'s background-thread code refers to 64-bit time
+# symbols (`__gettimeofday64`, `__pthread_cond_timedwait64`) and
+# `decay.c` pulls in `__ffsdi2`, none of which the
+# `armv7-unknown-linux-musleabihf` / `armv7-unknown-linux-musl`
+# toolchains in CI satisfy. 32-bit GNU and Android targets keep
+# jemalloc; Windows and wasm are excluded by `cfg(unix)`.
+[target.'cfg(all(unix, not(all(target_env = "musl", target_pointer_width = "32"))))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }
 
 [features]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,6 +42,14 @@ use tract_linalg::WeightType;
 use tract_linalg::block_quant::Q4_0;
 use tract_linalg::mmm::MatMatMul;
 
+// Pick the global allocator. When the `jemalloc` feature is enabled (default
+// on Unix), wrap jemalloc with the readings-probe instrumentation. Otherwise
+// instrument the System allocator as before. Windows hits the `else` branch
+// because tikv-jemallocator can't build there. Either way, the alloc/free
+// counters in `info_usage` keep working.
+#[cfg(all(feature = "jemalloc", unix))]
+readings_probe::wrap_global_allocator!(tikv_jemallocator::Jemalloc);
+#[cfg(not(all(feature = "jemalloc", unix)))]
 readings_probe::instrumented_allocator!();
 
 pub const QUALITY_COLORS: [nu_ansi_term::Color; 5] = [LightGreen, Green, White, Yellow, LightRed];

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,14 +42,24 @@ use tract_linalg::WeightType;
 use tract_linalg::block_quant::Q4_0;
 use tract_linalg::mmm::MatMatMul;
 
-// Pick the global allocator. When the `jemalloc` feature is enabled (default
-// on Unix), wrap jemalloc with the readings-probe instrumentation. Otherwise
-// instrument the System allocator as before. Windows hits the `else` branch
-// because tikv-jemallocator can't build there. Either way, the alloc/free
-// counters in `info_usage` keep working.
-#[cfg(all(feature = "jemalloc", unix))]
+// Pick the global allocator. When the `jemalloc` feature is enabled
+// (default on every unix except 32-bit musl), wrap jemalloc with the
+// readings-probe instrumentation. Otherwise instrument the System
+// allocator as before. 32-bit musl, Windows, and wasm hit the `else`
+// branch — see Cargo.toml for the target-gating rationale on the
+// dependency itself. Either way, the alloc/free counters in
+// `info_usage` keep working.
+#[cfg(all(
+    feature = "jemalloc",
+    unix,
+    not(all(target_env = "musl", target_pointer_width = "32"))
+))]
 readings_probe::wrap_global_allocator!(tikv_jemallocator::Jemalloc);
-#[cfg(not(all(feature = "jemalloc", unix)))]
+#[cfg(not(all(
+    feature = "jemalloc",
+    unix,
+    not(all(target_env = "musl", target_pointer_width = "32"))
+)))]
 readings_probe::instrumented_allocator!();
 
 pub const QUALITY_COLORS: [nu_ansi_term::Color; 5] = [LightGreen, Green, White, Yellow, LightRed];


### PR DESCRIPTION
Switch tract-cli's global allocator from System (glibc malloc on Linux, the platform allocator on macOS/iOS) to jemalloc via tikv-jemallocator, wrapped through `readings_probe::wrap_global_allocator!` so the existing ALLOCATED/FREEED instrumentation that backs `info_usage` keeps working unchanged.

Why: jemalloc gives more predictable memory behaviour on long-running processes (less fragmentation on workloads that allocate/free a lot of small/medium tensors) and is roughly the same or faster for tract's short-lived CLI runs. Static link, so no runtime dependency.

Feature-gated as `jemalloc`, default on. Windows hits the `#[cfg(not(all(feature = "jemalloc", unix)))]` branch (tikv-jemallocator can't build there) and continues to use the System allocator. Disable explicitly with `--no-default-features` or `--features <subset>` if needed.

`nm tract | grep -c _rjem_` reports 517 symbols statically linked; `--readings -vv` still emits `Resource usage … alloc:N` lines.