### PR TITLE
transformers: ScaledMaskedSoftmax declares its axes mapping

### DIFF
--- a/transformers/src/ops/scaled_masked_softmax.rs
+++ b/transformers/src/ops/scaled_masked_softmax.rs
@@ -1,4 +1,5 @@
 use tract_nnef::internal::*;
+use tract_nnef::tract_core::axes::{AxesMapping, Axis};
 use tract_nnef::tract_core::ops::binary::{BinMiniOp, TypedBinOp};
 use tract_nnef::tract_core::ops::logic::Iff;
 use tract_nnef::tract_core::ops::math::{Add, Mul};
@@ -141,6 +142,61 @@ impl TypedOp for ScaledMaskedSoftmax {
         }
         // Bubbling: delegate to the natural blanket implementation.
         tract_nnef::tract_core::optim::propagate_roi::bubble_roi(model, node)
+    }
+
+    /// Axes layout: every non-reducing axis is identity-mapped between
+    /// inputs and the output (with the bool mask right-aligned and
+    /// possibly missing leading axes).  The softmax-reducing axis (last)
+    /// is *deliberately disconnected* between input side and output side:
+    /// its size is preserved but it is not "the same axis" — splitting it
+    /// through a reshape would break softmax's normalisation semantics.
+    fn axes_mapping(
+        &self,
+        inputs: &[&TypedFact],
+        _outputs: &[&TypedFact],
+    ) -> TractResult<AxesMapping> {
+        let input = inputs[0];
+        let mask = inputs[1];
+        let rank = input.rank();
+        let mask_rank = mask.rank();
+        if rank == 0 {
+            return AxesMapping::disconnected_for_ranks(&[rank, mask_rank], &[rank]);
+        }
+
+        let mut axes: TVec<Axis> = tvec!();
+        let mut labels = 'a'..;
+        let rank_diff = rank.saturating_sub(mask_rank);
+        let mask_non_reducing = mask_rank.saturating_sub(1);
+
+        // Non-reducing axes (all but the last): identity-mapped between
+        // input 0 and the output.  Mask broadcasts right-aligned; align
+        // its non-reducing axes with the trailing input 0 axes.
+        for i in 0..rank.saturating_sub(1) {
+            let mut ax = Axis::new(labels.next().unwrap(), 2, 1).input(0, i).output(0, i);
+            if i >= rank_diff {
+                let mask_axis = i - rank_diff;
+                if mask_axis < mask_non_reducing {
+                    ax = ax.input(1, mask_axis);
+                }
+            }
+            axes.push(ax);
+        }
+
+        // Softmax-reducing axis on the *input* side: last axis of input 0
+        // (and last axis of the mask, when present).  Not connected to
+        // any output axis.
+        let mut in_red = Axis::new(labels.next().unwrap(), 2, 1).input(0, rank - 1);
+        if 0 < mask_rank && mask_rank <= rank {
+            in_red = in_red.input(1, mask_rank - 1);
+        }
+        axes.push(in_red);
+
+        // Reducing axis on the *output* side: a fresh label, only on the
+        // output.  Same size as the input-side reducing axis but
+        // semantically distinct (post-normalisation positions).
+        axes.push(Axis::new(labels.next().unwrap(), 2, 1).output(0, rank - 1));
+
+        AxesMapping::new(2, 1, axes)
     }
 
     as_op!();
@@ -367,4 +423,84 @@ fn try_extract_scale(
         .copied()
         .find(|o| model.outlet_fact(*o).map(|f| f.konst.is_none()).unwrap_or(false))?;
     Some((scores_outlet, scale))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tract_nnef::tract_core::ops::change_axes::InOut;
+
+    fn smsoftmax() -> ScaledMaskedSoftmax {
+        ScaledMaskedSoftmax { scale: tensor0(1f32).into_arc_tensor(), post_softmax_mask: false }
+    }
+
+    /// Same-rank f32 mask: non-reducing axes identity-mapped on both
+    /// inputs and output; reducing axis disconnected (input vs output).
+    #[test]
+    fn axes_mapping_same_rank_float_mask() {
+        let op = smsoftmax();
+        let input = f32::fact([2usize, 3, 4]);
+        let mask = f32::fact([2usize, 3, 4]);
+        let output = f32::fact([2usize, 3, 4]);
+        let am = op.axes_mapping(&[&input, &mask], &[&output]).unwrap();
+
+        // Non-reducing input axes track to the corresponding output axes.
+        assert_eq!(am.track_axis((InOut::In(0), 0), InOut::Out(0)).unwrap(), Some(0));
+        assert_eq!(am.track_axis((InOut::In(0), 1), InOut::Out(0)).unwrap(), Some(1));
+        // Mask's non-reducing axes also track to the same outputs.
+        assert_eq!(am.track_axis((InOut::In(1), 0), InOut::Out(0)).unwrap(), Some(0));
+        assert_eq!(am.track_axis((InOut::In(1), 1), InOut::Out(0)).unwrap(), Some(1));
+        // Reducing axis on either input does NOT track to the output.
+        assert_eq!(am.track_axis((InOut::In(0), 2), InOut::Out(0)).unwrap(), None);
+        assert_eq!(am.track_axis((InOut::In(1), 2), InOut::Out(0)).unwrap(), None);
+    }
+
+    /// Same-rank bool mask: same shape as f32 mask above.
+    #[test]
+    fn axes_mapping_same_rank_bool_mask() {
+        let op = smsoftmax();
+        let input = f32::fact([2usize, 3, 4]);
+        let mask = bool::fact([2usize, 3, 4]);
+        let output = f32::fact([2usize, 3, 4]);
+        let am = op.axes_mapping(&[&input, &mask], &[&output]).unwrap();
+        assert_eq!(am.track_axis((InOut::In(0), 0), InOut::Out(0)).unwrap(), Some(0));
+        assert_eq!(am.track_axis((InOut::In(0), 1), InOut::Out(0)).unwrap(), Some(1));
+        assert_eq!(am.track_axis((InOut::In(0), 2), InOut::Out(0)).unwrap(), None);
+    }
+
+    /// Lower-rank bool mask: broadcasts right-aligned.  Mask axis 0
+    /// aligns with input axis 1 (= rank − mask_rank + 0 = 3 − 2 + 0).
+    #[test]
+    fn axes_mapping_broadcast_bool_mask() {
+        let op = smsoftmax();
+        let input = f32::fact([2usize, 3, 4]);
+        let mask = bool::fact([3usize, 4]);
+        let output = f32::fact([2usize, 3, 4]);
+        let am = op.axes_mapping(&[&input, &mask], &[&output]).unwrap();
+        // Input non-reducing axes still track to output.
+        assert_eq!(am.track_axis((InOut::In(0), 0), InOut::Out(0)).unwrap(), Some(0));
+        assert_eq!(am.track_axis((InOut::In(0), 1), InOut::Out(0)).unwrap(), Some(1));
+        // Mask's non-reducing axis (0) aligns with input axis 1.
+        assert_eq!(am.track_axis((InOut::In(1), 0), InOut::In(0)).unwrap(), Some(1));
+        // Mask's reducing axis (1) aligns with input axis 2.
+        assert_eq!(am.track_axis((InOut::In(1), 1), InOut::In(0)).unwrap(), Some(2));
+        // Reducing axes don't reach output.
+        assert_eq!(am.track_axis((InOut::In(0), 2), InOut::Out(0)).unwrap(), None);
+        assert_eq!(am.track_axis((InOut::In(1), 1), InOut::Out(0)).unwrap(), None);
+    }
+
+    /// Scalar bool mask: no axes shared between mask and input/output.
+    /// Input non-reducing axes still track to output; reducing axis still
+    /// disconnected from output.
+    #[test]
+    fn axes_mapping_scalar_bool_mask() {
+        let op = smsoftmax();
+        let input = f32::fact([2usize, 3, 4]);
+        let mask = bool::fact([] as [usize; 0]);
+        let output = f32::fact([2usize, 3, 4]);
+        let am = op.axes_mapping(&[&input, &mask], &[&output]).unwrap();
+        assert_eq!(am.track_axis((InOut::In(0), 0), InOut::Out(0)).unwrap(), Some(0));
+        assert_eq!(am.track_axis((InOut::In(0), 1), InOut::Out(0)).unwrap(), Some(1));
+        assert_eq!(am.track_axis((InOut::In(0), 2), InOut::Out(0)).unwrap(), None);
+    }
 }


### PR DESCRIPTION
Override the default `disconnected` axes_mapping with one that reflects the op's actual axis flow:

* every non-reducing axis (= every axis but the last) is identity-mapped from input 0 → output 0, and — when ranks line up — also from the mask (input 1) → input 0, with the bool mask right-aligned over input 0's trailing axes;
* the softmax-reducing axis (last axis of input 0, plus last axis of the mask) is **deliberately kept disconnected** from the output: its size is preserved, but it is not "the same axis" — splitting it through a reshape would break softmax's normalisation semantics. Leaving it disconnected lets axis-tracking passes (e.g. `track_axis`) correctly answer "no" when asked whether an axis-changing transform on the reducing axis can pass through.

Adds 4 unit tests covering same-rank float/bool mask, lower-rank broadcast bool mask (right-aligned), and scalar bool mask.