### PR TITLE
nnef: implement copy by routing to Cast (or identity)

### DIFF
--- a/harness/nnef-test-cases/copy-identity/graph.nnef
+++ b/harness/nnef-test-cases/copy-identity/graph.nnef
@@ -1,0 +1,7 @@
+version 1.0;
+
+graph main(input) -> (output)
+{
+    input = external<scalar>(shape = [1, 4]);
+    output = copy(input);
+}

--- a/harness/nnef-test-cases/copy-identity/runme.sh
+++ b/harness/nnef-test-cases/copy-identity/runme.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# No graph.quant: copy is pure identity, no Cast node should appear.
+$TRACT_RUN --nnef-tract-core . dump --assert-op-count Cast 0
+$TRACT_RUN --nnef-tract-core . run --allow-random-input

--- a/harness/nnef-test-cases/copy-requant/graph.nnef
+++ b/harness/nnef-test-cases/copy-requant/graph.nnef
@@ -1,0 +1,7 @@
+version 1.0;
+
+graph main(input) -> (output)
+{
+    input = external<scalar>(shape = [1, 4]);
+    output = copy(input);
+}

--- a/harness/nnef-test-cases/copy-requant/graph.quant
+++ b/harness/nnef-test-cases/copy-requant/graph.quant
@@ -1,0 +1,2 @@
+"input": zero_point_linear_quantize(zero_point = 0, scale = 0.003921568859368563, bits = 8, signed = false, symmetric = false);
+"output": zero_point_linear_quantize(zero_point = -128, scale = 0.003921568859368563, bits = 8, signed = true, symmetric = false);

--- a/harness/nnef-test-cases/copy-requant/runme.sh
+++ b/harness/nnef-test-cases/copy-requant/runme.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# u8 input → i8 output, both with the same scale, zero-point shifted by 128.
+# Cast must subtract 128 from each byte to land the same real-valued range
+# in the signed representation.
+$TRACT_RUN --nnef-tract-core . dump --assert-op-count Cast 1
+$TRACT_RUN --nnef-tract-core . run --allow-random-input

--- a/nnef/src/ops/nnef/deser.rs
+++ b/nnef/src/ops/nnef/deser.rs
@@ -892,6 +892,26 @@ pub fn unstack(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> T
         .map(Value::from)
 }
 
+// fragment copy<?>( x: tensor<?> ) -> ( y: tensor<?> );
+//
+// Identity on the value, but graph.quant may declare a different
+// quantization for the output named tensor, in which case the operator is
+// the spec-compliant way to express a requantization. If declared output
+// type matches the input, return the input outlet unchanged (no node
+// added); otherwise wire a `Cast`, which performs real byte-level
+// requantization for any (zp, scale) change between two quantized
+// variants of the same physical type.
+pub fn copy(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> TractResult<Value> {
+    let input: OutletId = invocation.named_arg_as(builder, "x")?;
+    if let Some(Some(to)) = invocation.dt_from_quant_file.first().copied() {
+        let in_dt = builder.model.outlet_fact(input)?.datum_type;
+        if to != in_dt {
+            return builder.wire(cast(to), &[input]);
+        }
+    }
+    Ok(Value::Wire(input))
+}
+
 /*
  * fragment softmax( x: tensor<scalar>, axes: integer[] = [1] ) -> ( y: tensor<scalar> )
  * {

--- a/nnef/src/ops/nnef/mod.rs
+++ b/nnef/src/ops/nnef/mod.rs
@@ -45,6 +45,8 @@ pub fn tract_nnef() -> Registry {
     primitive(&mut registry, "stack", deser::stack);
     primitive(&mut registry, "unstack", deser::unstack);
 
+    primitive(&mut registry, "copy", deser::copy);
+
     registry.register_binary("add", &ops::math::Add {});
     registry.register_binary("sub", &ops::math::Sub {});
     registry.register_binary("mul", &ops::math::Mul {});


### PR DESCRIPTION
The NNEF spec defines `copy` as identity on the value, but graph.quant attaches quantization to the named tensor (the wire), not to the op, so a `copy(x)` followed by a different graph.quant entry on the output is the spec-compliant way to express a requantization between two quantized variants of the same physical width. Tract's `Cast` op already does that requantization correctly, so map `copy` to it at deser time when the declared output type differs from the input, and to a plain pass-through (no node added) otherwise.

Closes #1318. Picks up the conversation between @kali and @mmagician that had landed on "this should map to Cast" — the diff in #1318 introduced a redundant element-wise no-op core op that the framework's auto-cast then chained onto; routing directly to Cast at the deser boundary skips that node entirely.

Adds two harness tests:
- copy-requant: u8 → i8 with same scale, zp shifted by 128. Asserts exactly one Cast in the graph, runs end-to-end with random input.
- copy-identity: no graph.quant. Asserts zero Cast nodes (copy fully shunts to its input outlet).