### PR TITLE
optim: include 0 in PushSliceUp boundaries when no slicer covers prefix

### DIFF
--- a/core/src/optim/slice.rs
+++ b/core/src/optim/slice.rs
@@ -182,6 +182,11 @@ fn should_slice_output(
     rule_if_let!(Ok(mut boundaries) =
         boundaries.iter().map(|x| x.to_usize()).collect::<TractResult<TVec<usize>>>());
     rule_if_let!(Ok(end) = node.outputs[0].fact.shape[axis].to_usize());
+    // op_slices_to_slice_op requires boundaries to cover the full
+    // [0..full_len] range. When every slicing successor starts at
+    // some offset > 0, the collected boundaries miss the leading 0;
+    // sort+dedup handles the case where a slicer already starts at 0.
+    boundaries.push(0);
     boundaries.push(end);
     boundaries.sort();
     boundaries.dedup();
@@ -246,4 +251,35 @@ pub fn rewire_sliced_outputs(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::math;
+
+    /// Two slice successors that both start at > 0. None covers the
+    /// prefix [0..2]. Before the fix, `should_slice_output` returned
+    /// boundaries `[2, 4, 5, 8]` (start at 2, not 0), and
+    /// `op_slices_to_slice_op` failed `boundaries[0] == 0.to_dim()`.
+    #[test]
+    fn push_slice_up_multi_succ_no_prefix() -> TractResult<()> {
+        let mut model = TypedModel::default();
+        let a = model.add_source("a", f32::fact([8]))?;
+        let b = model.add_source("b", f32::fact([8]))?;
+        let sum = model.wire_node("sum", math::add(), &[a, b])?[0];
+        let s1 = model.wire_node(
+            "s1",
+            Slice { axis: 0, start: 2.to_dim(), end: 4.to_dim() },
+            &[sum],
+        )?[0];
+        let s2 = model.wire_node(
+            "s2",
+            Slice { axis: 0, start: 5.to_dim(), end: 8.to_dim() },
+            &[sum],
+        )?[0];
+        model.select_output_outlets(&[s1, s2])?;
+        let _ = model.into_decluttered()?;
+        Ok(())
+    }
 }

--- a/core/src/optim/slice.rs
+++ b/core/src/optim/slice.rs
@@ -268,16 +268,12 @@ mod tests {
         let a = model.add_source("a", f32::fact([8]))?;
         let b = model.add_source("b", f32::fact([8]))?;
         let sum = model.wire_node("sum", math::add(), &[a, b])?[0];
-        let s1 = model.wire_node(
-            "s1",
-            Slice { axis: 0, start: 2.to_dim(), end: 4.to_dim() },
-            &[sum],
-        )?[0];
-        let s2 = model.wire_node(
-            "s2",
-            Slice { axis: 0, start: 5.to_dim(), end: 8.to_dim() },
-            &[sum],
-        )?[0];
+        let s1 =
+            model.wire_node("s1", Slice { axis: 0, start: 2.to_dim(), end: 4.to_dim() }, &[sum])?
+                [0];
+        let s2 =
+            model.wire_node("s2", Slice { axis: 0, start: 5.to_dim(), end: 8.to_dim() }, &[sum])?
+                [0];
         model.select_output_outlets(&[s1, s2])?;
         let _ = model.into_decluttered()?;
         Ok(())


### PR DESCRIPTION
## Summary

`should_slice_output` collects boundaries from each slicing successor and appends `end = full_len`, but never appends `0`. When every slicer has `start > 0` (no successor covers the leading `[0..start_min]` segment), the resulting boundaries skip the leading zero. `op_slices_to_slice_op` then trips `ensure!(boundaries[0] == 0.to_dim())` and the declutter pass aborts.

Fix: push `0` before `sort + dedup`. `sort + dedup` handles the case where a slicer already starts at 0, so this is a no-op for graphs that previously succeeded.

Triggers on `torch.split` / `chunk` patterns where the post-split chunks all start at offset > 0. Hit while exporting a Mamba prefill graph with a custom scan op via `torch-to-nnef`.

## Verification

The new test `optim::slice::tests::push_slice_up_multi_succ_no_prefix` builds a minimal `add` node with two `Slice` successors `[2..4]` and `[5..8]`. Without the fix it reproduces the exact `Val(2) vs Val(0)` assertion seen on the Mamba export. With the fix it passes, alongside all 237 prior `tract-core` tests, plus `tract-nnef`, `tract-pulse`, and `tract-onnx`.