### PR TITLE
pulse: LCM-merge stream-axis dims + slope-based per-pulse for Range

### DIFF
--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -1236,6 +1236,27 @@ impl TDim {
         self.clone().neg().prove_strict_positive()
     }
 
+    /// Pulse-divisibility merge: smallest scalar dim that is a multiple of
+    /// both `self` and `other`.  Used at pulse meet-points (elementwise
+    /// ops where parallel paths produced different per-pulse sizes — e.g.
+    /// stride and kernel of a ConvTranspose surfacing as `(K_steady,
+    /// K_initial)` on the two phases of the pulse cycle).
+    ///
+    /// For pure positive integers, returns the exact LCM as `Val(.)`.
+    /// For symbolic TDims, returns `None` -- the caller can fall back to
+    /// the existing `Broadcast` semantics or use a safe upper bound.
+    pub fn pulse_lcm(&self, other: &TDim) -> Option<TDim> {
+        match (self.as_i64(), other.as_i64()) {
+            (Some(a), Some(b)) if a > 0 && b > 0 => {
+                let g = (a as u64).gcd(&(b as u64));
+                let l = (a as u64 / g).saturating_mul(b as u64);
+                if l > i64::MAX as u64 { None } else { Some(TDim::Val(l as i64)) }
+            }
+            (Some(0), _) | (_, Some(0)) => Some(TDim::Val(0)),
+            _ => None,
+        }
+    }
+
     pub fn gcd(&self) -> u64 {
         use self::TDim::*;
         match self {
@@ -1291,7 +1312,7 @@ impl TDim {
         TDim::Div(Box::new(Add(vec![self, Val(rhs as i64 - 1)])), rhs).reduce()
     }
 
-    pub(super) fn guess_slope(&self, sym: &Symbol) -> (i64, u64) {
+    pub fn guess_slope(&self, sym: &Symbol) -> (i64, u64) {
         fn slope_rec(d: &TDim, sym: &Symbol) -> (i64, i64) {
             match d {
                 Val(_) => (0, 1),
@@ -1655,6 +1676,19 @@ mod tests {
     #[test]
     fn reduce_add() {
         assert_eq!(add(&A.to_dim(), &neg(&A.to_dim())).reduce(), Val(0))
+    }
+
+    #[test]
+    fn pulse_lcm_basic() {
+        // Two pulse-cycle phases of an upsample (stride=16, kernel=32):
+        // steady-state output = 16, initial-state with overlap = 32.
+        // Merged pulse-divisibility constraint = LCM = 32.
+        assert_eq!(Val(16).pulse_lcm(&Val(32)), Some(Val(32)));
+        assert_eq!(Val(32).pulse_lcm(&Val(16)), Some(Val(32)));
+        assert_eq!(Val(6).pulse_lcm(&Val(8)), Some(Val(24)));
+        assert_eq!(Val(7).pulse_lcm(&Val(7)), Some(Val(7)));
+        // Symbolic: not computable, return None for the fallback path.
+        assert_eq!(Val(16).pulse_lcm(&A.to_dim()), None);
     }
 
     #[test]

--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -1236,16 +1236,14 @@ impl TDim {
         self.clone().neg().prove_strict_positive()
     }
 
-    /// Pulse-divisibility merge: smallest scalar dim that is a multiple of
-    /// both `self` and `other`.  Used at pulse meet-points (elementwise
-    /// ops where parallel paths produced different per-pulse sizes — e.g.
-    /// stride and kernel of a ConvTranspose surfacing as `(K_steady,
-    /// K_initial)` on the two phases of the pulse cycle).
+    /// Least common multiple of two `TDim`s when both reduce to positive
+    /// integers.
     ///
-    /// For pure positive integers, returns the exact LCM as `Val(.)`.
-    /// For symbolic TDims, returns `None` -- the caller can fall back to
-    /// the existing `Broadcast` semantics or use a safe upper bound.
-    pub fn pulse_lcm(&self, other: &TDim) -> Option<TDim> {
+    /// Returns `Val(0)` if either operand is `0`, and `None` if either is
+    /// symbolic, negative, or if the LCM would overflow `i64`. Callers
+    /// that need a safe answer for symbolic operands should fall back at
+    /// the call site.
+    pub fn lcm(&self, other: &TDim) -> Option<TDim> {
         match (self.as_i64(), other.as_i64()) {
             (Some(a), Some(b)) if a > 0 && b > 0 => {
                 let g = (a as u64).gcd(&(b as u64));
@@ -1679,16 +1677,13 @@ mod tests {
     }
 
     #[test]
-    fn pulse_lcm_basic() {
-        // Two pulse-cycle phases of an upsample (stride=16, kernel=32):
-        // steady-state output = 16, initial-state with overlap = 32.
-        // Merged pulse-divisibility constraint = LCM = 32.
-        assert_eq!(Val(16).pulse_lcm(&Val(32)), Some(Val(32)));
-        assert_eq!(Val(32).pulse_lcm(&Val(16)), Some(Val(32)));
-        assert_eq!(Val(6).pulse_lcm(&Val(8)), Some(Val(24)));
-        assert_eq!(Val(7).pulse_lcm(&Val(7)), Some(Val(7)));
-        // Symbolic: not computable, return None for the fallback path.
-        assert_eq!(Val(16).pulse_lcm(&A.to_dim()), None);
+    fn lcm_basic() {
+        assert_eq!(Val(16).lcm(&Val(32)), Some(Val(32)));
+        assert_eq!(Val(32).lcm(&Val(16)), Some(Val(32)));
+        assert_eq!(Val(6).lcm(&Val(8)), Some(Val(24)));
+        assert_eq!(Val(7).lcm(&Val(7)), Some(Val(7)));
+        // Symbolic: not computable; callers fall back.
+        assert_eq!(Val(16).lcm(&A.to_dim()), None);
     }
 
     #[test]

--- a/pulse/src/lib.rs
+++ b/pulse/src/lib.rs
@@ -1,32 +1,3 @@
-//! Pulsification: rewrite a TypedModel that processes a full stream into a
-//! PulsedModel that processes one chunk (`pulse`) at a time, preserving
-//! state (lookback buffers, KV caches) across calls.
-//!
-//! ## Stream-axis dim merging at meet points
-//!
-//! When two parallel pulse paths converge at an elementwise op (Add,
-//! residual, etc.), the merged tensor's *stream-axis* dim is the **LCM**
-//! of the inputs' per-pulse stream dims, not the NumPy-style broadcast.
-//! Two semantics get conflated otherwise:
-//!
-//! * Tensor shape compatibility (must match at runtime): non-stream axes
-//!   use NumPy `Broadcast` -- equal or one is 1, anything else fails.
-//! * Pulse-divisibility (a scalar constraint on per-pulse cycle): on the
-//!   stream axis, two paths with steady-state size `K_a` and `K_b` are
-//!   compatible at any pulse that is a multiple of `LCM(K_a, K_b)`.
-//!
-//! Conflating the two surfaces as `Broadcast(K_a, K_b)` on the stream axis
-//! when paths produce different per-pulse sizes (e.g. ConvTranspose with
-//! kernel > stride at steady-state vs initial-state phases). The merge
-//! lives in [`crate::model::stream_axis_lcm`] called from
-//! `PulseWrappingOp::pulsed_output_facts`.
-//!
-//! Op-specific pulsifiers (cnn, range, deconv, …) compute stream-axis
-//! sizes in their own pulsify functions; they should follow the same
-//! "slope × pulse" convention -- the *coefficient* of the streaming
-//! symbol times the pulse value, NOT `stream_dim.substitute(symbol,
-//! pulse)` (which includes any constant tail produced by overlap-add).
-
 #![allow(clippy::len_zero)]
 #[macro_use]
 pub mod macros;

--- a/pulse/src/lib.rs
+++ b/pulse/src/lib.rs
@@ -1,3 +1,32 @@
+//! Pulsification: rewrite a TypedModel that processes a full stream into a
+//! PulsedModel that processes one chunk (`pulse`) at a time, preserving
+//! state (lookback buffers, KV caches) across calls.
+//!
+//! ## Stream-axis dim merging at meet points
+//!
+//! When two parallel pulse paths converge at an elementwise op (Add,
+//! residual, etc.), the merged tensor's *stream-axis* dim is the **LCM**
+//! of the inputs' per-pulse stream dims, not the NumPy-style broadcast.
+//! Two semantics get conflated otherwise:
+//!
+//! * Tensor shape compatibility (must match at runtime): non-stream axes
+//!   use NumPy `Broadcast` -- equal or one is 1, anything else fails.
+//! * Pulse-divisibility (a scalar constraint on per-pulse cycle): on the
+//!   stream axis, two paths with steady-state size `K_a` and `K_b` are
+//!   compatible at any pulse that is a multiple of `LCM(K_a, K_b)`.
+//!
+//! Conflating the two surfaces as `Broadcast(K_a, K_b)` on the stream axis
+//! when paths produce different per-pulse sizes (e.g. ConvTranspose with
+//! kernel > stride at steady-state vs initial-state phases). The merge
+//! lives in [`crate::model::stream_axis_lcm`] called from
+//! `PulseWrappingOp::pulsed_output_facts`.
+//!
+//! Op-specific pulsifiers (cnn, range, deconv, …) compute stream-axis
+//! sizes in their own pulsify functions; they should follow the same
+//! "slope × pulse" convention -- the *coefficient* of the streaming
+//! symbol times the pulse value, NOT `stream_dim.substitute(symbol,
+//! pulse)` (which includes any constant tail produced by overlap-add).
+
 #![allow(clippy::len_zero)]
 #[macro_use]
 pub mod macros;
@@ -195,5 +224,100 @@ mod tests {
         let chunk2 = tensor1(&[3f32, 4.0]);
         let out2 = state.run(tvec!(chunk2.into_tvalue())).unwrap();
         assert_eq!(*out2[0], tensor2(&[[3f32, 4.0]]).into());
+    }
+
+    /// Two parallel pulse paths meeting at an elementwise op produce
+    /// different per-pulse stream-axis sizes when one path goes through a
+    /// ConvTranspose (kernel > stride) and the other doesn't.  Pre-fix
+    /// pulsification bailed at the meet point because the typed
+    /// `output_facts`' `multi_broadcast` returned `Broadcast(K_a, K_b)`
+    /// on the stream axis -- not equal, not 1, doesn't simplify.  After fix
+    /// the merge uses LCM for the stream axis specifically.
+    ///
+    /// Minimal repro of the Pocket-TTS upsample-then-attention pattern:
+    /// a ConvTranspose1d(stride=4, kernel=8) emits steady-state stride=4
+    /// frames per pulse with 4-frame overlap-add; an arange of the same
+    /// post-convtr length produces (after our Range slope-based fix) also
+    /// 4 frames per pulse; an elementwise Add of the two requires the
+    /// meet-point merge to be LCM(4, 4) = 4 (trivial here, but the path
+    /// went through Broadcast(4, 8) before slope+LCM fixes were in place).
+    #[test]
+    fn test_pulse_meet_with_arange_branch_types_through() {
+        use tract_core::ops::array::Range;
+        use tract_core::ops::cnn::{Deconv, KernelFormat, PaddingSpec, PoolSpec};
+        use tract_core::ops::nn::DataFormat;
+
+        let mut model = TypedModel::default();
+        let t = model.symbols.sym("T");
+        let src = model.add_source("x", f32::fact(dims![1, 2, t.to_dim()].as_ref())).unwrap();
+
+        // ConvTranspose1d(C=2, kernel=8, stride=4) → stream-axis dim
+        // becomes 4*T + 4 (post overlap-add tail).
+        let kernel = model
+            .add_const("kernel", tract_core::ndarray::Array3::<f32>::zeros((2, 2, 8)))
+            .unwrap();
+        let bias = model.add_const("bias", tract_core::ndarray::arr1(&[0.0f32, 0.0])).unwrap();
+        let conv_out = model
+            .wire_node(
+                "convtr",
+                Deconv {
+                    pool_spec: PoolSpec {
+                        data_format: DataFormat::NCHW,
+                        kernel_shape: tvec!(8),
+                        padding: PaddingSpec::Valid,
+                        dilations: Some(tvec!(1)),
+                        strides: Some(tvec!(4)),
+                        input_channels: 2,
+                        output_channels: 2,
+                    },
+                    kernel_format: KernelFormat::OIHW,
+                    adjustments: tvec!(0),
+                    group: 1,
+                },
+                &[src, kernel, bias],
+            )
+            .unwrap()[0];
+
+        // arange(0, 4*T + 4) of the same stream-axis length — this is the
+        // branch that surfaced the Broadcast bug pre-fix.
+        let start = model.add_const("range_start", tensor0(TDim::Val(0))).unwrap();
+        let end = model
+            .add_const(
+                "range_end",
+                tract_core::ndarray::arr0(t.to_dim() * 4 + 4).into_dyn().into_tensor(),
+            )
+            .unwrap();
+        let step = model.add_const("range_step", tensor0(TDim::Val(1))).unwrap();
+        let range_out = model
+            .wire_node("range", Range::new(t.to_dim() * 4 + 4), &[start, end, step])
+            .unwrap()[0];
+
+        // Cast range to f32 and broadcast-shape with conv_out so they Add.
+        let range_f32 = model
+            .wire_node("range_cast", tract_core::ops::cast::cast(f32::datum_type()), &[range_out])
+            .unwrap()[0];
+        let range_bc = model
+            .wire_node(
+                "range_unsqueeze",
+                tract_core::ops::change_axes::AxisOp::Add(0),
+                &[range_f32],
+            )
+            .unwrap()[0];
+        let range_bc = model
+            .wire_node(
+                "range_unsqueeze2",
+                tract_core::ops::change_axes::AxisOp::Add(0),
+                &[range_bc],
+            )
+            .unwrap()[0];
+
+        let added =
+            model.wire_node("add", tract_core::ops::math::add(), &[conv_out, range_bc]).unwrap();
+        model.select_output_outlets(&added).unwrap();
+
+        // The point of the test: this used to panic with
+        // `Pulsification requires pulse Broadcast(4, 8) ...` at the
+        // downstream meet point.  Now it should pulsify without error.
+        let _pulse = PulsedModel::new(&model, t, &2.to_dim()).expect("pulsification");
     }
 }

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -43,21 +43,28 @@ fn check_no_unannotated_superlinear_wires(model: &TypedModel, symbol: &Symbol) -
     Ok(())
 }
 
-/// LCM of the stream-axis dims across all stream-bearing inputs.  Used at
-/// elementwise meet points where parallel pulse paths emit different
-/// per-pulse sizes (steady-state vs initial-state phases).  Returns
-/// `None` when the LCM isn't computable (any input has a non-integer
-/// symbolic stream dim) -- the caller falls back to the unmodified shape
-/// that `multi_broadcast` produced.
+/// LCM of the stream-axis dims across all stream-bearing inputs.
+///
+/// Used at elementwise pulse meet-points where parallel paths emit
+/// different per-pulse sizes (e.g. ConvTranspose with kernel > stride
+/// surfacing as `(K_steady, K_initial)` on the two phases of the pulse
+/// cycle). Two semantics get conflated otherwise:
+///
+/// * Tensor shape compatibility (must match at runtime): non-stream
+///   axes use NumPy `Broadcast` -- equal or one is 1, anything else
+///   fails.
+/// * Pulse-divisibility (a scalar constraint on per-pulse cycle): on
+///   the stream axis, two paths with steady-state size `K_a` and `K_b`
+///   are compatible at any pulse that is a multiple of
+///   `LCM(K_a, K_b)`.
+///
+/// Returns `None` if any stream-axis dim is symbolic; the caller falls
+/// back to the unmodified shape `multi_broadcast` produced.
 pub fn stream_axis_lcm(inputs: &[&PulsedFact]) -> Option<TDim> {
-    let dims: Vec<&TDim> =
-        inputs.iter().filter_map(|f| f.stream.as_ref().map(|s| &f.shape[s.axis])).collect();
-    let (first, rest) = dims.split_first()?;
-    let mut acc = (*first).clone();
-    for d in rest {
-        acc = acc.pulse_lcm(d)?;
-    }
-    Some(acc)
+    let mut dims =
+        inputs.iter().filter_map(|f| f.stream.as_ref().map(|s| &f.shape[s.axis]));
+    let first = dims.next()?.clone();
+    dims.try_fold(first, |acc, d| acc.lcm(d))
 }
 
 #[allow(clippy::new_ret_no_self)]

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -61,8 +61,7 @@ fn check_no_unannotated_superlinear_wires(model: &TypedModel, symbol: &Symbol) -
 /// Returns `None` if any stream-axis dim is symbolic; the caller falls
 /// back to the unmodified shape `multi_broadcast` produced.
 pub fn stream_axis_lcm(inputs: &[&PulsedFact]) -> Option<TDim> {
-    let mut dims =
-        inputs.iter().filter_map(|f| f.stream.as_ref().map(|s| &f.shape[s.axis]));
+    let mut dims = inputs.iter().filter_map(|f| f.stream.as_ref().map(|s| &f.shape[s.axis]));
     let first = dims.next()?.clone();
     dims.try_fold(first, |acc, d| acc.lcm(d))
 }

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -43,6 +43,23 @@ fn check_no_unannotated_superlinear_wires(model: &TypedModel, symbol: &Symbol) -
     Ok(())
 }
 
+/// LCM of the stream-axis dims across all stream-bearing inputs.  Used at
+/// elementwise meet points where parallel pulse paths emit different
+/// per-pulse sizes (steady-state vs initial-state phases).  Returns
+/// `None` when the LCM isn't computable (any input has a non-integer
+/// symbolic stream dim) -- the caller falls back to the unmodified shape
+/// that `multi_broadcast` produced.
+pub fn stream_axis_lcm(inputs: &[&PulsedFact]) -> Option<TDim> {
+    let dims: Vec<&TDim> =
+        inputs.iter().filter_map(|f| f.stream.as_ref().map(|s| &f.shape[s.axis])).collect();
+    let (first, rest) = dims.split_first()?;
+    let mut acc = (*first).clone();
+    for d in rest {
+        acc = acc.pulse_lcm(d)?;
+    }
+    Some(acc)
+}
+
 #[allow(clippy::new_ret_no_self)]
 pub trait PulsedModelExt {
     fn new(source: &TypedModel, symbol: Symbol, pulse: &TDim) -> TractResult<PulsedModel>;
@@ -322,13 +339,31 @@ impl PulsedOp for PulseWrappingOp {
         let axes_mapping = self.0.axes_mapping(&input_facts_ref, &output_facts_ref)?;
         let axis_info = axes_mapping.axis((InOut::In(pulsing_input), stream.axis))?;
         std::mem::drop(output_facts_ref);
+        // When parallel pulse paths converge at an elementwise op, the
+        // typed `output_facts` falls through to `multi_broadcast` for shape
+        // merging, which produces `Broadcast([K_a, K_b])` on the stream
+        // axis when the inputs have different per-pulse sizes (e.g.
+        // steady-state `stride` vs initial-state `kernel` of a
+        // streaming convtr surfacing on two phases of the cycle).
+        // `Broadcast` is the right semantic for non-stream axes (shape
+        // compatibility at runtime) but a category error for the stream
+        // axis: there the merged constraint is *scalar pulse-divisibility*
+        // and the right answer is LCM. Compute it post-hoc and override
+        // the offending dim before it propagates downstream.
+        let merged_stream_dim = stream_axis_lcm(inputs);
         output_facts
             .into_iter()
             .enumerate()
             .map(|(ix, tf)| {
                 if let &[axis] = &*axis_info.outputs[ix] {
+                    let mut shape = tf.shape;
+                    if let Some(merged) = merged_stream_dim.as_ref() {
+                        if matches!(shape[axis], TDim::Broadcast(_)) {
+                            shape.set(axis, merged.clone());
+                        }
+                    }
                     Ok(PulsedFact {
-                        shape: tf.shape,
+                        shape,
                         datum_type: tf.datum_type,
                         stream: Some(StreamInfo {
                             delay: stream.delay,

--- a/pulse/src/ops/array/range.rs
+++ b/pulse/src/ops/array/range.rs
@@ -40,10 +40,26 @@ fn pulsify(
     let start = start.clone().into_tensor();
     let step = step.clone().into_tensor();
 
-    // Per-pulse element count on the stream axis: substitute the stream
-    // symbol in the (full) stream dim by the pulse value.  Matches Source's
-    // pulsification for `[c·S, …]` shapes (per-pulse on axis = `c·pulse`).
-    let per_pulse: usize = stream_dim.clone().substitute(symbol, pulse)?.to_usize()?;
+    // Per-pulse element count on the stream axis = slope (coefficient of
+    // the streaming symbol) × pulse, NOT the full evaluated length at the
+    // first pulse. For `stream_dim = c·S + k` (e.g. an arange over the
+    // post-upsample length where the convtr's kernel-stride window
+    // adds a constant tail `k`), the data path downstream emits `c·pulse`
+    // new frames per pulse with the constant `k` absorbed into the
+    // streaming state. Range must match that to keep the stream-axis dim
+    // consistent at elementwise meet points (otherwise the constant `k`
+    // surfaces as `Broadcast(c·pulse, c·pulse + k)` and downstream
+    // pulse-divisibility checks bail).
+    //
+    // `guess_slope` returns `(num, den)` for the rational slope; we
+    // require integer slopes (den == 1) — Range over a fractional-slope
+    // stream dim doesn't have a single per-pulse count.
+    let (slope_num, slope_den) = stream_dim.guess_slope(symbol);
+    rule_if!(slope_num > 0 && slope_den == 1);
+    let pulse_int = pulse.to_usize()?;
+    let per_pulse: usize = (slope_num as usize).checked_mul(pulse_int).ok_or_else(|| {
+        format_err!("Range pulsification: per-pulse overflow ({}*{})", slope_num, pulse_int)
+    })?;
     let pulsed =
         PulsedRange { datum_type, start, step, stream_dim: stream_dim.clone(), pulse: per_pulse };
     target.wire_node(&*node.name, pulsed, &[]).map(Some)


### PR DESCRIPTION
When two parallel pulse paths converge at an elementwise op, the merged tensor's stream-axis dim is the **Least Common Multiple (LCM)** of the inputs' per-pulse stream dims, not the NumPy-style broadcast. Two semantics get conflated otherwise:

- Tensor shape compatibility (must match at runtime): non-stream axes use NumPy `Broadcast`. Equal or one is 1.
- Pulse-divisibility (a scalar constraint on per-pulse cycle): on the stream axis, two paths with steady-state size `K_a` and `K_b` are compatible at any pulse that is a multiple of `LCM(K_a, K_b)`.

`PulseWrappingOp::pulsed_output_facts` was using the typed op's `output_facts` for shape merging, which falls through to `multi_broadcast` and produces `Broadcast([K_a, K_b])` on the stream axis when paths produce different per-pulse sizes (e.g. ConvTranspose with kernel > stride at steady-state vs initial-state phases). Downstream pulse-divisibility checks then bail.

## Changes

- New `TDim::pulse_lcm` helper (pure-integer LCM; returns `None` for symbolic, caller falls back).
- `PulseWrappingOp::pulsed_output_facts` post-processes typed `output_facts`: when the stream-axis dim is a `Broadcast`, replace with LCM of all stream-bearing inputs' stream dims. Non-stream axes keep `Broadcast` semantics (correct for runtime shape compatibility).
- `Range::pulsify` (`pulse/src/ops/array/range.rs`): replace `stream_dim.substitute(symbol, pulse).to_usize()` (full evaluated length, includes constant tail from upstream overlap-add) with slope-based `guess_slope(symbol).0 × pulse_int` (steady-state increment per pulse). The substitute form was forcing per-pulse to the kernel-state size when downstream paths were producing the steady-state size, surfacing exactly as the `Broadcast(stride, kernel)` we were merging.
- `TDim::guess_slope` made `pub` (was `pub(super)`) so pulse op-pulsifiers outside `tract-data` can use it.

## Module-level doc

`pulse/src/lib.rs` now documents the stream-axis vs non-stream-axis merge contract so future maintainers don't reintroduce the conflation.

## Surfaced by

Pocket-TTS Mimi audio decode (`upsample[stride=16, kernel=32] → linear → view → unbind → arange-based mask → SDPA → linear → conv`). Pre-fix: failed at `Pulsification requires pulse Broadcast(16, 32) to be a stride (1) multiple`. Post-fix: pulsifies cleanly through optimize at pulse=1, 2, 4, 8.

## Depends on

[#2201](https://github.com/sonos/tract/pull/2201) (`tdim: PartialEq second-chance`). Needed for the LayerNorm-after-ConvTranspose case where the GCD-factoring rewrite produces algebraically-equal-but-structurally-different canonical forms.

## Tests

- `pulse_lcm_basic` in `tract-data`.
- `test_pulse_meet_with_arange_branch_types_through` in `tract-pulse`: minimal repro of the upsample-then-arange-mask pattern; pulsifies cleanly post-fix.
- 132 + 34 lib tests green; 55 `core-proptest-pulse` tests green (no regressions in existing pad+conv, deconv, conv+conv, etc. proptests).

## Known limitations / follow-ups

- `pulse_lcm` returns `None` for symbolic operands; callers fall back to existing `Broadcast` behavior (still safe). A symbolic LCM is worth following up.
- Op-specific pulsifiers (cnn::conv, deconv, fft, etc.) that compute stream-axis sizes in their own pulsify functions don't go through `PulseWrappingOp`; they should follow the same slope-based convention. This PR fixes Range; quick audit of others recommended.
- A pre-existing tract bug exists in `Deconv` pulse runtime semantics (output diverges at chunk boundaries for kernel > stride). Exposed by `tract compare --stream` once the type-level fix in this PR is in. Filed as [#2203](https://github.com/sonos/tract/issues/2203).