### PR TITLE
blockify: derive chunked DiagGather offset from op.offset + window_start

### DIFF
--- a/pulse/src/blockify.rs
+++ b/pulse/src/blockify.rs
@@ -695,8 +695,16 @@ fn build_section_patch(
             );
         }
         let dg_op = dg_node.op_as::<DiagGather>().unwrap();
-        let dg_chunked =
-            wire_initiator_diag_gather(&mut patch, model, dg_node, dg_op, &sec.mask, chunk_sym, k)?;
+        let dg_chunked = wire_initiator_diag_gather(
+            &mut patch,
+            model,
+            dg_node,
+            dg_op,
+            &sec.mask,
+            sec.contracted_axis,
+            chunk_sym,
+            k,
+        )?;
         chunked.insert(OutletId::new(nid, 0), dg_chunked);
         chunked.insert(OutletId::new(dg_id, 0), dg_chunked);
         already_wired.insert(nid);
@@ -836,7 +844,16 @@ fn wire_initiator(
         }
     }
     if let Some(op) = node.op_as::<DiagGather>() {
-        return wire_initiator_diag_gather(patch, model, node, op, mask, chunk_sym, k);
+        return wire_initiator_diag_gather(
+            patch,
+            model,
+            node,
+            op,
+            mask,
+            contracted_axis,
+            chunk_sym,
+            k,
+        );
     }
     if let Some(op) = node.op_as::<TypedBinOp>() {
         return wire_initiator_typed_binop(
@@ -868,8 +885,9 @@ fn wire_initiator_diag_gather(
     patch: &mut TypedModelPatch,
     model: &TypedModel,
     node: &TypedNode,
-    _op: &DiagGather,
+    op: &DiagGather,
     mask: &MaskForm,
+    contracted_axis: usize,
     chunk_sym: &Symbol,
     k: i64,
 ) -> TractResult<OutletId> {
@@ -894,18 +912,27 @@ fn wire_initiator_diag_gather(
     let chunked = wire_chunk_split(patch, &node.name, tapped, stream_axis, chunk_sym, k)?;
 
     // The R (relative-position) axis of pos_raw is the last axis: a constant
-    // 2*T_max-1 from the original skew construction.  In batch the DiagGather's
-    // centre is at column T_max-1 = (R-1)/2.  The chunked formula picks
-    //   pos_raw[c·P+δi, T_max-1 + (j-i)]   with j = (c-L)·P + δj
-    // → in[c, δi, (T_max-1) - L·P + δj − δi]
-    // so the chunked DiagGather offset is (T_max-1) - L·P, with out_len = W.
+    // width carrying the rel-pos table.  The DiagGather op's `offset` field
+    // points to the column where rel-pos = 0 lives in the R-axis numbering.
+    // Per chunk c, the W = (L+1)·k key-window starts at chunk
+    // `c + window_start` (= `c − L` for lookback, `c` for lookahead), so the
+    // (δi, δj)-th in-window key has rel-pos `δj − δi + window_start·k`.
+    // Solving `chunked_offset + δj − δi = (op.offset) + (δj − δi + window_start·k)`
+    // gives `chunked_offset = op.offset + window_start·k`.
     let r_axis = in_fact_patch.shape.last().context("DiagGather input has no last axis")?;
     let r = r_axis.to_i64().context("DiagGather R axis must be a constant integer")?;
-    let t_max = (r + 1) / 2;
+    // Prefer `op.offset` if it simplifies to a concrete column index — this is
+    // the path the streaming-rel-pos rewrite (subsequent commit) uses to plant
+    // a centre that doesn't match the canonical `(R-1)/2`.  Fall back to the
+    // T-XL convention `centre = (R-1)/2` for models where the op was built
+    // with a row-count-based symbolic offset (e.g. `T - 1`) that hasn't
+    // simplified post-substitution.
+    let centre = op.offset.to_i64().ok().unwrap_or((r - 1) / 2);
     let l = mask.upper - mask.lower;
     let w = (l + 1) * k;
-    let offset = t_max - 1 - l * k;
-    let chunked_op = DiagGather { offset: offset.to_dim(), out_len: w.to_dim() };
+    let window_start = window_start_for(mask, contracted_axis);
+    let chunked_offset = centre + window_start * k;
+    let chunked_op = DiagGather { offset: chunked_offset.to_dim(), out_len: w.to_dim() };
     Ok(patch.wire_node(format!("{}.blockified", node.name), chunked_op, &[chunked])?[0])
 }
 


### PR DESCRIPTION
The existing initiator hard-coded the rel-pos centre as `(R-1)/2`, which only matches the canonical Transformer-XL skew chain where the rel-pos table is pre-sized to `2·T_max - 1` and centred at column `T_max - 1`. That formula is also lookback-only: `chunked_offset = (T_max-1) - L·k` substitutes `j = (c-L)·k + δj` for the in-window key position, but for a lookahead band (window covering chunks `[c, c+L]`) the substitution is `j = c·k + δj`, giving a different shift.

Generalise by reading the centre from `op.offset` (the column where rel-pos zero lives in the input's R-axis numbering) and folding the window-direction offset in via `window_start_for(mask, contracted_axis)`:

  chunked_offset = op.offset + window_start·k

On the canonical lookback case `op.offset = T_max - 1` and `window_start = -mask.upper = -L`, so the new formula collapses to `(T_max-1) - L·k` — same value as before.  The change is correctness- preserving for every model the previous code accepted and unlocks non-canonical layouts where `op.offset` is set explicitly (e.g. by a downstream rewrite that resizes the rel-pos table).