### PR TITLE
pulse: declutter after detect_diag_gather inside PulseTransform

### DIFF
--- a/pulse/src/lib.rs
+++ b/pulse/src/lib.rs
@@ -45,15 +45,9 @@ impl ModelTransform for PulseTransform {
         let symbol = self.0.symbol.as_deref().unwrap_or("S");
         let sym = model.symbols.sym(symbol);
         let pulse_dim = parse_tdim(&model.symbols, &self.0.pulse)?;
-        // Pre-pulsification: fold skew-trick chains into DiagGather.  Then
-        // re-run ROI propagation — the fold replaces Slice nodes that may
-        // have carried ROI annotations, so the new DiagGather needs its own
-        // ROI re-derived from downstream consumers.  Both are no-op idempotent
-        // when nothing changes, so they run unconditionally.
         ops::diag_gather::detect_diag_gather(model)?;
         tract_core::optim::propagate_roi::PropagateRoi.run_direct(model)?;
-        // Pulsification (which calls Blockify internally) consumes the
-        // model and produces a typed pulsed graph.
+        model.declutter()?;
         let pulsed = model::PulsedModel::new(model, sym, &pulse_dim)?;
         *model = pulsed.into_typed()?;
         Ok(())


### PR DESCRIPTION
The fold leaves dead Pad/Reshape/Slice nodes that confuse blockify's section recogniser.  The CLI's stage pipeline runs declutter between '-t' transforms, so '-t diag_gather_fold -t pulse' works while plain '-t pulse' didn't.