### PR TITLE
tdim: expand_polynomial + use it in Reshape volume check

### DIFF
--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -326,7 +326,17 @@ impl AxisOp {
             Reshape(at, from, to) => {
                 let from_volume = from.iter().product::<TDim>();
                 let to_volume = to.iter().product::<TDim>();
-                ensure!(from_volume == to_volume, "{from_volume} should be equal to {to_volume}");
+                // Two algebraically equal volumes can land in different
+                // factored forms when the same dimension is built two ways
+                // (e.g. (B+2BY)·(1+Y) vs B·(1+Y)·(1+2Y) on Conformer-style
+                // streaming attention).  Compare polynomial expansions so
+                // structural mismatch on factor ordering doesn't fail the
+                // check.
+                ensure!(
+                    from_volume.clone().expand_polynomial()
+                        == to_volume.clone().expand_polynomial(),
+                    "{from_volume} should be equal to {to_volume}"
+                );
                 ensure!(*at + from.len() <= shape.len());
                 if shape.len() >= from.len() + *at
                     && tract_itertools::izip!(shape.iter().skip(*at), from)

--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -390,16 +390,10 @@ impl TDim {
                 }
             }
             MulInt(c, inner) => MulInt(c, Box::new(inner.expand_polynomial())).simplify(),
-            Add(terms) => {
-                Add(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
-            }
+            Add(terms) => Add(terms.into_iter().map(Self::expand_polynomial).collect()).simplify(),
             Div(a, q) => Div(Box::new(a.expand_polynomial()), q).simplify(),
-            Min(terms) => {
-                Min(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
-            }
-            Max(terms) => {
-                Max(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
-            }
+            Min(terms) => Min(terms.into_iter().map(Self::expand_polynomial).collect()).simplify(),
+            Max(terms) => Max(terms.into_iter().map(Self::expand_polynomial).collect()).simplify(),
             Broadcast(terms) => {
                 Broadcast(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
             }

--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -355,6 +355,64 @@ impl TDim {
         Self::find_any_sym(self).and_then(|s| s.scope().clone())
     }
 
+    /// Fully distribute every `Mul` of `Add`s in `self` into a flat sum of
+    /// products, then `simplify`.  Used to compare two algebraically equal
+    /// but differently-factored TDims for equality (e.g. Reshape volume
+    /// checks on graphs where the same dimension is built two ways).
+    ///
+    /// Cost can blow up combinatorially on very deeply factored expressions
+    /// — call this only at boundaries where structural equality is needed,
+    /// not as a general-purpose simplifier.
+    pub fn expand_polynomial(self) -> TDim {
+        use self::TDim::*;
+        match self {
+            Mul(terms) => {
+                let terms: Vec<TDim> = terms.into_iter().map(Self::expand_polynomial).collect();
+                if let Some(add_idx) = terms.iter().position(|t| matches!(t, Add(_))) {
+                    let Add(add_terms) = terms[add_idx].clone() else { unreachable!() };
+                    let others: Vec<TDim> = terms
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| *i != add_idx)
+                        .map(|(_, t)| t.clone())
+                        .collect();
+                    Add(add_terms
+                        .into_iter()
+                        .map(|t| {
+                            let mut product = others.clone();
+                            product.push(t);
+                            Mul(product).expand_polynomial()
+                        })
+                        .collect())
+                    .simplify()
+                } else {
+                    Mul(terms).simplify()
+                }
+            }
+            MulInt(c, inner) => MulInt(c, Box::new(inner.expand_polynomial())).simplify(),
+            Add(terms) => {
+                Add(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
+            }
+            Div(a, q) => Div(Box::new(a.expand_polynomial()), q).simplify(),
+            Min(terms) => {
+                Min(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
+            }
+            Max(terms) => {
+                Max(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
+            }
+            Broadcast(terms) => {
+                Broadcast(terms.into_iter().map(Self::expand_polynomial).collect()).simplify()
+            }
+            Ge(a, b) => {
+                Ge(Box::new(a.expand_polynomial()), Box::new(b.expand_polynomial())).simplify()
+            }
+            Eq(a, b) => {
+                Eq(Box::new(a.expand_polynomial()), Box::new(b.expand_polynomial())).simplify()
+            }
+            it @ (Sym(_) | Val(_)) => it,
+        }
+    }
+
     pub fn simplify(self) -> TDim {
         use self::TDim::*;
         if let Ok(v) = self.eval_to_i64(&SymbolValues::default()) {
@@ -459,6 +517,14 @@ impl TDim {
                 // expand Mul([a, Add([b, c])]) => Add([Mul([a, b]), Mul([a, c])]).
                 // This lets (T+1)*P simplify to T*P + P, which is needed for
                 // cancellation in expressions like (T+1)*P - T*P.
+                //
+                // Multi-Add Muls are *not* eagerly expanded here — keeping them
+                // factored matters for `maybe_div`'s bag-of-factors path, which
+                // cancels common Add factors symbolically (e.g. dividing
+                // 16B·(1+Y)² by 8B·(1+Y) needs the (1+Y)s to be visible as
+                // factors, not melted into a polynomial sum).  Use
+                // `expand_polynomial` if you need a fully distributed canonical
+                // form for equality comparisons (see Reshape volume check).
                 {
                     let add_indices: Vec<usize> = terms
                         .iter()
@@ -1513,6 +1579,19 @@ mod tests {
     fn reduce_mul_div() {
         let e: TDim = A.to_dim() * 2 / 2;
         assert_eq!(e, A.to_dim());
+    }
+
+    #[test]
+    fn expand_polynomial_two_add_factors() {
+        // (a + 2*a*b) * (1 + b)  ==poly==  a * (1 + b) * (1 + 2*b)
+        // Both fully expand to a + 3*a*b + 2*a*b*b.  We don't auto-expand in
+        // simplify (it would block maybe_div on factored-form denominators),
+        // but expand_polynomial does, and Reshape uses it for volume checks.
+        let a = A.to_dim();
+        let b = B.to_dim();
+        let lhs = (a.clone() + a.clone() * &b * 2) * (TDim::from(1) + &b);
+        let rhs = a.clone() * (TDim::from(1) + &b) * (TDim::from(1) + b.clone() * 2);
+        assert_eq!(lhs.expand_polynomial(), rhs.expand_polynomial());
     }
 
     #[test]


### PR DESCRIPTION
Two algebraically equal volumes built in different factored orders — B·(1+2Y)·(1+Y) vs B·(1+Y)·(1+2Y) — were tripping Reshape's volume- equality `ensure!` on Conformer-style streaming attention exports (NeMo nemotron-streaming-asr): the simplifier keeps multi-Add Muls factored on purpose so maybe_div's bag-of-factors path can cancel common Add factors (e.g. 16B(1+Y)² ÷ 8B(1+Y) needs the (1+Y) visible as a factor, not melted into a polynomial sum), which means structural PartialEq mismatches on factor ordering even when the products agree algebraically.

New TDim::expand_polynomial fully distributes every Mul of Adds into a flat sum of products, then simplifies. Targeted use only — Reshape volume checks now compare expanded forms; the general simplifier is unchanged so divisibility tests on factored expressions keep working.

Test reduce_two_add_factors locks the equality.