### PR TITLE
linalg/cnn: contiguous-x fast path for im2col valid gather

### DIFF
--- a/core/src/ops/cnn/conv/im2col.rs
+++ b/core/src/ops/cnn/conv/im2col.rs
@@ -450,10 +450,7 @@ impl Patcher {
         // slice write — byte-identical to the per-element loop.
         if x_stride_ptr == 1 && x_max > x_min {
             unsafe {
-                let row = std::slice::from_raw_parts(
-                    iptr.offset(x_min),
-                    (x_max - x_min) as usize,
-                );
+                let row = std::slice::from_raw_parts(iptr.offset(x_min), (x_max - x_min) as usize);
                 writer.write_slice(row);
             }
         } else {

--- a/core/src/ops/cnn/conv/im2col.rs
+++ b/core/src/ops/cnn/conv/im2col.rs
@@ -328,12 +328,26 @@ impl Patcher {
                 geometry.b_pack.write_with_k_outer(pack.as_mut_ptr(), geometry.k, geometry.n);
             let iptr = input.as_ptr_unchecked::<T>();
             let iptr = iptr.add(g * geometry.ci_per_group * geometry.input_shape_with_n.c_stride());
+            let output_x = *geometry.pool.patch.output_shape.get_unchecked(0);
+            // Fast path: stride-1 contiguous read along x. Replaces the
+            // per-element pointer-arithmetic loop with a single write_slice
+            // (memcpy when the slice fits in the current panel).
+            // Byte-identical to the slow path (write_slice's contract).
+            let contiguous_x = x_stride == 1;
             for ci in 0..geometry.ci_per_group {
                 let iptr = iptr.offset(ci as isize * c_stride);
                 for koffset in &geometry.pool.patch.standard_layout_data_field {
                     let iptr = iptr.offset(*koffset);
-                    for x in 0..*geometry.pool.patch.output_shape.get_unchecked(0) {
-                        writer.write(*iptr.offset(x as isize * x_stride));
+                    if contiguous_x {
+                        let row = std::slice::from_raw_parts(iptr, output_x);
+                        writer.write_slice(row);
+                    } else {
+                        // Hoist multiplication out of inner loop.
+                        let mut iptr_x = iptr;
+                        for _ in 0..output_x {
+                            writer.write(*iptr_x);
+                            iptr_x = iptr_x.offset(x_stride);
+                        }
                     }
                 }
             }
@@ -431,8 +445,21 @@ impl Patcher {
         iptr: *const T,
         writer: &mut tract_linalg::pack::KOutWriter<T>,
     ) {
-        for x in x_min..x_max {
-            writer.write(unsafe { *iptr.offset(x * x_stride_ptr) });
+        // Fast path: x_stride_ptr == 1 means consecutive x values are at
+        // consecutive memory addresses, so the inner loop is a contiguous
+        // slice write — byte-identical to the per-element loop.
+        if x_stride_ptr == 1 && x_max > x_min {
+            unsafe {
+                let row = std::slice::from_raw_parts(
+                    iptr.offset(x_min),
+                    (x_max - x_min) as usize,
+                );
+                writer.write_slice(row);
+            }
+        } else {
+            for x in x_min..x_max {
+                writer.write(unsafe { *iptr.offset(x * x_stride_ptr) });
+            }
         }
     }
 
@@ -455,15 +482,30 @@ impl Patcher {
                 geometry.b_pack.write_with_k_outer(pack.as_mut_ptr(), geometry.k, geometry.n);
             let iptr = input.as_ptr_unchecked::<T>();
             let iptr = iptr.add(g * geometry.ci_per_group * shape.c_stride());
+            let output_y = *geometry.pool.patch.output_shape.get_unchecked(0);
+            let output_x = *geometry.pool.patch.output_shape.get_unchecked(1);
+            // Fast path: stride-1 contiguous reads along x within each y-row.
+            // Each y-row becomes a single write_slice (memcpy when the slice
+            // fits in the current panel). Byte-identical to the slow path.
+            let contiguous_x = x_stride_ptr == 1;
             for ci in 0..geometry.ci_per_group {
                 let iptr = iptr.offset(ci as isize * c_stride_ptr);
                 for koffset in &geometry.pool.patch.standard_layout_data_field {
                     let iptr = iptr.offset(*koffset);
-                    for y in 0..*geometry.pool.patch.output_shape.get_unchecked(0) {
-                        let iptr = iptr.offset(y as isize * y_stride_ptr);
-                        for x in 0..*geometry.pool.patch.output_shape.get_unchecked(1) {
-                            writer.write(*iptr.offset(x as isize * x_stride_ptr));
+                    let mut iptr_y = iptr;
+                    for _ in 0..output_y {
+                        if contiguous_x {
+                            let row = std::slice::from_raw_parts(iptr_y, output_x);
+                            writer.write_slice(row);
+                        } else {
+                            // Hoist x multiplication out of inner loop.
+                            let mut iptr_x = iptr_y;
+                            for _ in 0..output_x {
+                                writer.write(*iptr_x);
+                                iptr_x = iptr_x.offset(x_stride_ptr);
+                            }
                         }
+                        iptr_y = iptr_y.offset(y_stride_ptr);
                     }
                 }
             }

--- a/linalg/src/frame/pack.rs
+++ b/linalg/src/frame/pack.rs
@@ -403,6 +403,19 @@ impl PackedFormat {
 
 pub trait PackingWriter<T: Copy> {
     fn write(&mut self, t: T);
+
+    /// Write a contiguous slice of values. The default implementation falls
+    /// back to per-element `write`; concrete writers may override with a
+    /// `memcpy`-class fast path when the destination layout permits it.
+    ///
+    /// The output produced by `write_slice(s)` must be byte-identical to
+    /// `for &t in s { self.write(t); }` for any input.
+    #[inline]
+    fn write_slice(&mut self, ts: &[T]) {
+        for t in ts {
+            self.write(*t);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -432,6 +445,17 @@ where
         unsafe {
             *self.ptr = t;
             self.ptr = self.ptr.offset(1);
+        }
+    }
+
+    #[inline]
+    fn write_slice(&mut self, ts: &[T]) {
+        // KOutSinglePanelWriter writes elements consecutively with no panel
+        // boundaries. A direct `copy_nonoverlapping` is byte-identical to the
+        // per-element loop.
+        unsafe {
+            std::ptr::copy_nonoverlapping(ts.as_ptr(), self.ptr, ts.len());
+            self.ptr = self.ptr.add(ts.len());
         }
     }
 }
@@ -503,6 +527,57 @@ where
                 } else {
                     self.remain = self.panel_width;
                 }
+            }
+        }
+    }
+
+    #[inline]
+    fn write_slice(&mut self, ts: &[T]) {
+        // Fast path: the slice fits entirely within the current panel. Writes
+        // are then guaranteed to be `ts.len()` consecutive memory locations
+        // followed by the same panel/lane bookkeeping the per-element path
+        // performs. This produces byte-identical output to a per-element loop.
+        //
+        // When the slice would cross a panel boundary, fall back to the
+        // per-element path so all transition logic stays in one place.
+        let n = ts.len();
+        if n == 0 {
+            return;
+        }
+        if n < self.remain {
+            // Strictly inside the current panel: bulk copy, then advance.
+            unsafe {
+                std::ptr::copy_nonoverlapping(ts.as_ptr(), self.ptr, n);
+                self.ptr = self.ptr.add(n);
+            }
+            self.remain -= n;
+        } else if n == self.remain {
+            // Exactly fills the current panel: bulk copy, then run the same
+            // panel-transition bookkeeping that `write` does on its final
+            // element. The transition is performed unconditionally here
+            // (rather than calling `write` for the last element) to keep the
+            // semantics identical even when the trait is inlined separately.
+            unsafe {
+                std::ptr::copy_nonoverlapping(ts.as_ptr(), self.ptr, n);
+                self.ptr = self.ptr.add(n);
+                self.current_panel += 1;
+                if self.current_panel == self.panels {
+                    self.ptr = self.ptr.offset(self.next_lane);
+                    self.current_panel = 0;
+                } else {
+                    self.ptr = self.ptr.offset(self.next_panel);
+                }
+                if self.current_panel == self.panels - 1 {
+                    self.remain = self.last_panel_width;
+                } else {
+                    self.remain = self.panel_width;
+                }
+            }
+        } else {
+            // Spans a panel boundary. Fall back to per-element writes so the
+            // panel-transition state machine handles every step.
+            for t in ts {
+                self.write(*t);
             }
         }
     }


### PR DESCRIPTION
## Summary

Two profile-driven optimisations to `im2col`'s `valid_1d` / `valid_2d` / `padded_2d_valid_x_loop` paths. DFN3 audit flagged `Patcher::valid_2d` at 9.9% of df_dec self-time; the hot path is a per-element `writer.write(*iptr.offset(x * stride))` loop where `x_stride_ptr` typically equals 1.

## What changed

`linalg/src/frame/pack.rs` (+90): adds `write_slice(&[T])` to `PackingWriter` (default per-element); overrides on `KOutWriter` (memcpy when slice fits in panel; per-element across boundaries) and `KOutSinglePanelWriter` (unconditional memcpy).

`core/src/ops/cnn/conv/im2col.rs` (+~50): in the three valid-path gathers, take the `write_slice` fast path when `x_stride_ptr == 1`; otherwise hoist the per-iteration `iptr.offset(x * stride)` multiplication into a pointer increment.

## Tests

`cargo test -p tract-{linalg,core,pulse} --lib` passes (1062 / 231 / 13). Bit-identity verified end-to-end on DFN3 (df_dec, erb_dec) and MobileNet v2 across native arm64 + wasm32-wasip1; SHA-256 stable across hundreds of thousands of frames.

## Measured impact (wasm32-wasip1 + wasmtime, M-series)

| Model | Baseline | Patched | Δ |
|---|---:|---:|---:|
| DFN3 df_dec (PulsedModel S=1) | 173.5 µs | 168.3 µs | **−3.0%** |
| MobileNet v2 (1×3×224×224)    | 54.7 ms  | 52.3 ms  | **−4.4%** |

Native arm64 within noise (Apple memcpy is heavily tuned). Full bench data including 4-variant comparison: https://gist.github.com/czoli1976/aa22437108acacb4045a12858e0750f8

## Things this PR does NOT do

- Does not change the writer's per-element `write()` path.
- Does not implement chunked-memcpy across panel boundaries — empirical comparison showed +14% regression on small slices; spans-panel case stays on the per-element fallback.

— Ckristian (czoli1976)
