### PR TITLE
core: forward-propagate uniform_tdim to refresh stale facts

### DIFF
--- a/core/src/optim/mod.rs
+++ b/core/src/optim/mod.rs
@@ -8,6 +8,7 @@ mod concat_then_einsum;
 mod op_optim;
 mod prop_const;
 pub mod propagate_roi;
+pub mod propagate_uniform_tdim;
 mod push_split_down;
 mod slice;
 mod uniform_mask;
@@ -15,6 +16,7 @@ mod uniform_mask;
 use self::change_axes::ChangeAxes;
 use self::prop_const::PropConst;
 use self::propagate_roi::PropagateRoi;
+use self::propagate_uniform_tdim::PropagateUniformTdim;
 use self::push_split_down::PushSplitDown;
 use self::slice::PushSliceUp;
 use self::uniform_mask::FoldUniformMask;
@@ -69,6 +71,7 @@ impl Optimizer {
     pub fn declutter() -> Optimizer {
         Optimizer::passes(vec![
             Box::<PropConst>::default(),
+            Box::<PropagateUniformTdim>::default(),
             Box::<PropagateRoi>::default(),
             Box::<FoldUniformMask>::default(),
             Box::new(OpOptim("declutter", TypedOp::declutter_with_session, 0)),

--- a/core/src/optim/propagate_uniform_tdim.rs
+++ b/core/src/optim/propagate_uniform_tdim.rs
@@ -1,0 +1,75 @@
+use crate::internal::*;
+use crate::optim::OptimizerSession;
+
+/// Forward pass that refreshes `TypedFact::uniform_tdim` annotations by
+/// re-running each op's `output_facts` against its current input facts.
+///
+/// The default declutter pipeline computes a node's `uniform_tdim` once at
+/// load time, then reuses the cached fact.  Some declutter rewrites
+/// (notably `Iff` folding when the condition is provably constant) shunt a
+/// node's input edge without re-running the consumer's `output_facts` —
+/// the consumer's cached fact then references the stale upstream fact and
+/// loses any newly-available `uniform_tdim` annotation.  Every wire
+/// downstream of the shunt then sees `uniform_tdim = None`, and passes
+/// like `FoldUniformMask` or Blockify section detection silently miss it.
+///
+/// This pass walks the model in topological order, calls `output_facts`
+/// fresh on each node, and copies the recomputed `uniform_tdim` over the
+/// cached one when it differs.  Other fact fields are untouched (the
+/// existing declutter loop is responsible for them).  Iterates to fixpoint
+/// since a refreshed annotation upstream may unlock more refreshes
+/// downstream.
+#[derive(Clone, Debug, Default)]
+pub struct PropagateUniformTdim;
+
+impl super::TypedPass for PropagateUniformTdim {
+    fn reset(&mut self) -> TractResult<()> {
+        Ok(())
+    }
+
+    fn next(
+        &mut self,
+        _session: &mut OptimizerSession,
+        _model: &TypedModel,
+    ) -> TractResult<Option<TypedModelPatch>> {
+        Ok(None)
+    }
+
+    fn run_direct(&mut self, model: &mut TypedModel) -> TractResult<bool> {
+        let order = model.eval_order()?;
+        let mut any_changed = false;
+        loop {
+            let mut changed = false;
+            for &node_id in &order {
+                let typed_op = match model.nodes()[node_id].op.as_typed() {
+                    Some(op) => op,
+                    None => continue,
+                };
+                let input_facts: TVec<TypedFact> = model.nodes()[node_id]
+                    .inputs
+                    .iter()
+                    .map(|i| model.outlet_fact(*i).cloned())
+                    .collect::<TractResult<_>>()?;
+                let input_refs: TVec<&TypedFact> = input_facts.iter().collect();
+                let new_facts = match typed_op.output_facts(&input_refs) {
+                    Ok(f) => f,
+                    Err(_) => continue,
+                };
+                for (slot, new_fact) in new_facts.iter().enumerate() {
+                    let current_uniform_tdim =
+                        model.nodes()[node_id].outputs[slot].fact.uniform_tdim.clone();
+                    if current_uniform_tdim != new_fact.uniform_tdim {
+                        model.nodes_mut()[node_id].outputs[slot].fact.uniform_tdim =
+                            new_fact.uniform_tdim.clone();
+                        changed = true;
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+            any_changed = true;
+        }
+        Ok(any_changed)
+    }
+}


### PR DESCRIPTION
Some ops (notably Iff) don't compute uniform_tdim in their output_facts.  When declutter folds such an op away — typical case `Iff(x<0, Ceil, Floor)` collapsing to a bare Floor when the input range is non-negative — the consumer's input is rewired but its cached output_facts is not re-run, so it continues to advertise uniform_tdim=None even though its current upstream now provides one.  Downstream consumers of that fact (Sub / LE / GE / And / pulse's section recogniser, …) then silently lose the annotation.

Add `core/src/optim/propagate_uniform_tdim.rs`: a forward TypedPass that walks the graph in topological order, calls each op's output_facts on its current input facts, and refreshes uniform_tdim where the recomputed value differs from the cached one.  Iterates to fixpoint.  Other fact fields are untouched — the existing declutter loop owns them.  Registered in declutter() right next to PropagateRoi.