### PR TITLE
cli: --set X=value accepts TDim expressions

### DIFF
--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -468,9 +468,9 @@ impl Parameters {
         let mut subs = std::collections::HashMap::new();
         for set in set {
             let set = set.as_ref();
-            let (key, value) = set.split_once('=').with_context(|| {
-                format!("--set must be in the X=value form, got {set}")
-            })?;
+            let (key, value) = set
+                .split_once('=')
+                .with_context(|| format!("--set must be in the X=value form, got {set}"))?;
             let dim = tract_core::internal::parse_tdim(&typed_model.symbols, value)
                 .with_context(|| format!("--set: parsing TDim expression for {key}={value}"))?;
             let sym = typed_model.get_or_intern_symbol(key);

--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -456,6 +456,29 @@ impl Parameters {
         Ok(values)
     }
 
+    /// Parse `--set X=value` into a `Symbol → TDim` substitution map.
+    /// `value` may be a plain integer or any TDim expression parseable
+    /// against the model's symbol scope (e.g. `2*S` to rebase the
+    /// streaming symbol onto a finer-grained chunk symbol before
+    /// pulsification).  Feeds straight into `model.substitute_symbols`.
+    pub fn parse_set_subs(
+        typed_model: &TypedModel,
+        set: impl Iterator<Item = impl AsRef<str>>,
+    ) -> TractResult<std::collections::HashMap<Symbol, TDim>> {
+        let mut subs = std::collections::HashMap::new();
+        for set in set {
+            let set = set.as_ref();
+            let (key, value) = set.split_once('=').with_context(|| {
+                format!("--set must be in the X=value form, got {set}")
+            })?;
+            let dim = tract_core::internal::parse_tdim(&typed_model.symbols, value)
+                .with_context(|| format!("--set: parsing TDim expression for {key}={value}"))?;
+            let sym = typed_model.get_or_intern_symbol(key);
+            subs.insert(sym, dim);
+        }
+        Ok(subs)
+    }
+
     pub fn parse_npz(
         input: &str,
         get_values: bool,
@@ -755,27 +778,15 @@ impl Parameters {
         }
 
         if let Some(set) = matches.get_many::<String>("set") {
-            let values = Self::parse_set_and_hint(typed_model.as_ref().unwrap(), set)?;
-            stage!("set", typed_model -> typed_model, |mut m: TypedModel| {
-                for node in m.eval_order()? {
-                    let node = m.node_mut(node);
-                    if let Some(op) = node.op_as_mut::<Const>() {
-                        if op.val().datum_type() == DatumType::TDim { {
-                            // get inner value to Arc<Tensor>
-                            let mut constant:Tensor = (**op.val()).clone();
-                            // Generally a shape or hyperparam
-                            constant
-                                .try_as_plain_mut()?
-                                .as_slice_mut::<TDim>()?
-                                .iter_mut()
-                                .for_each(|x| *x = x.eval(&values));
-
-                            *op = Const::new(constant.into_arc_tensor())?;
-                        }
-                        }
-                    }
-                }
-                m.substitute_symbols(&values.to_dim_map())
+            // --set delegates to model.substitute_symbols with a
+            // Symbol → TDim map (same path the `concretize_symbols`
+            // model transform takes).  Values may be plain integers or
+            // TDim expressions (e.g. `--set T=2*S` to rebase the
+            // streaming symbol).  Const TDim tensors are rewritten
+            // through Const's own substitute_symbols hook.
+            let subs = Self::parse_set_subs(typed_model.as_ref().unwrap(), set)?;
+            stage!("set", typed_model -> typed_model, move |m: TypedModel| {
+                m.substitute_symbols(&subs)
             });
             stage!("set-declutter", typed_model -> typed_model, |mut m| {
                 let mut dec = tract_core::optim::Optimizer::declutter();


### PR DESCRIPTION
Plug --set into model.substitute_symbols (the same path the concretize_symbols transform takes).  Values may be plain integers (unchanged behaviour) or any TDim expression parseable against the model's symbol scope, e.g.:

  --set 'T=2*S'   rebase streaming symbol T onto a finer-grained S
  --set 'T=12'    concretise T to 12 (existing behaviour)

The integer-only manual loop that walked Const TDim tensors and ran TDim::eval against SymbolValues is gone — Const::substitute_symbols already handles TDim tensors via TDim::substitute_all, so a single model.substitute_symbols call covers both shape facts and Const TDim tensor values.

parse_set_and_hint stays integer-only because --hint feeds runtime memory-sizing hints (RunOptions::memory_sizing_hints) which are by contract concrete i64.  A new parse_set_subs returns HashMap<Symbol, TDim> for the --set path.