### PR TITLE
linalg/wasm: fix f32 GEMM routing to the 32x1 GEMV kernel (1.13-1.78x)

### DIFF
--- a/linalg/src/wasm.rs
+++ b/linalg/src/wasm.rs
@@ -44,16 +44,21 @@ pub fn plug(ops: &mut Ops) {
     ops.mmm_impls.push(wasm_f32_16x1.mmm());
     ops.mmm_impls.push(wasm_f32_32x1.mmm());
     ops.mmm_impls.push(wasm_f32_8x8.mmm());
-    // Selection paths:
-    //   - N>1 (GEMM): mmm_f32 returns 8x8. 8x8 stays TargetOptimized so
-    //     kernel_selection::strategize falls through to list_impls and picks
-    //     by max(nr*mr) — 8x8 still wins (4x4 would be the only alternative).
+    // Selection paths. Both rely on kernel_selection::strategize honouring
+    // the mmm_f32 / mmv_f32 callback, which it only does when the callback's
+    // kernel is tagged ManuallyOptimized. Otherwise strategize falls through
+    // to list_impls, whose retain() keeps only the top ImplementationQuality
+    // and drops every TargetOptimized kernel.
+    //   - N>1 (GEMM): mmm_f32 returns 8x8, so 8x8 MUST be ManuallyOptimized.
+    //     If it were TargetOptimized it would be dropped by retain(), and the
+    //     N>1 branch's max(nr*mr) over the surviving (ManuallyOptimized) GEMV
+    //     kernels would pick wasm_f32_32x1 — a matrix×vector kernel — for
+    //     every GEMM.
     //   - N=1 (GEMV): mmv_f32 routes by M-band to the kernel whose MR fits.
-    //     The four GEMV kernels are tagged ManuallyOptimized so strategize
-    //     hits its early-return at kernel_selection.rs:35 and honours the
-    //     callback's choice. Without that tag, strategize would discard the
-    //     callback and pick max(mr)=32x1 for every M, leaving up to ~37% on
-    //     the table for small-M GEMV.
+    //     The four GEMV kernels are ManuallyOptimized for the same reason —
+    //     without the tag strategize discards the callback and picks
+    //     max(mr)=32x1 for every M, leaving up to ~37% on the table for
+    //     small-M GEMV.
     ops.mmm_f32 = Box::new(|_m, _k, _n| wasm_f32_8x8.mmm());
     // Bands derived from microbench_dispatch_gemv. At each band edge, using
     // the next-larger kernel beats halving outer iterations of the smaller
@@ -2094,7 +2099,10 @@ unsafe fn kernel_f32_8x8(mut pnl: *const FusedKerSpec<f32>) -> isize {
     }
 }
 
-MMMRustKernel!(kernel_f32_8x8 => wasm_f32_8x8<f32>(8,8)@(8,8) quality(ImplementationQuality::TargetOptimized));
+// ManuallyOptimized so kernel_selection::strategize honours the mmm_f32
+// callback that returns it for N>1 GEMM (see the `plug` comment) — otherwise
+// strategize drops it and routes every GEMM onto the 32x1 GEMV kernel.
+MMMRustKernel!(kernel_f32_8x8 => wasm_f32_8x8<f32>(8,8)@(8,8) quality(ImplementationQuality::ManuallyOptimized));
 
 #[cfg(test)]
 mod dispatch_trace {
@@ -2144,6 +2152,41 @@ mod dispatch_trace {
         // 32x1 band: M ≥ 17
         trace_one("band 32x1 lo m=17", Some(17), Some(64), Some(1));
         trace_one("band 32x1 hi m=512", Some(512), Some(64), Some(1));
+    }
+
+    /// Regression guard for the GEMM/GEMV dispatch.
+    ///
+    /// `kernel_selection::strategize` honours the `mmm_f32` / `mmv_f32`
+    /// callback only when the returned kernel is `ManuallyOptimized`;
+    /// otherwise it falls through to `list_impls`, whose `retain()` drops
+    /// every `TargetOptimized` kernel, and for N>1 then picks `max(nr*mr)`
+    /// over the surviving `ManuallyOptimized` GEMV kernels — i.e.
+    /// `wasm_f32_32x1`, a matrix×vector kernel, for every GEMM. So every
+    /// kernel reachable through the dispatch callbacks must be
+    /// `ManuallyOptimized`.
+    #[test]
+    fn dispatch_kernels_are_manually_optimized() {
+        use crate::mmm::ImplementationQuality::ManuallyOptimized;
+        let mut ops = crate::generic();
+        super::plug(&mut ops);
+        for (label, m, k, n) in [
+            ("GEMM m=64 k=64 n=8", 64, 64, 8),
+            ("GEMM m=256 k=256 n=256", 256, 256, 256),
+            ("GEMM m=1024 k=576 n=10", 1024, 576, 10),
+            ("GEMV m=1 k=512 n=1", 1, 512, 1),
+            ("GEMV m=256 k=256 n=1", 256, 256, 1),
+        ] {
+            let mmm =
+                ops.mmm(tract_data::prelude::DatumType::F32, Some(m), Some(k), Some(n)).unwrap();
+            assert_eq!(
+                mmm.quality(),
+                ManuallyOptimized,
+                "{label}: dispatch returned {} tagged {:?} — strategize would \
+                 discard it and reroute onto a GEMV kernel",
+                mmm.name(),
+                mmm.quality(),
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

On `wasm32`, every f32 GEMM (`MatMul` with N > 1) was running on `wasm_f32_32x1` — a *matrix×vector* kernel (MR=32, NR=1) — instead of `wasm_f32_8x8`.

`kernel_selection::strategize` honours the `mmm_f32` dispatch callback only when the callback's kernel is tagged `ManuallyOptimized`. `wasm_f32_8x8` was tagged `TargetOptimized`, so `strategize` discarded the callback and fell through to `list_impls`, where `retain()` keeps only the top `ImplementationQuality` and drops every `TargetOptimized` kernel. That left only the four `ManuallyOptimized` GEMV kernels (`*x1`), and the N>1 branch then picked `max(nr*mr)` among them → `wasm_f32_32x1`. The in-code comment claimed "8x8 still wins" through that fallthrough — it missed the `retain()` step.

## Fix

Tag `wasm_f32_8x8` `ManuallyOptimized` so `strategize` honours the `mmm_f32` callback that already returns it. Also: correct the stale comment, and add a regression test asserting every kernel reachable through the `mmm_f32`/`mmv_f32` callbacks is `ManuallyOptimized` (the invariant `strategize` depends on). The GEMV path is unaffected — the `*x1` kernels were already `ManuallyOptimized`.

## Benchmark — standalone f32 MatMul, wasm32

| Shape M×K×N | before | after | speedup | ORT-Web | after vs ORT |
|---|--:|--:|--:|--:|---|
| 256×256×100 | 347 µs | 279 µs | 1.24× | 376 µs | **tract 1.35×** |
| 256×256×256 | 840 µs | 643 µs | 1.31× | 850 µs | **tract 1.32×** |
| 768×256×100 | 907 µs | 782 µs | 1.16× | 1109 µs | **tract 1.42×** |
| 8×576×1024 | 403 µs | 226 µs | 1.78× | 291 µs | **tract 1.29×** |
| 10×576×1024 | 453 µs | 402 µs | 1.13× | 350 µs | ORT 1.15× |
| 16×576×1024 | 601 µs | 400 µs | 1.50× | 527 µs | **tract 1.32×** |

`wasmtime 44`, `+simd128,+relaxed-simd`, single-thread. tract = whole `MatMul` node, interleaved min-of-N paired (before/after measured back-to-back each round → ratio robust to machine load). ORT-Web = `onnxruntime-web` 1.24.3, wasm EP, 1 thread, per-op profiler `e.dur` (pure kernel time, apples-to-apples with tract's per-node timing). Models are standalone `MatMul` ONNX, const weight × runtime activation.

After the fix tract's WASM GEMM beats ORT-Web on 5 of 6 shapes (1.29–1.42×). The one loss — 10×576×1024 — is the ragged-N case: N=10 with the 8×8 kernel's NR=8 needs 2 N-tiles, the second only 2/8 utilised. That's a separate, larger change (a narrower-NR kernel + NR-aware dispatch).

## Correctness

- `cargo test -p tract-linalg --target wasm32-wasip1 --lib`: **1741 passed, 0 failed, 3 ignored.** The `MMMRustKernel!`-generated suite covers `wasm_f32_8x8`'s mat_mul / packed_packed / property / fused-op tests — the kernel body is unchanged, only its quality tag.
- New `dispatch_trace::dispatch_kernels_are_manually_optimized` regression test passes.
- `cargo fmt` clean.
- Native builds unaffected — the `wasm` module is `#[cfg(all(target_family = "wasm", target_feature = "simd128"))]`.