### PR TITLE
linalg/arm64/fp16: add f16 _a55 prefetch hints (16x8, 32x4)

### DIFF
--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_16x8/loop2/cortex_a55.S.raw
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_16x8/loop2/cortex_a55.S.raw
@@ -14,9 +14,13 @@ ldr         x6, [x1], #8
 fmla        v23.8h, v1.8h, v4.h[3]
 
 fmla        v24.8h, v0.8h, v4.h[4]
+prfm        pldl1keep, [x1, #256]
 fmla        v25.8h, v1.8h, v4.h[4]
+prfm        pldl1keep, [x1, #320]
 fmla        v26.8h, v0.8h, v4.h[5]
+prfm        pldl1keep, [x2, #256]
 fmla        v27.8h, v1.8h, v4.h[5]
+prfm        pldl1keep, [x2, #320]
 fmla        v28.8h, v0.8h, v4.h[6]
 ins         v2.d[1], x5
 fmla        v29.8h, v1.8h, v4.h[6]
@@ -41,9 +45,13 @@ ldr         x6, [x1], #8
 fmla        v23.8h, v3.8h, v6.h[3]
 
 fmla        v24.8h, v2.8h, v6.h[4]
+prfm        pldl1keep, [x1, #384]
 fmla        v25.8h, v3.8h, v6.h[4]
+prfm        pldl1keep, [x1, #448]
 fmla        v26.8h, v2.8h, v6.h[5]
+prfm        pldl1keep, [x2, #384]
 fmla        v27.8h, v3.8h, v6.h[5]
+prfm        pldl1keep, [x2, #448]
 fmla        v28.8h, v2.8h, v6.h[6]
 ins         v0.d[1], x5
 fmla        v29.8h, v3.8h, v6.h[6]

--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_32x4/loop2/cortex_a55.S.raw
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_f16_32x4/loop2/cortex_a55.S.raw
@@ -33,6 +33,8 @@ ins         v8.d[1], x8
 fmla        v30.8h, v2.8h, v4.h[3]
 ins         v9.d[1], x9
 fmla        v31.8h, v3.8h, v4.h[3]
+prfm        pldl1keep, [x1, #256]
+prfm        pldl1keep, [x2, #256]
 
 // mul a: v5, v6, v7, v8 b: v9
 // load a: v0(d0/x5), v1(d1,x6), v2(d2,x7), v3(d3, x8)
@@ -69,3 +71,5 @@ ins         v3.d[1], x8
 fmla        v30.8h, v7.8h, v9.h[3]
 ins         v4.d[1], x9
 fmla        v31.8h, v8.8h, v9.h[3]
+prfm        pldl1keep, [x1, #320]
+prfm        pldl1keep, [x2, #320]


### PR DESCRIPTION
Companion to #2238 (f32 `_a55` prefetch). Same audit pattern applied to the f16 `_a55` schedules — both `16x8` and `32x4` loop2 had 0 PRFM today despite having `FMLA`+`INS` pairs in the back half (`INS` dispatches to NEON pipe 1, leaving the integer pipes E0/E1 idle for PRFM hints).

## What
- `16x8` loop2: +8 PRFM (4 per K iter, placed inside the bare-FMLA stretch where each cycle dispatches only 1 NEON op — pure fill, no displaced data-flow work)
- `32x4` loop2: +4 PRFM (2 per K iter, at end-of-iter to avoid interfering with the denser `FMLA`+`INS` section)
- `128x1` GEMV: **unchanged.** Already has 5 PRFM in a GEMV-appropriate cadence (deep A-side prefetch at +1024..+1216, light B-side reuse pattern). Intentionally left alone.

## Models that would benefit on A55 silicon
Realistic f16 transformer workloads sized for A55 (small models, batch=1, short-to-medium seq):
- f16 BERT-class encoders for on-device understanding: DistilBERT, MiniLM, sentence-embedding models (~100-500 MB f16)
- f16 Whisper-tiny encoder (~80 MB f16) — long-seq audio (3000 frames), `32x4` dominant
- f16 Conformer-class ASR (small variants)
- f16 small audio transformers for keyword-spotting / sound classification (AudioMAE-tiny, BEATs-tiny)
- f16 ViT-tiny / small vision transformers for on-device image classification
- The `16x8` kernel covers batch=1 short-seq attention/FFN; `32x4` covers long-seq encoders

Not in scope: on-device LLM inference. A55 is typically a big.LITTLE efficiency core or a low-power IoT/smart-speaker CPU — LLMs run on the P-cores or dedicated NPUs, not A55.

## Why now
Companion to #2223 (RmsNorm F16 fix) which unblocked F16 transformer inference on tract. Once F16 models are running in production, these `_a55` kernels are hot — better to complete the prefetch parity now while audit context is fresh than to leave a known gap.

## Test plan
- [x] `cargo test -p tract-linalg --lib arm64` with `TRACT_CPU_AARCH64_KIND=a55` on M1 Pro: **2124 tests pass, 0 fail**. PRFM is non-semantic so bit-equivalence is guaranteed by construction.
- [ ] **Needs Cortex-A55 bench from Sonos's internal harness, on a f16 workload, to confirm.** Best case: similar ~3% gain to what #2238 targets on f32. Worst case: neutral — PRFM is non-faulting and the runtime can ignore the hints.

## Risk
- Zero correctness risk: PRFM is a CPU hint; the change cannot affect output.
- Maintenance: 12 lines across 2 `.S.raw` files. Pattern matches the just-filed `_a55` f32 PR.
