### PR TITLE
nnef: fix <= and >= parsing in rvalue expressions

### DIFF
--- a/harness/nnef-test-cases/cmp-operators/graph.nnef
+++ b/harness/nnef-test-cases/cmp-operators/graph.nnef
@@ -1,0 +1,12 @@
+version 1.0;
+
+graph cmp_operators(input) -> (lt, le, gt, ge, eq, ne)
+{
+    input = external<scalar>(shape = [4]);
+    lt = input < 0.5;
+    le = input <= 0.5;
+    gt = input > 0.5;
+    ge = input >= 0.5;
+    eq = input == 0.5;
+    ne = input != 0.5;
+}

--- a/harness/nnef-test-cases/cmp-operators/runme.sh
+++ b/harness/nnef-test-cases/cmp-operators/runme.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+$TRACT_RUN . run --allow-random-input

--- a/nnef/src/ast/parse.rs
+++ b/nnef/src/ast/parse.rs
@@ -348,7 +348,7 @@ fn rvalue(i: &str) -> R<'_, RValue> {
     bin!(exp, sub, tag("^"));
     bin!(mul, exp, one_of("*/"));
     bin!(add, mul, one_of("+-"));
-    bin!(comp, add, alt((tag("=="), tag("!="), tag("<"), tag(">"), tag("<="), tag(">="))));
+    bin!(comp, add, alt((tag("=="), tag("!="), tag("<="), tag(">="), tag("<"), tag(">"))));
     bin!(boolean, comp, alt((tag("||"), tag("&&"))));
     bin!(in_for, boolean, tag("in"));
 
@@ -792,6 +792,20 @@ mod test {
         p(rvalue, "1 + sqrt(var + eps)");
         p(rvalue, "[for i in range_of(output_size) yield output_size[i] * sampling_rate[i]]");
         p(rvalue, "scalar(2 ^ (bits - 1) - integer(symmetric) if signed else 0)");
+    }
+
+    #[test]
+    fn test_rvalue_comparison_operators() {
+        p(rvalue, "a == b");
+        p(rvalue, "a != b");
+        p(rvalue, "a < b");
+        p(rvalue, "a > b");
+        p(rvalue, "a <= b");
+        p(rvalue, "a >= b");
+        p(rvalue, "a<=b");
+        p(rvalue, "a>=b");
+        p(rvalue, "(a + b) <= (c + d)");
+        p(rvalue, "a >= b && c <= d");
     }
 
     #[test]


### PR DESCRIPTION
The comparison-operator alt tried tag("<") before tag("<="), so a <= b matched < first and left = b, which then failed at the next token. Same for > vs >=. Reorder so the two-character forms are tried first, and add an end-to-end harness test (cmp-operators) plus a parser unit test covering all six relational operators.