### PR TITLE
fix: update expected NNEF output for pulse.streaming_symbol property

### DIFF
--- a/harness/pre-optimized-graphes/mdl-en-2019-Q3-librispeech/expected
+++ b/harness/pre-optimized-graphes/mdl-en-2019-Q3-librispeech/expected
@@ -123,7 +123,7 @@ fragment scan_body_1(
 fragment tract_core_properties(
 ) -> (properties: (string, tensor<scalar>)[])
 {
-  properties = [("pulse.delay", tract_core_cast([6], to = "i64")), ("pulse.input_axes", tract_core_cast([0], to = "i64")), ("pulse.output_axes", tract_core_cast([0], to = "i64")), ("tract_nnef_ser_version", "0.19.3-pre"), ("tract_nnef_format_version", "beta1")];
+  properties = [("pulse.delay", tract_core_cast([6], to = "i64")), ("pulse.input_axes", tract_core_cast([0], to = "i64")), ("pulse.output_axes", tract_core_cast([0], to = "i64")), ("pulse.streaming_symbol", ["S"]), ("tract_nnef_ser_version", "0.19.3-pre"), ("tract_nnef_format_version", "beta1")];
 }
 
 graph network(input) -> (output) {


### PR DESCRIPTION
The pulse serialiser now emits a "pulse.streaming_symbol" property; update the pre-optimized-graphes harness expected file to match.