### PR TITLE
linalg/arm64: swap ld1{v.d}[0] -> ldr d in per_col cols=3/6 paths (~2x A55 instruction-level)

### DIFF
--- a/linalg/arm64/arm64fp16/arm64fp16_mmm_8h_ops.j2
+++ b/linalg/arm64/arm64fp16/arm64fp16_mmm_8h_ops.j2
@@ -60,7 +60,7 @@ b           .non_linear_loop
 {% elif cols == 4 %}
         ldr         d0, [ x2 ]
 {% elif cols == 6 %}
-        ld1         {v0.d}[0], [ x2 ], #8
+        ldr         d0, [ x2 ], #8
         ld1         {v0.s}[2], [ x2 ]
 {% else %}
     {% for reg in range(1, loads + 1) %}

--- a/linalg/arm64/arm64simd/arm64simd_mmm_4s_ops.j2
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_4s_ops.j2
@@ -55,7 +55,7 @@ b           .non_linear_loop
 {%if cols == 1 %}
         ld1         {v0.s}[0], [ x2 ]
 {% elif cols == 3 %}
-        ld1         {v0.d}[0], [ x2 ], #8
+        ldr         d0, [ x2 ], #8
         ld1         {v0.s}[2], [ x2 ]
 {% else %}
     {% for reg in range(1, loads + 1) %}


### PR DESCRIPTION
Citation: `linalg/benches/arm64simd.rs` microbench data shared in #2238's discussion.

| Instruction pair | A55 cycles |
|---|---|
| `fmla + ldr d` (`fmla_with_d_load`) | **1.00** |
| `fmla + ld1 {v.d}[0]` (`fmla_with_d_load_as_v`) | **1.97** |

~2× instruction-level cliff for the same data load on A55. A53 unaffected (both forms cost ~2 cyc).

## Change
Two 1-line swaps in shared `_ops.j2` files:
- `arm64simd_mmm_4s_ops.j2`: `per_col` cols=3 branch
- `arm64fp16_mmm_8h_ops.j2`: `per_col` cols=6 branch

## Correctness
The two forms differ only in `v.d[1]` behaviour:
- `ldr d0` **zero-extends** the upper half
- `ld1 {v0.d}[0]` **preserves** it

In both branches, the subsequent `dup` loop reads only `s[0..2]` (f32) / `h[0..5]` (f16). The unused upper lane is never referenced, so zero-extension is harmless.

Note: `arm64fp16_mmm_8h_ops.j2` already uses `ldr d0` in the `cols == 4` branch — this PR makes `cols == 6` consistent with that.

## Impact framing
The `per_col` path fires for MMM with N=3 (f32) or N=6 (f16) columns — typically narrow-N fuse-op chains during model lowering. Whether this is hot in production depends on actual workload N-counts. Conservative framing: **strictly-positive but bounded** — a 2× instruction-level win on a path whose production frequency we haven't measured.

If your A55 bench shows this neutral, the upside is just code consistency with the existing `cols == 4` branch and the documented-faster pattern. If it shows improvement, even better.

## Test plan
- [x] `cargo test -p tract-linalg --lib arm64` with `TRACT_CPU_AARCH64_KIND=a55` on M1 Pro: **2124 tests pass**. The auto-generated MMM test suite covers `per_col` fuse-ops across all kernel shapes; correctness is bit-equivalent (the unused lane is never read).
- [ ] Cortex-A55 bench from Sonos's internal harness, on any workload that exercises the `per_col` fuse-op path.

## Risk
- Zero correctness risk: the only behavioral difference is in lanes that are never read.
- Maintenance: 2 lines changed across 2 `.j2` files. The new form is already used elsewhere in the same fp16 file.