### PR TITLE
substitute_symbols: take HashMap<Symbol, TDim> instead of SymbolValues

### DIFF
--- a/cli/src/compare.rs
+++ b/cli/src/compare.rs
@@ -473,7 +473,8 @@ pub fn handle_stream(
     }
 
     // Concretize the reference model and delegate to compare()
-    let concrete_ref = Arc::new(reference.clone().concretize_dims(&concrete_sym_values)?);
+    let concrete_ref =
+        Arc::new(reference.clone().substitute_symbols(&concrete_sym_values.to_dim_map())?);
     compare(
         false,
         &concrete_ref,

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -775,7 +775,7 @@ impl Parameters {
                         }
                     }
                 }
-                m.concretize_dims(&values)
+                m.substitute_symbols(&values.to_dim_map())
             });
             stage!("set-declutter", typed_model -> typed_model, |mut m| {
                 let mut dec = tract_core::optim::Optimizer::declutter();

--- a/core/src/model/fact.rs
+++ b/core/src/model/fact.rs
@@ -56,6 +56,22 @@ impl ShapeFact {
         }
     }
 
+    /// Substitute symbols by TDim expressions in every dim of the shape.
+    /// Concrete shapes pass through unchanged.
+    #[inline]
+    pub fn substitute(
+        &self,
+        subs: &std::collections::HashMap<Symbol, TDim>,
+    ) -> TractResult<Cow<'_, ShapeFact>> {
+        if self.is_concrete() {
+            Ok(Cow::Borrowed(self))
+        } else {
+            Ok(Cow::Owned(
+                self.iter().map(|d| d.substitute_all(subs)).collect::<TractResult<ShapeFact>>()?,
+            ))
+        }
+    }
+
     #[inline]
     pub fn eval_to_usize(&self, values: &SymbolValues) -> TractResult<Cow<'_, TVec<usize>>> {
         if let Some(c) = &self.concrete {

--- a/core/src/model/typed.rs
+++ b/core/src/model/typed.rs
@@ -256,8 +256,8 @@ impl TypedModel {
         Ok(())
     }
 
-    pub fn concretize_dims(&self, values: &SymbolValues) -> TractResult<TypedModel> {
-        values.translate_model(self)
+    pub fn substitute_symbols(&self, subs: &HashMap<Symbol, TDim>) -> TractResult<TypedModel> {
+        crate::model::translator::Translate::translate_model(subs, self)
     }
 
     pub fn prop_consts(&mut self) -> TractResult<()> {
@@ -311,7 +311,7 @@ impl TypedModel {
 }
 
 use crate::model::translator::Translate;
-impl Translate<TypedFact, Box<dyn TypedOp>, TypedFact, Box<dyn TypedOp>> for SymbolValues {
+impl Translate<TypedFact, Box<dyn TypedOp>, TypedFact, Box<dyn TypedOp>> for HashMap<Symbol, TDim> {
     fn translate_node(
         &self,
         source: &TypedModel,
@@ -320,7 +320,7 @@ impl Translate<TypedFact, Box<dyn TypedOp>, TypedFact, Box<dyn TypedOp>> for Sym
         mapping: &HashMap<OutletId, OutletId>,
     ) -> TractResult<TVec<OutletId>> {
         target.check_consistency()?;
-        let outlets = node.op.concretize_dims(source, node, target, mapping, self)?;
+        let outlets = node.op.substitute_symbols(source, node, target, mapping, self)?;
         for &outlet in &outlets {
             let fact = &mut target.nodes[outlet.node].outputs[outlet.slot].fact;
             if fact.shape.volume().is_zero()

--- a/core/src/ops/array/broadcast.rs
+++ b/core/src/ops/array/broadcast.rs
@@ -102,17 +102,18 @@ impl TypedOp for MultiBroadcastTo {
         crate::optim::propagate_roi::bubble_roi(model, node)
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         let input = mapping[&node.inputs[0]];
-        let op =
-            Self { shape: self.shape.iter().map(|d| d.eval(values)).collect::<TVec<_>>().into() };
+        let shape: TVec<_> =
+            self.shape.iter().map(|d| d.substitute_all(subs)).collect::<TractResult<_>>()?;
+        let op = Self { shape: shape.into() };
         target.wire_node(&node.name, op, &[input])
     }
 

--- a/core/src/ops/array/slice.rs
+++ b/core/src/ops/array/slice.rs
@@ -178,16 +178,19 @@ impl TypedOp for Slice {
         }
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
-        let op =
-            Slice { axis: self.axis, start: self.start.eval(values), end: self.end.eval(values) };
+        let op = Slice {
+            axis: self.axis,
+            start: self.start.substitute_all(subs)?,
+            end: self.end.substitute_all(subs)?,
+        };
         let inputs = node.inputs.iter().map(|i| mapping[i]).collect::<TVec<_>>();
         target.wire_node(&node.name, op, &inputs)
     }

--- a/core/src/ops/array/tile.rs
+++ b/core/src/ops/array/tile.rs
@@ -45,15 +45,16 @@ impl EvalOp for Tile {
 impl TypedOp for Tile {
     as_op!();
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
-        let multipliers = self.multipliers.iter().map(|m| m.eval(values)).collect();
+        let multipliers =
+            self.multipliers.iter().map(|m| m.substitute_all(subs)).collect::<TractResult<_>>()?;
         target.wire_node(&node.name, Self { multipliers }, &[mapping[&node.inputs[0]]])
     }
 

--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -833,19 +833,19 @@ impl TypedOp for AxisOp {
         Ok(Some(op))
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         let op = if let AxisOp::Reshape(axis, from, to) = self {
             AxisOp::Reshape(
                 *axis,
-                from.iter().map(|d| d.eval(values)).collect(),
-                to.iter().map(|d| d.eval(values)).collect(),
+                from.iter().map(|d| d.substitute_all(subs)).collect::<TractResult<_>>()?,
+                to.iter().map(|d| d.substitute_all(subs)).collect::<TractResult<_>>()?,
             )
         } else {
             self.clone()

--- a/core/src/ops/cnn/deconv/deconv_sum.rs
+++ b/core/src/ops/cnn/deconv/deconv_sum.rs
@@ -106,17 +106,17 @@ impl TypedOp for DeconvSum {
         Ok(tvec!(inputs[0].datum_type.fact(shape)))
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         target.wire_node(
             &node.name,
-            Self { input_shape: self.input_shape.eval(values)?.into_owned(), ..self.clone() },
+            Self { input_shape: self.input_shape.substitute(subs)?.into_owned(), ..self.clone() },
             &[mapping[&node.inputs[0]], mapping[&node.inputs[1]]],
         )
     }

--- a/core/src/ops/konst.rs
+++ b/core/src/ops/konst.rs
@@ -76,18 +76,18 @@ impl TypedOp for Const {
         Ok(tvec!((Cost::Params(self.0.datum_type().unquantized()), self.0.len().into())))
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         _mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         let op = if self.0.datum_type() == TDim::datum_type() {
             let mut tensor = self.0.clone().into_tensor();
             for d in tensor.try_as_plain_mut()?.as_slice_mut::<TDim>()? {
-                *d = d.eval(values);
+                *d = d.substitute_all(subs)?;
             }
             Const(tensor.into_arc_tensor(), self.1.clone())
         } else {

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -291,15 +291,17 @@ pub trait TypedOp:
         Ok(None)
     }
 
-    /// Transform the op into by providing a value to one or more symbols.
+    /// Transform the op by substituting one or more symbols with TDim
+    /// expressions (a concrete integer is `TDim::Val(v)`; an expression
+    /// can be any other TDim, including symbolic ones).
     #[allow(unused_variables)]
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         let inputs = node.inputs.iter().map(|i| mapping[i]).collect::<TVec<_>>();
         target.wire_node(&node.name, node.op.clone(), &inputs)

--- a/core/src/ops/scan/decluttered.rs
+++ b/core/src/ops/scan/decluttered.rs
@@ -864,22 +864,22 @@ impl TypedOp for Scan {
         Ok(None)
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         let inputs = node.inputs.iter().map(|o| mapping[o]).collect::<TVec<_>>();
         let op = Self {
             output_mapping: self
                 .output_mapping
                 .iter()
-                .map(|om| om.concretize_dims(values))
+                .map(|om| om.substitute_symbols(subs))
                 .collect::<TractResult<Vec<_>>>()?,
-            body: self.body.concretize_dims(values)?,
+            body: self.body.substitute_symbols(subs)?,
             ..self.clone()
         };
         target.wire_node(&node.name, op, &inputs)

--- a/core/src/ops/scan/mod.rs
+++ b/core/src/ops/scan/mod.rs
@@ -52,9 +52,16 @@ impl<F: Clone> OutputMapping<F> {
 }
 
 impl<F: Clone + DimLike> OutputMapping<F> {
-    pub fn concretize_dims(&self, values: &SymbolValues) -> TractResult<OutputMapping<F>> {
+    pub fn substitute_symbols(
+        &self,
+        subs: &std::collections::HashMap<Symbol, F>,
+    ) -> TractResult<OutputMapping<F>> {
         Ok(Self {
-            full_dim_hint: self.full_dim_hint.as_ref().map(|h| h.eval(values)),
+            full_dim_hint: self
+                .full_dim_hint
+                .as_ref()
+                .map(|h| h.substitute_all(subs))
+                .transpose()?,
             ..self.clone()
         })
     }

--- a/core/src/ops/source.rs
+++ b/core/src/ops/source.rs
@@ -66,15 +66,16 @@ impl TypedOp for TypedSource {
         )))
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         _mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
-        let shape: TVec<_> = self.fact.shape.iter().map(|d| d.eval(values)).collect();
+        let shape: TVec<_> =
+            self.fact.shape.iter().map(|d| d.substitute_all(subs)).collect::<TractResult<_>>()?;
         target.wire_node(&node.name, Self { fact: self.fact.datum_type.fact(&*shape) }, &[])
     }
 

--- a/core/src/transform.rs
+++ b/core/src/transform.rs
@@ -248,9 +248,18 @@ pub fn get_transform_with_params(
     Ok(None)
 }
 
+/// Per-symbol substitution: either a concrete integer or a TDim
+/// expression string parsed against the model's symbol scope.
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+pub enum SymbolValueSpec {
+    Int(i64),
+    Expr(String),
+}
+
 #[derive(Debug, Default, serde::Deserialize)]
 pub struct ConcretizeSymbolsConfig {
-    pub values: std::collections::HashMap<String, i64>,
+    pub values: std::collections::HashMap<String, SymbolValueSpec>,
 }
 
 #[derive(Debug)]
@@ -262,11 +271,19 @@ impl ModelTransform for ConcretizeSymbolsTransform {
     }
 
     fn transform(&self, model: &mut TypedModel) -> TractResult<()> {
-        let mut table = SymbolValues::default();
-        for (k, v) in &self.0.values {
-            table = table.with(&model.symbols.sym(k), *v);
+        let mut subs = std::collections::HashMap::new();
+        for (k, spec) in &self.0.values {
+            let sym = model.symbols.sym(k);
+            let dim = match spec {
+                SymbolValueSpec::Int(v) => TDim::Val(*v),
+                SymbolValueSpec::Expr(s) => model
+                    .symbols
+                    .parse_tdim(s)
+                    .with_context(|| format!("Parsing TDim expression {s:?} for symbol {k}"))?,
+            };
+            subs.insert(sym, dim);
         }
-        *model = model.concretize_dims(&table)?;
+        *model = model.substitute_symbols(&subs)?;
         Ok(())
     }
 }

--- a/cuda/src/ops/quant_q81.rs
+++ b/cuda/src/ops/quant_q81.rs
@@ -104,15 +104,15 @@ impl TypedOp for CudaGgmlQuantQ81 {
         .with_context(|| format!("Error while computing facts for {:?}", self.name()))
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
-        let op = Self::new(self.io_facts.in_fact.eval(values)?.into_owned())?;
+        let op = Self::new(self.io_facts.in_fact.substitute(subs)?.into_owned())?;
         target.wire_node(&node.name, op, &[mapping[&node.inputs[0]]])
     }
     as_op!();

--- a/data/src/dim/sym.rs
+++ b/data/src/dim/sym.rs
@@ -492,6 +492,12 @@ impl SymbolValues {
     pub fn get(&self, s: &Symbol) -> Option<i64> {
         self.values.get(s).copied()
     }
+
+    /// View the bindings as `Symbol → TDim` (each `i64` lifted to `TDim::Val`),
+    /// for callers that need to plug into APIs taking `HashMap<Symbol, TDim>`.
+    pub fn to_dim_map(&self) -> HashMap<Symbol, TDim> {
+        self.values.iter().map(|(s, v)| (s.clone(), TDim::Val(*v))).collect()
+    }
 }
 
 #[cfg(test)]

--- a/gpu/src/ops/change_axes.rs
+++ b/gpu/src/ops/change_axes.rs
@@ -162,19 +162,19 @@ impl TypedOp for GpuAxisOp {
         self.inner.axes_mapping(&ref_inputs, &ref_outputs)
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         let inner = if let AxisOp::Reshape(axis, from, to) = &self.inner {
             AxisOp::Reshape(
                 *axis,
-                from.iter().map(|d| d.eval(values)).collect(),
-                to.iter().map(|d| d.eval(values)).collect(),
+                from.iter().map(|d| d.substitute_all(subs)).collect::<TractResult<_>>()?,
+                to.iter().map(|d| d.substitute_all(subs)).collect::<TractResult<_>>()?,
             )
         } else {
             self.inner.clone()

--- a/gpu/src/ops/slice.rs
+++ b/gpu/src/ops/slice.rs
@@ -94,19 +94,19 @@ impl TypedOp for GpuSlice {
             .with_context(|| format!("Error while computing facts for {:?}", self.name()))
     }
 
-    fn concretize_dims(
+    fn substitute_symbols(
         &self,
         _source: &TypedModel,
         node: &TypedNode,
         target: &mut TypedModel,
         mapping: &HashMap<OutletId, OutletId>,
-        values: &SymbolValues,
+        subs: &HashMap<Symbol, TDim>,
     ) -> TractResult<TVec<OutletId>> {
         let op = GpuSlice {
             inner: Slice {
                 axis: self.inner.axis,
-                start: self.inner.start.eval(values),
-                end: self.inner.end.eval(values),
+                start: self.inner.start.substitute_all(subs)?,
+                end: self.inner.end.substitute_all(subs)?,
             },
         };
         let inputs = node.inputs.iter().map(|i| mapping[i]).collect::<TVec<_>>();

--- a/harness/core-proptest-pulse/src/lib.rs
+++ b/harness/core-proptest-pulse/src/lib.rs
@@ -44,9 +44,10 @@ fn proptest_regular_against_pulse(
     let model = model.into_decluttered().unwrap();
     // dbg!(&model);
     let s = model.symbols.sym("S");
-    let symbols = SymbolValues::default().with(&s, len as i64);
+    let subs =
+        std::collections::HashMap::from([(s.clone(), tract_data::prelude::TDim::Val(len as i64))]);
 
-    let concrete = model.clone().concretize_dims(&symbols).unwrap();
+    let concrete = model.clone().substitute_symbols(&subs).unwrap();
     if concrete.nodes.iter().any(|n| n.outputs.iter().any(|o| o.fact.shape.volume().is_zero())) {
         return Err(TestCaseError::reject("too short input"));
     }
@@ -62,6 +63,7 @@ fn proptest_regular_against_pulse(
     let output_fact = pulsed.output_fact(0).unwrap().clone();
 
     let stream_info = output_fact.stream.as_ref().unwrap();
+    let symbols = SymbolValues::default().with(&s, len as i64);
     prop_assert!(stream_info.dim.eval(&symbols) == outputs[0].shape()[stream_info.axis].to_dim());
     let output_stream_axis = stream_info.axis;
     let delay = stream_info.delay;


### PR DESCRIPTION
The old `concretize_dims` was constrained to integer substitutions because it threaded `SymbolValues` (Symbol → i64) through every op impl. TDim already has `substitute_all` taking `HashMap<Symbol, TDim>`; this change lifts that capability to the model level — a symbol can now be substituted with any TDim expression, integer-concretization is the special case where the value is `TDim::Val(v)`. Renamed for the broader semantics.

- Trait method `TypedOp::concretize_dims` → `substitute_symbols`, signature changes from `&SymbolValues` to `&HashMap<Symbol, TDim>`. Each op impl swaps `dim.eval(values)` for `dim.substitute_all(subs)?`. Affected: source, konst, slice, broadcast, tile, change_axes, deconv_sum, scan (and its OutputMapping helper), gpu::slice / change_axes, cuda::quant_q81.
- `TypedModel::concretize_dims` → `substitute_symbols`, ditto for the matching Translate impl.
- `ShapeFact::substitute(&HashMap<Symbol, TDim>)` mirrors `ShapeFact::eval(&SymbolValues)` for callers that need the latter semantics on a whole shape.
- Transform `concretize_symbols` (CLI name kept for back-compat) accepts an untagged-enum value spec: either an integer or a TDim expression string parsed against the model's symbol scope. Existing integer configs still parse.

SymbolValues is left unchanged. Where existing call sites had a `SymbolValues` in hand and need to pass it to the new API, they go through `SymbolValues::to_dim_map()`, a new read-only accessor that lifts each `i64` to `TDim::Val`.