### PR TITLE
pulse: add Deconv bias once after overlap-add

### DIFF
--- a/harness/core-proptest-pulse/src/deconv.rs
+++ b/harness/core-proptest-pulse/src/deconv.rs
@@ -300,3 +300,78 @@ fn deconv2d() {
         .for_each(|(ix, x)| *x = ix as f32);
     proptest_regular_against_pulse(model, 1, input.into_plain_array().unwrap(), 2).unwrap()
 }
+
+// Issue #2203: pulse-mode Deconv with non-zero bias and kernel > stride
+// double-counts the bias in the overlap region. Bulk adds bias once per
+// output slot; the per-pulse Deconv also adds bias to its full
+// ``P*S + (K-1)`` output, and the DeconvDelay overlap-add then sums
+// pulse N's bias-included tail into pulse N+1's bias-included head.
+// Surfaced by Pocket-TTS / Mimi (depthwise ConvTranspose1d, K=32, S=16).
+// Existing ``proptest`` and ``example_*`` cases all use ``bias=0`` (see
+// ``DeconvOp::chain``), which masks the bug.
+
+fn run_issue_2203(group: usize, output_channels: usize, bias: tract_ndarray::Array1<f32>) {
+    let ker_len = 32usize;
+    let stride = 16usize;
+    let pulse = 2usize;
+    let input_len = 8usize;
+    let in_channels_per_group = output_channels / group;
+
+    let mut model = TypedModel::default();
+    let mut fact = f32::fact(&[1, output_channels, input_len]);
+    let s = model.symbols.sym("S");
+    fact.shape.set(2, s.to_dim());
+    let input = model.add_source("a", fact).unwrap();
+    let kernel = tract_ndarray::Array3::from_shape_vec(
+        (output_channels, in_channels_per_group, ker_len),
+        (0..output_channels * in_channels_per_group * ker_len)
+            .map(|i| 0.001_f32 * (i as f32 + 1.0))
+            .collect(),
+    )
+    .unwrap();
+    let deconv = tract_core::ops::cnn::Deconv {
+        pool_spec: PoolSpec {
+            data_format: DataFormat::NCHW,
+            kernel_shape: tvec!(ker_len),
+            padding: PaddingSpec::Explicit(tvec!(0), tvec!(0)),
+            strides: Some(tvec!(stride)),
+            dilations: None,
+            input_channels: output_channels,
+            output_channels,
+        },
+        kernel_format: tract_core::ops::cnn::KernelFormat::OIHW,
+        adjustments: tvec!(0),
+        group,
+    };
+    let kernel_node = model.add_const("kernel", kernel).unwrap();
+    let bias_node = model.add_const("bias", bias).unwrap();
+    let id = model.wire_node("deconv1", deconv, &[input, kernel_node, bias_node]).unwrap()[0];
+    model.select_output_outlets(&[id]).unwrap();
+
+    let input = tract_ndarray::Array3::from_shape_vec(
+        (1, output_channels, input_len),
+        (0..output_channels * input_len).map(|i| 0.1_f32 * (i as f32 + 1.0)).collect(),
+    )
+    .unwrap();
+    proptest_regular_against_pulse(model, pulse as _, input.into_dyn(), 2).unwrap()
+}
+
+#[test]
+fn issue_2203_dense_with_bias_kernel_32_stride_16() {
+    run_issue_2203(1, 8, tract_ndarray::Array1::<f32>::from_elem((8,), 0.5_f32))
+}
+
+#[test]
+fn issue_2203_depthwise_with_bias_kernel_32_stride_16() {
+    // Mimi's actual configuration: depthwise (groups = output_channels),
+    // kernel (G, 1, K) in OIHW.
+    run_issue_2203(
+        8,
+        8,
+        tract_ndarray::Array1::<f32>::from_shape_vec(
+            (8,),
+            (0..8).map(|i| 0.001_f32 * (i as f32 + 1.0)).collect(),
+        )
+        .unwrap(),
+    )
+}

--- a/pulse/src/ops/cnn/deconv.rs
+++ b/pulse/src/ops/cnn/deconv.rs
@@ -45,7 +45,19 @@ fn pulsify(
     };
     wire = target.wire_node(format!("{}.mask", node.name), mask, &wire)?;
     wire.push(mapping[&node.inputs[1]]);
-    wire.push(mapping[&node.inputs[2]]);
+    // Feed a zero bias to the per-pulse Deconv. With kernel > stride the
+    // per-pulse output has overlap slots that the bulk Deconv would never
+    // emit; DeconvDelay's overlap-add then double-counts the bias on
+    // those slots. Adding the original bias back after DeconvDelay
+    // guarantees it's added exactly once per output position.
+    let source_bias_fact = source.outlet_fact(node.inputs[2])?.clone();
+    let bias_tensor = source_bias_fact
+        .konst
+        .clone()
+        .context("Deconv bias must be a constant for pulsification")?;
+    let zero_bias = Tensor::zero_dt(bias_tensor.datum_type(), bias_tensor.shape())?;
+    let zero_bias = target.add_const(format!("{}.zero_bias", node.name), zero_bias)?;
+    wire.push(zero_bias);
     wire = target.wire_node(format!("{}.deconv", node.name), pulse_op, &wire)?;
     let overlap = overlap(stream.axis, op);
     let deconv_input_dim = (stream.dim.clone() - 1) * stride + 1;
@@ -91,6 +103,38 @@ fn pulsify(
             wire = target.wire_node(format!("{}.padding.{}", node.name, geo_axis), op, &wire)?;
         }
     }
+
+    // Add the original bias to the now-merged output. See the zero-bias
+    // comment above pulse_op wiring for why this can't be done inside
+    // per-pulse Deconv.
+    let out_shape = target.outlet_fact(wire[0])?.shape.clone();
+    let out_rank = out_shape.rank();
+    let c_axis = op.pool_spec.data_format.shape(out_shape.to_tvec())?.c_axis();
+    let mut reshaped_bias_shape: TVec<usize> = tvec![1; out_rank];
+    reshaped_bias_shape[c_axis] = op.pool_spec.output_channels;
+    // Broadcast the bias to ``(1, ..., C, ..., 1)`` so the post-Deconv
+    // Add is a clean elementwise op. Bulk Deconv accepts both scalar and
+    // rank-1 ``(C,)`` biases (handled by ``wire_reshape_bias_for_bin``);
+    // we mirror that here at build time.
+    let bias_const = if bias_tensor.rank() == 0 {
+        bias_tensor.broadcast_scalar_to_shape(&reshaped_bias_shape)?.into_arc_tensor()
+    } else if bias_tensor.shape() == [op.pool_spec.output_channels] {
+        bias_tensor.clone().into_tensor().into_shape(&reshaped_bias_shape)?.into_arc_tensor()
+    } else if bias_tensor.shape() == &*reshaped_bias_shape {
+        bias_tensor.clone()
+    } else {
+        bail!(
+            "Unexpected Deconv bias shape {:?} for {} output channels",
+            bias_tensor.shape(),
+            op.pool_spec.output_channels
+        );
+    };
+    let bias = target.add_const(format!("{}.bias", node.name), bias_const)?;
+    wire = target.wire_node(
+        format!("{}.add_bias", node.name),
+        crate::model::PulseWrappingOp(Box::new(tract_core::ops::math::add())),
+        &[wire[0], bias],
+    )?;
 
     Ok(Some(wire))
 }


### PR DESCRIPTION
## Summary
- Fixes #2203. Pulse-mode `Deconv` with `kernel > stride` was double-counting the bias on every overlap slot: per-pulse `Deconv` adds bias to its full `(P-1)*S + K + (S-1)` output, and `DeconvDelay`'s overlap-add then sums pulse N's bias-included tail into pulse N+1's bias-included head.
- Feed a zero bias to the per-pulse `Deconv`, then add the original bias broadcast to `(1, ..., C, ..., 1)` post-`DeconvDelay` so it lands exactly once per output position.
- Surfaced by Pocket-TTS / Mimi (depthwise `ConvTranspose1d`, K=32, S=16). Existing harness Deconv tests all use `bias=0` (see `DeconvOp::chain`), which masked the bug.

## Test plan
- [x] `cargo test -p core-proptest-pulse deconv::` (13 tests, including 2 new regressions: dense and depthwise with non-zero bias and `kernel > stride`).
- [x] Pocket-TTS Mimi end-to-end pulse pipeline now matches bulk output bit-exactly.