### PR TITLE
linalg: enable rustfft `wasm_simd` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ readings-probe = "0.1.8"
 regex = "1.5.4"
 ron = "0.12"
 reqwest = { version = "0.13", features = [ "blocking", "rustls-no-provider" ], default-features = false }
-rustfft = { version = "6.1", features = [ "neon" ] }
+rustfft = { version = "6.1", features = [ "neon", "wasm_simd" ] }
 rustls = { version = "0.23", default-features = false, features = [ "ring", "std", "tls12" ] }
 webpki-roots = "1"
 safetensors = "0.7"


### PR DESCRIPTION
## Summary

`rustfft` ships a comprehensive WASM SIMD path (`src/wasm_simd/`, ~537 KB, parity with the NEON backend in scope and shape) but it is gated behind a non-default `wasm_simd` feature flag. Without it, rustfft falls back to scalar on `wasm32` even when the build has `+simd128` enabled.

The tract `rustfft` dep at workspace level is opted into `neon` but not `wasm_simd`, so every WASM consumer of tract was running rustfft in scalar mode despite a fully-tuned SIMD implementation existing in the library.

Adding `"wasm_simd"` to the features list closes the gap. The flag is a no-op on non-wasm targets per rustfft's own design.

## Isolated FFT bench (wasmtime / Cranelift, M-class Mac)

Direct rustfft microbench, forward + inverse FFT round-trip. Standalone bench crate at `/tmp/rustfft-wasm-bench`, depending on `rustfft = "^6.4"`. Build with `RUSTFLAGS='-C target-feature=+simd128'` against `wasm32-wasip1`, run via `wasmtime`:

| FFT size            | scalar (no wasm_simd) | with wasm_simd | Δ     |
|---------------------|----------------------:|---------------:|------:|
| n=480 (DFN3 STFT)   | 3042 ns               |     1280 ns    | -58%  |
| n=512 (pow2)        | 2601 ns               |     1146 ns    | -56%  |
| n=256 (pow2)        | 1172 ns               |      543 ns    | -54%  |
| n=1024 (pow2)       | 5906 ns               |     2482 ns    | -58%  |
| n=2048              | 12051 ns              |     5324 ns    | -56%  |
| n=4096              | 26149 ns              |    11270 ns    | -57%  |

Consistent ~2.2-2.4× speedup across power-of-2 and non-power-of-2 sizes. The exception is sizes with prime factor 5 (e.g. n=400, where rustfft uses Rader's algorithm; observed 1.03× — flat). Not a regression, just no SIMD lift on those paths.

## End-to-end on a real model (DFN3, deepfilternet)

`compose_filter` round-trip with vendored libDF on a 30-second synthetic test signal at 48 kHz, 3 timed passes per build, min-of-3 reported:

| Runtime              | Baseline RTF | With wasm_simd | Δ     |
|----------------------|-------------:|---------------:|------:|
| wasmtime / Cranelift | 0.0533       | 0.0529         | -0.7% (within noise) |
| Node 22 / V8         | 0.0520       | 0.0510         | -1.9% |

DFN3 makes ~2 FFT calls per 10 ms hop (one forward + one inverse). FFT is ~1% of DFN3's per-hop budget, so the FFT speedup translates to a small E2E gain. For more FFT-bound workloads (Whisper, vocoders, music-processing models, pure DSP code) the gain is much larger — proportional to the FFT share of the per-call budget.

## Realfft callers — separate flag needed

A note for downstream users: `realfft` (a wrapper around rustfft for real-valued signals — used by deepfilternet's STFT, among others) declares `rustfft = { default-features = false }` and exposes its **own** `wasm_simd` feature flag. Enabling `rustfft/wasm_simd` here does not automatically activate the SIMD path through realfft. Consumers that go through realfft must additionally enable `realfft/wasm_simd`. This is a realfft wiring detail, not a tract issue, but worth flagging in case downstream readers wonder why their FFT speedup didn't materialise.

## Test plan

- [x] `cargo check -p tract-core --target=wasm32-unknown-unknown` clean
- [x] Isolated FFT microbench across {256, 480, 512, 1024, 2048, 4096} on wasmtime — speedup confirmed
- [x] DFN3 RTF E2E bench on wasmtime + Node 22 (V8) — modest E2E gain confirmed for V8, within noise on Cranelift
- [ ] Real browser validation (Chrome / Firefox / Safari) — not done; happy to add if you'd like

🤖 Generated with [Claude Code](https://claude.com/claude-code)