### PR TITLE
linalg/pack: add rbytes=96 and 128 fast paths for mn_major packing

### DIFF
--- a/linalg/src/frame/pack.rs
+++ b/linalg/src/frame/pack.rs
@@ -311,6 +311,8 @@ impl PackedFormat {
                 32 => pack_mn_major::<[u8; 32]>(bb, pbb, panel_len, k_stride_bytes, mn_range_bytes, k_range),
                 48 => pack_mn_major::<[u8; 48]>(bb, pbb, panel_len, k_stride_bytes, mn_range_bytes, k_range),
                 64 => pack_mn_major::<[u8; 64]>(bb, pbb, panel_len, k_stride_bytes, mn_range_bytes, k_range),
+                96 => pack_mn_major::<[u8; 96]>(bb, pbb, panel_len, k_stride_bytes, mn_range_bytes, k_range),
+                128 => pack_mn_major::<[u8; 128]>(bb, pbb, panel_len, k_stride_bytes, mn_range_bytes, k_range),
                 _ => {
                     let mut packer = self.write_with_k_outer(pb, k_range.len(), mn_range.len());
                     for k in k_range {


### PR DESCRIPTION
## Summary

`PackedFormat::pack_t`'s `mn_major` dispatch matches on `rbytes` (= datum × kernel-r) and routes to a `Chunk: Copy` specialised inner loop. The match covered N ∈ {16, 24, 32, 48, 64} but not **96 or 128**, so the f32 panels with r=24 (rbytes=96) and r=32 (rbytes=128) — the two dominant ARM64 f32 widths — fell through to the per-element `KOutWriter` state-machine path.

This patch adds the two missing arms (2 lines):

```rust
+ 96 => pack_mn_major::<[u8; 96]>(bb, pbb, panel_len, k_stride_bytes, mn_range_bytes, k_range),
+ 128 => pack_mn_major::<[u8; 128]>(bb, pbb, panel_len, k_stride_bytes, mn_range_bytes, k_range),
```

## Bench

DFN3 (Apple M1 Pro, `RAYON_NUM_THREADS=1`, T=100 input, n=200 baseline + n=150 fix interleaved across 4 baseline + 3 fix runs to control thermal drift):

| submodel | base mean | fix mean | Δ mean | bootstrap 95% CI | Mann-Whitney p |
|---|---|---|---|---|---|
| `enc.onnx` | 9.832 ms | 9.692 ms | **−1.42%** | [−1.66%, −1.19%] | 4×10⁻²⁶ |
| `erb_dec.onnx` | 9.830 ms | 9.731 ms | **−1.01%** | [−1.20%, −0.81%] | 1×10⁻²³ |
| `df_dec.onnx` | 11.130 ms | 11.141 ms | +0.10% | [−0.10%, +0.31%] | 0.59 (no signal) |

Drift control: 3 fix runs interleaved with 4 baseline runs; the gain reproduces consistently across them, ruling out thermal artefacts.

The win is on **mean** rather than `min` (min deltas are within noise). That's expected given the patch eliminates an occasional slow path triggered by particular panel widths rather than shifting the steady-state floor — it removes a long-tail contribution to inference time.

## Profiler trace

Pre-patch erb_dec (samply, 4 kHz):
- 3.83% self `tract_linalg::frame::pack::PackedFormat::pack_t`
- 4.27% incl `pack_tensor_view`

The slow per-element path emits its body via `write_with_k_outer` which has worse vectorisation than the templated `pack_mn_major::<[u8; N]>` chunked copy. Filling in the missing chunk widths puts the f32-r24 and f32-r32 paths back on the fast lane.

## Test plan

- [x] `cargo test -p tract-linalg --release` — **3524 / 3524 pass**, 0 failures
- [x] `cargo build --release -p tract-cli` — clean build
- [x] Bit-exact DFN3 output verification: ran both binaries (baseline and fix) on `enc/erb_dec/df_dec` reference NPZ inputs, compared output `.npz` element-wise — `max_abs_diff = 0` across all 9 output tensors. The patch is byte-for-byte identical to baseline tract on DFN3 inference.
- [x] DFN3 perf: 4 interleaved baseline + 3 interleaved fix runs (n=200/150 samples), Mann-Whitney one-sided p < 10⁻²³ on enc and erb_dec.
- [x] `cargo fmt --check` clean (no diff from cargo fmt).

## Note on coverage

This patch only helps panel widths whose `rbytes` happens to equal 96 or 128. On ARM64 f32 that's the dominant case (the 32×* family). On other targets and datums the existing arms already cover them. If r=64 (rbytes=256) becomes a hot kernel size in the future, the same pattern applies — the match will just need another arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)