### PR TITLE
core/cnn: make eager-vs-lazy Im2col choice shape-aware

### DIFF
--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1198,13 +1198,7 @@ impl TypedOp for Conv {
             } else if input_fact
                 .shape
                 .as_concrete()
-                .map(|s| {
-                    should_use_lazy(
-                        &self.pool_spec.data_format.shape(s.into()).unwrap(),
-                        &self.pool_spec,
-                        self.group,
-                    )
-                })
+                .map(|s| should_use_lazy(&self.pool_spec, self.group, s, input_fact.datum_type))
                 .unwrap_or(false)
             {
                 let mut patch = TypedModelPatch::new("lazy-im2col");
@@ -1265,7 +1259,45 @@ fn lazy_im2col_min_kernel() -> usize {
     })
 }
 
-fn should_use_lazy(input_shape: &DataShape, pool_spec: &PoolSpec, group: usize) -> bool {
+/// Default eager-Im2col scratch-size ceiling, in bytes, above which LazyIm2col is
+/// preferred regardless of kernel volume.
+///
+/// Eager Im2col materialises a `[k, n]` packed scratch of `k·n·sizeof` bytes — it is
+/// allocated, written, then read back by the matmul. While that scratch is small it
+/// stays hot in cache and the round-trip is cheap, so the kernel-volume rule above
+/// governs. Once it is large, the materialisation becomes a pure memory-bandwidth tax
+/// (write + read of multiple MB every inference) that outweighs LazyIm2col's per-panel
+/// gather indirection — so prefer lazy. The kernel-volume rule alone misses this case:
+/// a *small* kernel over a *large* output (big `n`) still materialises multiple MB.
+///
+/// The crossover is target-dependent. On WASM the materialisation tax bites harder
+/// (no hardware-prefetch help, bounds-checked stores), so lazy wins from ~1 MiB of
+/// scratch upward. On native CPUs the caches and prefetchers absorb a few MB, so the
+/// crossover sits higher (~4 MiB, measured on Apple Silicon). Hence the per-family
+/// defaults below. Override on either target via `TRACT_LAZY_IM2COL_MAX_EAGER_BYTES`;
+/// this value is the key knob for the canary-model regression gate.
+#[cfg(target_family = "wasm")]
+const DEFAULT_LAZY_IM2COL_MAX_EAGER_BYTES: usize = 1024 * 1024;
+#[cfg(not(target_family = "wasm"))]
+const DEFAULT_LAZY_IM2COL_MAX_EAGER_BYTES: usize = 4 * 1024 * 1024;
+
+fn lazy_im2col_max_eager_bytes() -> usize {
+    use std::sync::OnceLock;
+    static V: OnceLock<usize> = OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("TRACT_LAZY_IM2COL_MAX_EAGER_BYTES")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_LAZY_IM2COL_MAX_EAGER_BYTES)
+    })
+}
+
+fn should_use_lazy(
+    pool_spec: &PoolSpec,
+    group: usize,
+    input_shape: &[usize],
+    dt: DatumType,
+) -> bool {
     // Depthwise convs (group == in_channels == out_channels) have a specialised
     // `DepthWise` op downstream that's much faster than the generic im2col + matmul
     // path on every backend we measured (Apple AMX, x64, aarch64). Don't intercept
@@ -1275,8 +1307,24 @@ fn should_use_lazy(input_shape: &DataShape, pool_spec: &PoolSpec, group: usize) 
     if is_depthwise {
         return false;
     }
-    input_shape.n().unwrap_or(&1) == &1
-        && pool_spec.kernel_shape.iter().product::<usize>() >= lazy_im2col_min_kernel()
+    let Ok(output_shape) = pool_spec.output_shape(input_shape) else { return false };
+    // LazyIm2col's offset tables are built for a single batch.
+    if output_shape.n().unwrap_or(&1) != &1 {
+        return false;
+    }
+    let kernel_volume = pool_spec.kernel_shape.iter().product::<usize>();
+    // Primary rule: kernel volume. LazyIm2col's per-output-position gather indirection
+    // is cheap relative to materialising the scratch for a sizeable kernel.
+    if kernel_volume >= lazy_im2col_min_kernel() {
+        return true;
+    }
+    // Shape-aware rule: prefer lazy when the eager scratch (`k·n·sizeof`) is large,
+    // even for a small kernel. `n` is the output spatial volume — the dimension the
+    // kernel-volume rule ignores but which actually drives the materialisation cost.
+    let n: usize = output_shape.hw_dims().iter().product();
+    let k = pool_spec.input_channels * kernel_volume / group;
+    let eager_scratch_bytes = k.saturating_mul(n).saturating_mul(dt.size_of());
+    eager_scratch_bytes >= lazy_im2col_max_eager_bytes()
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
## What & why

`should_use_lazy` (`core/src/ops/cnn/conv/conv.rs`) picks eager vs lazy `Im2col` purely on **kernel volume** (`>= lazy_im2col_min_kernel()`, default 6). It never looks at `n`, the output spatial size — yet the eager `Im2col` scratch is `k · n · sizeof` bytes. So a *small kernel over a large output* still allocates, writes, and reads back multiple MB of scratch every inference — a pure memory-bandwidth tax that lazy's on-the-fly per-panel gather avoids.

Profiling DeepFilterNet 3 against ONNX Runtime Web surfaced this: `df_dec`'s `df_convp.1` (`in=64 out=10`, kernel `5×1`, `group=2` → `m=5 k=160 n=9600`) has kernel volume 5 — one below the threshold — so eager is chosen and materialises a ~5.9 MiB scratch. That `Im2col` node alone measured *more than the matmul it feeds*.

## The change

One file. An **additive** shape-aware term in `should_use_lazy`: also pick lazy when the eager scratch would exceed `TRACT_LAZY_IM2COL_MAX_EAGER_BYTES`.

- Default is **cfg-gated** — 1 MiB on wasm, 4 MiB native: the materialisation tax bites harder on wasm (no hardware prefetch, bounds-checked stores) while native caches/prefetchers absorb a few MB.
- The kernel-volume rule stays as the primary signal. The new term is **purely additive** — it only ever moves a conv eager → lazy, never the reverse, so **nothing that was lazy can regress**.
- The new env var mirrors the existing `TRACT_LAZY_IM2COL_MIN_KERNEL` pattern.

## Results — `df_dec` end-to-end

Per-node profiler, `S=100`, alternating-order interleave, median of paired runs:

| target | before | after | Δ |
|---|---|---|---|
| wasm (wasip1, `+simd128,+relaxed-simd`) | 11.07 ms | 9.43 ms | **−1.64 ms (−14.8%)** |
| native (Apple Silicon) | 11.02 ms | 10.34 ms | **−0.68 ms (−6.2%)** |

## Validation

- **Bit-exact output** — `df_dec`, `erb_dec`, MobileNetV2, SqueezeNet, InceptionV3, native + wasm: every output element is byte-identical before/after (lazy and eager `Im2col` are mathematically identical).
- **Test suite** — `cargo test --release` over `tract-core` / `tract-onnx` / `tract-nnef` / `tract-hir`: 348 passed, 0 failed.
- **No CNN regression** — MobileNetV2 / SqueezeNet / InceptionV3 reroute **zero** convs (their sub-6 kernels are 1×1 → einsum or depthwise; their ≥3×3 convs already took the lazy path). Optimized graphs are byte-identical to before, native and wasm.
- `cargo fmt` clean; no new `clippy` warnings.

## Open questions — this is a draft, opinion wanted

1. **Is lazy gated out for small kernels for a reason** beyond gather-indirection cost — a past regression, a memory-constrained-target consideration, a correctness edge case? The `should_use_lazy` comment reads as a deliberate eager/lazy tradeoff, so I'd rather ask than assume.

2. **Is a tunable shape-aware heuristic the right level here**, or would you rather this become a proper cost model (estimate `eager_cost` vs `lazy_cost` from shape + hardware params, pick the cheaper)? A cost model is more principled, but trades two threshold constants for a handful of hardware-model constants; `Op::cost()` might be the natural hook. **Is it worth investing further in that direction**, or is a good default + env override the shape you'd want?

3. The wasm/native cfg split is the crude part — a runtime-detected cache size could replace the hardcoded 4 MiB if you'd prefer less magic.

The second commit (profiling tooling under `examples/wasm-model-bench`) is throwaway — happy to drop or relocate it; it's only there so the numbers above reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
