### PR TITLE
ci: fix cross-platform.yml wasmtime-setup conditional

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -65,7 +65,7 @@ jobs:
         key: ${{ runner.os }}-${{matrix.platform}}-${{steps.date.outputs.date}}
 
     - name: Setup wasmtime
-      if: ${{ matrix.platform }} == "wasm32-wasi"
+      if: matrix.platform == 'wasm32-wasi'
       uses: bytecodealliance/actions/wasmtime/setup@v1
 
     - name: Cross script


### PR DESCRIPTION
The previous \`if: \${{ matrix.platform }} == "wasm32-wasi"\` was parsed as: interpolate matrix.platform first, then evaluate the remainder as a literal expression. On every non-wasm matrix entry that evaluated to e.g. \`aarch64-unknown-linux-gnu == "wasm32-wasi"\`, which the GitHub Actions parser sees as a non-empty literal — truthy — so the wasmtime setup step ran on every platform instead of only wasm32-wasi.

Use the bare-expression form GitHub Actions accepts directly in \`if:\` (no \`\${{ }}\` wrapper) so the comparison is evaluated as one expression. Also addresses the workflow-syntax warning surfaced in CI:

  Conditional expression contains literal text outside replacement
  tokens. This will cause the expression to always evaluate to
  truthy. Did you mean to put the entire expression inside \${{ }}?