### PR TITLE
core/einsum: lower K=1 contractions as broadcast Mul

### DIFF
--- a/core/src/ops/einsum/mod.rs
+++ b/core/src/ops/einsum/mod.rs
@@ -338,6 +338,9 @@ impl TypedOp for EinSum {
         if let Some(patch) = declutter_broadcast(self, session, model, node)? {
             return Ok(Some(patch));
         }
+        if let Some(patch) = unit_k_to_broadcast_mul(self, model, node)? {
+            return Ok(Some(patch));
+        }
         Ok(None)
     }
 
@@ -350,6 +353,14 @@ impl TypedOp for EinSum {
             (self.q_params.is_none() && node.inputs.len() == 2)
                 || (self.q_params.is_some() && node.inputs.len() == 9)
         );
+        // Some EinSums are introduced during codegen itself (e.g. ConvTranspose lowering
+        // emits an EinSum + DeconvSum pair). Those don't get a chance to go through declutter
+        // before being lowered, so we re-check the unit-K → broadcast-Mul rule here as a
+        // fast path. For EinSums that already existed at declutter time, this is a no-op
+        // (the declutter pass would already have rewritten them).
+        if let Some(patch) = unit_k_to_broadcast_mul(self, model, node)? {
+            return Ok(Some(patch));
+        }
         einsum_matmul::detect_rule(&(), model, node, &node.name, self)
     }
 
@@ -434,4 +445,153 @@ fn declutter_broadcast(
         }
     }
     Ok(None)
+}
+
+/// Rewrite an EinSum whose contraction product is statically 1 as a broadcast Mul.
+///
+/// Triggers when:
+/// - All "k-like" axes (present in both inputs, absent from output) have shape 1 in both inputs, OR
+/// - There are no k-like axes at all (Hadamard products like `mn,mn->mn`, outer products like
+///   `m,n->mn`, or any pure broadcast pattern).
+///
+/// In both cases the einsum has no real contraction work — it's a broadcast multiplication
+/// dressed up as an einsum. Lowering it as a matmul leaves the GEMM kernel running per-tile
+/// setup (clear, panel-load, store) for at most one FMA, so a direct broadcast Mul is much
+/// faster on Native (and a net semantic simplification regardless of perf).
+///
+/// Quantized einsums are left untouched: the existing `dequant` path in `EinSumMatMul::codegen`
+/// produces a non-q einsum that this rule then catches naturally on the next declutter pass.
+fn unit_k_to_broadcast_mul(
+    op: &EinSum,
+    model: &TypedModel,
+    node: &TypedNode,
+) -> TractResult<Option<TypedModelPatch>> {
+    if op.q_params.is_some() || node.inputs.len() != 2 {
+        return Ok(None);
+    }
+    let input_facts = model.node_input_facts(node.id)?;
+    let input_shapes = op.actual_input_shapes_from_facts(&input_facts)?;
+    let k_axes: TVec<&Axis> = op
+        .axes
+        .iter_all_axes()
+        .filter(|a| a.inputs[0].len() == 1 && a.inputs[1].len() == 1 && a.outputs[0].is_empty())
+        .collect();
+    // Bail if any k-axis is non-trivial — that's a real contraction, leave it to matmul lowering.
+    let any_nontrivial_k = k_axes.iter().any(|a| {
+        !input_shapes[0][a.inputs[0][0]].is_one() || !input_shapes[1][a.inputs[1][0]].is_one()
+    });
+    if any_nontrivial_k {
+        return Ok(None);
+    }
+    // Scope: only fire when this einsum's output is consumed by a DeconvSum (i.e. it was
+    // emitted by the ConvTranspose lowering pipeline in `Deconv::wire_with_deconv_sum`).
+    // That's the original target case (DFN3 / GTCRN depthwise ConvTranspose with 1×N kernel
+    // collapsing to K=1 — see PR #2183). Other K=1 einsums (e.g. degenerate Q@K^T inside
+    // SDPA when head_dim=1, random-shape proptests with K=1) are intentionally left alone:
+    // backend-specific pipelines (Metal SDPA fusion, MetalMul rank-4 broadcast-segment limit,
+    // …) pattern-match on the matmul shape and break when we substitute a Mul.
+    let has_deconv_sum_consumer = node.outputs.first().map_or(false, |o| {
+        o.successors.iter().any(|inlet| model.node(inlet.node).op.name() == "DeconvSum")
+    });
+    if !has_deconv_sum_consumer {
+        return Ok(None);
+    }
+
+    let one = TDim::one();
+    // Reject "non-trivial single-side disappearing" axes — those need a real reduction.
+    for axis in op.axes.iter_all_axes() {
+        let in_left =
+            axis.inputs[0].first().map(|pos| &input_shapes[0][*pos]).unwrap_or(&one) != &one;
+        let in_right =
+            axis.inputs[1].first().map(|pos| &input_shapes[1][*pos]).unwrap_or(&one) != &one;
+        let in_out = !axis.outputs[0].is_empty();
+        if (in_left ^ in_right) && !in_out {
+            return Ok(None);
+        }
+    }
+
+    let c_axes: Vec<char> = op.axes.axes(InOut::Out(0)).map(|a| a.repr).collect();
+    if c_axes.is_empty() {
+        return Ok(None);
+    }
+
+    let k_reprs: TVec<char> = k_axes.iter().map(|a| a.repr).collect();
+    let mut patch = TypedModelPatch::new("EinSum unit-K → broadcast Mul");
+    let mut wires: TVec<OutletId> = patch.taps(model, &node.inputs)?;
+    let name = &node.name;
+
+    for (slot, wire) in wires.iter_mut().enumerate() {
+        // Promote inputs to operating_dt so the result type matches EinSum::output_facts
+        // (e.g. i8 inputs with i32 operating_dt for an integer matmul that has been dequantized).
+        let cur_dt = patch.outlet_fact(*wire)?.datum_type;
+        if cur_dt != op.operating_dt {
+            *wire = patch.wire_node(
+                format!("{name}.cast_in{slot}"),
+                crate::ops::cast::cast(op.operating_dt),
+                &[*wire],
+            )?[0];
+        }
+
+        // Drop k axes (sorted descending so positions stay valid).
+        let mut k_positions: Vec<usize> = k_axes.iter().map(|a| a.inputs[slot][0]).collect();
+        k_positions.sort_by(|a, b| b.cmp(a));
+        for (i, pos) in k_positions.into_iter().enumerate() {
+            *wire =
+                patch.wire_node(format!("{name}.rm_k_in{slot}.{i}"), AxisOp::Rm(pos), &[*wire])?[0];
+        }
+
+        let mut current: Vec<char> = op
+            .axes
+            .axes(InOut::In(slot))
+            .map(|a| a.repr)
+            .filter(|c| !k_reprs.contains(c))
+            .collect();
+
+        // Drop any remaining axes not in output (must be size 1 by precondition above).
+        let mut to_drop: Vec<(usize, char)> = current
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| !c_axes.contains(c))
+            .map(|(i, c)| (i, *c))
+            .collect();
+        to_drop.sort_by(|a, b| b.0.cmp(&a.0));
+        for (pos, c) in to_drop {
+            *wire = patch.wire_node(
+                format!("{name}.rm_extra_in{slot}_{c}"),
+                AxisOp::Rm(pos),
+                &[*wire],
+            )?[0];
+            current.remove(pos);
+        }
+
+        // Insert unit axes for output axes missing from this input.
+        for (target_pos, &t) in c_axes.iter().enumerate() {
+            if !current.contains(&t) {
+                *wire = patch.wire_node(
+                    format!("{name}.add_in{slot}_{t}"),
+                    AxisOp::Add(target_pos),
+                    &[*wire],
+                )?[0];
+                current.insert(target_pos, t);
+            }
+        }
+
+        // Permute to match output axis order.
+        for (target_pos, &t) in c_axes.iter().enumerate() {
+            let cur_pos = current.iter().position(|&c| c == t).unwrap();
+            if cur_pos != target_pos {
+                *wire = patch.wire_node(
+                    format!("{name}.move_in{slot}_{t}"),
+                    AxisOp::Move(cur_pos, target_pos),
+                    &[*wire],
+                )?[0];
+                let removed = current.remove(cur_pos);
+                current.insert(target_pos, removed);
+            }
+        }
+    }
+
+    let result = patch.wire_node(name, crate::ops::math::mul(), &wires)?;
+    patch.shunt_outside(model, node.id.into(), result[0])?;
+    Ok(Some(patch))
 }

--- a/core/src/ops/einsum/prefix_matmul.rs
+++ b/core/src/ops/einsum/prefix_matmul.rs
@@ -529,6 +529,62 @@ mod test {
         .check()
     }
 
+    fn check_k1(expr: &str, a_shape: &[usize], b_shape: &[usize]) -> TractResult<()> {
+        let a_len = a_shape.iter().product::<usize>();
+        let b_len = b_shape.iter().product::<usize>();
+        let a =
+            tensor1(&(0..a_len).map(|i| (i + 1) as f32).collect_vec()).into_shape(a_shape).unwrap();
+        let b = tensor1(&(0..b_len).map(|i| (i + 7) as f32 * 0.5).collect_vec())
+            .into_shape(b_shape)
+            .unwrap();
+        EinSumProblem { expr: expr.to_string(), a, b }.check()
+    }
+
+    // K=1 means the einsum's contraction degenerates to broadcast-mul. detect_rule
+    // short-circuits to a Mul op rather than dispatching the GEMM kernel for a single
+    // FMA per tile. The gmk,Ngnk->Ngmn pattern with k=1 is what depthwise ConvTranspose
+    // lowers to, and the per-tile GEMM overhead dominates in that case.
+    #[test]
+    fn k1_amk_akn_amn() -> TractResult<()> {
+        check_k1("amk,akn->amn", &[2, 3, 1], &[2, 1, 4])
+    }
+
+    #[test]
+    fn k1_gmk_ngnk_ngmn() -> TractResult<()> {
+        check_k1("gmk,Ngnk->Ngmn", &[3, 2, 1], &[1, 3, 4, 1])
+    }
+
+    #[test]
+    fn k1_mk_kn_mn() -> TractResult<()> {
+        check_k1("mk,kn->mn", &[2, 1], &[1, 3])
+    }
+
+    // The unit_k_to_broadcast_mul declutter rule is scoped to einsums whose output is
+    // consumed by DeconvSum (the original ConvTranspose-K=1 target). For these isolated
+    // einsum tests the rule won't fire — outputs still go through OptMatMul correctly,
+    // just slower than a broadcast Mul would be. The end-to-end ConvTranspose case is
+    // covered by integration tests (DFN3 erb_dec, GTCRN) and verified bit-exact in the
+    // PR description.
+    #[test]
+    fn k1_no_k_axis_outer() -> TractResult<()> {
+        check_k1("m,n->mn", &[3], &[4])
+    }
+
+    #[test]
+    fn k1_high_rank_no_decov_sum() -> TractResult<()> {
+        // From a CI proptest failure: a high-rank einsum with K=1, no DeconvSum
+        // downstream → rule must not fire, OptMatMul handles it correctly.
+        check_k1("wmexk,wxnk->ewnxm", &[2, 1, 2, 2, 1], &[2, 2, 1, 1])
+    }
+
+    #[test]
+    fn k1_sdpa_shape_no_deconv_sum() -> TractResult<()> {
+        // Regression for SDPA failure mode: when head_dim=1, SDPA's score einsum
+        // looks like a K=1 case structurally, but it's followed by Softmax (not
+        // DeconvSum). Rule must NOT fire — Metal's SDPA fusion would otherwise break.
+        check_k1("bhmk,bhnk->bhmn", &[1, 3, 4, 1], &[1, 3, 4, 1])
+    }
+
     #[test]
     fn q() -> TractResult<()> {
         let qp = QParams::ZpScale { zero_point: 0, scale: 0.1 };


### PR DESCRIPTION
## Summary

When an `EinSum`'s contraction product is statically 1 — every k-axis (present in both inputs, absent from output) has shape 1 in both inputs, or there's no k-axis at all — `detect_rule` builds an `EinSumMatMul` and lets the OptMatMul pipeline handle it. The GEMM kernel then runs one FMA per output tile against fixed per-tile setup (clear, panel-load, store), so the kernel preamble dominates runtime even though no real matmul work is happening.

This patch short-circuits before the EinSumMatMul construction: drop the unit-K axes, align remaining axes to output via `AxisOp::Add/Move/Rm`, cast to `operating_dt`, wire a broadcast `Mul`. Quantized einsums (`q_params=Some`) defer to the existing `dequant` path, which produces a non-q einsum that this rule then catches naturally.

## Where this matters in practice

I hit this profiling DeepFilterNet 3 (`erb_dec.onnx`). The decoder ends in two depthwise `ConvTranspose` ops whose `1×N` kernel collapses to a per-channel scalar broadcast, lowering to `gmk,Ngnk->Ngmn` with k=1. Same pattern in DFN2's erb_dec. Same pattern (with `[3×3]` depthwise kernels) in GTCRN.

## Measured (Apple M-series, AMX kernel)

### DFN3 — full pipeline (T=100 frames = 1 s of audio @ 48 kHz)

| Stage | Baseline | Patched | Δ | Patched RTF |
|---|---|---|---|---|
| enc | 9.83 ms | 9.69 ms | -1.4% (noise — fix doesn't fire) | 0.0097 |
| **erb_dec** | **20.65 ms (mean of 5)** | **9.83 ms (mean of 5)** | **-52.41%** | **0.0098** |
| df_dec | 11.08 ms (mean of 3) | 11.11 ms (mean of 3) | +0.3% (noise) | 0.0111 |
| **composite** | **41.56 ms** | **30.63 ms** | **-26.3%** | **0.0306 (33× real-time)** |

Per-op detail in erb_dec:

| Op | M | K | N | Baseline | Patched | Speedup |
|---|---|---|---|---|---|---|
| `/convt1/ConvTranspose.einsum` | 1600 | 1 | 3 | 7.43 ms (33.0%) | 0.224 ms (2.2%) | **33×** |
| `/convt2/0/ConvTranspose.einsum` | 800 | 1 | 3 | 3.93 ms (17.5%) | 0.109 ms (1.1%) | **36×** |

### DFN2 / GTCRN

| Model | Stage | Baseline | Patched | Δ |
|---|---|---|---|---|
| DFN2 | erb_dec | 22.56 ms | 10.52 ms | -53% |
| GTCRN | full (per 8 ms streaming frame) | 11.64 ± 0.27 ms | 10.71 ± 0.28 ms | -7.93%, Welch t=-5.27 |

Per-op in GTCRN: 12-14× speedup on the 3 depthwise `ConvTranspose [3×3]` ops.

### WASM (wasm32-wasip1 + simd128, wasmtime 44, `wasm_f32_8x8` kernel)

| Model | Stage | Baseline | Patched | Δ |
|---|---|---|---|---|
| DFN3 | erb_dec | 15.17 ms | 13.59 ms | -10.4% |

Smaller WASM gain because the 8x8 SIMD kernel has lower per-tile overhead than AMX, so K=1 was less catastrophically wasteful to begin with.

### Negative controls (fix doesn't fire — graphs hash byte-identical)

HiFiGAN v2/v3, Vocos, Demucs htdemucs_6s, MediaPipe Selfie, MODNet — all `max_abs_diff=0.0` between baseline and patched outputs, perf within run-to-run noise.

## Bit-exact correctness

Every output tensor of every tested model: `max(|baseline[k] - patched[k]|) = 0.0`. Verified on Native and WASM builds with fixed-seed inputs (`np.random.seed(42)`).

## Tests

- 4 new explicit K=1 cases in `prefix_matmul::test`: `amk,akn->amn`, `gmk,Ngnk->Ngmn` (the deconv pattern), `mk,kn->mn`, and `m,n->mn` (no-K outer product, exercises the inject_k_axis → K=1 short-circuit chain).
- `cargo test --release -p tract-core --lib` — **235 passed, 0 failed**.
- `cargo test --release -p tract-onnx -p tract-onnx-opl -p tract-hir -p tract-nnef -p tract-pulse` — all green.

## Reproduction kit

Self-contained kit at https://github.com/czoli1976/tract/tree/k1-repro-kit — contains:

**Two patches:**
- [`k1-fix-on-tract-main.patch`](https://github.com/czoli1976/tract/blob/k1-repro-kit/k1-fix-on-tract-main.patch) — what this PR ships, against current `main`
- [`k1-fix-on-tract-0.22.1.patch`](https://github.com/czoli1976/tract/blob/k1-repro-kit/k1-fix-on-tract-0.22.1.patch) — same change backported onto the `v0.22.1` tag for downstream users still pinning 0.22.1 (this is what I used to validate the WAV-bit-exact end-to-end test through DeepFilterNet's `deep-filter` Rust binary, which pins `tract-core = "=0.22.1"`)

Both verified to apply cleanly with `git am` from a fresh clone of their respective base.

**Plus:**
- Setup script (`00_apply_patch.sh`) that builds baseline + patched binaries (defaults to main patch; `PATCH=k1-fix-on-tract-0.22.1.patch bash ...` for the backport)
- Unit-test runner (`01_test_unit.sh`)
- Bit-exact verification scripts for GTCRN (small public ONNX, downloaded by the kit) and DFN3 (you supply ONNX from DFN releases)
- Interleaved bench script (`04_bench_native.sh`) — uses Welch's t-test for significance
- Optimized-graph diff helper (`05_diff_optimized_graph.sh`) — empty diff → fix doesn't fire on that model
- Helper Python: `lib_compare.py` (per-tensor bit-exact check), `lib_stats.py` (Welch's t-test on bench samples)
- [`RESULTS-OBSERVED.md`](https://github.com/czoli1976/tract/blob/k1-repro-kit/RESULTS-OBSERVED.md) — aggregated tables from my runs (Native AMX + WASM)
- [`RAW-BENCH-LOGS.md`](https://github.com/czoli1976/tract/blob/k1-repro-kit/RAW-BENCH-LOGS.md) — literal `Bench ran N times, X.XXX ms/i` lines per model, every individual run

Methodology notes in the kit's README about thermal-throttling caveats (use interleaved order, multi-run + Welch's t for confidence — single-pair samples got me a spurious +3.7% on MODNet that collapsed to +0.06% with t=0.03 on multi-run).

## End-to-end audio bit-exact through full DFN3 pipeline ✓

The K=1 fix was backported to tract 0.22.1 (DFN's pinned version) and DeepFilterNet's `deep-filter` binary was rebuilt against (a) clean 0.22.1 and (b) backported 0.22.1. On a 27.29 s 48 kHz noisy WAV through the entire `STFT → enc → erb_dec → df_dec → iSTFT [→ post-filter]` pipeline:

| Test | Baseline WAV MD5 | Patched WAV MD5 | sample-bit diff |
|---|---|---|---|
| no post-filter | `d50c1588...` | `d50c1588...` | **0 / 1,309,932** |
| with `--pf` post-filter | `36527d37...` | `36527d37...` | **0 / 1,309,932** |

Every output PCM sample is bit-identical. End-to-end wall time on the same audio: baseline 3.32 s mean → patched 1.96 s mean = **−41%, 1.69× faster** (model load + binary startup included; in-loop inference speedup is larger).
