### PR TITLE
cli+pulse: bind streaming symbol on session for pulse run path

### DIFF
--- a/api/rs/src/lib.rs
+++ b/api/rs/src/lib.rs
@@ -410,7 +410,7 @@ impl RunnableInterface for Runnable {
                 &self.0,
                 &BenchLimits::default(),
                 &mut annotations,
-                &RunTensors { sources: vec![inputs] },
+                &RunTensors { sources: vec![inputs], streaming_input_len: None },
                 None,
                 true,
             )?;

--- a/api/tests/mobilenet/mod.rs
+++ b/api/tests/mobilenet/mod.rs
@@ -156,7 +156,7 @@ fn test_pulse() -> anyhow::Result<()> {
     assert_eq!(typed.output_fact(0)?.to_string(), "5,1000,f32");
     let mut properties = typed.property_keys()?;
     properties.sort();
-    assert_eq!(&properties, &["pulse.delay", "pulse.input_axes", "pulse.output_axes"]);
+    assert_eq!(&properties, &["pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]);
     assert_eq!(typed.property("pulse.delay")?.as_slice::<i64>()?, &[0i64]);
     Ok(())
 }
@@ -194,7 +194,7 @@ fn test_runtime_properties() -> anyhow::Result<()> {
     let runnable = typed.into_runnable()?;
     let mut properties = runnable.property_keys()?;
     properties.sort();
-    assert_eq!(&properties, &["pulse.delay", "pulse.input_axes", "pulse.output_axes"]);
+    assert_eq!(&properties, &["pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]);
     assert_eq!(runnable.property("pulse.delay")?.as_slice::<i64>()?, &[0i64]);
     Ok(())
 }

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -182,9 +182,49 @@ where
         Vec::new()
     };
 
+    // Pre-compute the streaming-symbol binding so we can re-apply it every
+    // turn (run_plan_with_eval calls reset_turn at the end, wiping
+    // resolved_symbols).  Without this, PulsePad's `end_input.eval(...)`
+    // hits the `usize::MAX` fallback and the tail-pad fill silently never
+    // triggers — pulse output then disagrees with batch on the boundary.
+    let pulse_sym_binding: Option<(Symbol, i64)> =
+        if let (Some(sym_name), Some(stream_len), Some(first_input)) = (
+            state
+                .model()
+                .properties
+                .get("pulse.streaming_symbol")
+                .and_then(|t| t.to_plain_array_view::<String>().ok())
+                .and_then(|a| a.first().cloned()),
+            inputs.streaming_input_len,
+            inputs.sources.first().and_then(|t| t.first()),
+        ) {
+            let input_axes = state
+                .model()
+                .properties
+                .get("pulse.input_axes")
+                .context("Expect pulse.input_axes when pulse.streaming_symbol is set")?
+                .cast_to::<i64>()?;
+            let input_axis = input_axes.try_as_plain()?.as_slice::<i64>()?[0] as usize;
+            let pulse_value = first_input.shape()[input_axis];
+            // Linear case: stream.dim = pulse_value · symbol.  For non-linear
+            // dims (e.g. `4·s + 1`) this would be wrong, but blockified models
+            // arrive here with a chunk-aligned linear dim by construction.
+            if pulse_value > 0 && stream_len % pulse_value == 0 {
+                let sym = state.model().symbols.sym(&sym_name);
+                Some((sym, (stream_len / pulse_value) as i64))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
     let mut sources = inputs.sources;
     for turn in 0..sources.len() {
         let inputs = std::mem::replace(&mut sources[turn], TVec::new());
+        if let Some((sym, val)) = &pulse_sym_binding {
+            state.turn_state.resolved_symbols.set(sym, *val);
+        }
         let turn_results =
             state.run_plan_with_eval(inputs, |session_state, state, node, input| {
                 if steps {

--- a/libcli/src/tensor.rs
+++ b/libcli/src/tensor.rs
@@ -306,6 +306,13 @@ pub struct RunParams {
 
 pub struct RunTensors {
     pub sources: Vec<TVec<TValue>>,
+    /// In pulse mode, the *real* input length on the streaming axis
+    /// (i.e. before the trailing turns of zero-padding that
+    /// `get_or_make_tensors` adds to flush the pipeline).  Used by the
+    /// runner to bind the streaming symbol so PulsePad and friends
+    /// resolve `end_input` correctly at end-of-stream.  `None` for
+    /// non-pulse runs.
+    pub streaming_input_len: Option<usize>,
 }
 
 #[cfg(feature = "transformers")]
@@ -402,6 +409,7 @@ fn get_or_make_tensors(
     name: &str,
     input_idx: usize,
     target: &mut TVec<Vec<TValue>>,
+    streaming_input_len: &mut Option<usize>,
 ) -> TractResult<()> {
     if let Some(mut value) = params
         .tensors_values
@@ -467,6 +475,14 @@ fn get_or_make_tensors(
                     input_len,
                     input_pulse_axis
                 );
+            }
+            // Record the real streaming-axis length on the *first* input we
+            // see; downstream uses it to bind the streaming symbol so that
+            // PulsePad's `end_input` resolves to the correct end-of-stream.
+            // (All inputs share the same streaming dim, so picking the first
+            // is fine.)
+            if streaming_input_len.is_none() {
+                *streaming_input_len = Some(input_len);
             }
 
             // how many pulses do we need to push full result out ?
@@ -540,10 +556,19 @@ fn get_or_make_tensors(
 pub fn get_or_make_inputs(tract: &Arc<dyn Model>, params: &RunParams) -> TractResult<RunTensors> {
     // Resolve source inputs
     let mut tmp_inputs = tvec![];
+    let mut streaming_input_len = None;
     for (ix, input) in tract.input_outlets().iter().enumerate() {
         let fact = tract.outlet_typedfact(*input)?;
         let name = tract.node_name(input.node);
-        get_or_make_tensors(tract, params, fact, name, ix, &mut tmp_inputs)?;
+        get_or_make_tensors(
+            tract,
+            params,
+            fact,
+            name,
+            ix,
+            &mut tmp_inputs,
+            &mut streaming_input_len,
+        )?;
     }
 
     let n_turns = tmp_inputs.iter().map(|t| t.len()).max().unwrap_or(0);
@@ -556,7 +581,7 @@ pub fn get_or_make_inputs(tract: &Arc<dyn Model>, params: &RunParams) -> TractRe
         })
         .collect::<Vec<_>>();
 
-    Ok(RunTensors { sources })
+    Ok(RunTensors { sources, streaming_input_len })
 }
 
 fn make_inputs(values: &[impl std::borrow::Borrow<TypedFact>]) -> TractResult<TVec<TValue>> {

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -140,6 +140,22 @@ impl PulsedModelExt for PulsedModel {
                 .collect::<TractResult<TVec<i64>>>()?,
         );
         typed.properties.insert("pulse.output_axes".to_string(), output_axes.into_arc_tensor());
+        // Stash the streaming symbol's name so downstream consumers (CLI run
+        // path, etc.) can resolve `op.end_input.eval(...)` and other symbolic
+        // dims at runtime.  The symbol lives in TDims like a PulsePad's
+        // `end_input = stream.dim + …`; without binding it, those evals hit
+        // `usize::MAX` fallbacks and end-of-stream padding silently misfires.
+        let stream_syms: Vec<String> = self
+            .input_outlets()?
+            .iter()
+            .flat_map(|oo| self.outlet_fact(*oo).unwrap().stream.as_ref().unwrap().dim.symbols())
+            .map(|s| s.to_string())
+            .collect();
+        if let Some(name) = stream_syms.into_iter().next() {
+            typed
+                .properties
+                .insert("pulse.streaming_symbol".to_string(), tensor1(&[name]).into_arc_tensor());
+        }
         Ok(typed)
     }
 }


### PR DESCRIPTION
PulsePad's `end_input` is a TDim like `4*s + 2`.  When the CLI runs a pulsed model with --input-from-bundle, no one was setting the streaming symbol on the session, so `end_input.eval(...)` returned Err and the existing `unwrap_or(usize::MAX)` fallback kicked in. Result: pulse_end never crossed end_input, the tail-pad fill silently never triggered, and PulsePad forwarded the source's zero-padding unchanged.  Pulse output then disagreed with batch on the boundary windows of any pool/conv with non-zero `after` padding.

Fix three layers:

- `pulse/src/model.rs`: stash the streaming symbol's name as a `pulse.streaming_symbol` model property when converting PulsedModel back to typed.  The symbol is otherwise unrecoverable from the post-pulse typed model (input fact dim is concrete pulse value).

- `libcli/src/tensor.rs`: thread the *real* streaming-axis input length (before the trailing zero-padding turns) through RunTensors as `streaming_input_len`.  Computed naturally inside `get_or_make_tensors` from the source value's shape.

- `cli/src/run.rs`: in `run_regular_t`, pre-compute the binding from these two pieces (assuming `stream.dim = pulse_value · symbol`, which holds for chunk-aligned blockified models) and re-apply it before each `run_plan_with_eval` call — `reset_turn` clears `resolved_symbols` at the end of every turn.

This was a latent bug; existing pulse harnesses don't exercise pool after-padding so it never surfaced.