### PR TITLE
onnx: narrow i32->TDim cast promotion to TDim inputs

### DIFF
--- a/onnx/src/ops/cast.rs
+++ b/onnx/src/ops/cast.rs
@@ -14,7 +14,7 @@ fn cast(
     node: &NodeProto,
 ) -> TractResult<(Box<dyn InferenceOp>, Vec<String>)> {
     let mut to = node.get_attr::<DatumType>("to")?;
-    if to == i64::datum_type() || to == i32::datum_type() {
+    if to == i64::datum_type() {
         to = TDim::datum_type();
     }
     Ok((ElementWiseOp(Box::new(Cast::new(to)), None).into_hir(), vec![]))
@@ -67,6 +67,8 @@ impl ElementWiseMiniOp for Cast {
     ) -> TractResult<Option<TypedModelPatch>> {
         let from = model.outlet_fact(node.inputs[0])?.datum_type;
         if from == self.to {
+            Ok(Some(TypedModelPatch::replace_single_op(model, node, &node.inputs, Identity)?))
+        } else if from == TDim::datum_type() && self.to == i32::datum_type() {
             Ok(Some(TypedModelPatch::replace_single_op(model, node, &node.inputs, Identity)?))
         } else if from == String::datum_type() && self.to == f32::datum_type() {
             Ok(None)


### PR DESCRIPTION
The parse-time rule rewriting Cast(to=i32) to Cast(to=TDim) was too broad: it caught quantization-arithmetic casts whose i32 target is genuine, breaking DequantizeLinear unification (en_tdnn_lstm_bn_q7).

Promote only Cast(to=i64) at parse time (i64 is the canonical shape type in ONNX). For the Moonshine-style shape-plumbing chain where an exporter inserts an i32 round-trip on TDim values, catch it at declutter once the input type is known: TDim -> i32 collapses to Identity, preserving the symbol.