### PR TITLE
tdim: PartialEq second-chance via diff-and-simplify

### DIFF
--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -30,7 +30,7 @@ impl std::error::Error for TooEarly {}
 
 macro_rules! b( ($e:expr) => { Box::new($e) } );
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Eq, Hash, Debug)]
 pub enum TDim {
     Val(i64),
     Sym(Symbol),
@@ -48,6 +48,73 @@ pub enum TDim {
 }
 
 use TDim::*;
+
+/// Structural equality on the TDim tree -- what `#[derive(PartialEq)]` would
+/// produce. Used as the fast-path inside `PartialEq` and by the simplifier's
+/// internal `HashMap<TDim, _>`, which compares within same-hash buckets where
+/// structural equality is the only thing that matters.
+fn eq_structural(a: &TDim, b: &TDim) -> bool {
+    match (a, b) {
+        (Val(x), Val(y)) => x == y,
+        (Sym(x), Sym(y)) => x == y,
+        (Add(x), Add(y))
+        | (Mul(x), Mul(y))
+        | (Broadcast(x), Broadcast(y))
+        | (Min(x), Min(y))
+        | (Max(x), Max(y)) => {
+            x.len() == y.len() && x.iter().zip(y).all(|(a, b)| eq_structural(a, b))
+        }
+        (MulInt(p, x), MulInt(q, y)) => p == q && eq_structural(x, y),
+        (Div(x, p), Div(y, q)) => p == q && eq_structural(x, y),
+        (Ge(a, b), Ge(c, d)) | (Eq(a, b), Eq(c, d)) => eq_structural(a, c) && eq_structural(b, d),
+        _ => false,
+    }
+}
+
+// Thread-local guard: while simplifying the difference inside `eq`, fall back
+// to the structural-only path for any nested `==` calls. Without this guard
+// the simplifier's internal `HashMap<TDim, i64>` re-enters `eq` from inside
+// `(self - other).simplify()`, recursing without bound on
+// non-structurally-equal inputs.
+std::thread_local! {
+    static EQ_GUARD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+impl PartialEq for TDim {
+    fn eq(&self, other: &Self) -> bool {
+        // Fast path: structural tree equality.
+        if eq_structural(self, other) {
+            return true;
+        }
+        // Inside an enclosing simplification triggered by a previous
+        // second-chance call, fall back to structural equality only.
+        if EQ_GUARD.with(|g| g.get()) {
+            return false;
+        }
+        // Skip second-chance when either side is a leaf (`Val` or `Sym`).
+        // For `Val(c)` vs anything non-`Val`: if they were semantically
+        // equal, the simplifier should already have folded the other side
+        // to `Val(c)`; running a diff-and-simplify here just risks
+        // arithmetic overflow on extreme constants (e.g. the simplifier
+        // filters against `Val(i64::MAX)`/`Val(i64::MIN)` sentinels in
+        // Min/Max simplification). For `Sym(x)` leaves, assertion-driven
+        // equality belongs in `simplify`, not in `eq`.
+        if matches!(self, Val(_) | Sym(_)) || matches!(other, Val(_) | Sym(_)) {
+            return false;
+        }
+        // Second chance: prove the difference simplifies to zero. Two
+        // algebraically equal TDims often arrive at different canonical
+        // forms via different construction paths -- e.g. `16T+16` (Add of
+        // MulInt and Val) and `16*(T+1)` (MulInt of Add) reached after
+        // the GCD-factoring simplifier runs on one path but not the
+        // other. Subtracting and simplifying lets the existing simplifier
+        // rules cancel them out.
+        EQ_GUARD.with(|g| g.set(true));
+        let diff = (self.clone() - other.clone()).simplify();
+        EQ_GUARD.with(|g| g.set(false));
+        matches!(diff, Val(0))
+    }
+}
 
 fn tdim_lexi_order(a: &TDim, b: &TDim) -> Ordering {
     match (a, b) {
@@ -1477,6 +1544,42 @@ mod tests {
     #[test]
     fn reduce_add() {
         assert_eq!(add(&A.to_dim(), &neg(&A.to_dim())).reduce(), Val(0))
+    }
+
+    #[test]
+    fn eq_add_vs_mulint_factored() {
+        // 16*A+16 (Add form) vs 16*(A+1) (MulInt-factored form): same value,
+        // different canonical forms.  Surfaced by Pocket-TTS export where a
+        // ConvTranspose1d output (kernel=32, stride=16) carries the Add
+        // form on one path and a downstream simplifier re-factors via the
+        // GCD pass on another path, producing MulInt(16, Add(.., 1)).
+        // PartialEq must call them equal so Broadcast::simplify dedup
+        // collapses them — otherwise downstream Sub volume checks emit
+        // `(16T+16)#(16T+1)` which can't reduce.
+        let lhs = add(&mul(16, &A.to_dim()), &Val(16));
+        let rhs = mul(16, &add(&A.to_dim(), &Val(1)));
+        let diff = (lhs.clone() - rhs.clone()).simplify();
+        eprintln!("lhs = {lhs:?}");
+        eprintln!("rhs = {rhs:?}");
+        eprintln!("diff = {diff:?}");
+        assert_eq!(lhs, rhs);
+    }
+
+    #[test]
+    fn broadcast_dedup_two_canonical_forms() {
+        // Same algebraic value in two different canonical forms going
+        // into a Broadcast: dedup must collapse them so the downstream
+        // Reshape volume check sees a single dim, not a Broadcast.
+        let add_form = add(&mul(16, &A.to_dim()), &Val(16));
+        let mul_form = mul(16, &add(&A.to_dim(), &Val(1)));
+        let broadcast = TDim::Broadcast(vec![add_form, mul_form]).simplify();
+        eprintln!("broadcast = {broadcast:?}");
+        // After dedup we should have a single-element broadcast that
+        // returns the single term (i.e. NOT a `Broadcast(_)` enum value).
+        assert!(
+            !matches!(broadcast, Broadcast(_)),
+            "expected single-term collapse, got {broadcast:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two algebraically equal TDims can arrive at different canonical forms via different construction paths. For example, the GCD-factoring simplifier rewrites `16T+16` (`Add([MulInt(16, T), Val(16)])`) to `16(T+1)` (`MulInt(16, Add([T, 1]))`) on one path while another keeps the Add form. Structural `PartialEq` returns false; `Broadcast::simplify`'s dedup keeps both, and downstream Reshape volume checks emit `(16T+16)#(16T+1)` which can't reduce.

Plug a second-chance into `PartialEq`: if structural equality fails, try `(self - other).simplify() == Val(0)`.

## Guards

- Thread-local `EQ_GUARD` prevents the simplifier's internal `HashMap<TDim, _>` from re-entering `eq` on each insertion (would recurse without bound on non-structurally-equal inputs).
- Skip second-chance when either side is a `Val` or `Sym` leaf. For `Val(c)` vs anything non-`Val`, simplify should already have folded the other side; running a diff-and-simplify here just risks arithmetic overflow on extreme constants. For `Sym` leaves, assertion-driven equality belongs in `simplify`, not in `eq`.

## Surfaced by

Pocket-TTS pulsification (LayerNorm-after-ConvTranspose with dynamic axis): the variance-branch dim ended up in MulInt-factored form while the residual dim kept the Add form, broadcast couldn't dedup, downstream pulse-divisibility check bailed on the Reshape's symbolic shape.

## Tests

- `eq_add_vs_mulint_factored`: `Add([MulInt(16, A), Val(16)])` == `MulInt(16, Add([A, Val(1)]))` returns true.
- `broadcast_dedup_two_canonical_forms`: `Broadcast([add_form, mul_form]).simplify()` collapses to a single term.