### PR TITLE
linalg/mmm: hoist TLS borrow + sync out of per-tile loop

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -57,3 +57,7 @@ proptest.workspace = true
 criterion = { version = "0.8", default-features = false, features = ["plotters", "cargo_bench_support"] }
 # Wasm doesn't support the `fork` feature of proptest.
 proptest = { version = "1.0.0", default-features = false, features = ["std", "bit-set"] }
+
+[[bench]]
+name = "plan_overhead"
+harness = false

--- a/core/benches/plan_overhead.rs
+++ b/core/benches/plan_overhead.rs
@@ -1,0 +1,42 @@
+//! Plan-loop dispatch overhead micro-bench.
+//!
+//! Builds chains of N trivial ops (Add(unique-const)) and measures `plan.run()`
+//! wall-time. Per-op dispatch overhead is `ns_per_run / n_nodes` for large N
+//! (small N is dominated by run-entry cost).
+//!
+//! Use this to detect regressions in `do_exec_plan_with_eval`'s per-node loop.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use tract_core::internal::*;
+use tract_core::ops::math::add;
+
+const VEC_LEN: usize = 8;
+
+fn build_chain(n: usize) -> Arc<TypedRunnableModel> {
+    let mut model = TypedModel::default();
+    let input_fact = f32::fact([VEC_LEN]);
+    let mut prev = model.add_source("input", input_fact).unwrap();
+    for i in 0..n {
+        let v = (i as f32 + 1.0) * 1e-6;
+        let c = model.add_const(format!("c{i}"), tensor1(&vec![v; VEC_LEN])).unwrap();
+        prev = model.wire_node(format!("a{i}"), add(), &[prev, c]).unwrap()[0];
+    }
+    model.select_output_outlets(&[prev]).unwrap();
+    model.into_optimized().unwrap().into_runnable().unwrap()
+}
+
+fn bench_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("plan_overhead");
+    let input: TValue = tensor1(&vec![1.0f32; VEC_LEN]).into();
+
+    for &n in &[1, 10, 100, 1000] {
+        let plan = build_chain(n);
+        group.bench_function(format!("chain_n{n}"), |b| {
+            b.iter(|| plan.run(tvec![input.clone()]).unwrap())
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_chain);
+criterion_main!(benches);

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -227,12 +227,12 @@ unsafe fn run_with_scratch_space_vec<K: MatMatMulKer>(
 ) -> TractResult<()> {
     unsafe {
         match crate::multithread::current_tract_executor() {
-            Executor::SingleThread => {
+            Executor::SingleThread => scratch.run_in_tls_scope(|scratch, tls| {
                 for ia in 0..m.divceil(ker.mr()) {
-                    scratch.run(ker, non_linear, ia, 0)?;
+                    scratch.run_one_tile(ker, non_linear, tls, ia, 0)?;
                 }
-                Ok(())
-            }
+                TractResult::Ok(())
+            }),
             #[cfg(feature = "multithread-mm")]
             Executor::MultiThread(pool) => {
                 chunked_dispatch_rayon(Some(&pool), m.divceil(ker.mr()), 1, |ia, _| {
@@ -258,14 +258,14 @@ unsafe fn run_with_scratch_space_col_outer<K: MatMatMulKer>(
 ) -> TractResult<()> {
     unsafe {
         match crate::multithread::current_tract_executor() {
-            Executor::SingleThread => {
+            Executor::SingleThread => scratch.run_in_tls_scope(|scratch, tls| {
                 for ib in 0..n.divceil(ker.nr()) {
                     for ia in 0..m.divceil(ker.mr()) {
-                        scratch.run(ker, non_linear, ia, ib)?;
+                        scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
                     }
                 }
-                Ok(())
-            }
+                TractResult::Ok(())
+            }),
             #[cfg(feature = "multithread-mm")]
             Executor::MultiThread(pool) => chunked_dispatch_rayon(
                 Some(&pool),
@@ -292,14 +292,14 @@ unsafe fn run_with_scratch_space_row_outer<K: MatMatMulKer>(
 ) -> TractResult<()> {
     unsafe {
         match crate::multithread::current_tract_executor() {
-            Executor::SingleThread => {
+            Executor::SingleThread => scratch.run_in_tls_scope(|scratch, tls| {
                 for ia in 0..m.divceil(ker.mr()) {
                     for ib in 0..n.divceil(ker.nr()) {
-                        scratch.run(ker, non_linear, ia, ib)?;
+                        scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
                     }
                 }
-                Ok(())
-            }
+                TractResult::Ok(())
+            }),
             #[cfg(feature = "multithread-mm")]
             Executor::MultiThread(pool) => chunked_dispatch_rayon(
                 Some(&pool),

--- a/linalg/src/frame/mmm/scratch.rs
+++ b/linalg/src/frame/mmm/scratch.rs
@@ -14,7 +14,7 @@ thread_local! {
 }
 
 #[derive(Default, Debug)]
-struct TLSScratch {
+pub(crate) struct TLSScratch {
     generation: usize,
     blob: Blob,
     ker_specs_16: Vec<FusedKerSpec<f16>>,
@@ -204,33 +204,55 @@ impl<TI: LADatum> ScratchSpaceImpl<TI> {
         down: usize,
         right: usize,
     ) -> TractResult<()> {
+        // Per-tile entry: enter the TLS scope (does sync once) then run a single
+        // tile. Single-threaded callers should prefer `run_in_tls_scope`+
+        // `run_one_tile` to amortise the TLS borrow + sync over many tiles.
         unsafe {
-            TLS.with_borrow_mut(|tls| {
-                tls.sync(self);
-                if down < self.valid_down_tiles && right < self.valid_right_tiles {
-                    self.for_valid_tile(ker, specs, tls, down, right)?;
-                    let err = ker.kernel(tls.ker_specs());
-                    debug_assert_eq!(err, 0, "Kernel return error {err}");
-                } else {
-                    let remnant_down =
-                        if down < self.valid_down_tiles { ker.mr() } else { self.remnant_down };
-                    let remnant_right =
-                        if right < self.valid_right_tiles { ker.nr() } else { self.remnant_right };
-                    self.for_border_tile(
-                        ker,
-                        specs,
-                        tls,
-                        down,
-                        right,
-                        remnant_down,
-                        remnant_right,
-                    )?;
-                    let err = ker.kernel(tls.ker_specs());
-                    debug_assert_eq!(err, 0, "Kernel return error {err}");
-                    self.postprocess_tile(specs, tls, down, right, remnant_down, remnant_right)?;
-                }
-                Ok(())
-            })
+            self.run_in_tls_scope(|this, tls| this.run_one_tile(ker, specs, tls, down, right))
+        }
+    }
+
+    /// Borrow the per-thread scratch blob for a single MMM call and `sync` it
+    /// once. The closure is invoked once with a mutable reference to the TLS
+    /// scratch and to `self`. Used by single-threaded matmul drivers to avoid
+    /// re-entering TLS / re-running `sync` per tile.
+    pub(crate) unsafe fn run_in_tls_scope<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&Self, &mut TLSScratch) -> R,
+    {
+        TLS.with_borrow_mut(|tls| {
+            tls.sync(self);
+            f(self, tls)
+        })
+    }
+
+    /// Run a single tile against an already-borrowed TLS scratch. Caller is
+    /// responsible for entering `run_in_tls_scope` first (so `sync` has run).
+    #[inline(always)]
+    pub(crate) unsafe fn run_one_tile(
+        &self,
+        ker: &impl MatMatMulKer<Acc = TI>,
+        specs: &[FusedSpec],
+        tls: &mut TLSScratch,
+        down: usize,
+        right: usize,
+    ) -> TractResult<()> {
+        unsafe {
+            if down < self.valid_down_tiles && right < self.valid_right_tiles {
+                self.for_valid_tile(ker, specs, tls, down, right)?;
+                let err = ker.kernel(tls.ker_specs());
+                debug_assert_eq!(err, 0, "Kernel return error {err}");
+            } else {
+                let remnant_down =
+                    if down < self.valid_down_tiles { ker.mr() } else { self.remnant_down };
+                let remnant_right =
+                    if right < self.valid_right_tiles { ker.nr() } else { self.remnant_right };
+                self.for_border_tile(ker, specs, tls, down, right, remnant_down, remnant_right)?;
+                let err = ker.kernel(tls.ker_specs());
+                debug_assert_eq!(err, 0, "Kernel return error {err}");
+                self.postprocess_tile(specs, tls, down, right, remnant_down, remnant_right)?;
+            }
+            Ok(())
         }
     }
 


### PR DESCRIPTION
## Summary

`ScratchSpaceImpl::run()` enters the thread-local `TLS` cell and runs `tls.sync(self)` **once per tile**. For an M×N MMM split into many tiles, the per-tile TLS access (and the `sync` function call past the first generation match) is pure overhead.

This patch lets the **single-threaded** `run_with_scratch_space_*` drivers (`vec` / `col_outer` / `row_outer`) enter TLS once per MMM call:

- New `ScratchSpaceImpl::run_in_tls_scope(f)` — borrows TLS, runs `sync` once, calls `f(self, &mut TLSScratch)`.
- New `run_one_tile(...)` — per-tile body without TLS access (caller must already be inside `run_in_tls_scope`).
- Existing `run()` keeps its prior behaviour and wraps the two new calls; multi-threaded paths still use it because each rayon worker owns its own TLS.

`TLSScratch` becomes `pub(crate)` so the closure type can be named within the crate.

## Bench

DFN3 (Apple M1 Pro, `RAYON_NUM_THREADS=1`, T=100 input, 50 outer × `tract bench --warmup-time 500 --max-time 2000`):

| model | baseline `min` | fix `min` | Δ | Mann-Whitney one-sided p |
|---|---|---|---|---|
| `enc.onnx` | 9.335 ms | 9.149 ms | **−2.0%** | 1.6×10⁻¹⁴ |
| `erb_dec.onnx` | 9.260 ms | 9.106 ms | **−1.4%** | 4.0×10⁻¹⁷ |
| `df_dec.onnx` | 10.921 ms | 10.787 ms | **−1.1%** | 3.7×10⁻¹⁶ |

Drift between two independent fix runs (same code, ~20 min apart): <0.3%/model — the gain is not thermal noise.

Total weighted DFN3 inference: **−1.3%** (≈0.4 ms / 31 ms across enc + erb_dec + df_dec).

The wins generalise to any single-threaded MMM-heavy graph; multi-threaded behaviour is bit-for-bit unchanged.

## Profiler trace

Pre-patch erb_dec self-time on M1 Pro (samply, 4 kHz):
```
1.03%  TLSScratch::sync
1.03%  std::thread::local::LocalKey::with
```
Both visible inside the per-tile loop of `run_with_scratch_space_*`.

Post-patch the loop body is `run_one_tile` (no TLS access); only the outer `run_in_tls_scope` enters TLS once per MMM call.

## Test plan

- [x] `cargo test -p tract-linalg --release` — **3524 / 3524 pass**, 0 failures
- [x] `cargo test --release` across `tract-data`, `tract-linalg`, `tract-core`, `tract-hir`, `tract-nnef`, `tract-onnx`, `tract-onnx-opl`, `tract-pulse`, `tract-pulse-opl`, `tract-extra`, `tract-transformers` — **4059 / 4059 pass**, 0 failures
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p tract-linalg --release` — **no new warnings** (12 pre-existing, identical count on baseline)
- [x] `cargo bench --bench plan_overhead` (`tract-core`'s synthetic chain bench, included with this PR's regression bench) — chain_n1000 within session noise of baseline (the chain has no MMM, so the patch is a no-op there as expected)
- [x] DFN3 reproducibility re-run (`fix9b`): drift between back-to-back fix runs <0.3%/model, confirming gain is not thermal
- [x] **DFN3 output bit-exact identical** to baseline (max_abs_diff = 0 across all 9 output tensors of enc/erb_dec/df_dec; both tract versions also match PyTorch reference output within 1e-5 of standard f32 drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Note on embedded targets

Numbers above are M1 Pro. The win comes from skipping a thread-local borrow + a function call per tile, both of which are **slower on embedded ARM** (Cortex-A series typically resolves `pthread_getspecific` in several ns vs M1's ~1-2 ns). On Sonos's streaming-inference hardware the gain is plausibly **~1.5-2× larger** than the M1 numbers in this PR — though I haven't measured directly. Wasm targets benefit similarly: TLS access itself is cheap on wasm, but the per-tile `sync` function call is not, and that's eliminated for all but the first tile of each MMM.