### PR TITLE
cli-tests: add trunet pulse=1 stream-vs-batch numerical check

### DIFF
--- a/.travis/cli-tests.sh
+++ b/.travis/cli-tests.sh
@@ -114,6 +114,8 @@ $TRACT_RUN $MODELS/hey_snips_v4_model17.pb -i S,20,f32 \
 
 $CACHE_FILE trunet_dummy.nnef.tgz
 $TRACT_RUN --nnef-tract-core $MODELS/trunet_dummy.nnef.tgz dump -q
+$TRACT_RUN --nnef-tract-core $MODELS/trunet_dummy.nnef.tgz --pulse 1 \
+    compare --stream --allow-random-input -q
 
 echo $WHITE     LLM $NC
 


### PR DESCRIPTION
compare --stream contrasts the pulsed plan against the unpulsed reference on the same random input. Catches state-recurrence breakage on stateful Scan ops (issue #2157) — turn_0 matches but turn_1+ diverges when the body's State input gets re-seeded each call, which is what an over-eager iter=1 Scan inliner produces.