### PR TITLE
linalg/arm64: add f32 _a55 prefetch hints in back-half integer-idle slots

### DIFF
--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_12x8/packed_packed_loop2/cortex_a55.S.raw
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_12x8/packed_packed_loop2/cortex_a55.S.raw
@@ -37,9 +37,13 @@ fmla        v22.4s, v2.4s, v5.s[0]
 fmla        v23.4s, v0.4s, v5.s[1]
 
 fmla        v24.4s, v1.4s, v5.s[1]
+prfm        pldl1keep, [x1, #256]
 fmla        v25.4s, v2.4s, v5.s[1]
+prfm        pldl1keep, [x1, #320]
 fmla        v26.4s, v0.4s, v5.s[2]
+prfm        pldl1keep, [x2, #256]
 fmla        v27.4s, v1.4s, v5.s[2]
+prfm        pldl1keep, [x2, #320]
 fmla        v28.4s, v2.4s, v5.s[2]
 fmla        v29.4s, v0.4s, v5.s[3]
 ins         v3.d[1], x23
@@ -80,9 +84,13 @@ ldr         d2, [x1], #8
 fmla        v19.4s, v7.4s, v4.s[3]
 ldr         x22, [x1], #8
 fmla        v20.4s, v3.4s, v5.s[0]
+prfm        pldl1keep, [x1, #384]
 fmla        v21.4s, v6.4s, v5.s[0]
+prfm        pldl1keep, [x1, #448]
 fmla        v22.4s, v7.4s, v5.s[0]
+prfm        pldl1keep, [x2, #384]
 fmla        v23.4s, v3.4s, v5.s[1]
+prfm        pldl1keep, [x2, #448]
 fmla        v24.4s, v6.4s, v5.s[1]
 fmla        v25.4s, v7.4s, v5.s[1]
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_16x4/packed_packed_loop2/cortex_a55.S.raw
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_16x4/packed_packed_loop2/cortex_a55.S.raw
@@ -34,6 +34,8 @@ ins         v8.d[1], x8
 fmla        v30.4s, v2.4s, v4.s[3]
 ins         v9.d[1], x9
 fmla        v31.4s, v3.4s, v4.s[3]
+prfm        pldl1keep, [x1, #256]
+prfm        pldl1keep, [x2, #256]
 
 // mul a: v5, v6, v7, v8 b: v9
 // load a: v0(d0/x5), v1(d1,x6), v2(d2,x7), v3(d3, x8)
@@ -71,3 +73,5 @@ ins         v3.d[1], x8
 fmla        v30.4s, v7.4s, v9.s[3]
 ins         v4.d[1], x9
 fmla        v31.4s, v8.4s, v9.s[3]
+prfm        pldl1keep, [x1, #320]
+prfm        pldl1keep, [x2, #320]

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_24x4/loop2/cortex_a55.S.raw
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_24x4/loop2/cortex_a55.S.raw
@@ -34,6 +34,8 @@ ins         v8.d[1], x8
 fmla        v30.4s, v2.4s, v4.s[3]
 ins         v9.d[1], x9
 fmla        v31.4s, v3.4s, v4.s[3]
+prfm        pldl1keep, [x1, #256]
+prfm        pldl1keep, [x2, #256]
 
 // mul a: v5, v6, v7, v8 b: v9
 // load a: v0(d0/x5), v1(d1,x6), v2(d2,x7), v3(d3, x8)
@@ -71,3 +73,5 @@ ins         v3.d[1], x8
 fmla        v30.4s, v7.4s, v9.s[3]
 ins         v4.d[1], x9
 fmla        v31.4s, v8.4s, v9.s[3]
+prfm        pldl1keep, [x1, #320]
+prfm        pldl1keep, [x2, #320]

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_8x8/packed_packed_loop2/cortex_a55.S.raw
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_8x8/packed_packed_loop2/cortex_a55.S.raw
@@ -16,9 +16,13 @@ fmla        v23.4s, v1.4s, v4.s[3]
 ldr         x8, [x2], #8
 
 fmla        v24.4s, v0.4s, v5.s[0]
+prfm        pldl1keep, [x1, #256]
 fmla        v25.4s, v1.4s, v5.s[0]
+prfm        pldl1keep, [x1, #320]
 fmla        v26.4s, v0.4s, v5.s[1]
+prfm        pldl1keep, [x2, #256]
 fmla        v27.4s, v1.4s, v5.s[1]
+prfm        pldl1keep, [x2, #320]
 fmla        v28.4s, v0.4s, v5.s[2]
 ins         v2.d[1], x5
 fmla        v29.4s, v1.4s, v5.s[2]
@@ -46,9 +50,13 @@ fmla        v23.4s, v3.4s, v6.s[3]
 ldr         x8, [x2], #8
 
 fmla        v24.4s, v2.4s, v7.s[0]
+prfm        pldl1keep, [x1, #384]
 fmla        v25.4s, v3.4s, v7.s[0]
+prfm        pldl1keep, [x1, #448]
 fmla        v26.4s, v2.4s, v7.s[1]
+prfm        pldl1keep, [x2, #384]
 fmla        v27.4s, v3.4s, v7.s[1]
+prfm        pldl1keep, [x2, #448]
 fmla        v28.4s, v2.4s, v7.s[2]
 ins         v0.d[1], x5
 fmla        v29.4s, v3.4s, v7.s[2]


### PR DESCRIPTION
Sibling to #2231 (which added `_a53` prefetch parity and gave a measured **7% on Sonos's ASR acoustic model**). Same audit pattern applied to `_a55` schedules.

## What

The K-loop-2 back-halves of the f32 `_a55` MMM schedules use `FMLA`+`INS` pairs where `INS` dispatches to NEON pipe 1 (the mov/dup pipe), leaving the integer pipes (E0/E1) idle. `PRFM` (which dispatches to E0/E1) fits cleanly there without displacing any data-flow work.

- `8x8` loop2: +8 PRFM (4 in each K iter)
- `12x8` loop2: +8 PRFM (4 in each K iter)
- `16x4` loop2: +4 PRFM (more conservative — denser INS coverage)
- `24x4` loop2: +4 PRFM (file is identical to 16x4 _a55; mirror)

Less aggressive than the `_a53` cadence (4 per operand) because A55's hardware prefetcher is significantly better than A53's — software hints are supplementary rather than primary.

## Test plan
- [x] `cargo test -p tract-linalg --lib arm64` with `TRACT_CPU_AARCH64_KIND=a55` on M1 Pro: **2124 tests pass, 0 fail**. PRFM is non-semantic so bit-equivalence is guaranteed by construction.
- [ ] **Needs Cortex-A55 bench from Sonos's internal harness to confirm.** Best case: similar production-model gain to what #2231 saw on A53 (though likely smaller given A55's better baseline). Worst case: neutral — PRFM hints are non-faulting and the runtime can ignore them. If the bench shows regression, revert and close.

## Risk
- Zero correctness risk: PRFM is a CPU hint; the change cannot affect output.
- Maintenance: 24 lines added across 4 `.S.raw` files. Pattern matches the existing `_a53` schedules (now post-#2231).