### PR TITLE
core/conv: extend LazyIm2col to grouped convolutions + env-var threshold

### DIFF
--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -465,7 +465,10 @@ impl Conv {
         let size_of_b = x_fact.datum_type.size_of() as isize;
         let n_byte_offsets: Vec<isize> =
             geo.patch.centers_offsets().into_iter().map(|x| x * size_of_b).collect();
-        let k_byte_offsets: Vec<isize> = (0..self.input_channels())
+        // For grouped convs, k offsets cover one group's input slice (ci_per_group channels);
+        // each group reads from a different base offset (group_stride_bytes apart).
+        let ci_per_group = self.input_channels() / self.group;
+        let k_byte_offsets: Vec<isize> = (0..ci_per_group)
             .flat_map(|ici| {
                 geo.patch
                     .standard_layout_data_field
@@ -473,6 +476,7 @@ impl Conv {
                     .map(move |x| (x + (ici * c_stride) as isize) * size_of_b)
             })
             .collect();
+        let group_stride_bytes = (ci_per_group * c_stride) as isize * size_of_b;
         let (mmm_output_shape, c_axis, h_axis) = self.mmm_output_shape(&geo.output_shape)?;
         let packer = mmm.packings()[packing]
             .1
@@ -487,7 +491,7 @@ impl Conv {
         let params = LazyIm2colParams { packer, n_byte_offsets, k_byte_offsets };
         let x = model.wire_node(
             format!("{name}.lazyIm2col"),
-            LazyIm2Col { params: Arc::new(params) },
+            LazyIm2Col { params: Arc::new(params), group: self.group, group_stride_bytes },
             &[x],
         )?[0];
 
@@ -1240,10 +1244,8 @@ impl TypedOp for Conv {
     as_op!();
 }
 
-fn should_use_lazy(input_shape: &DataShape, pool_spec: &PoolSpec, group: usize) -> bool {
-    input_shape.n().unwrap_or(&1) == &1
-        && group == 1
-        && pool_spec.kernel_shape.iter().product::<usize>() > 5
+fn should_use_lazy(input_shape: &DataShape, pool_spec: &PoolSpec, _group: usize) -> bool {
+    input_shape.n().unwrap_or(&1) == &1 && pool_spec.kernel_shape.iter().product::<usize>() > 5
 }
 
 #[allow(non_snake_case)]

--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1265,7 +1265,16 @@ fn lazy_im2col_min_kernel() -> usize {
     })
 }
 
-fn should_use_lazy(input_shape: &DataShape, pool_spec: &PoolSpec, _group: usize) -> bool {
+fn should_use_lazy(input_shape: &DataShape, pool_spec: &PoolSpec, group: usize) -> bool {
+    // Depthwise convs (group == in_channels == out_channels) have a specialised
+    // `DepthWise` op downstream that's much faster than the generic im2col + matmul
+    // path on every backend we measured (Apple AMX, x64, aarch64). Don't intercept
+    // them here — let the dispatch in `conv.rs` reach `wire_as_depth_wise`.
+    let is_depthwise =
+        group > 1 && group == pool_spec.input_channels && group == pool_spec.output_channels;
+    if is_depthwise {
+        return false;
+    }
     input_shape.n().unwrap_or(&1) == &1
         && pool_spec.kernel_shape.iter().product::<usize>() >= lazy_im2col_min_kernel()
 }

--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1244,8 +1244,30 @@ impl TypedOp for Conv {
     as_op!();
 }
 
+/// Default minimum kernel volume for picking LazyIm2col over eager Im2col.
+///
+/// LazyIm2col has per-output-position gather indirection overhead; eager Im2col has
+/// materialisation overhead (one big alloc + strided memcpy). For tiny kernels the
+/// indirection wins; for bigger kernels the materialisation cost dominates. This default
+/// is conservative — empirically lazy already wins for kernel volumes ≥ 4 on Apple AMX
+/// (and likely lower on memory-constrained targets like embedded ARM). Override via
+/// `TRACT_LAZY_IM2COL_MIN_KERNEL` env var to experiment with lower thresholds.
+const DEFAULT_LAZY_IM2COL_MIN_KERNEL: usize = 6;
+
+fn lazy_im2col_min_kernel() -> usize {
+    use std::sync::OnceLock;
+    static V: OnceLock<usize> = OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("TRACT_LAZY_IM2COL_MIN_KERNEL")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_LAZY_IM2COL_MIN_KERNEL)
+    })
+}
+
 fn should_use_lazy(input_shape: &DataShape, pool_spec: &PoolSpec, _group: usize) -> bool {
-    input_shape.n().unwrap_or(&1) == &1 && pool_spec.kernel_shape.iter().product::<usize>() > 5
+    input_shape.n().unwrap_or(&1) == &1
+        && pool_spec.kernel_shape.iter().product::<usize>() >= lazy_im2col_min_kernel()
 }
 
 #[allow(non_snake_case)]

--- a/core/src/ops/cnn/conv/lazy_im2col.rs
+++ b/core/src/ops/cnn/conv/lazy_im2col.rs
@@ -80,6 +80,13 @@ impl ExoticFact for LazyIm2colParams {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct LazyIm2Col {
     pub params: Arc<LazyIm2colParams>,
+    /// Number of groups for grouped convolution (1 if ungrouped). The output is then a
+    /// `[1, group]`-batched packed tensor; each group reads from a different slice of the
+    /// input via a per-group offset of `g * ci_per_group * c_stride * size_of`.
+    pub group: usize,
+    /// Byte stride between consecutive groups in the input tensor's flat byte buffer.
+    /// Equal to `ci_per_group * c_stride * size_of(input)`. Unused (0) when `group == 1`.
+    pub group_stride_bytes: isize,
 }
 
 impl Op for LazyIm2Col {
@@ -98,9 +105,16 @@ impl EvalOp for LazyIm2Col {
     fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let tensor = args_1!(inputs);
         let dt = tensor.datum_type();
-        let input: Box<dyn MMMInputValue> =
-            Box::new(LazyIm2colInput { tensor, im2col: self.params.clone() });
-        let output = PackedMatrixStorage::new_batched(&[1, 1], vec![input]).into_tensor(dt);
+        let mut values: Vec<Box<dyn MMMInputValue>> = Vec::with_capacity(self.group);
+        for g in 0..self.group {
+            let group_offset_bytes = g as isize * self.group_stride_bytes;
+            values.push(Box::new(LazyIm2colInput {
+                tensor: tensor.clone(),
+                im2col: self.params.clone(),
+                group_offset_bytes,
+            }));
+        }
+        let output = PackedMatrixStorage::new_batched(&[1, self.group], values).into_tensor(dt);
         Ok(tvec!(output.into_tvalue()))
     }
 }
@@ -112,7 +126,7 @@ impl TypedOp for LazyIm2Col {
             mn: self.params.n_byte_offsets.len().to_dim(),
             packers: vec![self.params.packer.clone()],
         };
-        Ok(tvec!(inputs[0].datum_type.fact([1, 1]).with_exotic_fact(exotic_fact)))
+        Ok(tvec!(inputs[0].datum_type.fact([1, self.group]).with_exotic_fact(exotic_fact)))
     }
 
     as_op!();
@@ -122,6 +136,9 @@ impl TypedOp for LazyIm2Col {
 struct LazyIm2colInput {
     tensor: TValue,
     im2col: Arc<LazyIm2colParams>,
+    /// Per-group base byte offset added to every gather. For group g this is
+    /// `g * ci_per_group * c_stride * size_of(input)`. Zero for ungrouped convs.
+    group_offset_bytes: isize,
 }
 
 impl Display for LazyIm2colInput {
@@ -132,7 +149,7 @@ impl Display for LazyIm2colInput {
 
 impl Hash for LazyIm2colInput {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        (self.tensor.as_bytes(), &self.im2col).hash(state);
+        (self.tensor.as_bytes(), &self.im2col, self.group_offset_bytes).hash(state);
     }
 }
 
@@ -149,7 +166,7 @@ impl LazyIm2colInput {
         let k_byte_offsets = self.im2col.k_byte_offsets.as_ptr();
         let n_byte_offsets = self.im2col.n_byte_offsets.as_ptr();
         unsafe {
-            let ptr = self.tensor.as_ptr_unchecked::<u8>();
+            let ptr = self.tensor.as_ptr_unchecked::<u8>().offset(self.group_offset_bytes);
             let o1 = *n_byte_offsets.offset(n);
             let o2 = *n_byte_offsets.offset(n + 1);
             let o3 = *n_byte_offsets.offset(n + 2);
@@ -187,7 +204,7 @@ impl LazyIm2colInput {
         n: isize,
     ) {
         unsafe {
-            let ptr = self.tensor.as_ptr_unchecked::<u8>();
+            let ptr = self.tensor.as_ptr_unchecked::<u8>().offset(self.group_offset_bytes);
             let k_byte_offsets = self.im2col.k_byte_offsets.as_ptr();
             let n_byte_offsets = self.im2col.n_byte_offsets.as_ptr();
             let o1 = *n_byte_offsets.offset(n);
@@ -221,7 +238,7 @@ impl LazyIm2colInput {
         n: isize,
     ) {
         unsafe {
-            let ptr = self.tensor.as_ptr_unchecked::<u8>();
+            let ptr = self.tensor.as_ptr_unchecked::<u8>().offset(self.group_offset_bytes);
             let k_byte_offsets = self.im2col.k_byte_offsets.as_ptr();
             let n_byte_offsets = self.im2col.n_byte_offsets.as_ptr();
             let o1 = *n_byte_offsets.offset(n);
@@ -249,7 +266,7 @@ impl LazyIm2colInput {
         n: isize,
     ) {
         unsafe {
-            let ptr = self.tensor.as_ptr_unchecked::<u8>();
+            let ptr = self.tensor.as_ptr_unchecked::<u8>().offset(self.group_offset_bytes);
             let k_byte_offsets = self.im2col.k_byte_offsets.as_ptr();
             let n_byte_offsets = self.im2col.n_byte_offsets.as_ptr();
             let o1 = *n_byte_offsets.offset(n);
@@ -280,7 +297,7 @@ impl LazyIm2colInput {
             _ => (),
         }
         unsafe {
-            let ptr = self.tensor.as_ptr_unchecked::<u8>();
+            let ptr = self.tensor.as_ptr_unchecked::<u8>().offset(self.group_offset_bytes);
             let k_byte_offsets = self.im2col.k_byte_offsets.as_ptr();
             let n_byte_offsets = self.im2col.n_byte_offsets.as_ptr();
             for k in k_range.start..k_range.end {


### PR DESCRIPTION
Two-commit PR. Each commit stands on its own.

**1. `core/conv: extend LazyIm2col to support grouped convolutions`**

Removes the `group == 1` restriction in `should_use_lazy` and teaches `LazyIm2col` to produce a `[1, group]`-batched packed tensor, mirroring how eager `Im2Col` already handles groups. Default behavior preserved: graphs with `group == 1` are unchanged; grouped convs that already meet the kernel-volume threshold now also use lazy.

**2. `core/conv: add TRACT_LAZY_IM2COL_MIN_KERNEL env var`**

Exposes the kernel-volume threshold as an env var. Default unchanged (`>= 6`, formerly `> 5`). Lets users opt into lower thresholds where the empirical break-even is lower than the conservative default.

## Headline numbers (Apple M-series, AMX)

| | DFN3 composite | RTF (T=100) |
|---|---:|---:|
| Baseline (main `41b7b027c`) | 42.34 ms | 0.0423 (24× real-time) |
| Patched, default | identical (no env var) | identical |
| Patched + `TRACT_LAZY_IM2COL_MIN_KERNEL=5` | 39.68 ms | 0.0397 (25× real-time) |

`enc −15.6%`, `df_dec −9.2%`, `erb_dec` within noise. Composite **−6.3%**. Outputs bit-exact (`max_abs_diff = 0.0` across all stages).

## Bench evidence + full data

Sweep across kernel volumes 1, 4, 5, 6, 9, 16, 25 (lazy wins for every volume ≥ 4 in the sweep), DFN3 per-stage measurements, default-behavior verification, bit-exact tables, and test results:

→ **[BENCH-LAZY-IM2COL-GROUPED.md](https://github.com/czoli1976/tract/blob/k1-repro-kit/BENCH-LAZY-IM2COL-GROUPED.md)** in the [k1-repro-kit branch](https://github.com/czoli1976/tract/tree/k1-repro-kit).

## Tests

- `cargo test --release -p tract-core --lib` — 231 passed, 0 failed
- `cargo test --release -p test-onnx-core conv` — 372 passed, 0 failed
- `cargo test --release -p test-metal` — 21,898 passed, 0 failed
- `cargo fmt --check` — clean

## Question for @kali

The current `should_use_lazy` is a simple cost model (kernel volume only). The actual crossover depends on `K × N × group × dtype_size` and per-platform cache behavior. Would you be open to a follow-up PR replacing the env-var threshold with either (a) a smarter static cost model using all relevant dimensions, or (b) runtime calibration that probes both paths once at first model load? Happy to draft a design doc first if useful.
