### PR TITLE
pulse+blockify: pulse-driven substitute, blockify becomes a section r…

### DIFF
--- a/pulse/src/blockify.rs
+++ b/pulse/src/blockify.rs
@@ -179,43 +179,65 @@ impl ModelTransform for BlockifyTransform {
         if !sections.iter().all(|s| s.mask.chunk_size == k) {
             bail!(
                 "Blockify found multiple quadratic sections with mismatched chunk \
-                 sizes; a single global symbol substitution cannot cover them.  \
+                 sizes; a single global substitution cannot cover them.  \
                  Refusing to blockify rather than produce a partial rewrite."
             );
         }
 
-        // Phase 1: introduce S, substitute T → k·S globally via core.
         let chunk_sym = model.symbols.new_with_prefix("S");
         let subs: HashMap<Symbol, TDim> =
             HashMap::from([(stream_sym.clone(), chunk_sym.to_dim() * k)]);
-        let mut new_model = model.substitute_symbols(&subs)?;
-
-        // Phase 2: one TypedModelPatch per section.  Sections the rewriter
-        // can't fully handle (unknown body op, out-of-range mask form, …)
-        // bail out of `build_section_patch` with a specific error: better
-        // a clear Blockify failure here than a confusing pulsification
-        // error a few stages later.
-        for sec in &sections {
-            let patch = build_section_patch(&new_model, sec, &chunk_sym, k)?;
-            patch.apply(&mut new_model)?;
-        }
-
-        // Ancillary outputs — describe the substitution for downstream
-        // consumers (e.g. the pulse transform that needs to translate its
-        // pulse value from token-units to chunk-units).
-        new_model.properties.insert(
-            BLOCKIFY_CHUNK_SYMBOL.to_string(),
-            tensor1(&[format!("{chunk_sym}")]).into_arc_tensor(),
-        );
-        new_model.properties.insert(BLOCKIFY_CHUNK_SIZE.to_string(), tensor0(k).into_arc_tensor());
-        new_model.properties.insert(
+        let new_model = model.substitute_symbols(&subs)?;
+        *model = new_model;
+        rewrite_sections(model, &chunk_sym, k)?;
+        model.properties.insert(
             BLOCKIFY_ORIGINAL_SYMBOL.to_string(),
             tensor1(&[symbol_name.to_string()]).into_arc_tensor(),
         );
-
-        *model = new_model;
         Ok(())
     }
+}
+
+pub fn has_quadratic_sections(model: &TypedModel, stream_sym: &Symbol) -> TractResult<bool> {
+    Ok(!find_quadratic_sections(model, stream_sym)?.is_empty())
+}
+
+/// Rewrite every quadratic section in `model`.  The model is expected to
+/// already be in post-substitute form (streaming dim = `multiplier · chunk_sym`).
+/// `substitute_multiplier` is recorded as `BLOCKIFY_CHUNK_SIZE` for downstream
+/// pulse-value translation; the section rewrite itself uses each section's
+/// own `mask.chunk_size` for its chunked Reshape.
+pub fn rewrite_sections(
+    model: &mut TypedModel,
+    chunk_sym: &Symbol,
+    substitute_multiplier: i64,
+) -> TractResult<bool> {
+    let sections = find_quadratic_sections(model, chunk_sym)?;
+    if sections.is_empty() {
+        return Ok(false);
+    }
+    let k = sections[0].mask.chunk_size;
+    if !sections.iter().all(|s| s.mask.chunk_size == k) {
+        bail!(
+            "Blockify found multiple quadratic sections with mismatched chunk \
+             sizes; a single global substitution cannot cover them.  \
+             Refusing to blockify rather than produce a partial rewrite."
+        );
+    }
+
+    for sec in &sections {
+        let patch = build_section_patch(model, sec, chunk_sym, sec.mask.chunk_size)?;
+        patch.apply(model)?;
+    }
+
+    model.properties.insert(
+        BLOCKIFY_CHUNK_SYMBOL.to_string(),
+        tensor1(&[format!("{chunk_sym}")]).into_arc_tensor(),
+    );
+    model
+        .properties
+        .insert(BLOCKIFY_CHUNK_SIZE.to_string(), tensor0(substitute_multiplier).into_arc_tensor());
+    Ok(true)
 }
 
 /// Read back the `(chunk_symbol, chunk_size)` ancillary outputs that

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -66,6 +66,34 @@ pub fn stream_axis_lcm(inputs: &[&PulsedFact]) -> Option<TDim> {
     dims.try_fold(first, |acc, d| acc.lcm(d))
 }
 
+/// Pulse-driven path: the pulse value is concrete, so we mint S, substitute
+/// `T → pulse_value · S` ourselves, and call blockify just for the section
+/// rewrites.  The audio-side multiplier is user-driven — required when
+/// there's subsampling between the streaming source and the section's mask
+/// wire (e.g. a stride-2 pool: audio chunk = 2 × post-pool chunk).
+fn pulse_driven_blockify(
+    model: &mut TypedModel,
+    symbol: &Symbol,
+    pulse_value: i64,
+) -> TractResult<(Symbol, TDim)> {
+    let chunk_sym = model.symbols.new_with_prefix("S");
+    // `S >= 0` is the precondition for the `Div(Add([k·X, …, c]), k) → X`
+    // simplification (commit 11b310622).  Without it, post-substitute shapes
+    // like `1 + (3 + 56·S)/4` stay unreduced and blockify's chunked Reshape
+    // volume check fails comparing them to `14·S`.
+    model.symbols.add_assertion(format!("{chunk_sym} >= 0"))?;
+    let subs: HashMap<Symbol, TDim> =
+        HashMap::from([(symbol.clone(), chunk_sym.to_dim() * pulse_value)]);
+    *model = model.substitute_symbols(&subs)?;
+    crate::blockify::rewrite_sections(model, &chunk_sym, pulse_value)?;
+    model.properties.insert(
+        crate::blockify::BLOCKIFY_ORIGINAL_SYMBOL.to_string(),
+        tensor1(&[format!("{symbol}")]).into_arc_tensor(),
+    );
+    // Streaming dim is now `pulse_value · S`, so one pulse covers exactly one S.
+    Ok((chunk_sym, 1.to_dim()))
+}
+
 #[allow(clippy::new_ret_no_self)]
 pub trait PulsedModelExt {
     fn new(source: &TypedModel, symbol: Symbol, pulse: &TDim) -> TractResult<PulsedModel>;
@@ -90,35 +118,16 @@ impl PulsedModelExt for PulsedModel {
         pulse: &TDim,
     ) -> TractResult<(PulsedModel, HashMap<OutletId, OutletId>)> {
         check_no_unannotated_superlinear_wires(source, &symbol)?;
-        // Blockify rewrites multi-streaming-axis subgraphs (block-diagonal
-        // attention-like patterns) into single-streaming-axis chunked form
-        // before pulsification.  When it fires, it rebinds the streaming
-        // symbol from T (token count) to S (chunk count) and stashes
-        // (chunk_symbol, chunk_size) in model.properties; we read those
-        // back to translate the pulse value.  No-op if no such pattern.
-        use tract_core::transform::ModelTransform;
         let mut blockified = source.clone();
-        crate::blockify::BlockifyTransform(crate::blockify::BlockifyConfig {
-            symbol: Some(format!("{symbol}")),
-        })
-        .transform(&mut blockified)?;
-        let (stream_sym, pulse_dim) = match crate::blockify::blockify_output(&blockified) {
-            Some((chunk_sym, k)) => {
-                let translated =
-                    pulse.clone().maybe_div(&k.to_dim()).map(|(d, _)| d).map_err(|e| {
-                        format_err!("Blockify: pulse {pulse} not divisible by chunk size {k}: {e}")
-                    })?;
-                (chunk_sym, translated)
+        let (stream_sym, pulse_dim) = match pulse.as_i64() {
+            Some(pv) if crate::blockify::has_quadratic_sections(&blockified, &symbol)? => {
+                pulse_driven_blockify(&mut blockified, &symbol, pv)?
             }
-            None => (symbol, pulse.clone()),
+            _ => (symbol, pulse.clone()),
         };
         let pulsifiers = crate::ops::OpPulsifier::inventory();
         let (mut pulsed, mapping) = Pulsifier(stream_sym, pulse_dim, pulsifiers)
             .translate_model_with_mappings(&blockified)?;
-        // Forward Blockify's bookkeeping (chunk_symbol/chunk_size/original
-        // symbol) onto the pulsed model so downstream consumers — notably
-        // the CLI's `compare --stream` symbol-binding — can see what the
-        // stream symbol got translated to.
         for key in [
             crate::blockify::BLOCKIFY_CHUNK_SYMBOL,
             crate::blockify::BLOCKIFY_CHUNK_SIZE,


### PR DESCRIPTION
…ewriter

Blockify auto-discovered `k` from the mask's `chunk_size` and substituted `T → k·S` itself.  When there's subsampling between the streaming source and the mask wire (e.g. ex11's stride-2 pool), the mask's chunk size is in post-subsample units while T is in pre-subsample (audio) units — blockify picked the wrong audio-side `k`.

Split the responsibility: add `rewrite_sections(model, chunk_sym, mul)` that assumes the model is already in post-substitute form and just rewrites sections.  `PulsedModel::new` mints S, substitutes `T → pulse_value · S`, and hands off to `rewrite_sections` — only when the pulse value is concrete and the model has quadratic sections. Otherwise the pulse path runs unchanged (no blockify invocation).

`BlockifyTransform::transform` keeps its standalone auto-discover behaviour and remains registered as `-t blockify` for CLI auditing, but is no longer called implicitly from `PulsedModel::new`.

The pulse-driven path also asserts `S >= 0` on the new chunk symbol before substitute, so tract's `Div(Add([k·X, …, c]), k) → X` simplifier (gated on `prove_positive_or_zero`) can reduce post-substitute shapes like `1 + (3 + 56·S)/4` that the blockify Reshape volume check then compares to `14·S`.