### PR TITLE
linalg: enable rayon multithreading on wasm32-unknown-unknown + 2D MMM dispatch

### DIFF
--- a/linalg/MULTITHREAD_BENCHMARKS.md
+++ b/linalg/MULTITHREAD_BENCHMARKS.md
@@ -1,0 +1,114 @@
+# Multithreaded MMM benchmarks
+
+Validation data for the `multithread-mm` rayon path with this PR's
+`chunked_dispatch_rayon` + `THREADING_PANEL_THRESHOLD` + `RayonGlobal`
+changes.
+
+## Setup
+
+- **Base**: tract `main` (commit `41b7b02`), with the merged WASM kernel
+  kit (PRs `#2164` + `#2173`).
+- **Vanilla baseline**: same commit, MMM dispatch unchanged
+  (1D `into_par_iter` over single panel axis).
+- **Patched**: this PR applied — chunked 2D dispatch, threshold, RayonGlobal.
+- **Both binaries built identically**: same compiler, same kernel kit, same
+  `+atomics +bulk-memory +mutable-globals +simd128` target features for
+  WASM.
+- **Driver**: Playwright headless, real browser engines. Median of 60
+  iterations after 3-iter warmup.
+- **Output verification**: FNV-1a hash of result tensor. All 60 cells
+  produce identical hash (`20ea4579c427f925` for DFN3,
+  shape-deterministic for synthetic) — bit-equal output preserved.
+
+## Synthetic dense matmul (the parallelism-bound case)
+
+| Shape | Engine | Vanilla (1 thread) | Patched, 4 threads | Speedup |
+|---|---|---|---|---|
+| **1024×1024×1024** (transformer FFN) | Chromium | 55.4 ms | 16.6 ms | **3.34×** |
+|  | WebKit | 79.8 ms | 25.6 ms | **3.12×** |
+|  | Firefox | 1107 ms | 325 ms | **3.40×** |
+| **512×768×768** (BERT FFN) | Chromium | 15.7 ms | 5.1 ms | **3.07×** |
+|  | WebKit | 22.6 ms | 6.8 ms | **3.30×** |
+|  | Firefox | 311 ms | 91 ms | **3.42×** |
+| **256×256×128** | Chromium | 0.47 ms | 0.22 ms | **2.19×** |
+|  | WebKit | 0.66 ms | 0.20 ms | **3.30×** |
+|  | Firefox | 9.0 ms | 2.6 ms | **3.41×** |
+| 64×256×64 (DFN-like small) | Chromium | 0.07 ms | 0.07 ms | 1.0× (within noise) |
+|  | WebKit | 0.08 ms | 0.04 ms | 2.00× |
+|  | Firefox | 1.18 ms | 0.38 ms | **3.11×** |
+| 32×32×32 (tiny) | All | sub-ms | sub-ms | **1.0× (threshold gates)** |
+
+The threshold correctly gates the smallest shape; threading kicks in once
+panel count clears the gate, and scales near-linearly with thread count
+on all three engines.
+
+## Real model (DeepFilterNet 3, full streaming inference)
+
+5-frame chunks at 48 kHz (50 ms of audio per iteration).
+
+| Engine | Vanilla mono | Patched, 4 threads | RTF (vanilla → patched) | Speedup |
+|---|---|---|---|---|
+| Chromium | 3.31 ms | 3.17 ms | 0.066 → 0.063 | 1.04× (within noise) |
+| WebKit | 4.32 ms | 4.00 ms | 0.086 → 0.080 | 1.08× |
+| Firefox | 34.20 ms | 33.34 ms | 0.684 → 0.667 | 1.03× |
+
+DFN3 is Amdahl-bound: only ~25% of runtime is in MMMs that clear the
+threshold; the rest is FFT, complex multiplication, and small RNN-internal
+matmuls that the threshold deliberately keeps single-threaded. The
+threshold's role here is to **prevent regression**, not deliver speedup.
+This is correct behavior — DFN3-class workloads should not pay rayon
+overhead on tiny ops.
+
+## Native (macOS aarch64, generic kernels)
+
+Spot-check on the rayon path before/after. Tract's existing rayon path
+already worked well on native; the change is mostly a refactor.
+
+| Shape | Vanilla 1D | Patched 2D | Change |
+|---|---|---|---|
+| 256×256, 4 threads | 2.13 ms | 2.12 ms | net-neutral |
+| 512×512, 4 threads | 9.93 ms | 9.80 ms | +1% |
+| 64×256, 4 threads | 615 µs | 625 µs | −2% |
+
+Within noise on common shapes. The 2D dispatch shows a latent benefit on
+shapes 1D parallelism handles poorly (e.g. m=8 n=2048, where 1D over m
+can only feed 2 threads); not yet measured directly on native but the
+dispatch math is the same on both targets.
+
+## Determinism
+
+Across all measured cells (synthetic + DFN3, 3 engines, 1/2/3/4 threads):
+
+- **WASM**: 60 cells, all produce identical hash per `(shape, mode)` pair.
+- **Native**: existing tract proptests (3524 lib tests) pass with this
+  PR's `multithread-mm` enabled.
+
+## Reproduction
+
+The harness uses [Vonage's libDF fork](https://github.com/czoli1976/DeepFilterNet)
+(branch `dfn3-wasm-opt-tract-022-kernel-kit`) migrated to tract main, with
+a `wasm-bindgen-rayon`-based threading bootstrap. Build:
+
+```bash
+RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128" \
+wasm-pack build --target web --release \
+    --no-default-features --features wasm-mt -- \
+    -Z build-std=std,panic_abort
+```
+
+JS-side:
+
+```javascript
+import init, { initThreadPool, df_set_thread_count } from './pkg/df.js';
+await init();
+await initThreadPool(navigator.hardwareConcurrency);  // wasm-bindgen-rayon
+df_set_thread_count(4);  // sets Executor::RayonGlobal in tract-linalg
+```
+
+Without `Executor::RayonGlobal` (this PR), `df_set_thread_count` would
+need to construct an `Arc<rayon::ThreadPool>` — which fails on
+`wasm32-unknown-unknown` because `rayon::ThreadPoolBuilder::new().build()`
+internally calls `std::thread::spawn` (unsupported there). That's the
+crux of why this enabling change is needed in tract-linalg itself: any
+browser threading via wasm-bindgen-rayon would otherwise silently fall
+back to single-threaded.

--- a/linalg/MULTITHREAD_BENCHMARKS.md
+++ b/linalg/MULTITHREAD_BENCHMARKS.md
@@ -83,6 +83,31 @@ Across all measured cells (synthetic + DFN3, 3 engines, 1/2/3/4 threads):
 - **Native**: existing tract proptests (3524 lib tests) pass with this
   PR's `multithread-mm` enabled.
 
+## Tuning the threshold
+
+The default `THREADING_PANEL_THRESHOLD` is `64` panels (m_panels ×
+n_panels). Adjust at runtime via:
+
+```rust
+use tract_linalg::multithread::set_threading_panel_threshold;
+
+set_threading_panel_threshold(0);    // thread every size, no gate
+set_threading_panel_threshold(256);  // gate harder — transformer-only
+set_threading_panel_threshold(64);   // default
+```
+
+Useful when profiling or specialising the build for a known workload class:
+
+| Workload class | Suggested threshold |
+|---|---|
+| Streaming RNN / mobile vision (many small MMMs) | 64 (default) or higher |
+| Mid-size dense (BERT-class) | 32–64 |
+| Large dense only (transformer FFN, LLM) | 16 or lower |
+
+The constant lives in `linalg/src/multithread.rs`; readers go through
+`current_threading_panel_threshold()` (`AtomicUsize::Relaxed`, no lock on
+the dispatch hot path).
+
 ## Reproduction
 
 The harness uses [Vonage's libDF fork](https://github.com/czoli1976/DeepFilterNet)

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -16,8 +16,6 @@ mod storage;
 pub mod tests;
 
 use crate::multithread::Executor;
-#[cfg(feature = "multithread-mm")]
-use rayon::prelude::*;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::Debug;
@@ -236,11 +234,17 @@ unsafe fn run_with_scratch_space_vec<K: MatMatMulKer>(
                 Ok(())
             }
             #[cfg(feature = "multithread-mm")]
-            Executor::MultiThread(pool) => pool.install(|| {
-                (0..m.div_ceil(ker.mr()))
-                    .into_par_iter()
-                    .try_for_each(|ia| scratch.run(ker, non_linear, ia, 0))
-            }),
+            Executor::MultiThread(pool) => {
+                chunked_dispatch_rayon(Some(&pool), m.divceil(ker.mr()), 1, |ia, _| {
+                    scratch.run(ker, non_linear, ia, 0)
+                })
+            }
+            #[cfg(feature = "multithread-mm")]
+            Executor::RayonGlobal => {
+                chunked_dispatch_rayon(None, m.divceil(ker.mr()), 1, |ia, _| {
+                    scratch.run(ker, non_linear, ia, 0)
+                })
+            }
         }
     }
 }
@@ -263,14 +267,18 @@ unsafe fn run_with_scratch_space_col_outer<K: MatMatMulKer>(
                 Ok(())
             }
             #[cfg(feature = "multithread-mm")]
-            Executor::MultiThread(pool) => pool.install(|| {
-                (0..n.div_ceil(ker.nr())).into_par_iter().try_for_each(|ib| {
-                    for ia in 0..m.divceil(ker.mr()) {
-                        scratch.run(ker, non_linear, ia, ib)?;
-                    }
-                    Ok(())
+            Executor::MultiThread(pool) => chunked_dispatch_rayon(
+                Some(&pool),
+                m.divceil(ker.mr()),
+                n.divceil(ker.nr()),
+                |ia, ib| scratch.run(ker, non_linear, ia, ib),
+            ),
+            #[cfg(feature = "multithread-mm")]
+            Executor::RayonGlobal => {
+                chunked_dispatch_rayon(None, m.divceil(ker.mr()), n.divceil(ker.nr()), |ia, ib| {
+                    scratch.run(ker, non_linear, ia, ib)
                 })
-            }),
+            }
         }
     }
 }
@@ -293,16 +301,114 @@ unsafe fn run_with_scratch_space_row_outer<K: MatMatMulKer>(
                 Ok(())
             }
             #[cfg(feature = "multithread-mm")]
-            Executor::MultiThread(pool) => pool.install(|| {
-                pool.install(|| {
-                    (0..m.div_ceil(ker.mr())).into_par_iter().try_for_each(|ia| {
-                        for ib in 0..n.divceil(ker.nr()) {
-                            scratch.run(ker, non_linear, ia, ib)?;
-                        }
-                        Ok(())
-                    })
+            Executor::MultiThread(pool) => chunked_dispatch_rayon(
+                Some(&pool),
+                m.divceil(ker.mr()),
+                n.divceil(ker.nr()),
+                |ia, ib| scratch.run(ker, non_linear, ia, ib),
+            ),
+            #[cfg(feature = "multithread-mm")]
+            Executor::RayonGlobal => {
+                chunked_dispatch_rayon(None, m.divceil(ker.mr()), n.divceil(ker.nr()), |ia, ib| {
+                    scratch.run(ker, non_linear, ia, ib)
                 })
-            }),
+            }
         }
     }
+}
+
+/// Below this many output panels (m_panels × n_panels), skip parallel
+/// dispatch and run inline single-threaded. Per-MMM kickoff cost (rayon
+/// scheduling, web-worker postMessage, atomic-instruction tax) dominates
+/// the kernel runtime for tiny MMMs; threading them is a net loss.
+///
+/// 64 panels is empirically tuned: above the rayon native overhead (~5 µs
+/// per dispatch) and the wasm-bindgen-rayon worker dispatch overhead
+/// (~50 µs), well within "still big enough to win."
+#[cfg(feature = "multithread-mm")]
+const THREADING_PANEL_THRESHOLD: usize = 64;
+
+/// Chunk grid for the 2D dispatch.
+///
+/// Mirrors ggml's `mul_mat` heuristic (`ggml/src/ggml-cpu/ggml-cpu.c:1378-1398`):
+///  * 16-tile panel chunks by default;
+///  * 64-tile chunks when one dimension is 1 (vec / vec-mat);
+///  * fallback to "block-per-thread along the longer axis" when the natural
+///    grid would have fewer than `4·nth` chunks.
+///
+/// Returns `(nchunks_m, nchunks_n, dr_m, dr_n)`.
+#[cfg(feature = "multithread-mm")]
+fn chunk_grid(n_panels_m: usize, n_panels_n: usize, nth: usize) -> (usize, usize, usize, usize) {
+    let chunk_size = if n_panels_m == 1 || n_panels_n == 1 { 64 } else { 16 };
+    let mut nchunks_m = n_panels_m.div_ceil(chunk_size);
+    let mut nchunks_n = n_panels_n.div_ceil(chunk_size);
+    if nchunks_m * nchunks_n < 4 * nth {
+        if n_panels_m > n_panels_n {
+            nchunks_m = nth;
+            nchunks_n = 1;
+        } else {
+            nchunks_m = 1;
+            nchunks_n = nth;
+        }
+    }
+    let dr_m = n_panels_m.div_ceil(nchunks_m).max(1);
+    let dr_n = n_panels_n.div_ceil(nchunks_n).max(1);
+    (nchunks_m, nchunks_n, dr_m, dr_n)
+}
+
+/// 2D chunked dispatcher across the (m_panels × n_panels) grid for the
+/// rayon path. Replaces a 1D `into_par_iter` over a single panel axis.
+/// Better-utilises threads on small/skewed shapes where one dimension has
+/// fewer panels than there are workers.
+///
+/// `pool`:
+///   * `Some(p)` with `p.current_num_threads() > 1` → scoped via `p.install`
+///     (native, custom pool path).
+///   * `Some(p)` with single-thread pool, or `None` → dispatched via
+///     `into_par_iter` directly, which uses rayon's GLOBAL pool. This is
+///     the only working path on `wasm32-unknown-unknown` via
+///     `wasm_bindgen_rayon::init_thread_pool`.
+#[cfg(feature = "multithread-mm")]
+unsafe fn chunked_dispatch_rayon<F>(
+    pool: Option<&rayon::ThreadPool>,
+    n_panels_m: usize,
+    n_panels_n: usize,
+    run_one: F,
+) -> TractResult<()>
+where
+    F: Fn(usize, usize) -> TractResult<()> + Sync,
+{
+    use rayon::prelude::*;
+    if n_panels_m == 0 || n_panels_n == 0 {
+        return Ok(());
+    }
+    if n_panels_m * n_panels_n < THREADING_PANEL_THRESHOLD {
+        for ia in 0..n_panels_m {
+            for ib in 0..n_panels_n {
+                run_one(ia, ib)?;
+            }
+        }
+        return Ok(());
+    }
+    let use_global = pool.is_none_or(|p| p.current_num_threads() <= 1);
+    let body = || {
+        let nth = rayon::current_num_threads();
+        let (nchunks_m, nchunks_n, dr_m, dr_n) = chunk_grid(n_panels_m, n_panels_n, nth);
+        let total = nchunks_m * nchunks_n;
+        (0..total).into_par_iter().try_for_each(|idx| {
+            let im = idx % nchunks_m;
+            let in_ = idx / nchunks_m;
+            let ia_start = im * dr_m;
+            let ia_end = (ia_start + dr_m).min(n_panels_m);
+            let ib_start = in_ * dr_n;
+            let ib_end = (ib_start + dr_n).min(n_panels_n);
+            for ia in ia_start..ia_end {
+                for ib in ib_start..ib_end {
+                    run_one(ia, ib)?;
+                }
+            }
+            TractResult::Ok(())
+        })
+    };
+    if use_global { body() } else { pool.unwrap().install(body) }
 }

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -317,17 +317,6 @@ unsafe fn run_with_scratch_space_row_outer<K: MatMatMulKer>(
     }
 }
 
-/// Below this many output panels (m_panels × n_panels), skip parallel
-/// dispatch and run inline single-threaded. Per-MMM kickoff cost (rayon
-/// scheduling, web-worker postMessage, atomic-instruction tax) dominates
-/// the kernel runtime for tiny MMMs; threading them is a net loss.
-///
-/// 64 panels is empirically tuned: above the rayon native overhead (~5 µs
-/// per dispatch) and the wasm-bindgen-rayon worker dispatch overhead
-/// (~50 µs), well within "still big enough to win."
-#[cfg(feature = "multithread-mm")]
-const THREADING_PANEL_THRESHOLD: usize = 64;
-
 /// Chunk grid for the 2D dispatch.
 ///
 /// Mirrors ggml's `mul_mat` heuristic (`ggml/src/ggml-cpu/ggml-cpu.c:1378-1398`):
@@ -382,7 +371,7 @@ where
     if n_panels_m == 0 || n_panels_n == 0 {
         return Ok(());
     }
-    if n_panels_m * n_panels_n < THREADING_PANEL_THRESHOLD {
+    if n_panels_m * n_panels_n < crate::multithread::current_threading_panel_threshold() {
         for ia in 0..n_panels_m {
             for ib in 0..n_panels_n {
                 run_one(ia, ib)?;

--- a/linalg/src/multithread.rs
+++ b/linalg/src/multithread.rs
@@ -1,4 +1,6 @@
 use std::cell::RefCell;
+#[cfg(feature = "multithread-mm")]
+use std::sync::atomic::{AtomicUsize, Ordering};
 #[allow(unused_imports)]
 use std::sync::{Arc, Mutex};
 
@@ -64,4 +66,28 @@ pub fn multithread_tract_scope<R, F: FnOnce() -> R>(pool: Executor, f: F) -> R {
     let result = f();
     TLS_EXECUTOR_OVERRIDE.set(previous);
     result
+}
+
+/// Threshold (in panels) below which the rayon MMM dispatcher skips
+/// parallelism and runs inline single-threaded. Below this size,
+/// per-call dispatch overhead (~5 µs native, ~50 µs wasm-bindgen-rayon
+/// worker) exceeds the parallel speedup.
+///
+/// Default `64`. Tune higher for many-small-MMM workloads (mobile vision,
+/// streaming RNN) or lower for transformer-class workloads where every MMM
+/// is large. `0` disables the gate entirely (always thread).
+#[cfg(feature = "multithread-mm")]
+static THREADING_PANEL_THRESHOLD: AtomicUsize = AtomicUsize::new(64);
+
+/// Read the current MMM panel-count threshold for the rayon path.
+#[cfg(feature = "multithread-mm")]
+pub fn current_threading_panel_threshold() -> usize {
+    THREADING_PANEL_THRESHOLD.load(Ordering::Relaxed)
+}
+
+/// Set the MMM panel-count threshold for the rayon path. Default is `64`.
+/// Pass `0` to thread regardless of size.
+#[cfg(feature = "multithread-mm")]
+pub fn set_threading_panel_threshold(panels: usize) {
+    THREADING_PANEL_THRESHOLD.store(panels, Ordering::Relaxed);
 }

--- a/linalg/src/multithread.rs
+++ b/linalg/src/multithread.rs
@@ -11,6 +11,16 @@ pub enum Executor {
     SingleThread,
     #[cfg(feature = "multithread-mm")]
     MultiThread(Arc<ThreadPool>),
+    /// Use rayon's GLOBAL thread pool — the one set up by
+    /// `wasm_bindgen_rayon::init_thread_pool` on `wasm32-unknown-unknown`,
+    /// or rayon's auto-initialised default on native.
+    ///
+    /// Exists because `Arc<rayon::ThreadPool>` cannot be constructed on
+    /// `wasm32-unknown-unknown`: rayon's default `spawn_handler` calls
+    /// `std::thread::spawn`, which is unsupported there. The only working
+    /// route is rayon's global pool, accessed via `into_par_iter` directly.
+    #[cfg(feature = "multithread-mm")]
+    RayonGlobal,
 }
 
 impl Executor {


### PR DESCRIPTION
Started as a hunt for more DFN3 speed in browser-WASM. DFN3 itself
doesn't benefit (Amdahl-bound on FFT/complex-mul/RNN-internal small
matmuls), but transformer-class workloads do — 3.0–3.5× at 4 threads
on Chromium / WebKit / Firefox. Sharing for the wider community using
tract for browser ML (Whisper, BERT, sentence-transformers, LLMs).

Hope this can be considered to take the WASM Path to new heights 

Three commits:

1. `Executor::RayonGlobal` — payload-free variant. Required because
   `Arc<rayon::ThreadPool>` cannot be constructed on
   `wasm32-unknown-unknown` (rayon's default `spawn_handler` calls
   `std::thread::spawn`, unsupported there). With `wasm-bindgen-rayon`'s
   `init_thread_pool` the global pool works fine — but only via
   `into_par_iter` directly, not through an `Arc<ThreadPool>` payload.
   Without this, `multithread-mm` is unreachable in browsers.

2. 2D chunked dispatch (`chunked_dispatch_rayon`) replacing 1D
   `into_par_iter` over a single panel axis. ggml-style 16-tile (or
   64-tile when one dim is 1) panel chunks with a row-block-per-thread
   fallback. Plus `THREADING_PANEL_THRESHOLD = 64` to skip the
   dispatcher entirely on tiny MMMs (per-call overhead exceeds
   parallel speedup; prevents regression on mobile-vision / streaming
   RNN workloads).

3. Promote the threshold to a runtime-tunable `AtomicUsize` with
   `set_threading_panel_threshold` / `current_threading_panel_threshold`
   accessors. Default 64 unchanged.

Cross-engine validation (Playwright, real DFN3 + synthetic dense
MMMs from 32×32 to 1024×1024, 60-iter median):

| Workload | Chromium | WebKit | Firefox |
|---|---|---|---|
| 1024×1024×1024 (transformer FFN) | **3.34×** | 3.12× | 3.40× |
| 512×768×768 (BERT FFN) | 3.07× | 3.30× | 3.42× |
| 256×256×128 | 2.19× | 3.30× | 3.41× |
| 64×256×64 (DFN-like small) | 1.0× | 2.00× | 3.11× |
| 32×32×32 (tiny) | 1.0× | 1.0× | 1.0× *(threshold gates)* |
| DFN3 streaming inference | 1.04× | 1.08× | 1.03× *(Amdahl)* |

All 60 measured cells produce bit-equal output. 3524 native
`tract-linalg` lib tests pass with `multithread-mm`. `cargo fmt`,
`RUSTFLAGS="-D warnings" cargo check` (with and without
`multithread-mm`), and `cargo check --target wasm32-unknown-unknown`
clean.

Native (macOS aarch64, rayon path, common shapes 256×256 / 512×512 /
64×256 at 4 threads): net-neutral within ±2%. Latent benefit on
1D-parallelism-hostile shapes (e.g. m=8 n=2048).

Full benchmark methodology + reproduction recipe in
`linalg/MULTITHREAD_BENCHMARKS.md`.