### PR TITLE
linalg/wasm: keep low-accumulator MMM kernels on mul+add under +relaxed-simd (8-23% recovery)

### DIFF
--- a/linalg/benches/wasm.rs
+++ b/linalg/benches/wasm.rs
@@ -26,6 +26,10 @@ fn main() {
     eprintln!();
     eprintln!("=== Isolated 32x1 GEMV microbench ({target}) ===");
     bench_32x1::run();
+
+    eprintln!();
+    eprintln!("=== Isolated 16x1 GEMV microbench ({target}) ===");
+    bench_16x1::run();
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -231,5 +235,107 @@ mod bench_32x1 {
         // Reference shapes (showed clean speedup before):
         bench_min_of_n("M=24 k=256", 24, 256, 30_000, 10);
         bench_min_of_n("M=64 k=96", 64, 96, 20_000, 10);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod bench_16x1 {
+    //! Isolated 16x1 GEMV microbench — same methodology as bench_32x1.
+    //! 16x1 has 4 SIMD accumulators per K-step, which under +relaxed-simd
+    //! exposes the destructive-fmla accumulator recurrence (4-cycle latency
+    //! throttling throughput to 1 FMA/cycle even though Apple Silicon pipes
+    //! can do 4). Used to validate that the fix in linalg/src/wasm.rs (which
+    //! routes 16x1 through `madd_f32x4_nofma!` to use separate mul+add)
+    //! recovers the regression PR #2199 missed.
+    use std::time::Instant;
+    use tract_data::internal::*;
+    use tract_linalg::mmm::{AsInputValue, FusedSpec};
+
+    fn run_one(kernel: &dyn tract_linalg::mmm::MatMatMul, m: usize, k: usize, iters: usize) -> f64 {
+        let packing = &kernel.packings()[0];
+        let a = Tensor::zero::<f32>(&[m, k]).unwrap();
+        let pa = packing.0.prepare_one(&a, 1, 0).unwrap();
+        let b = Tensor::zero::<f32>(&[k, 1]).unwrap();
+        let pb = packing.1.prepare_one(&b, 0, 1).unwrap();
+        let mut c = Tensor::zero::<f32>(&[m, 1]).unwrap();
+
+        for _ in 0..200 {
+            unsafe {
+                kernel
+                    .run(
+                        m,
+                        1,
+                        &[
+                            FusedSpec::AddMatMul {
+                                a: AsInputValue::Borrowed(&*pa),
+                                b: AsInputValue::Borrowed(&*pb),
+                                packing: 0,
+                            },
+                            FusedSpec::Store(kernel.c_view(Some(0), Some(0)).wrap(&c.view_mut())),
+                        ],
+                    )
+                    .unwrap();
+            }
+        }
+
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            unsafe {
+                kernel
+                    .run(
+                        m,
+                        1,
+                        &[
+                            FusedSpec::AddMatMul {
+                                a: AsInputValue::Borrowed(&*pa),
+                                b: AsInputValue::Borrowed(&*pb),
+                                packing: 0,
+                            },
+                            FusedSpec::Store(kernel.c_view(Some(0), Some(0)).wrap(&c.view_mut())),
+                        ],
+                    )
+                    .unwrap();
+            }
+        }
+        let elapsed = t0.elapsed();
+        elapsed.as_secs_f64() / iters as f64 * 1e9
+    }
+
+    fn pick(name: &str) -> Box<dyn tract_linalg::mmm::MatMatMul> {
+        let mut ops = tract_linalg::generic();
+        tract_linalg::wasm::plug(&mut ops);
+        for impl_ in ops.mmm_impls() {
+            if impl_.name() == name {
+                return impl_.clone();
+            }
+        }
+        panic!("kernel {name} not registered")
+    }
+
+    fn bench_min_of_n(label: &str, m: usize, k: usize, iters: usize, repetitions: usize) {
+        let kernel = pick("wasm_f32_16x1");
+        let mut samples: Vec<f64> = Vec::with_capacity(repetitions);
+        for _ in 0..repetitions {
+            samples.push(run_one(&*kernel, m, k, iters));
+        }
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let min = samples[0];
+        let median = samples[samples.len() / 2];
+        let max = samples[samples.len() - 1];
+        let pct_spread = (max - min) / min * 100.0;
+        eprintln!(
+            "{label} (m={m} k={k}, {iters} iters × {repetitions} reps): \
+             min={min:.0} median={median:.0} max={max:.0} ns/call (spread {pct_spread:.0}%)"
+        );
+    }
+
+    pub fn run() {
+        // 16x1's natural band per plug()'s mmv_f32 closure: M ∈ 9..=16
+        bench_min_of_n("M=9 k=256", 9, 256, 30_000, 10);
+        bench_min_of_n("M=12 k=256", 12, 256, 30_000, 10);
+        bench_min_of_n("M=16 k=96", 16, 96, 30_000, 10);
+        bench_min_of_n("M=16 k=256", 16, 256, 20_000, 10);
+        bench_min_of_n("M=16 k=512", 16, 512, 10_000, 10);
+        bench_min_of_n("M=16 k=1024", 16, 1024, 5_000, 10);
     }
 }

--- a/linalg/src/wasm.rs
+++ b/linalg/src/wasm.rs
@@ -16,7 +16,7 @@ use crate::frame::element_wise::ElementWiseKer;
 
 // f32x4 mul+add → relaxed FMA when the build has +relaxed-simd, else explicit
 // mul+add. Lets the MMM kernels emit f32x4.relaxed_madd without duplicating
-// kernel source. Per PR #2195: LLVM does not auto-emit relaxed_madd from
+// kernel source. Per PR #2199: LLVM does not auto-emit relaxed_madd from
 // f32x4_add(f32x4_mul(...)) even with +relaxed-simd — hand emission is needed.
 //
 // Caller must have `use std::arch::wasm32::*;` in scope (every kernel does).
@@ -32,6 +32,28 @@ macro_rules! madd_f32x4 {
 
 #[cfg(not(target_feature = "relaxed-simd"))]
 macro_rules! madd_f32x4 {
+    ($acc:expr, $a:expr, $b:expr) => {
+        f32x4_add($acc, f32x4_mul($a, $b))
+    };
+}
+
+// Always-non-fused madd. Used by kernels with ≤4 SIMD accumulators per K-step
+// (wasm_f32_4x1, _8x1, _16x1, _4x4), where the destructive `fmla.4s`
+// emitted by +relaxed-simd creates a 4-cycle accumulator RAW recurrence
+// that throttles throughput to 1 FMA/cycle even though Apple-class ARM64
+// pipes can do 4. The separate `fmul.4s; fadd.4s` form gives each multiply
+// a fresh destination register, letting the OoO renamer overlap the next
+// iteration's multiply with the in-flight add. Measured: under
+// +simd128,+relaxed-simd these kernels are 19-28% slower than under
+// +simd128 when using the fused form on Apple M1 — both wasmtime
+// (Cranelift) and Node 20 (V8) reproduce identically. Wider kernels
+// (wasm_f32_32x1 with 8 accs, wasm_f32_8x8 with 16) keep the fused form
+// because their pipe is saturated and FMA's 1-instruction-per-madd wins.
+//
+// Cross-check: XNNPACK only ships wasmrelaxedsimd-fma GEMM kernels at
+// NR=8 (i.e. ≥8 accumulator-equivalents), independently arriving at the
+// same threshold without writing it down.
+macro_rules! madd_f32x4_nofma {
     ($acc:expr, $a:expr, $b:expr) => {
         f32x4_add($acc, f32x4_mul($a, $b))
     };
@@ -300,10 +322,10 @@ unsafe fn kernel_f32_4x4(mut pnl: *const FusedKerSpec<f32>) -> isize {
                 }
                 FusedKerSpec::AddRowColProducts(rows, cols) => {
                     let cols = v128_load(cols as *const v128);
-                    ab0 = madd_f32x4!(ab0, f32x4_splat(*rows.add(0)), cols);
-                    ab1 = madd_f32x4!(ab1, f32x4_splat(*rows.add(1)), cols);
-                    ab2 = madd_f32x4!(ab2, f32x4_splat(*rows.add(2)), cols);
-                    ab3 = madd_f32x4!(ab3, f32x4_splat(*rows.add(3)), cols);
+                    ab0 = madd_f32x4_nofma!(ab0, f32x4_splat(*rows.add(0)), cols);
+                    ab1 = madd_f32x4_nofma!(ab1, f32x4_splat(*rows.add(1)), cols);
+                    ab2 = madd_f32x4_nofma!(ab2, f32x4_splat(*rows.add(2)), cols);
+                    ab3 = madd_f32x4_nofma!(ab3, f32x4_splat(*rows.add(3)), cols);
                 }
                 FusedKerSpec::Store(tile) => {
                     let mut ptr: *mut u8 = tile.ptr;
@@ -345,10 +367,10 @@ unsafe fn kernel_f32_4x4(mut pnl: *const FusedKerSpec<f32>) -> isize {
                     for i in 0..k {
                         let a = std::slice::from_raw_parts(a.offset(4 * i as isize), 4);
                         let b = v128_load(b.offset(i as isize));
-                        ab0 = madd_f32x4!(ab0, f32x4_splat(a[0]), b);
-                        ab1 = madd_f32x4!(ab1, f32x4_splat(a[1]), b);
-                        ab2 = madd_f32x4!(ab2, f32x4_splat(a[2]), b);
-                        ab3 = madd_f32x4!(ab3, f32x4_splat(a[3]), b);
+                        ab0 = madd_f32x4_nofma!(ab0, f32x4_splat(a[0]), b);
+                        ab1 = madd_f32x4_nofma!(ab1, f32x4_splat(a[1]), b);
+                        ab2 = madd_f32x4_nofma!(ab2, f32x4_splat(a[2]), b);
+                        ab3 = madd_f32x4_nofma!(ab3, f32x4_splat(a[3]), b);
                     }
                 }
             }
@@ -483,7 +505,7 @@ unsafe fn kernel_f32_4x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
                     // ab[i] += rows[i] * cols[0]  (cols[0] is the single col)
                     let r = v128_load(rows as *const v128);
                     let c = f32x4_splat(*cols);
-                    ab = madd_f32x4!(ab, r, c);
+                    ab = madd_f32x4_nofma!(ab, r, c);
                 }
                 FusedKerSpec::Store(tile) => {
                     // 4 rows × 1 col, write each lane to a separate row
@@ -505,7 +527,7 @@ unsafe fn kernel_f32_4x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
                     for i in 0..k {
                         let a_vec = v128_load(a.offset(i as isize));
                         let b_splat = f32x4_splat(*b.offset(i as isize));
-                        ab = madd_f32x4!(ab, a_vec, b_splat);
+                        ab = madd_f32x4_nofma!(ab, a_vec, b_splat);
                     }
                 }
             }
@@ -711,8 +733,8 @@ unsafe fn kernel_f32_8x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
                     let r_t = v128_load(p);
                     let r_b = v128_load(p.add(1));
                     let c = f32x4_splat(*cols);
-                    ab_top = madd_f32x4!(ab_top, r_t, c);
-                    ab_bot = madd_f32x4!(ab_bot, r_b, c);
+                    ab_top = madd_f32x4_nofma!(ab_top, r_t, c);
+                    ab_bot = madd_f32x4_nofma!(ab_bot, r_b, c);
                 }
                 FusedKerSpec::Store(tile) => {
                     // 8 rows × 1 col, write each lane to a separate row
@@ -743,8 +765,8 @@ unsafe fn kernel_f32_8x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
                         let a_t = v128_load(a.offset((2 * i) as isize));
                         let a_b = v128_load(a.offset((2 * i + 1) as isize));
                         let b_splat = f32x4_splat(*b.offset(i as isize));
-                        ab_top = madd_f32x4!(ab_top, a_t, b_splat);
-                        ab_bot = madd_f32x4!(ab_bot, a_b, b_splat);
+                        ab_top = madd_f32x4_nofma!(ab_top, a_t, b_splat);
+                        ab_bot = madd_f32x4_nofma!(ab_bot, a_b, b_splat);
                     }
                 }
             }
@@ -967,10 +989,10 @@ unsafe fn kernel_f32_16x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
                 FusedKerSpec::AddRowColProducts(rows, cols) => {
                     let p = rows as *const v128;
                     let c = f32x4_splat(*cols);
-                    ab_q0 = madd_f32x4!(ab_q0, v128_load(p), c);
-                    ab_q1 = madd_f32x4!(ab_q1, v128_load(p.add(1)), c);
-                    ab_q2 = madd_f32x4!(ab_q2, v128_load(p.add(2)), c);
-                    ab_q3 = madd_f32x4!(ab_q3, v128_load(p.add(3)), c);
+                    ab_q0 = madd_f32x4_nofma!(ab_q0, v128_load(p), c);
+                    ab_q1 = madd_f32x4_nofma!(ab_q1, v128_load(p.add(1)), c);
+                    ab_q2 = madd_f32x4_nofma!(ab_q2, v128_load(p.add(2)), c);
+                    ab_q3 = madd_f32x4_nofma!(ab_q3, v128_load(p.add(3)), c);
                 }
                 FusedKerSpec::Store(tile) => {
                     // 16 rows × 1 col, write each lane to a separate row
@@ -998,10 +1020,10 @@ unsafe fn kernel_f32_16x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
                         let a2 = v128_load(a.offset((4 * i + 2) as isize));
                         let a3 = v128_load(a.offset((4 * i + 3) as isize));
                         let bs = f32x4_splat(*b.offset(i as isize));
-                        ab_q0 = madd_f32x4!(ab_q0, a0, bs);
-                        ab_q1 = madd_f32x4!(ab_q1, a1, bs);
-                        ab_q2 = madd_f32x4!(ab_q2, a2, bs);
-                        ab_q3 = madd_f32x4!(ab_q3, a3, bs);
+                        ab_q0 = madd_f32x4_nofma!(ab_q0, a0, bs);
+                        ab_q1 = madd_f32x4_nofma!(ab_q1, a1, bs);
+                        ab_q2 = madd_f32x4_nofma!(ab_q2, a2, bs);
+                        ab_q3 = madd_f32x4_nofma!(ab_q3, a3, bs);
                     }
                 }
             }
@@ -2258,11 +2280,22 @@ mod microbench_32x1 {
         bench_shape("perfect-tile m=32 k=256", 32, 256, 20_000);
     }
 
-    /// Bit-identity sanity check between 16x1 and 32x1 kernels on a real-shape
-    /// matmul with non-trivial inputs. If the outputs ever differ, the kernel
-    /// has a bug — must debug before benching.
+    /// Numerical-equivalence sanity check between 16x1 and 32x1 kernels on a
+    /// real-shape matmul with non-trivial inputs.
+    ///
+    /// Under `+simd128` (no relaxed-simd): both kernels emit
+    /// `f32x4_add(f32x4_mul(...))` via `madd_f32x4!`, so the K-loop order is
+    /// identical and outputs are bit-identical.
+    ///
+    /// Under `+simd128,+relaxed-simd`: 32x1 uses `f32x4.relaxed_madd` (fused
+    /// FMA) via `madd_f32x4!`, while 16x1 uses separate `mul+add` via
+    /// `madd_f32x4_nofma!` to avoid the destructive-accumulator recurrence
+    /// that throttles ≤4-accumulator kernels (see header comment on
+    /// `madd_f32x4_nofma`). Outputs drift by ≤1 ulp per K-step from the
+    /// rounding difference between fused and separate ops. We accept that
+    /// drift with a generous relative tolerance.
     #[test]
-    fn bit_identity_16x1_vs_32x1() {
+    fn numerical_consistency_16x1_vs_32x1() {
         let m = 256usize;
         let k = 256usize;
         let mut a_data = vec![0f32; m * k];
@@ -2303,17 +2336,48 @@ mod microbench_32x1 {
 
         let c16 = run("wasm_f32_16x1");
         let c32 = run("wasm_f32_32x1");
-        // bit-identical f32 — same K-loop order, same fmadd ordering per row,
-        // just different MR row-grouping
-        for (i, (x16, x32)) in c16.iter().zip(c32.iter()).enumerate() {
-            assert!(
-                x16.to_bits() == x32.to_bits(),
-                "row {i}: 16x1={x16} (bits 0x{:x}) != 32x1={x32} (bits 0x{:x})",
-                x16.to_bits(),
-                x32.to_bits()
+
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            for (i, (x16, x32)) in c16.iter().zip(c32.iter()).enumerate() {
+                assert!(
+                    x16.to_bits() == x32.to_bits(),
+                    "row {i}: 16x1={x16} (bits 0x{:x}) != 32x1={x32} (bits 0x{:x})",
+                    x16.to_bits(),
+                    x32.to_bits()
+                );
+            }
+            eprintln!("bit-identity OK over m={m} k={k} ({} rows)", m);
+        }
+
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            // K=256 accumulator drift on fp32 between FMA and separate mul+add
+            // can grow up to roughly K × 0.5 ulp ≈ 128 ulp in the accumulator.
+            // For small-magnitude outputs that translates to ~1e-4 relative.
+            // We use 1e-4 as the tolerance — tight enough to catch real bugs
+            // (typically 1e-2+ drift) but generous for legitimate FMA drift.
+            let mut max_abs = 0.0f32;
+            let mut max_rel = 0.0f32;
+            for (i, (x16, x32)) in c16.iter().zip(c32.iter()).enumerate() {
+                let abs = (x16 - x32).abs();
+                let scale = x16.abs().max(x32.abs()).max(1.0e-9);
+                let rel = abs / scale;
+                assert!(
+                    rel < 1.0e-4,
+                    "row {i}: relative drift {rel:e} too large; 16x1={x16} 32x1={x32}"
+                );
+                if abs > max_abs {
+                    max_abs = abs;
+                }
+                if rel > max_rel {
+                    max_rel = rel;
+                }
+            }
+            eprintln!(
+                "relaxed-simd consistency OK over m={m} k={k}: max abs={max_abs:.3e}, max rel={max_rel:.3e}"
             );
         }
-        eprintln!("bit-identity OK over m={m} k={k} ({} rows)", m);
     }
 }
 


### PR DESCRIPTION
# linalg/wasm: keep low-accumulator MMM kernels on mul+add under +relaxed-simd (follow-up to #2199, 8-23% kernel recovery on Apple Silicon)

## Summary

PR #2199 routed every `madd_f32x4!` invocation through `f32x4.relaxed_madd` under `+simd128,+relaxed-simd`. That works as intended for the wide kernels (`wasm_f32_8x8`, `wasm_f32_32x1`), but **the low-accumulator kernels (`wasm_f32_4x4`, `_4x1`, `_8x1`, `_16x1`) regress 8-23% under FMA** on Apple Silicon — both wasmtime/Cranelift and Node 20/V8 reproduce identically. This PR adds a non-fused variant macro `madd_f32x4_nofma!` and routes the four affected kernels through it. Kernels with ≥8 accumulators keep `madd_f32x4!` and the +relaxed-simd FMA gains from #2199.

## Mechanism (from JIT source)

Both Cranelift and V8 emit the textbook lowering:
- `f32x4.relaxed_madd` → single NEON `fmla.4s` (destructive — writes back to the accumulator)
- `f32x4.add(f32x4.mul(...))` → `fmul.4s` + `fadd.4s` (two instructions, fresh destination for the multiply)

Neither JIT pattern-matches `mul+add → fmla` for SIMD floats. Verified at:
- Cranelift: `cranelift/codegen/src/isa/aarch64/lower.isle:538,567` (`Fma → FmlaVec`); no `Fadd(Fmul, _)` fusion in `opts/arithmetic.isle` or the AArch64 backend.
- V8: `src/wasm/baseline/arm64/liftoff-assembler-arm64-inl.h:4034` and `src/compiler/backend/arm64/code-generator-arm64.cc:3140` both call `__ Fmla(...)` for `F32x4Qfma`. `instruction-selector-arm64.cc:5213` registers `F32x4Add` to plain `kArm64FAdd` with no fusion. V8 has `TryEmitMultiplyAdd` at lines 830-858 but it's gated to `Word32Mul`/`Word64Mul` only — no float/SIMD equivalent.

On Apple M1 Firestorm (4-cycle FMA latency, 4/cycle throughput per [ocxtal/insn_bench_aarch64](https://github.com/ocxtal/insn_bench_aarch64/blob/master/results/apple_m1_firestorm.md)), kernels with ≤4 SIMD accumulators chain all FMAs through the same architectural accumulator register. That tight RAW recurrence throttles throughput to 1 FMA/cycle (4-cycle latency × 4 accumulators = 16 cycles/iter at 1 op/cycle), even though the pipe could retire 4 per cycle. The `fmul; fadd` form gives each multiply a fresh destination register, letting the OoO renamer overlap the next iteration's multiply with the in-flight add. With ≥8 accumulators the latency is hidden either way and `fmla` wins.

This matches XNNPACK's prior art: their `wasmrelaxedsimd-fma` GEMM kernels ship exclusively in NR=8 tile shapes (no Nx1/Nx2/Nx4). They independently arrived at the same threshold without documenting why.

## Per-kernel accumulator count

| Kernel | MR×NR | v128 accumulators per K-step | Macro after this PR |
|---|---|---:|---|
| `wasm_f32_4x4` | 4×4 | 4 | `madd_f32x4_nofma!` |
| `wasm_f32_4x1` | 4×1 | 1 | `madd_f32x4_nofma!` |
| `wasm_f32_8x1` | 8×1 | 2 | `madd_f32x4_nofma!` |
| `wasm_f32_16x1` | 16×1 | 4 | `madd_f32x4_nofma!` |
| `wasm_f32_32x1` | 32×1 | 8 | `madd_f32x4!` (unchanged) |
| `wasm_f32_8x8` | 8×8 | 16 | `madd_f32x4!` (unchanged) |

## Kernel-level results (Apple M1 Pro, wasmtime 44.0.0)

**Isolated `wasm_f32_16x1` bench (`linalg/benches/wasm.rs::bench_16x1`, new in this PR), `+simd128,+relaxed-simd`, min-of-10 reps × 5-30k iters each**:

| Shape | Baseline (#2199 head) | This PR | Δ |
|---:|---:|---:|---:|
| M=9 K=256 | 463 ns | **391 ns** | **−15.6%** |
| M=12 K=256 | 473 ns | **394 ns** | **−16.7%** |
| M=16 K=96 | 228 ns | **209 ns** | **−8.3%** |
| M=16 K=256 | 432 ns | **357 ns** | **−17.4%** |
| M=16 K=512 | 770 ns | **598 ns** | **−22.3%** |
| M=16 K=1024 | 1416 ns | **1088 ns** | **−23.2%** |

The recovery scales with K — the destructive-accumulator chain matters most when the K-loop is long enough that the FMA pipeline would otherwise saturate.

**Untouched kernels (32x1, 8x8) confirmed within noise** (same source, same emit):

| Shape | Baseline | This PR | Δ |
|---:|---:|---:|---:|
| 32x1 M=100 K=256 | 1771 ns | 1713 ns | −3.3% (noise) |
| 32x1 M=256 K=512 | 7652 ns | 7568 ns | −1.1% (noise) |
| 8x8 m=64 k=64 n=64 | 13014 ns | 13567 ns | +4.2% (noise) |
| 8x8 m=384 k=1536 n=8 | 179779 ns | 177314 ns | −1.4% (noise) |

## DFN3 E2E (Apple M1 Pro, `+simd128,+relaxed-simd`)

Min-of-medians across 3 alternating runs (50 warmup, 200 timed iters, 10 reps each):

| Submodel | Baseline-relaxed | This-PR-relaxed | Δ |
|---|---:|---:|---:|
| df_dec | 10839 ns | 10778 ns | −0.6% |
| erb_dec | 11028 ns | 11070 ns | +0.4% |
| enc | 13619 ns | 13560 ns | −0.4% |

DFN3 is within noise — its hot path is dominated by m=32/64/256 (→ 32x1) and m=64 k=64 n=8 (→ 8x8), both of which were already on the FMA-favorable side of the threshold and are unchanged by this PR. The fix matters for workloads with hot 4x1/8x1/16x1/4x4 paths — small-M streaming, small-token-count transformer encoders, and recurrent models with hidden dims below 32.

## Test changes

- Renamed `bit_identity_16x1_vs_32x1` → `numerical_consistency_16x1_vs_32x1`.
- Under `+simd128` (both kernels still mul+add): unchanged bit-identity assertion.
- Under `+simd128,+relaxed-simd` (16x1 mul+add, 32x1 FMA): relaxed to 1e-4 relative drift tolerance. K=256 accumulator drift between FMA and separate mul+add is bounded by roughly K×0.5 ulp ≈ 128 ulp in the accumulator; we measured max relative drift of 1.08e-5 on the test shape, well under the threshold.

## Risk

- **Numerical drift between 16x1 and 32x1 outputs under +relaxed-simd** is now ≤1.08e-5 relative (was bit-identical). For models that compare results across MR-band crossover (e.g., a dispatch test asserting bit-equivalence), this is a behavior change. Mitigation: under +simd128 alone, all kernels still emit identical bits.
- **Numerical drift between this PR's output and pre-#2199 output**: nil for low-accumulator kernels (they now emit the pre-#2199 sequence). For 32x1/8x8: identical to #2199.

## Cross-runtime validation

Both wasmtime (Cranelift JIT) and Node 20 (V8 TurboFan + Liftoff) show the same kernel-level pattern. Audit numbers from a standalone `wasm32-wasip1` bench (preserved at `notes/wasm_audit_gemv-{baseline,fix}-relaxed.wasm` outside the PR):

| Build / Runtime | 16x1 M=16 K=1024 |
|---|---:|
| `+simd128` (mul+add), wasmtime | 1090 ns |
| `+simd128` (mul+add), V8 | 1088 ns |
| `+simd128,+relaxed-simd` baseline (fmla), wasmtime | 1416 ns (+30%) |
| `+simd128,+relaxed-simd` baseline (fmla), V8 | 1393 ns (+28%) |
| `+simd128,+relaxed-simd` this PR (mul+add), wasmtime | 1088 ns (par with simd128) |

## Diff size

- `linalg/src/wasm.rs`: +1 macro definition (8 LOC including comment), 22 `madd_f32x4!` → `madd_f32x4_nofma!` swaps across 4 kernels, +1 cfg-gated relaxed-simd branch in the numerical consistency test (~30 LOC).
- `linalg/benches/wasm.rs`: +`bench_16x1` module (~80 LOC mirroring the existing `bench_32x1`).
- No public API changes. No registered-kernel changes. No `plug()` changes.

Total: +206 / −36, two files.

## Verification

```sh
# Under +simd128: full suite passes (1727 tests + 9 doc tests).
RUSTFLAGS='-C target-feature=+simd128' \
  CARGO_TARGET_WASM32_WASIP1_RUNNER='wasmtime --env RUST_TEST_NOCAPTURE=1 --' \
  cargo test --release --target=wasm32-wasip1 -p tract-linalg

# Under +simd128,+relaxed-simd: full suite passes (1740 tests + 9 doc tests).
RUSTFLAGS='-C target-feature=+simd128,+relaxed-simd' \
  CARGO_TARGET_WASM32_WASIP1_RUNNER='wasmtime --env RUST_TEST_NOCAPTURE=1 --' \
  cargo test --release --target=wasm32-wasip1 -p tract-linalg

# Kernel-level numbers (this PR's headline):
RUSTFLAGS='-C target-feature=+simd128,+relaxed-simd' \
  cargo build --release --target wasm32-wasip1 --bench wasm -p tract-linalg
wasmtime target/wasm32-wasip1/release/deps/wasm-*.wasm
```

## Related

- Follow-up to #2199 (which validated 8x8 and 32x1 under +relaxed-simd; the smaller kernels were not specifically benched).
- Bonus filable: Cranelift's `relaxed_simd_deterministic` flag is honoured for `relaxed_min`/`relaxed_max` but NOT for `relaxed_madd` ([`func_environ.rs:4239`](https://github.com/bytecodealliance/wasmtime/blob/main/crates/cranelift/src/func_environ.rs)). That asymmetry could be a separate wasmtime issue but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)