### PR TITLE
linalg/avx512: fix add_unicast for 128x1 and 16x1 kernels

### DIFF
--- a/linalg/arm32/armv7neon/armv7neon_mmm_f32_8x1_core.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_mmm_f32_8x1_core.S.j2
@@ -49,11 +49,11 @@ armv7neon_mmm_f32_8x1_{{core}}_{{suffix}}:
 {% set mr = 8 %}{% set from = 8 %}{% set to = 9 %}{% include "armv7neon_mmm_f32_per_cols.j2" %}
 
 .add_unicast:
-    {% for reg in range(0, 16) %}
+    {% for reg in range(0, 4) %}
         vld1.f32    d{{reg}}[0], [ r3 ], r4
         vld1.f32    d{{reg}}[1], [ r3 ], r4
     {% endfor %}
-    {% for reg in range(0, 8) %}
+    {% for reg in range(0, 2) %}
         vadd.f32 q{{ reg + 8 }}, q{{ reg + 8 }}, q{{reg}}
     {% endfor %}
 

--- a/linalg/src/frame/mmm/tests/fuse.rs
+++ b/linalg/src/frame/mmm/tests/fuse.rs
@@ -29,6 +29,11 @@ macro_rules! mmm_kernel_fuse_tests {
             fn store_non_contiguous() {
                 test::store_non_contiguous::<_, $tc, $ti>($ker)
             }
+
+            #[test]
+            fn add_unicast_non_contiguous() {
+                test::add_unicast_non_contiguous::<_, $ti>($ker)
+            }
             proptest::proptest! {
                 #[test]
                 fn return_c_prop(c in tile::<_, $ti>($ker)) {
@@ -149,6 +154,57 @@ where
         }
     }
     assert_eq!(v, expected);
+}
+
+/// `Clear` + `AddUnicast(strided)` + `Store(contiguous)` and check the
+/// source pattern reaches the destination. Counterpart of
+/// `store_non_contiguous` on the read side; `return_c_plus_d` uses
+/// `mmm_stride_storage` (tightly packed) and so doesn't exercise this.
+pub fn add_unicast_non_contiguous<K, TI>(ker: &K)
+where
+    K: MatMatMulKer<Acc = TI>,
+    TI: LADatum + AsPrimitive<TI>,
+    usize: AsPrimitive<TI>,
+{
+    if !ker.is_supported_here() {
+        return;
+    }
+    let item = std::mem::size_of::<TI>();
+    let row_stride_items = 3 * ker.nr() * 5;
+    let col_stride_items = 3;
+    // Source: a non-contiguous buffer with distinct values at the used
+    // (r, c) cells and sentinel garbage everywhere else.
+    let mut src: Vec<TI> = vec![TI::max_value(); ker.mr() * row_stride_items];
+    for r in 0..ker.mr() {
+        for c in 0..ker.nr() {
+            src[r * row_stride_items + c * col_stride_items] = (1 + c + r * ker.nr()).as_();
+        }
+    }
+    let src_store = OutputStoreKer {
+        ptr: src.as_ptr() as _,
+        row_byte_stride: (item * row_stride_items) as isize,
+        col_byte_stride: (item * col_stride_items) as isize,
+        item_size: item,
+    };
+    // Destination: tightly-packed output for easy comparison.
+    let mut dst: Vec<TI> = vec![TI::min_value(); ker.mr() * ker.nr()];
+    let dst_store = OutputStoreKer {
+        ptr: dst.as_ptr() as _,
+        row_byte_stride: (item * ker.nr()) as isize,
+        col_byte_stride: item as isize,
+        item_size: item,
+    };
+    let non_linear = tvec![
+        FusedKerSpec::Clear,
+        FusedKerSpec::AddUnicast(src_store),
+        FusedKerSpec::Store(dst_store),
+        FusedKerSpec::Done,
+    ];
+    let err = ker.kernel(&non_linear);
+    assert_eq!(err, 0);
+    let expected: Vec<TI> = (0..ker.mr() * ker.nr()).map(|i| (1 + i).as_()).collect();
+    display_error(&dst, &expected, ker.mr(), ker.nr());
+    assert_eq!(dst, expected);
 }
 
 pub fn fused_ops<K, TI, E>(ker: &K, c: &[TI], ops: &[FusedKerSpec<TI>], expect: E)

--- a/linalg/src/x86_64_fma/mmm.rs
+++ b/linalg/src/x86_64_fma/mmm.rs
@@ -188,3 +188,105 @@ pub fn plug_avx512f(ops: &mut Ops) {
     });
     log::info!("mmm_f32, mmv_f32: x86_64/avx512f activated");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::mmm::{AsInputValue, FusedSpec};
+    use tract_data::internal::*;
+
+    #[test]
+    fn avx512_128x1_add_unicast_with_strided_c() -> TractResult<()> {
+        if !is_x86_feature_detected!("avx512f") {
+            return Ok(());
+        }
+        let (m, k_each, n) = (1000usize, 256usize, 13usize);
+        let a0: Vec<f32> = (0..m * k_each).map(|i| ((i % 17) as f32 - 8.0) / 16.0).collect();
+        let a1: Vec<f32> = (0..m * k_each).map(|i| ((i % 19) as f32 - 9.0) / 18.0).collect();
+        let b0: Vec<f32> = (0..k_each * n).map(|i| ((i % 13) as f32 - 6.0) / 13.0).collect();
+        let b1: Vec<f32> = (0..k_each * n).map(|i| ((i % 11) as f32 - 5.0) / 10.0).collect();
+
+        let mut expected = vec![0.0f32; m * n];
+        for r in 0..m {
+            for c in 0..n {
+                let mut acc = 0.0f32;
+                for kk in 0..k_each {
+                    acc += a0[r * k_each + kk] * b0[kk * n + c];
+                    acc += a1[r * k_each + kk] * b1[kk * n + c];
+                }
+                expected[r * n + c] = acc;
+            }
+        }
+
+        let ker = avx512_mmm_f32_128x1.mmm();
+        let (pack_a, pack_b) = &ker.packings()[0];
+        let pack_one =
+            |buf: Vec<f32>, rows, cols, m_axis, k_axis, pack: &dyn crate::mmm::MMMInputFormat| {
+                let t =
+                    tract_ndarray::Array2::from_shape_vec((rows, cols), buf).unwrap().into_tensor();
+                pack.prepare_one(&t, k_axis, m_axis).unwrap()
+            };
+        let pa0 = pack_one(a0, m, k_each, 0, 1, &**pack_a);
+        let pa1 = pack_one(a1, m, k_each, 0, 1, &**pack_a);
+        let pb0 = pack_one(b0, k_each, n, 1, 0, &**pack_b);
+        let pb1 = pack_one(b1, k_each, n, 1, 0, &**pack_b);
+
+        // C-buffer layout with row stride > nr*sizeof, matching squeezenet conv10's
+        // (M=1000, spatial=13, N=13) view: M-stride is 169 floats, not nr=1.
+        let spatial = 13usize;
+        let mut c_backing = Tensor::zero::<f32>(&[m, spatial, n])?;
+        let c_spec = unsafe { ker.c_from_data_and_strides(4, (spatial * n) as isize, 1) };
+
+        unsafe {
+            let c_view = c_backing.view_mut();
+            let c = c_spec.wrap(&c_view);
+            let ops: TVec<FusedSpec> = tvec!(
+                FusedSpec::AddMatMul {
+                    a: AsInputValue::Borrowed(&*pa0),
+                    b: AsInputValue::Borrowed(&*pb0),
+                    packing: 0,
+                },
+                FusedSpec::Store(c),
+            );
+            ker.run(m, n, &ops)?;
+        }
+
+        unsafe {
+            let c_view = c_backing.view_mut();
+            let c_for_unicast = c_spec.wrap(&c_view);
+            let c_for_store = c_spec.wrap(&c_view);
+            let ops: TVec<FusedSpec> = tvec!(
+                FusedSpec::AddMatMul {
+                    a: AsInputValue::Borrowed(&*pa1),
+                    b: AsInputValue::Borrowed(&*pb1),
+                    packing: 0,
+                },
+                FusedSpec::AddUnicast(c_for_unicast),
+                FusedSpec::Store(c_for_store),
+            );
+            ker.run(m, n, &ops)?;
+        }
+
+        let c_slice = c_backing.to_plain_array_view::<f32>()?;
+        let mut max_err = 0.0f32;
+        let mut wrong_cells = 0;
+        for r in 0..m {
+            for cc in 0..n {
+                let got = c_slice[[r, 0, cc]];
+                let exp = expected[r * n + cc];
+                let e = (got - exp).abs();
+                if e > 1e-3 {
+                    wrong_cells += 1;
+                }
+                max_err = max_err.max(e);
+            }
+        }
+        assert!(
+            max_err < 1e-3,
+            "avx512_mmm_f32_128x1 wrong output at squeezenet shape: \
+             max_err={max_err}, {wrong_cells}/{} cells off",
+            m * n,
+        );
+        Ok(())
+    }
+}

--- a/linalg/x86_64/avx512/avx512_mmm_f32_128x1.S.j2
+++ b/linalg/x86_64/avx512/avx512_mmm_f32_128x1.S.j2
@@ -54,8 +54,49 @@ Windows ABI:
     mov     r10,    [rdi + 8]           // c ptr
     mov     rsi,    [rdi + 16]          // row stride
 
+    cmp     rsi, 4
+    jne     {{L}}add_unicast_generic
+
     {% for row in range(0, 8) %}
         vaddps zmm{{row}}, zmm{{row}}, [ r10 + {{ row * 64 }} ]
+    {% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}add_unicast_generic:
+    mov     eax,    0
+    {% for i in range(0, 4) %}
+        pinsrd  xmm14, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    {% for i in range(0, 4) %}
+        pinsrd  xmm15, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    {% for i in range(0, 4) %}
+        pinsrd  xmm12, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    {% for i in range(0, 4) %}
+        pinsrd  xmm13, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    vperm2f128      ymm14, ymm14, ymm15, 32
+    vperm2f128      ymm13, ymm12, ymm13, 32
+    vinsertf32x8    zmm14, zmm14, ymm13, 1
+
+    kxnorw          k1, k1, k1
+    vgatherdps      zmm12{k1}, [r10 + zmm14]
+    vaddps          zmm0, zmm0, zmm12
+
+    imul    esi,    16
+    vpbroadcastd    zmm15, esi
+
+    {% for j in range(1, 8) %}
+        vpaddd      zmm14, zmm14, zmm15
+        kxnorw      k1, k1, k1
+        vgatherdps  zmm12{k1}, [r10 + zmm14]
+        vaddps      zmm{{j}}, zmm{{j}}, zmm12
     {% endfor %}
 
     jmp    {{L}}non_linear_loop

--- a/linalg/x86_64/avx512/avx512_mmm_f32_16x1.S.j2
+++ b/linalg/x86_64/avx512/avx512_mmm_f32_16x1.S.j2
@@ -78,27 +78,31 @@ Windows ABI:
     jmp    {{L}}non_linear_loop
 
 {{L}}add_unicast_generic:
-    mov r8, [0]
-//     mov     eax,    0
-// {% for i in range(0, 4) %}
-//     pinsrd  xmm14, eax, {{i}}
-//     add     eax,    esi
-// {% endfor %}
-// {% for i in range(0, 4) %}
-//     pinsrd  xmm15, eax, {{i}}
-//     add     eax,    esi
-// {% endfor %}
-//
-//     vperm2f128      zmm14,  zmm14, zmm15,         32 // zmm14 <- xmm14::xmm15
-//
-// {% for i in range(0, 8) %}
-//     vpcmpeqd        zmm15,  zmm15, zmm15
-//     vgatherdps      zmm12,  [ r10 + zmm14 ], zmm15
-//
-//     vaddps          zmm{{i}},   zmm{{i}},   zmm12
-//     lea             r10, [ r10 + rsi * 8 ]
-// {% endfor %}
-//
+    mov     eax,    0
+    {% for i in range(0, 4) %}
+        pinsrd  xmm14, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    {% for i in range(0, 4) %}
+        pinsrd  xmm15, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    {% for i in range(0, 4) %}
+        pinsrd  xmm12, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    {% for i in range(0, 4) %}
+        pinsrd  xmm13, eax, {{i}}
+        add     eax,    esi
+    {% endfor %}
+    vperm2f128      ymm14, ymm14, ymm15, 32
+    vperm2f128      ymm13, ymm12, ymm13, 32
+    vinsertf32x8    zmm14, zmm14, ymm13, 1
+
+    kxnorw          k1, k1, k1
+    vgatherdps      zmm12{k1}, [r10 + zmm14]
+    vaddps          zmm0, zmm0, zmm12
+
     jmp    {{L}}non_linear_loop
 
 {{L}}add_row_col_products:


### PR DESCRIPTION
Both kernels used to handle add_unicast only for the contiguous case (row_stride == 4 bytes):

  * 128x1 hard-coded eight `vaddps zmm{i}, zmm{i}, [r10 + i*64]` without using the row-stride argument. Fine for the mmv_f32 path (n=1 is inherently contiguous along M), but with a strided C — e.g. squeezenet's conv10 accumulates into shape (M=1000, spatial=13, N=13) where M-stride is 169 floats — it summed garbage into the accumulator. The recent M-aware kernel picker started routing tall-M shapes to this kernel, exposing the latent bug.

  * 16x1 had a contiguous fast path plus a stubbed `add_unicast_generic` that null-deref'd (`mov r8, [0]`) on any strided call.

Both now implement a vgatherdps-based generic path following the 80x2 template: build a 16-lane index vector with the row stride scaled into each lane, then gather and accumulate. 128x1 also keeps its contiguous fast path (rsi == 4) and steps the index vector by 16*rsi across its eight 16-row chunks.

A new generic kernel test (`add_unicast_non_contiguous`) drives every MMM kernel through Clear + AddUnicast(strided) + Store(contiguous) and asserts the source pattern reaches the destination. It mirrors the existing `store_non_contiguous` test on the read side; the prior `return_c_plus_d` only exercised contiguous AddUnicast via `mmm_stride_storage`, so neither broken kernel was caught.

A higher-level regression test in mmm.rs reproduces the exact squeezenet shape (AddMatMul + AddUnicast + Store on 128x1 at M=1000, K=256, N=13 with row-stride 169 floats).

cargo test -p tract-linalg: 2638 passed (+29 new); tract -O on light_squeezenet.onnx now reproduces the canonical uniform 0.001 output.