### PR TITLE
binary: weaken And uniform_tdim propagation under one-side-unknown

### DIFF
--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -248,6 +248,20 @@ impl TypedOp for TypedBinOp {
                 }
             }
         }
+        // And(known_band, runtime_unknown) → the band acts as an upper bound:
+        // outside the band, the band is 0 and AND is provably 0; inside the
+        // band, AND = runtime_unknown.  The band is therefore a valid upper
+        // bound on where the AND result can be true — sufficient for ROI-
+        // bubbling and FoldUniformMask region-splitting consumers, which
+        // both treat uniform_tdim as "where the result can be nonzero".
+        if fact.uniform_tdim.is_none() && self.0.is::<crate::ops::logic::And>() {
+            for src in [&inputs[0].uniform_tdim, &inputs[1].uniform_tdim] {
+                if let Some(known) = src {
+                    fact.uniform_tdim = Some(known.clone());
+                    break;
+                }
+            }
+        }
         Ok(tvec!(fact))
     }
 

--- a/core/src/ops/logic.rs
+++ b/core/src/ops/logic.rs
@@ -548,4 +548,36 @@ mod tests {
 
         Ok(())
     }
+
+    /// `And(banded_mask, runtime_unknown)` — the banded side has uniform_tdim,
+    /// the other side doesn't.  We want the AND result to carry the band as
+    /// an upper-bound predicate: outside the band, the result is provably 0
+    /// (band=0 dominates); inside the band, it's whatever the runtime side
+    /// says.  Suffices for ROI-bubbling and FoldUniformMask consumers.
+    #[test]
+    fn and_band_with_unknown_keeps_band_uniform_tdim() -> TractResult<()> {
+        let mut model = TypedModel::default();
+        // Side A: a bool [10] with a band uniform_tdim (3 ≤ 🎯0 ≤ 8).
+        let sym = model.symbols.coord_sym(0);
+        let band = TDim::Mul(vec![
+            TDim::Ge(Box::new(TDim::Sym(sym.clone())), Box::new(TDim::Val(3))),
+            TDim::Ge(Box::new(TDim::Val(8)), Box::new(TDim::Sym(sym))),
+        ]);
+        let mut a_fact = bool::fact(&[10]);
+        a_fact.uniform_tdim = Some(band.clone());
+        let a = model.add_source("banded", a_fact)?;
+
+        // Side B: a bool [10] runtime input with no uniform_tdim.
+        let b = model.add_source("runtime_pad", bool::fact(&[10]))?;
+
+        let and = model.wire_node("and", crate::ops::logic::and(), &[a, b])?[0];
+
+        let and_fact = model.outlet_fact(and)?;
+        assert!(
+            and_fact.uniform_tdim.is_some(),
+            "And(banded, runtime) should retain the band as uniform_tdim, got {:?}",
+            and_fact.uniform_tdim
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
When And has one input with a band-style uniform_tdim and the other with none (e.g. runtime pad mask), propagate the known band as the output's uniform_tdim.

Mathematically the band is an upper bound on where AND can be nonzero: outside the band, the known side is 0 so AND is provably 0; inside the band, AND = unknown.  Both FoldUniformMask (region splitting injects const-true/false in each region, AND folds correctly per region) and ROI-bubbling consumers (ScaledMaskedSoftmax, Iff) treat uniform_tdim as "where the result can be nonzero" — upper bound is sufficient.

Unblocks the encoder.p1 chunked-mask path where chunkedLimitedMask carries the band and the runtime pad mask doesn't.