### PR TITLE
linalg/arm64/sve: VLA SVE/SVE2 backend for ARMv9 — f32/f16/int8 GEMM+GEMV

### DIFF
--- a/linalg/arm64/sve/sve_mmm_f16.c
+++ b/linalg/arm64/sve/sve_mmm_f16.c
@@ -1,0 +1,153 @@
+// SVE f16 GEMM kernel for tract's MMM framework (the mmm_f16 slot).
+//
+// Tile MR=8 x NR=8 with native f16 accumulation, the f16 sibling of
+// sve_mmm_f32.c. The hot AddMatMul is the same vector-length-agnostic
+// broadcast-A rank-1 update, but over f16 lanes: the NR columns are walked in
+// svcnth() chunks with whilelt predication and folded with svmla_n_f16 (native
+// f16 fused multiply-add, as the NEON arm64fp16 kernels do), so one binary is
+// correct and full-width at any SVE VL 128..2048-bit.
+//
+// Gated on FEAT_SVE2 AND FEAT_FP16 (Rust side). Built with +fp16. Consumes
+// tract's native f16 K-major packing. Fuse ops act on the MRxNR tile in memory
+// (scalar; not the hot path); as with the f32 kernel, LeakyRelu and the i32
+// quantization ops are excluded by CAN_FUSE. Returns 0 on success, 1 otherwise.
+
+#include <arm_sve.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MR 8
+#define NR 8
+
+enum {
+    DONE = 0, CLEAR, LOAD_TILE,
+    SCALAR_MIN, SCALAR_MAX, SCALAR_ADD, SCALAR_MUL, SCALAR_SUB, SCALAR_SUBF,
+    LEAKY_RELU,
+    PER_ROW_MIN, PER_ROW_MAX, PER_ROW_ADD, PER_ROW_MUL, PER_ROW_SUB, PER_ROW_SUBF,
+    PER_COL_MIN, PER_COL_MAX, PER_COL_ADD, PER_COL_MUL, PER_COL_SUB, PER_COL_SUBF,
+    Q_SCALE, Q_SHR, Q_SHL,
+    ADD_UNICAST, ADD_ROW_COL_PRODUCTS, STORE, ADD_MAT_MUL
+};
+
+typedef struct {
+    uint64_t disc;
+    uint64_t f0, f1, f2, f3;
+} spec_t;
+
+static inline __fp16 f16_of(uint64_t bits) {
+    __fp16 f;
+    uint16_t lo = (uint16_t)bits;
+    memcpy(&f, &lo, 2);
+    return f;
+}
+
+// AddMatMul: ab[m][n] += sum_k pa[k*MR+m] * pb[k*NR+n]. VLA over NR (f16 lanes).
+static void add_mat_mul(__fp16 ab[MR][NR], const __fp16 *pa, const __fp16 *pb, long k) {
+    for (long n0 = 0; n0 < NR; n0 += svcnth()) {
+        svbool_t pg = svwhilelt_b16((uint64_t)n0, (uint64_t)NR);
+        svfloat16_t a0 = svld1_f16(pg, &ab[0][n0]), a1 = svld1_f16(pg, &ab[1][n0]);
+        svfloat16_t a2 = svld1_f16(pg, &ab[2][n0]), a3 = svld1_f16(pg, &ab[3][n0]);
+        svfloat16_t a4 = svld1_f16(pg, &ab[4][n0]), a5 = svld1_f16(pg, &ab[5][n0]);
+        svfloat16_t a6 = svld1_f16(pg, &ab[6][n0]), a7 = svld1_f16(pg, &ab[7][n0]);
+        for (long kk = 0; kk < k; kk++) {
+            svfloat16_t b = svld1_f16(pg, &pb[kk * NR + n0]);
+            const __fp16 *arow = &pa[kk * MR];
+            a0 = svmla_n_f16_x(pg, a0, b, arow[0]);
+            a1 = svmla_n_f16_x(pg, a1, b, arow[1]);
+            a2 = svmla_n_f16_x(pg, a2, b, arow[2]);
+            a3 = svmla_n_f16_x(pg, a3, b, arow[3]);
+            a4 = svmla_n_f16_x(pg, a4, b, arow[4]);
+            a5 = svmla_n_f16_x(pg, a5, b, arow[5]);
+            a6 = svmla_n_f16_x(pg, a6, b, arow[6]);
+            a7 = svmla_n_f16_x(pg, a7, b, arow[7]);
+        }
+        svst1_f16(pg, &ab[0][n0], a0); svst1_f16(pg, &ab[1][n0], a1);
+        svst1_f16(pg, &ab[2][n0], a2); svst1_f16(pg, &ab[3][n0], a3);
+        svst1_f16(pg, &ab[4][n0], a4); svst1_f16(pg, &ab[5][n0], a5);
+        svst1_f16(pg, &ab[6][n0], a6); svst1_f16(pg, &ab[7][n0], a7);
+    }
+}
+
+// Store the MRxNR f16 tile with arbitrary row/col byte strides.
+static void store_tile(__fp16 ab[MR][NR], const spec_t *s) {
+    uint8_t *ptr = (uint8_t *)s->f0;
+    long rstride = (long)s->f1, cstride = (long)s->f2, isz = (long)s->f3;
+    for (long i = 0; i < MR; i++)
+        for (long j = 0; j < NR; j++) {
+            uint8_t *p = ptr + i * rstride + j * cstride;
+            if (isz == 2)
+                *(__fp16 *)p = ab[i][j];
+            else if (isz == 4)
+                *(float *)p = (float)ab[i][j];
+            else
+                memcpy(p, &ab[i][j], isz);
+        }
+}
+
+intptr_t sve_mmm_f16_kernel(const spec_t *ops) {
+    __fp16 ab[MR][NR];
+    memset(ab, 0, sizeof(ab));
+    for (const spec_t *s = ops;; s++) {
+        switch (s->disc) {
+            case DONE:
+                return 0;
+            case CLEAR:
+                memset(ab, 0, sizeof(ab));
+                break;
+            case ADD_MAT_MUL: {
+                long k = (long)s->f0;
+                add_mat_mul(ab, (const __fp16 *)s->f1, (const __fp16 *)s->f2, k);
+                break;
+            }
+            case STORE:
+                store_tile(ab, s);
+                break;
+            case LOAD_TILE: {
+                const __fp16 *src = (const __fp16 *)s->f1;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] = src[i * NR + j];
+                break;
+            }
+            case ADD_UNICAST: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, cstride = (long)s->f2, isz = (long)s->f3;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) {
+                        const uint8_t *p = ptr + i * rstride + j * cstride;
+                        if (isz == 2)
+                            ab[i][j] += *(const __fp16 *)p;
+                        else
+                            ab[i][j] += (__fp16) * (const float *)p;
+                    }
+                break;
+            }
+            case ADD_ROW_COL_PRODUCTS: {
+                const __fp16 *rows = (const __fp16 *)s->f0;
+                const __fp16 *cols = (const __fp16 *)s->f1;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] += rows[i] * cols[j];
+                break;
+            }
+            case SCALAR_MIN: { __fp16 v=f16_of(s->f0); for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<v?ab[i][j]:v; break; }
+            case SCALAR_MAX: { __fp16 v=f16_of(s->f0); for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>v?ab[i][j]:v; break; }
+            case SCALAR_ADD: { __fp16 v=f16_of(s->f0); for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]+=v; break; }
+            case SCALAR_MUL: { __fp16 v=f16_of(s->f0); for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]*=v; break; }
+            case SCALAR_SUB: { __fp16 v=f16_of(s->f0); for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=v-ab[i][j]; break; }
+            case SCALAR_SUBF:{ __fp16 v=f16_of(s->f0); for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-v; break; }
+            case PER_ROW_MIN: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<m[i]?ab[i][j]:m[i]; break; }
+            case PER_ROW_MAX: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>m[i]?ab[i][j]:m[i]; break; }
+            case PER_ROW_ADD: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]+=m[i]; break; }
+            case PER_ROW_MUL: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]*=m[i]; break; }
+            case PER_ROW_SUB: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=m[i]-ab[i][j]; break; }
+            case PER_ROW_SUBF:{ const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-m[i]; break; }
+            case PER_COL_MIN: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<m[j]?ab[i][j]:m[j]; break; }
+            case PER_COL_MAX: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>m[j]?ab[i][j]:m[j]; break; }
+            case PER_COL_ADD: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]+=m[j]; break; }
+            case PER_COL_MUL: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]*=m[j]; break; }
+            case PER_COL_SUB: { const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=m[j]-ab[i][j]; break; }
+            case PER_COL_SUBF:{ const __fp16*m=(const __fp16*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-m[j]; break; }
+            default:
+                return 1;
+        }
+    }
+}

--- a/linalg/arm64/sve/sve_mmm_f32.c
+++ b/linalg/arm64/sve/sve_mmm_f32.c
@@ -1,0 +1,159 @@
+// SVE f32 GEMM kernel for tract's MMM framework.
+//
+// Tile MR=8 x NR=8. The hot AddMatMul uses the vector-length-agnostic
+// broadcast-A rank-1 update: the NR columns are walked in svcntw() chunks with
+// whilelt predication, so the SAME code runs correctly (and uses the full
+// vector) at any SVE vector length — 128 to 2048-bit. The MR=8 accumulators are
+// held in SVE registers across the K loop. Fuse ops operate on an MRxNR tile in
+// memory (scalar C — they are not the hot path), mirroring the generic kernel.
+//
+// ABI: the kernel walks a *const FusedKerSpec<f32> array (40 bytes / entry,
+// discriminant u64 at offset 0, fields at 8/16/24/32) until Done, exactly like
+// the asm dispatcher. f32 GEMM consumes tract's native K-major packing
+// (pa[k*MR+m], pb[k*NR+n]) so no custom packing format is required.
+//
+// Returns 0 on success, 1 if asked to do an unsupported fused op.
+
+#include <arm_sve.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MR 8
+#define NR 8
+
+// FusedKerSpec discriminants (must match frame/mmm/fuse.rs enum order).
+enum {
+    DONE = 0, CLEAR, LOAD_TILE,
+    SCALAR_MIN, SCALAR_MAX, SCALAR_ADD, SCALAR_MUL, SCALAR_SUB, SCALAR_SUBF,
+    LEAKY_RELU,
+    PER_ROW_MIN, PER_ROW_MAX, PER_ROW_ADD, PER_ROW_MUL, PER_ROW_SUB, PER_ROW_SUBF,
+    PER_COL_MIN, PER_COL_MAX, PER_COL_ADD, PER_COL_MUL, PER_COL_SUB, PER_COL_SUBF,
+    Q_SCALE, Q_SHR, Q_SHL,
+    ADD_UNICAST, ADD_ROW_COL_PRODUCTS, STORE, ADD_MAT_MUL
+};
+
+typedef struct {
+    uint64_t disc;
+    uint64_t f0, f1, f2, f3; // fields at byte offsets 8, 16, 24, 32
+} spec_t;
+
+// AddMatMul: ab[m][n] += sum_k pa[k*MR+m] * pb[k*NR+n]. VLA over NR.
+static void add_mat_mul(float ab[MR][NR], const float *pa, const float *pb, long k) {
+    for (long n0 = 0; n0 < NR; n0 += svcntw()) {
+        svbool_t pg = svwhilelt_b32((uint64_t)n0, (uint64_t)NR);
+        svfloat32_t a0 = svld1_f32(pg, &ab[0][n0]), a1 = svld1_f32(pg, &ab[1][n0]);
+        svfloat32_t a2 = svld1_f32(pg, &ab[2][n0]), a3 = svld1_f32(pg, &ab[3][n0]);
+        svfloat32_t a4 = svld1_f32(pg, &ab[4][n0]), a5 = svld1_f32(pg, &ab[5][n0]);
+        svfloat32_t a6 = svld1_f32(pg, &ab[6][n0]), a7 = svld1_f32(pg, &ab[7][n0]);
+        for (long kk = 0; kk < k; kk++) {
+            svfloat32_t b = svld1_f32(pg, &pb[kk * NR + n0]);
+            const float *arow = &pa[kk * MR];
+            a0 = svmla_n_f32_x(pg, a0, b, arow[0]);
+            a1 = svmla_n_f32_x(pg, a1, b, arow[1]);
+            a2 = svmla_n_f32_x(pg, a2, b, arow[2]);
+            a3 = svmla_n_f32_x(pg, a3, b, arow[3]);
+            a4 = svmla_n_f32_x(pg, a4, b, arow[4]);
+            a5 = svmla_n_f32_x(pg, a5, b, arow[5]);
+            a6 = svmla_n_f32_x(pg, a6, b, arow[6]);
+            a7 = svmla_n_f32_x(pg, a7, b, arow[7]);
+        }
+        svst1_f32(pg, &ab[0][n0], a0); svst1_f32(pg, &ab[1][n0], a1);
+        svst1_f32(pg, &ab[2][n0], a2); svst1_f32(pg, &ab[3][n0], a3);
+        svst1_f32(pg, &ab[4][n0], a4); svst1_f32(pg, &ab[5][n0], a5);
+        svst1_f32(pg, &ab[6][n0], a6); svst1_f32(pg, &ab[7][n0], a7);
+    }
+}
+
+static inline float f32_of(uint64_t bits) {
+    float f;
+    uint32_t lo = (uint32_t)bits;
+    memcpy(&f, &lo, 4);
+    return f;
+}
+
+// Store the MRxNR tile to memory with arbitrary row/col byte strides.
+static void store_tile(float ab[MR][NR], const spec_t *s) {
+    uint8_t *ptr = (uint8_t *)s->f0;
+    long rstride = (long)s->f1, cstride = (long)s->f2, isz = (long)s->f3;
+    for (long i = 0; i < MR; i++)
+        for (long j = 0; j < NR; j++) {
+            uint8_t *p = ptr + i * rstride + j * cstride;
+            if (isz == 4)
+                *(float *)p = ab[i][j];
+            else
+                memcpy(p, &ab[i][j], isz);
+        }
+}
+
+// Returns isize (64-bit) to match tract's kernel ABI — NOT int (would leave the
+// upper 32 bits of x0 undefined).
+intptr_t sve_mmm_f32_kernel(const spec_t *ops) {
+    float ab[MR][NR];
+    memset(ab, 0, sizeof(ab));
+    for (const spec_t *s = ops;; s++) {
+        switch (s->disc) {
+            case DONE:
+                return 0;
+            case CLEAR:
+                memset(ab, 0, sizeof(ab));
+                break;
+            case ADD_MAT_MUL: {
+                long k = (long)s->f0;
+                const float *pa = (const float *)s->f1;
+                const float *pb = (const float *)s->f2;
+                add_mat_mul(ab, pa, pb, k);
+                break;
+            }
+            case STORE:
+                store_tile(ab, s);
+                break;
+            case LOAD_TILE: {
+                // LoadTile(col_major_ptr, row_major_ptr); use the row-major one.
+                const float *src = (const float *)s->f1;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] = src[i * NR + j];
+                break;
+            }
+            case ADD_UNICAST: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, cstride = (long)s->f2;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++)
+                        ab[i][j] += *(const float *)(ptr + i * rstride + j * cstride);
+                break;
+            }
+            case ADD_ROW_COL_PRODUCTS: {
+                const float *rows = (const float *)s->f0;
+                const float *cols = (const float *)s->f1;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] += rows[i] * cols[j];
+                break;
+            }
+            // ---- scalar fuse ops ----
+            case SCALAR_MIN: { float v = f32_of(s->f0); for (long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<v?ab[i][j]:v; break; }
+            case SCALAR_MAX: { float v = f32_of(s->f0); for (long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>v?ab[i][j]:v; break; }
+            case SCALAR_ADD: { float v = f32_of(s->f0); for (long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]+=v; break; }
+            case SCALAR_MUL: { float v = f32_of(s->f0); for (long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]*=v; break; }
+            case SCALAR_SUB: { float v = f32_of(s->f0); for (long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=v-ab[i][j]; break; }
+            case SCALAR_SUBF:{ float v = f32_of(s->f0); for (long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-v; break; }
+            // ---- per-row fuse ops (one value per m-row) ----
+            case PER_ROW_MIN: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<m[i]?ab[i][j]:m[i]; break; }
+            case PER_ROW_MAX: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>m[i]?ab[i][j]:m[i]; break; }
+            case PER_ROW_ADD: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]+=m[i]; break; }
+            case PER_ROW_MUL: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]*=m[i]; break; }
+            case PER_ROW_SUB: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=m[i]-ab[i][j]; break; }
+            case PER_ROW_SUBF:{ const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-m[i]; break; }
+            // ---- per-col fuse ops (one value per n-col) ----
+            case PER_COL_MIN: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<m[j]?ab[i][j]:m[j]; break; }
+            case PER_COL_MAX: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>m[j]?ab[i][j]:m[j]; break; }
+            case PER_COL_ADD: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]+=m[j]; break; }
+            case PER_COL_MUL: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]*=m[j]; break; }
+            case PER_COL_SUB: { const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=m[j]-ab[i][j]; break; }
+            case PER_COL_SUBF:{ const float*m=(const float*)s->f0; for(long i=0;i<MR;i++) for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-m[j]; break; }
+            default:
+                // LeakyRelu / QScale / RoundingShiftRight / ShiftLeft: excluded
+                // by CAN_FUSE for f32 — should never arrive. Anything else: error.
+                return 1;
+        }
+    }
+}

--- a/linalg/arm64/sve/sve_mmm_i32.c
+++ b/linalg/arm64/sve/sve_mmm_i32.c
@@ -1,0 +1,261 @@
+// SVE int8 -> int32 GEMM kernel for tract's MMM framework (the qmmm_i32 slot).
+//
+// Tile MR=8 x NR=8, i32 accumulator. The hot AddMatMul is the vector-length-
+// agnostic *widening* broadcast-A rank-1 update: per K-step it loads NR signed
+// bytes of a B row and sign-extends them to i32 with `svld1sb_s32`, then folds
+// MR `svmla_n_s32` updates with the (sign-extended) scalar from the A column.
+// The NR columns are walked in svcntw() chunks with whilelt predication, so the
+// SAME code is correct and full-width at any SVE vector length (128..2048-bit).
+//
+// Why widening MLA and not SDOT: SDOT reduces 4 K-contiguous i8 per i32 lane, so
+// it needs A and B packed K-contiguous within a lane. tract's PackedFormat is
+// K-major (mn-inner: for each k, r contiguous mn values), which is exactly what
+// the per-k widening update consumes — and what arm64simd's i32 kernel uses via
+// NEON SMLAL. A SDOT/SMMLA path would need a custom interleaved packer; that is
+// a separate (max-throughput) kernel, not this one.
+//
+// int8 inputs arrive via tract's native i8i8 packing (AddMatMul packing == 1).
+// The default i32i32 packing (packing == 0) is also handled (scalar) so the
+// generic auto-test surface (mmm_packed_packed_tests i32i32:0) passes.
+//
+// ABI: identical 40-byte FusedKerSpec<i32> walk as the f32 kernel (discriminant
+// u64 at offset 0, fields at 8/16/24/32). Fuse ops act on the MRxNR i32 tile in
+// memory (scalar C — not the hot path), including the quantization ops
+// q_scale / q_shr (rounding) / q_shl, ported bit-exact from
+// linalg/src/generic/rounding.rs.
+//
+// Returns 0 on success, 1 if asked to do an unsupported fused op / packing.
+
+#include <arm_sve.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MR 8
+#define NR 8
+
+// FusedKerSpec discriminants (must match frame/mmm/fuse.rs enum order).
+enum {
+    DONE = 0, CLEAR, LOAD_TILE,
+    SCALAR_MIN, SCALAR_MAX, SCALAR_ADD, SCALAR_MUL, SCALAR_SUB, SCALAR_SUBF,
+    LEAKY_RELU,
+    PER_ROW_MIN, PER_ROW_MAX, PER_ROW_ADD, PER_ROW_MUL, PER_ROW_SUB, PER_ROW_SUBF,
+    PER_COL_MIN, PER_COL_MAX, PER_COL_ADD, PER_COL_MUL, PER_COL_SUB, PER_COL_SUBF,
+    Q_SCALE, Q_SHR, Q_SHL,
+    ADD_UNICAST, ADD_ROW_COL_PRODUCTS, STORE, ADD_MAT_MUL
+};
+
+// RoundingPolicy is #[repr(usize)] in fuse.rs: Native=0, Zero=1, Away=2,
+// MinusInf=3, PlusInf=4, Even=5, Odd=6.
+enum { RP_NATIVE = 0, RP_ZERO, RP_AWAY, RP_MINUSINF, RP_PLUSINF, RP_EVEN, RP_ODD };
+
+typedef struct {
+    uint64_t disc;
+    uint64_t f0, f1, f2, f3; // fields at byte offsets 8, 16, 24, 32
+} spec_t;
+
+// AddMatMul, i8 x i8 -> i32 (packing 1): ab[m][n] += sum_k pa[k*MR+m]*pb[k*NR+n].
+// VLA widening rank-1 update over NR.
+static void add_mat_mul_i8(int32_t ab[MR][NR], const int8_t *pa, const int8_t *pb, long k) {
+    for (long n0 = 0; n0 < NR; n0 += svcntw()) {
+        svbool_t pg = svwhilelt_b32((uint64_t)n0, (uint64_t)NR);
+        svint32_t a0 = svld1_s32(pg, &ab[0][n0]), a1 = svld1_s32(pg, &ab[1][n0]);
+        svint32_t a2 = svld1_s32(pg, &ab[2][n0]), a3 = svld1_s32(pg, &ab[3][n0]);
+        svint32_t a4 = svld1_s32(pg, &ab[4][n0]), a5 = svld1_s32(pg, &ab[5][n0]);
+        svint32_t a6 = svld1_s32(pg, &ab[6][n0]), a7 = svld1_s32(pg, &ab[7][n0]);
+        for (long kk = 0; kk < k; kk++) {
+            // Load NR int8 of B row kk, sign-extending each lane to i32.
+            svint32_t b = svld1sb_s32(pg, &pb[kk * NR + n0]);
+            const int8_t *arow = &pa[kk * MR];
+            a0 = svmla_n_s32_x(pg, a0, b, (int32_t)arow[0]);
+            a1 = svmla_n_s32_x(pg, a1, b, (int32_t)arow[1]);
+            a2 = svmla_n_s32_x(pg, a2, b, (int32_t)arow[2]);
+            a3 = svmla_n_s32_x(pg, a3, b, (int32_t)arow[3]);
+            a4 = svmla_n_s32_x(pg, a4, b, (int32_t)arow[4]);
+            a5 = svmla_n_s32_x(pg, a5, b, (int32_t)arow[5]);
+            a6 = svmla_n_s32_x(pg, a6, b, (int32_t)arow[6]);
+            a7 = svmla_n_s32_x(pg, a7, b, (int32_t)arow[7]);
+        }
+        svst1_s32(pg, &ab[0][n0], a0); svst1_s32(pg, &ab[1][n0], a1);
+        svst1_s32(pg, &ab[2][n0], a2); svst1_s32(pg, &ab[3][n0], a3);
+        svst1_s32(pg, &ab[4][n0], a4); svst1_s32(pg, &ab[5][n0], a5);
+        svst1_s32(pg, &ab[6][n0], a6); svst1_s32(pg, &ab[7][n0], a7);
+    }
+}
+
+// AddMatMul, i32 x i32 -> i32 (packing 0, default): only used by the auto-test
+// surface, never in production (quantized matmul uses the i8i8 packing). Scalar.
+static void add_mat_mul_i32(int32_t ab[MR][NR], const int32_t *pa, const int32_t *pb, long k) {
+    for (long kk = 0; kk < k; kk++) {
+        const int32_t *arow = &pa[kk * MR], *brow = &pb[kk * NR];
+        for (long i = 0; i < MR; i++)
+            for (long j = 0; j < NR; j++) ab[i][j] += arow[i] * brow[j];
+    }
+}
+
+// ---- Quantization helpers, ported bit-exact from generic/rounding.rs ----
+
+// i32::q_shr(shift, rp): rounding arithmetic shift right.
+static int32_t q_shr_i32(int32_t v, long shift, int rp) {
+    int32_t half = (int32_t)1 << (shift - 1);
+    int32_t a = v < 0 ? -v : v; // abs (test inputs are small; matches Rust .abs())
+    int32_t nudge;
+    switch (rp) {
+        case RP_ZERO:     nudge = -1; break;
+        case RP_MINUSINF: nudge = -(int32_t)(v >= 0); break;
+        case RP_PLUSINF:  nudge = -(int32_t)(v <= 0); break;
+        case RP_AWAY:     nudge = 0; break;
+        case RP_EVEN:     nudge = ((a >> shift) & 0x1) - 1; break;
+        case RP_ODD:      nudge = -((a >> shift) & 0x1); break;
+        default:          nudge = 0; break; // Native: unreachable for q ops
+    }
+    int32_t sign = (v > 0) - (v < 0); // signum: -1 / 0 / 1
+    return sign * ((a + half + nudge) >> shift);
+}
+
+// i32::q_scale(Scaler{mult, shift, policy}) with mult always present (the QScale
+// fused op carries an explicit multiplier). Mirrors `Mul<i32> for Scaler`.
+static int32_t q_scale_i32(int32_t v, long shift_in, int policy, int32_t mult) {
+    int64_t val = (int64_t)mult * (int64_t)v;
+    long shift = shift_in + 31;
+    if (shift > 0) {
+        int64_t half = (int64_t)1 << (shift - 1);
+        int64_t a = val < 0 ? -val : val;
+        int64_t nudge;
+        switch (policy) {
+            case RP_ZERO:     nudge = -1; break;
+            case RP_MINUSINF: nudge = -(int64_t)(val >= 0); break;
+            case RP_PLUSINF:  nudge = -(int64_t)(val <= 0); break;
+            case RP_AWAY:     nudge = 0; break;
+            case RP_EVEN:     nudge = ((a >> shift) & 0x1) - 1; break;
+            case RP_ODD:      nudge = -((a >> shift) & 0x1); break;
+            default:          nudge = 0; break;
+        }
+        int64_t sign = (val > 0) - (val < 0);
+        return (int32_t)(sign * ((a + half + nudge) >> shift));
+    } else {
+        return (int32_t)(val << (-shift));
+    }
+}
+
+// Store the MRxNR i32 tile to memory with arbitrary row/col byte strides,
+// truncating to the destination item size (matches generic store_t semantics
+// for the tested widths 1 and 4).
+static void store_tile(int32_t ab[MR][NR], const spec_t *s) {
+    uint8_t *ptr = (uint8_t *)s->f0;
+    long rstride = (long)s->f1, cstride = (long)s->f2, isz = (long)s->f3;
+    for (long i = 0; i < MR; i++)
+        for (long j = 0; j < NR; j++) {
+            uint8_t *p = ptr + i * rstride + j * cstride;
+            int32_t v = ab[i][j];
+            switch (isz) {
+                case 1: *(uint8_t *)p = (uint8_t)v; break;
+                case 2: *(uint16_t *)p = (uint16_t)v; break;
+                case 4: *(int32_t *)p = v; break;
+                case 8: { int64_t w = v; memcpy(p, &w, 8); break; }
+                default: memcpy(p, &v, isz < 4 ? (size_t)isz : 4); break;
+            }
+        }
+}
+
+// Returns isize (64-bit) to match tract's kernel ABI.
+intptr_t sve_mmm_i32_kernel(const spec_t *ops) {
+    int32_t ab[MR][NR];
+    memset(ab, 0, sizeof(ab));
+    for (const spec_t *s = ops;; s++) {
+        switch (s->disc) {
+            case DONE:
+                return 0;
+            case CLEAR:
+                memset(ab, 0, sizeof(ab));
+                break;
+            case ADD_MAT_MUL: {
+                long k = (long)s->f0;
+                long packing = (long)s->f3;
+                if (packing == 1) {
+                    add_mat_mul_i8(ab, (const int8_t *)s->f1, (const int8_t *)s->f2, k);
+                } else if (packing == 0) {
+                    add_mat_mul_i32(ab, (const int32_t *)s->f1, (const int32_t *)s->f2, k);
+                } else {
+                    return 1;
+                }
+                break;
+            }
+            case STORE:
+                store_tile(ab, s);
+                break;
+            case LOAD_TILE: {
+                // LoadTile(col_major_ptr, row_major_ptr); use the row-major one.
+                const int32_t *src = (const int32_t *)s->f1;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] = src[i * NR + j];
+                break;
+            }
+            case ADD_UNICAST: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, cstride = (long)s->f2, isz = (long)s->f3;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) {
+                        const uint8_t *p = ptr + i * rstride + j * cstride;
+                        if (isz == 1)
+                            ab[i][j] += *(const int8_t *)p; // sign-extend
+                        else
+                            ab[i][j] += *(const int32_t *)p;
+                    }
+                break;
+            }
+            case ADD_ROW_COL_PRODUCTS: {
+                const int32_t *rows = (const int32_t *)s->f0;
+                const int32_t *cols = (const int32_t *)s->f1;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] += rows[i] * cols[j];
+                break;
+            }
+            // ---- quantization fuse ops ----
+            case Q_SCALE: {
+                long shift = (long)s->f0;
+                int policy = (int)s->f1;
+                int32_t mult = (int32_t)s->f2;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] = q_scale_i32(ab[i][j], shift, policy, mult);
+                break;
+            }
+            case Q_SHR: {
+                long shift = (long)s->f0;
+                int policy = (int)s->f1;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] = q_shr_i32(ab[i][j], shift, policy);
+                break;
+            }
+            case Q_SHL: {
+                long shift = (long)s->f0;
+                for (long i = 0; i < MR; i++)
+                    for (long j = 0; j < NR; j++) ab[i][j] = ab[i][j] << shift;
+                break;
+            }
+            // ---- scalar fuse ops (value is an i32 in the low 32 bits of f0) ----
+            case SCALAR_MIN: { int32_t v=(int32_t)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<v?ab[i][j]:v; break; }
+            case SCALAR_MAX: { int32_t v=(int32_t)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>v?ab[i][j]:v; break; }
+            case SCALAR_ADD: { int32_t v=(int32_t)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]+=v; break; }
+            case SCALAR_MUL: { int32_t v=(int32_t)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]*=v; break; }
+            case SCALAR_SUB: { int32_t v=(int32_t)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=v-ab[i][j]; break; }
+            case SCALAR_SUBF:{ int32_t v=(int32_t)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-v; break; }
+            // ---- per-row fuse ops (one i32 per m-row) ----
+            case PER_ROW_MIN: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<m[i]?ab[i][j]:m[i]; break; }
+            case PER_ROW_MAX: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>m[i]?ab[i][j]:m[i]; break; }
+            case PER_ROW_ADD: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]+=m[i]; break; }
+            case PER_ROW_MUL: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]*=m[i]; break; }
+            case PER_ROW_SUB: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=m[i]-ab[i][j]; break; }
+            case PER_ROW_SUBF:{ const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-m[i]; break; }
+            // ---- per-col fuse ops (one i32 per n-col) ----
+            case PER_COL_MIN: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]<m[j]?ab[i][j]:m[j]; break; }
+            case PER_COL_MAX: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]>m[j]?ab[i][j]:m[j]; break; }
+            case PER_COL_ADD: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]+=m[j]; break; }
+            case PER_COL_MUL: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]*=m[j]; break; }
+            case PER_COL_SUB: { const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=m[j]-ab[i][j]; break; }
+            case PER_COL_SUBF:{ const int32_t*m=(const int32_t*)s->f0; for(long i=0;i<MR;i++)for(long j=0;j<NR;j++) ab[i][j]=ab[i][j]-m[j]; break; }
+            default:
+                // LeakyRelu excluded by CAN_FUSE_I32; anything else is an error.
+                return 1;
+        }
+    }
+}

--- a/linalg/arm64/sve/sve_mmm_i32_64x1.c
+++ b/linalg/arm64/sve/sve_mmm_i32_64x1.c
@@ -1,0 +1,210 @@
+// SVE int8 -> int32 GEMV kernel for tract's MMM framework (the qmmv_i32 slot,
+// dispatched when N == 1: matrix x int8 column vector).
+//
+// Tile MR=64 x NR=1, i32 accumulator. The hot AddMatMul is the vector-length-
+// agnostic widening update vectorized over M: per K-step it loads MR signed
+// bytes of the A-panel column, sign-extends to i32 (svld1sb_s32), and folds a
+// single svmla_n_s32 with the (sign-extended) scalar B[k]. The MR rows are
+// walked in svcntw() chunks with whilelt predication, so the SAME code is
+// correct and full-width at any SVE vector length (128..2048-bit).
+//
+// Same rationale as the 8x8 kernel: widening MLA (not SDOT) consumes tract's
+// native K-major i8i8 packing directly. int8 inputs arrive via that packing
+// (AddMatMul packing == 1); the default i32i32 packing (packing == 0) is handled
+// scalar for the auto-test surface.
+//
+// ABI: identical 40-byte FusedKerSpec<i32> walk. At NR=1, per_col / scalar fuse
+// ops degenerate to a single broadcast value and per_row is element-wise over
+// the MR outputs. Quantization ops q_scale / q_shr / q_shl are ported bit-exact
+// from linalg/src/generic/rounding.rs. Returns 0 on success, 1 on an
+// unsupported fused op / packing.
+
+#include <arm_sve.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MR 64
+#define NR 1
+
+enum {
+    DONE = 0, CLEAR, LOAD_TILE,
+    SCALAR_MIN, SCALAR_MAX, SCALAR_ADD, SCALAR_MUL, SCALAR_SUB, SCALAR_SUBF,
+    LEAKY_RELU,
+    PER_ROW_MIN, PER_ROW_MAX, PER_ROW_ADD, PER_ROW_MUL, PER_ROW_SUB, PER_ROW_SUBF,
+    PER_COL_MIN, PER_COL_MAX, PER_COL_ADD, PER_COL_MUL, PER_COL_SUB, PER_COL_SUBF,
+    Q_SCALE, Q_SHR, Q_SHL,
+    ADD_UNICAST, ADD_ROW_COL_PRODUCTS, STORE, ADD_MAT_MUL
+};
+
+enum { RP_NATIVE = 0, RP_ZERO, RP_AWAY, RP_MINUSINF, RP_PLUSINF, RP_EVEN, RP_ODD };
+
+typedef struct {
+    uint64_t disc;
+    uint64_t f0, f1, f2, f3;
+} spec_t;
+
+// AddMatMul, i8 x i8 -> i32 (packing 1): ab[m] += sum_k pa[k*MR+m]*pb[k].
+// VLA widening update over MR.
+static void add_mat_mul_i8(int32_t ab[MR], const int8_t *pa, const int8_t *pb, long k) {
+    for (long m0 = 0; m0 < MR; m0 += svcntw()) {
+        svbool_t pg = svwhilelt_b32((uint64_t)m0, (uint64_t)MR);
+        svint32_t acc = svld1_s32(pg, &ab[m0]);
+        for (long kk = 0; kk < k; kk++) {
+            svint32_t a = svld1sb_s32(pg, &pa[kk * MR + m0]); // load i8 col, sign-extend
+            acc = svmla_n_s32_x(pg, acc, a, (int32_t)pb[kk]);
+        }
+        svst1_s32(pg, &ab[m0], acc);
+    }
+}
+
+// AddMatMul, i32 x i32 -> i32 (packing 0, default): auto-test surface only.
+static void add_mat_mul_i32(int32_t ab[MR], const int32_t *pa, const int32_t *pb, long k) {
+    for (long kk = 0; kk < k; kk++) {
+        int32_t b = pb[kk];
+        const int32_t *acol = &pa[kk * MR];
+        for (long m = 0; m < MR; m++) ab[m] += acol[m] * b;
+    }
+}
+
+// ---- quantization helpers, ported bit-exact from generic/rounding.rs ----
+
+static int32_t q_shr_i32(int32_t v, long shift, int rp) {
+    int32_t half = (int32_t)1 << (shift - 1);
+    int32_t a = v < 0 ? -v : v;
+    int32_t nudge;
+    switch (rp) {
+        case RP_ZERO:     nudge = -1; break;
+        case RP_MINUSINF: nudge = -(int32_t)(v >= 0); break;
+        case RP_PLUSINF:  nudge = -(int32_t)(v <= 0); break;
+        case RP_AWAY:     nudge = 0; break;
+        case RP_EVEN:     nudge = ((a >> shift) & 0x1) - 1; break;
+        case RP_ODD:      nudge = -((a >> shift) & 0x1); break;
+        default:          nudge = 0; break;
+    }
+    int32_t sign = (v > 0) - (v < 0);
+    return sign * ((a + half + nudge) >> shift);
+}
+
+static int32_t q_scale_i32(int32_t v, long shift_in, int policy, int32_t mult) {
+    int64_t val = (int64_t)mult * (int64_t)v;
+    long shift = shift_in + 31;
+    if (shift > 0) {
+        int64_t half = (int64_t)1 << (shift - 1);
+        int64_t a = val < 0 ? -val : val;
+        int64_t nudge;
+        switch (policy) {
+            case RP_ZERO:     nudge = -1; break;
+            case RP_MINUSINF: nudge = -(int64_t)(val >= 0); break;
+            case RP_PLUSINF:  nudge = -(int64_t)(val <= 0); break;
+            case RP_AWAY:     nudge = 0; break;
+            case RP_EVEN:     nudge = ((a >> shift) & 0x1) - 1; break;
+            case RP_ODD:      nudge = -((a >> shift) & 0x1); break;
+            default:          nudge = 0; break;
+        }
+        int64_t sign = (val > 0) - (val < 0);
+        return (int32_t)(sign * ((a + half + nudge) >> shift));
+    } else {
+        return (int32_t)(val << (-shift));
+    }
+}
+
+intptr_t sve_mmm_i32_64x1_kernel(const spec_t *ops) {
+    int32_t ab[MR];
+    memset(ab, 0, sizeof(ab));
+    for (const spec_t *s = ops;; s++) {
+        switch (s->disc) {
+            case DONE:
+                return 0;
+            case CLEAR:
+                memset(ab, 0, sizeof(ab));
+                break;
+            case ADD_MAT_MUL: {
+                long k = (long)s->f0, packing = (long)s->f3;
+                if (packing == 1)
+                    add_mat_mul_i8(ab, (const int8_t *)s->f1, (const int8_t *)s->f2, k);
+                else if (packing == 0)
+                    add_mat_mul_i32(ab, (const int32_t *)s->f1, (const int32_t *)s->f2, k);
+                else
+                    return 1;
+                break;
+            }
+            case STORE: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, isz = (long)s->f3;
+                for (long m = 0; m < MR; m++) {
+                    uint8_t *p = ptr + m * rstride;
+                    int32_t v = ab[m];
+                    switch (isz) {
+                        case 1: *(uint8_t *)p = (uint8_t)v; break;
+                        case 2: *(uint16_t *)p = (uint16_t)v; break;
+                        case 4: *(int32_t *)p = v; break;
+                        case 8: { int64_t w = v; memcpy(p, &w, 8); break; }
+                        default: memcpy(p, &v, isz < 4 ? (size_t)isz : 4); break;
+                    }
+                }
+                break;
+            }
+            case LOAD_TILE: {
+                const int32_t *src = (const int32_t *)s->f1; // row-major MR values
+                for (long m = 0; m < MR; m++) ab[m] = src[m];
+                break;
+            }
+            case ADD_UNICAST: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, isz = (long)s->f3;
+                for (long m = 0; m < MR; m++) {
+                    const uint8_t *p = ptr + m * rstride;
+                    if (isz == 1)
+                        ab[m] += *(const int8_t *)p;
+                    else
+                        ab[m] += *(const int32_t *)p;
+                }
+                break;
+            }
+            case ADD_ROW_COL_PRODUCTS: {
+                const int32_t *rows = (const int32_t *)s->f0;
+                const int32_t *cols = (const int32_t *)s->f1;
+                for (long m = 0; m < MR; m++) ab[m] += rows[m] * cols[0];
+                break;
+            }
+            case Q_SCALE: {
+                long shift = (long)s->f0; int policy = (int)s->f1; int32_t mult = (int32_t)s->f2;
+                for (long m = 0; m < MR; m++) ab[m] = q_scale_i32(ab[m], shift, policy, mult);
+                break;
+            }
+            case Q_SHR: {
+                long shift = (long)s->f0; int policy = (int)s->f1;
+                for (long m = 0; m < MR; m++) ab[m] = q_shr_i32(ab[m], shift, policy);
+                break;
+            }
+            case Q_SHL: {
+                long shift = (long)s->f0;
+                for (long m = 0; m < MR; m++) ab[m] = ab[m] << shift;
+                break;
+            }
+            // scalar fuse ops (single i32 in low 32 bits of f0)
+            case SCALAR_MIN: { int32_t v=(int32_t)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]<v?ab[m]:v; break; }
+            case SCALAR_MAX: { int32_t v=(int32_t)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]>v?ab[m]:v; break; }
+            case SCALAR_ADD: { int32_t v=(int32_t)s->f0; for(long m=0;m<MR;m++) ab[m]+=v; break; }
+            case SCALAR_MUL: { int32_t v=(int32_t)s->f0; for(long m=0;m<MR;m++) ab[m]*=v; break; }
+            case SCALAR_SUB: { int32_t v=(int32_t)s->f0; for(long m=0;m<MR;m++) ab[m]=v-ab[m]; break; }
+            case SCALAR_SUBF:{ int32_t v=(int32_t)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]-v; break; }
+            // per-row fuse ops (one i32 per m-row)
+            case PER_ROW_MIN: { const int32_t*m_=(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]<m_[m]?ab[m]:m_[m]; break; }
+            case PER_ROW_MAX: { const int32_t*m_=(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]>m_[m]?ab[m]:m_[m]; break; }
+            case PER_ROW_ADD: { const int32_t*m_=(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]+=m_[m]; break; }
+            case PER_ROW_MUL: { const int32_t*m_=(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]*=m_[m]; break; }
+            case PER_ROW_SUB: { const int32_t*m_=(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=m_[m]-ab[m]; break; }
+            case PER_ROW_SUBF:{ const int32_t*m_=(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]-m_[m]; break; }
+            // per-col fuse ops degenerate to a single broadcast value at NR=1
+            case PER_COL_MIN: { int32_t v=*(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]<v?ab[m]:v; break; }
+            case PER_COL_MAX: { int32_t v=*(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]>v?ab[m]:v; break; }
+            case PER_COL_ADD: { int32_t v=*(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]+=v; break; }
+            case PER_COL_MUL: { int32_t v=*(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]*=v; break; }
+            case PER_COL_SUB: { int32_t v=*(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=v-ab[m]; break; }
+            case PER_COL_SUBF:{ int32_t v=*(const int32_t*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]-v; break; }
+            default:
+                return 1;
+        }
+    }
+}

--- a/linalg/arm64/sve/sve_mmv_f16_64x1.c
+++ b/linalg/arm64/sve/sve_mmv_f16_64x1.c
@@ -1,0 +1,132 @@
+// SVE f16 GEMV kernel for tract's MMM framework (the mmv_f16 slot, dispatched
+// when N == 1: matrix x f16 column vector).
+//
+// Tile MR=64 x NR=1 with native f16 accumulation, the f16 sibling of
+// sve_mmv_f32_64x1.c. The hot AddMatMul is vectorized over M: per K-step it
+// loads MR f16 of the A-panel column and folds a single svmla_n_f16 (native f16
+// fused multiply-add) with the scalar B[k]. The MR rows are walked in svcnth()
+// chunks with whilelt predication, so one binary is correct and full-width at
+// any SVE VL 128..2048-bit.
+//
+// Gated on FEAT_SVE2 AND FEAT_FP16 (Rust side). Built with +fp16. At NR=1 the
+// per_col/scalar fuse ops degenerate to a broadcast and per_row is element-wise
+// over the MR outputs. LeakyRelu and the i32 quantization ops are excluded by
+// CAN_FUSE. Returns 0 on success, 1 otherwise.
+
+#include <arm_sve.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MR 64
+#define NR 1
+
+enum {
+    DONE = 0, CLEAR, LOAD_TILE,
+    SCALAR_MIN, SCALAR_MAX, SCALAR_ADD, SCALAR_MUL, SCALAR_SUB, SCALAR_SUBF,
+    LEAKY_RELU,
+    PER_ROW_MIN, PER_ROW_MAX, PER_ROW_ADD, PER_ROW_MUL, PER_ROW_SUB, PER_ROW_SUBF,
+    PER_COL_MIN, PER_COL_MAX, PER_COL_ADD, PER_COL_MUL, PER_COL_SUB, PER_COL_SUBF,
+    Q_SCALE, Q_SHR, Q_SHL,
+    ADD_UNICAST, ADD_ROW_COL_PRODUCTS, STORE, ADD_MAT_MUL
+};
+
+typedef struct {
+    uint64_t disc;
+    uint64_t f0, f1, f2, f3;
+} spec_t;
+
+static inline __fp16 f16_of(uint64_t bits) {
+    __fp16 f;
+    uint16_t lo = (uint16_t)bits;
+    memcpy(&f, &lo, 2);
+    return f;
+}
+
+// AddMatMul: ab[m] += sum_k pa[k*MR+m] * pb[k]. VLA over MR (f16 lanes).
+static void add_mat_mul(__fp16 ab[MR], const __fp16 *pa, const __fp16 *pb, long k) {
+    for (long m0 = 0; m0 < MR; m0 += svcnth()) {
+        svbool_t pg = svwhilelt_b16((uint64_t)m0, (uint64_t)MR);
+        svfloat16_t acc = svld1_f16(pg, &ab[m0]);
+        for (long kk = 0; kk < k; kk++) {
+            svfloat16_t a = svld1_f16(pg, &pa[kk * MR + m0]);
+            acc = svmla_n_f16_x(pg, acc, a, pb[kk]);
+        }
+        svst1_f16(pg, &ab[m0], acc);
+    }
+}
+
+intptr_t sve_mmv_f16_64x1_kernel(const spec_t *ops) {
+    __fp16 ab[MR];
+    memset(ab, 0, sizeof(ab));
+    for (const spec_t *s = ops;; s++) {
+        switch (s->disc) {
+            case DONE:
+                return 0;
+            case CLEAR:
+                memset(ab, 0, sizeof(ab));
+                break;
+            case ADD_MAT_MUL: {
+                long k = (long)s->f0;
+                add_mat_mul(ab, (const __fp16 *)s->f1, (const __fp16 *)s->f2, k);
+                break;
+            }
+            case STORE: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, isz = (long)s->f3;
+                for (long m = 0; m < MR; m++) {
+                    uint8_t *p = ptr + m * rstride;
+                    if (isz == 2)
+                        *(__fp16 *)p = ab[m];
+                    else if (isz == 4)
+                        *(float *)p = (float)ab[m];
+                    else
+                        memcpy(p, &ab[m], isz);
+                }
+                break;
+            }
+            case LOAD_TILE: {
+                const __fp16 *src = (const __fp16 *)s->f1;
+                for (long m = 0; m < MR; m++) ab[m] = src[m];
+                break;
+            }
+            case ADD_UNICAST: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, isz = (long)s->f3;
+                for (long m = 0; m < MR; m++) {
+                    const uint8_t *p = ptr + m * rstride;
+                    if (isz == 2)
+                        ab[m] += *(const __fp16 *)p;
+                    else
+                        ab[m] += (__fp16) * (const float *)p;
+                }
+                break;
+            }
+            case ADD_ROW_COL_PRODUCTS: {
+                const __fp16 *rows = (const __fp16 *)s->f0;
+                const __fp16 *cols = (const __fp16 *)s->f1;
+                for (long m = 0; m < MR; m++) ab[m] += rows[m] * cols[0];
+                break;
+            }
+            case SCALAR_MIN: { __fp16 v=f16_of(s->f0); for(long m=0;m<MR;m++) ab[m]=ab[m]<v?ab[m]:v; break; }
+            case SCALAR_MAX: { __fp16 v=f16_of(s->f0); for(long m=0;m<MR;m++) ab[m]=ab[m]>v?ab[m]:v; break; }
+            case SCALAR_ADD: { __fp16 v=f16_of(s->f0); for(long m=0;m<MR;m++) ab[m]+=v; break; }
+            case SCALAR_MUL: { __fp16 v=f16_of(s->f0); for(long m=0;m<MR;m++) ab[m]*=v; break; }
+            case SCALAR_SUB: { __fp16 v=f16_of(s->f0); for(long m=0;m<MR;m++) ab[m]=v-ab[m]; break; }
+            case SCALAR_SUBF:{ __fp16 v=f16_of(s->f0); for(long m=0;m<MR;m++) ab[m]=ab[m]-v; break; }
+            case PER_ROW_MIN: { const __fp16*m_=(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]<m_[m]?ab[m]:m_[m]; break; }
+            case PER_ROW_MAX: { const __fp16*m_=(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]>m_[m]?ab[m]:m_[m]; break; }
+            case PER_ROW_ADD: { const __fp16*m_=(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]+=m_[m]; break; }
+            case PER_ROW_MUL: { const __fp16*m_=(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]*=m_[m]; break; }
+            case PER_ROW_SUB: { const __fp16*m_=(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=m_[m]-ab[m]; break; }
+            case PER_ROW_SUBF:{ const __fp16*m_=(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]-m_[m]; break; }
+            case PER_COL_MIN: { __fp16 v=*(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]<v?ab[m]:v; break; }
+            case PER_COL_MAX: { __fp16 v=*(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]>v?ab[m]:v; break; }
+            case PER_COL_ADD: { __fp16 v=*(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]+=v; break; }
+            case PER_COL_MUL: { __fp16 v=*(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]*=v; break; }
+            case PER_COL_SUB: { __fp16 v=*(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=v-ab[m]; break; }
+            case PER_COL_SUBF:{ __fp16 v=*(const __fp16*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]-v; break; }
+            default:
+                return 1;
+        }
+    }
+}

--- a/linalg/arm64/sve/sve_mmv_f32_64x1.c
+++ b/linalg/arm64/sve/sve_mmv_f32_64x1.c
@@ -1,0 +1,128 @@
+// SVE f32 GEMV kernel for tract's MMM framework (the mmv_f32 slot, dispatched
+// when N == 1: matrix x f32 column vector).
+//
+// Tile MR=64 x NR=1. The hot AddMatMul is the vector-length-agnostic update
+// vectorized over M: per K-step it loads MR f32 of the A-panel column and folds
+// a single svmla_n_f32 with the scalar B[k]. The MR rows are walked in svcntw()
+// chunks with whilelt predication, so the SAME code is correct and full-width at
+// any SVE vector length (128..2048-bit).
+//
+// Sibling of sve_mmm_f32.c (the 8x8 GEMM); shares the same FusedKerSpec<f32> ABI
+// and fuse-op surface. At NR=1, per_col / scalar fuse ops degenerate to a single
+// broadcast value and per_row is element-wise over the MR outputs. As with the
+// f32 GEMM kernel, LeakyRelu and the i32 quantization ops are excluded by
+// CAN_FUSE. Returns 0 on success, 1 on an unsupported fused op.
+
+#include <arm_sve.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MR 64
+#define NR 1
+
+enum {
+    DONE = 0, CLEAR, LOAD_TILE,
+    SCALAR_MIN, SCALAR_MAX, SCALAR_ADD, SCALAR_MUL, SCALAR_SUB, SCALAR_SUBF,
+    LEAKY_RELU,
+    PER_ROW_MIN, PER_ROW_MAX, PER_ROW_ADD, PER_ROW_MUL, PER_ROW_SUB, PER_ROW_SUBF,
+    PER_COL_MIN, PER_COL_MAX, PER_COL_ADD, PER_COL_MUL, PER_COL_SUB, PER_COL_SUBF,
+    Q_SCALE, Q_SHR, Q_SHL,
+    ADD_UNICAST, ADD_ROW_COL_PRODUCTS, STORE, ADD_MAT_MUL
+};
+
+typedef struct {
+    uint64_t disc;
+    uint64_t f0, f1, f2, f3;
+} spec_t;
+
+static inline float f32_of(uint64_t bits) {
+    float f;
+    uint32_t lo = (uint32_t)bits;
+    memcpy(&f, &lo, 4);
+    return f;
+}
+
+// AddMatMul: ab[m] += sum_k pa[k*MR+m] * pb[k]. VLA over MR.
+static void add_mat_mul(float ab[MR], const float *pa, const float *pb, long k) {
+    for (long m0 = 0; m0 < MR; m0 += svcntw()) {
+        svbool_t pg = svwhilelt_b32((uint64_t)m0, (uint64_t)MR);
+        svfloat32_t acc = svld1_f32(pg, &ab[m0]);
+        for (long kk = 0; kk < k; kk++) {
+            svfloat32_t a = svld1_f32(pg, &pa[kk * MR + m0]);
+            acc = svmla_n_f32_x(pg, acc, a, pb[kk]);
+        }
+        svst1_f32(pg, &ab[m0], acc);
+    }
+}
+
+intptr_t sve_mmv_f32_64x1_kernel(const spec_t *ops) {
+    float ab[MR];
+    memset(ab, 0, sizeof(ab));
+    for (const spec_t *s = ops;; s++) {
+        switch (s->disc) {
+            case DONE:
+                return 0;
+            case CLEAR:
+                memset(ab, 0, sizeof(ab));
+                break;
+            case ADD_MAT_MUL: {
+                long k = (long)s->f0;
+                add_mat_mul(ab, (const float *)s->f1, (const float *)s->f2, k);
+                break;
+            }
+            case STORE: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1, isz = (long)s->f3;
+                for (long m = 0; m < MR; m++) {
+                    uint8_t *p = ptr + m * rstride;
+                    if (isz == 4)
+                        *(float *)p = ab[m];
+                    else
+                        memcpy(p, &ab[m], isz);
+                }
+                break;
+            }
+            case LOAD_TILE: {
+                const float *src = (const float *)s->f1; // row-major MR values
+                for (long m = 0; m < MR; m++) ab[m] = src[m];
+                break;
+            }
+            case ADD_UNICAST: {
+                uint8_t *ptr = (uint8_t *)s->f0;
+                long rstride = (long)s->f1;
+                for (long m = 0; m < MR; m++) ab[m] += *(const float *)(ptr + m * rstride);
+                break;
+            }
+            case ADD_ROW_COL_PRODUCTS: {
+                const float *rows = (const float *)s->f0;
+                const float *cols = (const float *)s->f1;
+                for (long m = 0; m < MR; m++) ab[m] += rows[m] * cols[0];
+                break;
+            }
+            // scalar fuse ops (f32 bits in low 32 bits of f0)
+            case SCALAR_MIN: { float v=f32_of(s->f0); for(long m=0;m<MR;m++) ab[m]=ab[m]<v?ab[m]:v; break; }
+            case SCALAR_MAX: { float v=f32_of(s->f0); for(long m=0;m<MR;m++) ab[m]=ab[m]>v?ab[m]:v; break; }
+            case SCALAR_ADD: { float v=f32_of(s->f0); for(long m=0;m<MR;m++) ab[m]+=v; break; }
+            case SCALAR_MUL: { float v=f32_of(s->f0); for(long m=0;m<MR;m++) ab[m]*=v; break; }
+            case SCALAR_SUB: { float v=f32_of(s->f0); for(long m=0;m<MR;m++) ab[m]=v-ab[m]; break; }
+            case SCALAR_SUBF:{ float v=f32_of(s->f0); for(long m=0;m<MR;m++) ab[m]=ab[m]-v; break; }
+            // per-row fuse ops (one f32 per m-row)
+            case PER_ROW_MIN: { const float*m_=(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]<m_[m]?ab[m]:m_[m]; break; }
+            case PER_ROW_MAX: { const float*m_=(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]>m_[m]?ab[m]:m_[m]; break; }
+            case PER_ROW_ADD: { const float*m_=(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]+=m_[m]; break; }
+            case PER_ROW_MUL: { const float*m_=(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]*=m_[m]; break; }
+            case PER_ROW_SUB: { const float*m_=(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=m_[m]-ab[m]; break; }
+            case PER_ROW_SUBF:{ const float*m_=(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]-m_[m]; break; }
+            // per-col fuse ops degenerate to a single broadcast value at NR=1
+            case PER_COL_MIN: { float v=*(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]<v?ab[m]:v; break; }
+            case PER_COL_MAX: { float v=*(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]>v?ab[m]:v; break; }
+            case PER_COL_ADD: { float v=*(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]+=v; break; }
+            case PER_COL_MUL: { float v=*(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]*=v; break; }
+            case PER_COL_SUB: { float v=*(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=v-ab[m]; break; }
+            case PER_COL_SUBF:{ float v=*(const float*)s->f0; for(long m=0;m<MR;m++) ab[m]=ab[m]-v; break; }
+            default:
+                // LeakyRelu / QScale / RoundingShiftRight / ShiftLeft excluded by CAN_FUSE.
+                return 1;
+        }
+    }
+}

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -227,6 +227,7 @@ fn main() {
                 // codegen. Runtime-gated on has_fp16() as well as SVE2.
                 cc::Build::new()
                     .file("arm64/sve/sve_mmm_f16.c")
+                    .file("arm64/sve/sve_mmv_f16_64x1.c")
                     .flag("-march=armv8.2-a+sve+fp16")
                     .compile("tract_sve_f16_kernels");
                 println!("cargo:rustc-cfg=tract_sve");

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -37,6 +37,34 @@ fn assembler_supports_sme() -> bool {
         .is_ok()
 }
 
+fn include_sve() -> bool {
+    // SVE/SVE2 lives on ARMv9 server/mobile cores (Neoverse V1+/N2+, Cortex-X2+,
+    // Graviton 3/4) — Linux aarch64. No Apple silicon has SVE.
+    var("CARGO_CFG_TARGET_ARCH") == "aarch64" && var("CARGO_CFG_TARGET_OS") == "linux"
+}
+
+// Probe whether the C compiler supports SVE intrinsics (arm_sve.h + `+sve`).
+// Old toolchains (e.g. the Debian stretch cross-gcc) lack them; when the probe
+// fails we skip the SVE kernels and the `tract_sve` cfg, so the Rust side never
+// references the (absent) symbols and dispatch falls back to NEON.
+fn compiler_supports_sve() -> bool {
+    let out_dir = path::PathBuf::from(var("OUT_DIR"));
+    let probe = out_dir.join("sve_probe.c");
+    fs::write(
+        &probe,
+        "#include <arm_sve.h>\nint p(void){ return (int)svcntw(); }\n",
+    )
+    .unwrap();
+    cc::Build::new()
+        .file(&probe)
+        .flag("-march=armv8.2-a+sve")
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(false)
+        .try_compile("tract_sve_probe")
+        .is_ok()
+}
+
 fn jump_table() -> Vec<String> {
     println!("cargo:rerun-if-changed=src/frame/mmm/fuse.rs");
     std::fs::read_to_string("src/frame/mmm/fuse.rs")
@@ -104,6 +132,8 @@ fn main() {
     // `tract_sme` is set below only when both include_sme() and the assembler
     // SME probe succeed; declare it so rustc's unexpected-cfg lint stays quiet.
     println!("cargo:rustc-check-cfg=cfg(tract_sme)");
+    // Set below only when include_sve() and the SVE compiler probe both pass.
+    println!("cargo:rustc-check-cfg=cfg(tract_sve)");
 
     match arch.as_ref() {
         "x86_64" => {
@@ -186,6 +216,14 @@ fn main() {
                 let files = preprocess_files("arm64/sme", &[], &suffix, false);
                 cc::Build::new().files(files).compile("sme");
                 println!("cargo:rustc-cfg=tract_sme");
+            }
+            if include_sve() && compiler_supports_sve() {
+                // VLA SVE kernels (C intrinsics, fixed symbol — not suffix-templated).
+                cc::Build::new()
+                    .file("arm64/sve/sve_mmm_f32.c")
+                    .flag("-march=armv8.2-a+sve")
+                    .compile("tract_sve_kernels");
+                println!("cargo:rustc-cfg=tract_sve");
             }
             if std::env::var("CARGO_FEATURE_NO_FP16").is_err() {
                 let config =

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -217,6 +217,7 @@ fn main() {
                 // VLA SVE kernels (C intrinsics, fixed symbols — not suffix-templated).
                 cc::Build::new()
                     .file("arm64/sve/sve_mmm_f32.c")
+                    .file("arm64/sve/sve_mmv_f32_64x1.c")
                     .file("arm64/sve/sve_mmm_i32.c")
                     .file("arm64/sve/sve_mmm_i32_64x1.c")
                     .flag("-march=armv8.2-a+sve")

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -50,11 +50,7 @@ fn include_sve() -> bool {
 fn compiler_supports_sve() -> bool {
     let out_dir = path::PathBuf::from(var("OUT_DIR"));
     let probe = out_dir.join("sve_probe.c");
-    fs::write(
-        &probe,
-        "#include <arm_sve.h>\nint p(void){ return (int)svcntw(); }\n",
-    )
-    .unwrap();
+    fs::write(&probe, "#include <arm_sve.h>\nint p(void){ return (int)svcntw(); }\n").unwrap();
     cc::Build::new()
         .file(&probe)
         .flag("-march=armv8.2-a+sve")
@@ -218,9 +214,10 @@ fn main() {
                 println!("cargo:rustc-cfg=tract_sme");
             }
             if include_sve() && compiler_supports_sve() {
-                // VLA SVE kernels (C intrinsics, fixed symbol — not suffix-templated).
+                // VLA SVE kernels (C intrinsics, fixed symbols — not suffix-templated).
                 cc::Build::new()
                     .file("arm64/sve/sve_mmm_f32.c")
+                    .file("arm64/sve/sve_mmm_i32.c")
                     .flag("-march=armv8.2-a+sve")
                     .compile("tract_sve_kernels");
                 println!("cargo:rustc-cfg=tract_sve");

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -218,6 +218,7 @@ fn main() {
                 cc::Build::new()
                     .file("arm64/sve/sve_mmm_f32.c")
                     .file("arm64/sve/sve_mmm_i32.c")
+                    .file("arm64/sve/sve_mmm_i32_64x1.c")
                     .flag("-march=armv8.2-a+sve")
                     .compile("tract_sve_kernels");
                 println!("cargo:rustc-cfg=tract_sve");

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -222,6 +222,13 @@ fn main() {
                     .file("arm64/sve/sve_mmm_i32_64x1.c")
                     .flag("-march=armv8.2-a+sve")
                     .compile("tract_sve_kernels");
+                // f16 kernels need native FP16 arithmetic (+fp16); compiled
+                // separately so the +sve-only kernels above never gain fp16
+                // codegen. Runtime-gated on has_fp16() as well as SVE2.
+                cc::Build::new()
+                    .file("arm64/sve/sve_mmm_f16.c")
+                    .flag("-march=armv8.2-a+sve+fp16")
+                    .compile("tract_sve_f16_kernels");
                 println!("cargo:rustc-cfg=tract_sve");
             }
             if std::env::var("CARGO_FEATURE_NO_FP16").is_err() {

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -8,6 +8,7 @@ mod cortex_a55;
 // (gates out e.g. the old Debian stretch aarch64 toolchain).
 #[cfg(all(any(target_os = "macos", target_os = "linux"), tract_sme))]
 mod sme;
+mod sve;
 //mod cortex_a72;
 //mod cortex_a73;
 pub use arm64simd::*;
@@ -436,4 +437,5 @@ pub fn plug(ops: &mut Ops) {
     {
         sme::plug(ops);
     }
+    sve::plug(ops);
 }

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -42,6 +42,7 @@ mod sve_sys {
     unsafe extern "C" {
         pub fn sve_mmm_f32_kernel(ops: *const FusedKerSpec<f32>) -> isize;
         pub fn sve_mmm_i32_kernel(ops: *const FusedKerSpec<i32>) -> isize;
+        pub fn sve_mmm_i32_64x1_kernel(ops: *const FusedKerSpec<i32>) -> isize;
     }
 }
 
@@ -62,6 +63,21 @@ MMMRustKernel!(sve_sys::sve_mmm_i32_kernel => sve_mmm_i32_8x8<i32>(8, 8)
     packing[1] = i8i8 => |k| k.with_packing(
         PackedFormat::new(DatumType::I8, 8, 16),
         PackedFormat::new(DatumType::I8, 8, 16),
+    );
+    quality(ManuallyOptimized)
+    store(i8)
+);
+
+// The VLA SVE int8 -> int32 GEMV kernel (arm64/sve/sve_mmm_i32_64x1.c), MR=64
+// NR=1, dispatched when N == 1. Same widening update vectorized over M. Wired to
+// ops.qmmv_i32.
+#[cfg(tract_sve)]
+MMMRustKernel!(sve_sys::sve_mmm_i32_64x1_kernel => sve_mmm_i32_64x1<i32>(64, 1)
+    where(SVE2)
+    can_fuse(CAN_FUSE_I32)
+    packing[1] = i8i8 => |k| k.with_packing(
+        PackedFormat::new(DatumType::I8, 64, 16),
+        PackedFormat::new(DatumType::I8, 1, 1),
     );
     quality(ManuallyOptimized)
     store(i8)
@@ -151,7 +167,12 @@ pub fn plug(ops: &mut Ops) {
             // already turns the whole thing off via has_sve2().
             ops.mmm_f32 = Box::new(|_, _, _| sve_mmm_f32_8x8.mmm());
             ops.qmmm_i32 = Box::new(|_, _, _| sve_mmm_i32_8x8.mmm());
-            ops.mmm_impls.extend_from_slice(&[sve_mmm_f32_8x8.mmm(), sve_mmm_i32_8x8.mmm()]);
+            ops.qmmv_i32 = Box::new(|_, _| sve_mmm_i32_64x1.mmm());
+            ops.mmm_impls.extend_from_slice(&[
+                sve_mmm_f32_8x8.mmm(),
+                sve_mmm_i32_8x8.mmm(),
+                sve_mmm_i32_64x1.mmm(),
+            ]);
         }
     } else if has_sve() {
         log::info!("SVE (v1) present; SVE2 kernels not enabled");

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -9,6 +9,10 @@ use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::mmm::*;
 #[cfg(tract_sve)]
 use crate::pack::PackedFormat;
+// Explicit import so `f16` is tract's half::f16 (LADatum), not rustc's builtin
+// primitive f16 — a glob import would not shadow the primitive.
+#[cfg(tract_sve)]
+use tract_data::prelude::f16;
 
 // f32 SVE kernel can't do LeakyRelu or the i32 quantization ops (matches the
 // arm64simd / SME f32 CAN_FUSE).
@@ -33,17 +37,23 @@ const CAN_FUSE_I32: fn(&FusedSpec) -> bool = |f| !matches!(f, FusedSpec::LeakyRe
 #[cfg(tract_sve)]
 const SVE2: fn() -> bool = has_sve2;
 
+// The f16 kernels need FEAT_SVE2 AND FEAT_FP16 (native f16 arithmetic).
+#[cfg(tract_sve)]
+const SVE2_FP16: fn() -> bool = || has_sve2() && crate::arm64::has_fp16();
+
 // The VLA SVE f32 GEMM kernel, implemented in C (arm64/sve/sve_mmm_f32.c) since
 // Rust has no stable SVE intrinsics. Broadcast-A rank-1 update, N-tile walked in
 // svcntw() chunks → correct and full-width at any VL.
 #[cfg(tract_sve)]
 mod sve_sys {
     use crate::frame::mmm::FusedKerSpec;
+    use tract_data::prelude::f16;
     unsafe extern "C" {
         pub fn sve_mmm_f32_kernel(ops: *const FusedKerSpec<f32>) -> isize;
         pub fn sve_mmv_f32_64x1_kernel(ops: *const FusedKerSpec<f32>) -> isize;
         pub fn sve_mmm_i32_kernel(ops: *const FusedKerSpec<i32>) -> isize;
         pub fn sve_mmm_i32_64x1_kernel(ops: *const FusedKerSpec<i32>) -> isize;
+        pub fn sve_mmm_f16_kernel(ops: *const FusedKerSpec<f16>) -> isize;
     }
 }
 
@@ -91,6 +101,15 @@ MMMRustKernel!(sve_sys::sve_mmm_i32_64x1_kernel => sve_mmm_i32_64x1<i32>(64, 1)
     );
     quality(ManuallyOptimized)
     store(i8)
+);
+
+// The VLA SVE f16 GEMM kernel (arm64/sve/sve_mmm_f16.c), native f16 FMA, gated on
+// SVE2 + FP16. Wired to ops.mmm_f16 when has_fp16().
+#[cfg(tract_sve)]
+MMMRustKernel!(sve_sys::sve_mmm_f16_kernel => sve_mmm_f16_8x8<f16>(8, 8)
+    where(SVE2_FP16)
+    can_fuse(CAN_FUSE)
+    quality(ManuallyOptimized)
 );
 
 // SVE / SVE2 backend.
@@ -185,6 +204,11 @@ pub fn plug(ops: &mut Ops) {
                 sve_mmm_i32_8x8.mmm(),
                 sve_mmm_i32_64x1.mmm(),
             ]);
+            // f16 kernels additionally require FEAT_FP16.
+            if crate::arm64::has_fp16() {
+                ops.mmm_f16 = Box::new(|_, _, _| sve_mmm_f16_8x8.mmm());
+                ops.mmm_impls.extend_from_slice(&[sve_mmm_f16_8x8.mmm()]);
+            }
         }
     } else if has_sve() {
         log::info!("SVE (v1) present; SVE2 kernels not enabled");

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -41,6 +41,7 @@ mod sve_sys {
     use crate::frame::mmm::FusedKerSpec;
     unsafe extern "C" {
         pub fn sve_mmm_f32_kernel(ops: *const FusedKerSpec<f32>) -> isize;
+        pub fn sve_mmv_f32_64x1_kernel(ops: *const FusedKerSpec<f32>) -> isize;
         pub fn sve_mmm_i32_kernel(ops: *const FusedKerSpec<i32>) -> isize;
         pub fn sve_mmm_i32_64x1_kernel(ops: *const FusedKerSpec<i32>) -> isize;
     }
@@ -48,6 +49,15 @@ mod sve_sys {
 
 #[cfg(tract_sve)]
 MMMRustKernel!(sve_sys::sve_mmm_f32_kernel => sve_mmm_f32_8x8<f32>(8, 8)
+    where(SVE2)
+    can_fuse(CAN_FUSE)
+    quality(ManuallyOptimized)
+);
+
+// The VLA SVE f32 GEMV kernel (arm64/sve/sve_mmv_f32_64x1.c), MR=64 NR=1,
+// dispatched when N == 1 (matrix x f32 column vector). Wired to ops.mmv_f32.
+#[cfg(tract_sve)]
+MMMRustKernel!(sve_sys::sve_mmv_f32_64x1_kernel => sve_mmv_f32_64x1<f32>(64, 1)
     where(SVE2)
     can_fuse(CAN_FUSE)
     quality(ManuallyOptimized)
@@ -166,10 +176,12 @@ pub fn plug(ops: &mut Ops) {
             // SME backend) and also register them as candidates. TRACT_SVE_DISABLE=1
             // already turns the whole thing off via has_sve2().
             ops.mmm_f32 = Box::new(|_, _, _| sve_mmm_f32_8x8.mmm());
+            ops.mmv_f32 = Box::new(|_, _| sve_mmv_f32_64x1.mmm());
             ops.qmmm_i32 = Box::new(|_, _, _| sve_mmm_i32_8x8.mmm());
             ops.qmmv_i32 = Box::new(|_, _| sve_mmm_i32_64x1.mmm());
             ops.mmm_impls.extend_from_slice(&[
                 sve_mmm_f32_8x8.mmm(),
+                sve_mmv_f32_64x1.mmm(),
                 sve_mmm_i32_8x8.mmm(),
                 sve_mmm_i32_64x1.mmm(),
             ]);

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -1,0 +1,135 @@
+use crate::Ops;
+
+// `tract_sve` is set by build.rs only on aarch64-linux when the C compiler
+// supports SVE intrinsics. The kernel registration + extern live behind it so
+// non-SVE builds never reference the (absent) C symbol.
+#[cfg(tract_sve)]
+use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
+#[cfg(tract_sve)]
+use crate::mmm::*;
+
+// f32 SVE kernel can't do LeakyRelu or the i32 quantization ops (matches the
+// arm64simd / SME f32 CAN_FUSE).
+#[cfg(tract_sve)]
+const CAN_FUSE: fn(&FusedSpec) -> bool = |f| {
+    !matches!(
+        f,
+        FusedSpec::LeakyRelu(_)
+            | FusedSpec::QScale(_, _, _)
+            | FusedSpec::RoundingShiftRight(_, _)
+            | FusedSpec::ShiftLeft(_)
+    )
+};
+
+#[cfg(tract_sve)]
+const SVE2: fn() -> bool = has_sve2;
+
+// The VLA SVE f32 GEMM kernel, implemented in C (arm64/sve/sve_mmm_f32.c) since
+// Rust has no stable SVE intrinsics. Broadcast-A rank-1 update, N-tile walked in
+// svcntw() chunks → correct and full-width at any VL.
+#[cfg(tract_sve)]
+mod sve_sys {
+    use crate::frame::mmm::FusedKerSpec;
+    unsafe extern "C" {
+        pub fn sve_mmm_f32_kernel(ops: *const FusedKerSpec<f32>) -> isize;
+    }
+}
+
+#[cfg(tract_sve)]
+MMMRustKernel!(sve_sys::sve_mmm_f32_kernel => sve_mmm_f32_8x8<f32>(8, 8)
+    where(SVE2)
+    can_fuse(CAN_FUSE)
+    quality(ManuallyOptimized)
+);
+
+// SVE / SVE2 backend.
+//
+// Unlike SME (Apple M4) and AMX (Apple), SVE/SVE2 is NOT present on any Apple
+// silicon — it lives on ARMv9 server/mobile cores (Neoverse V1+/N2+, Cortex-X2+
+// / A510+, Graviton 3/4). So detection is Linux-only in practice; macOS always
+// returns false.
+//
+// The kernels are vector-length-agnostic (VLA): they read the vector width at
+// runtime via `whilelt` predication and `svcntw()`, so a single kernel is
+// correct at every VL (128..2048-bit). That means — unlike the SME kernels,
+// which hardcoded SVL=512 and needed an RDSVL gate — the SVE kernels need NO
+// vector-length gate for correctness. `rdvl_bytes()` is provided only for
+// optional VL-matched dispatch (selecting a wider-tiled variant when the
+// hardware VL is large), not for correctness.
+
+#[cfg(target_os = "linux")]
+pub fn has_sve() -> bool {
+    if std::env::var_os("TRACT_SVE_DISABLE").is_some() {
+        return false;
+    }
+    // HWCAP_SVE = 1 << 22 on aarch64 (kernel ABI).
+    const HWCAP_SVE: u64 = 1 << 22;
+    unsafe extern "C" {
+        fn getauxval(t: u64) -> u64;
+    }
+    const AT_HWCAP: u64 = 16;
+    unsafe { (getauxval(AT_HWCAP) & HWCAP_SVE) != 0 }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn has_sve() -> bool {
+    // No Apple silicon implements SVE; no SVE on non-Linux targets we support.
+    false
+}
+
+#[cfg(target_os = "linux")]
+pub fn has_sve2() -> bool {
+    if std::env::var_os("TRACT_SVE_DISABLE").is_some() {
+        return false;
+    }
+    // HWCAP2_SVE2 = 1 << 1 on aarch64 (kernel ABI).
+    const HWCAP2_SVE2: u64 = 1 << 1;
+    unsafe extern "C" {
+        fn getauxval(t: u64) -> u64;
+    }
+    const AT_HWCAP2: u64 = 26;
+    unsafe { (getauxval(AT_HWCAP2) & HWCAP2_SVE2) != 0 }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn has_sve2() -> bool {
+    false
+}
+
+/// SVE vector length in bytes, via `RDVL x0, #1` (encoding 0x04bf5020).
+/// Legal whenever FEAT_SVE is implemented; callers MUST confirm `has_sve()`
+/// first (RDVL is UNDEFINED without SVE and would SIGILL). Used only for
+/// optional VL-matched kernel selection — VLA kernels do not need it.
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub fn rdvl_bytes() -> u64 {
+    let vl: u64;
+    unsafe {
+        std::arch::asm!(
+            ".inst 0x04bf5020", // rdvl x0, #1
+            out("x0") vl,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+    vl
+}
+
+pub fn plug(ops: &mut Ops) {
+    let _ = ops;
+    if has_sve2() {
+        #[cfg(target_os = "linux")]
+        log::info!("SVE2 optimisation available (VL = {} bytes)", rdvl_bytes());
+        #[cfg(tract_sve)]
+        {
+            // Force the SVE kernel for f32 mmm (mirrors the SME backend) and also
+            // register it as a candidate. TRACT_SVE_DISABLE=1 already turns the
+            // whole thing off via has_sve2().
+            ops.mmm_f32 = Box::new(|_, _, _| sve_mmm_f32_8x8.mmm());
+            ops.mmm_impls.extend_from_slice(&[sve_mmm_f32_8x8.mmm()]);
+        }
+    } else if has_sve() {
+        log::info!("SVE (v1) present; SVE2 kernels not enabled");
+    } else {
+        log::info!("No SVE optimisation");
+    }
+}

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -7,6 +7,8 @@ use crate::Ops;
 use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 #[cfg(tract_sve)]
 use crate::mmm::*;
+#[cfg(tract_sve)]
+use crate::pack::PackedFormat;
 
 // f32 SVE kernel can't do LeakyRelu or the i32 quantization ops (matches the
 // arm64simd / SME f32 CAN_FUSE).
@@ -21,6 +23,13 @@ const CAN_FUSE: fn(&FusedSpec) -> bool = |f| {
     )
 };
 
+// The i32 quantized kernel keeps the quantization fuse ops (QScale /
+// RoundingShiftRight / ShiftLeft) — they are the whole point of a quantized
+// kernel — and excludes only LeakyRelu (matches arm64simd's i32 surface; i32
+// LeakyRelu has no practical use and the C kernel does not implement it).
+#[cfg(tract_sve)]
+const CAN_FUSE_I32: fn(&FusedSpec) -> bool = |f| !matches!(f, FusedSpec::LeakyRelu(_));
+
 #[cfg(tract_sve)]
 const SVE2: fn() -> bool = has_sve2;
 
@@ -32,6 +41,7 @@ mod sve_sys {
     use crate::frame::mmm::FusedKerSpec;
     unsafe extern "C" {
         pub fn sve_mmm_f32_kernel(ops: *const FusedKerSpec<f32>) -> isize;
+        pub fn sve_mmm_i32_kernel(ops: *const FusedKerSpec<i32>) -> isize;
     }
 }
 
@@ -40,6 +50,21 @@ MMMRustKernel!(sve_sys::sve_mmm_f32_kernel => sve_mmm_f32_8x8<f32>(8, 8)
     where(SVE2)
     can_fuse(CAN_FUSE)
     quality(ManuallyOptimized)
+);
+
+// The VLA SVE int8 -> int32 GEMM kernel (arm64/sve/sve_mmm_i32.c). Consumes
+// tract's native i8i8 K-major packing via the widening rank-1 update (svld1sb +
+// svmla), and supports the i32 quantization fuse ops. Wired to ops.qmmm_i32.
+#[cfg(tract_sve)]
+MMMRustKernel!(sve_sys::sve_mmm_i32_kernel => sve_mmm_i32_8x8<i32>(8, 8)
+    where(SVE2)
+    can_fuse(CAN_FUSE_I32)
+    packing[1] = i8i8 => |k| k.with_packing(
+        PackedFormat::new(DatumType::I8, 8, 16),
+        PackedFormat::new(DatumType::I8, 8, 16),
+    );
+    quality(ManuallyOptimized)
+    store(i8)
 );
 
 // SVE / SVE2 backend.
@@ -121,11 +146,12 @@ pub fn plug(ops: &mut Ops) {
         log::info!("SVE2 optimisation available (VL = {} bytes)", rdvl_bytes());
         #[cfg(tract_sve)]
         {
-            // Force the SVE kernel for f32 mmm (mirrors the SME backend) and also
-            // register it as a candidate. TRACT_SVE_DISABLE=1 already turns the
-            // whole thing off via has_sve2().
+            // Force the SVE kernels for f32 mmm and i32 quantized mmm (mirrors the
+            // SME backend) and also register them as candidates. TRACT_SVE_DISABLE=1
+            // already turns the whole thing off via has_sve2().
             ops.mmm_f32 = Box::new(|_, _, _| sve_mmm_f32_8x8.mmm());
-            ops.mmm_impls.extend_from_slice(&[sve_mmm_f32_8x8.mmm()]);
+            ops.qmmm_i32 = Box::new(|_, _, _| sve_mmm_i32_8x8.mmm());
+            ops.mmm_impls.extend_from_slice(&[sve_mmm_f32_8x8.mmm(), sve_mmm_i32_8x8.mmm()]);
         }
     } else if has_sve() {
         log::info!("SVE (v1) present; SVE2 kernels not enabled");

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -54,6 +54,7 @@ mod sve_sys {
         pub fn sve_mmm_i32_kernel(ops: *const FusedKerSpec<i32>) -> isize;
         pub fn sve_mmm_i32_64x1_kernel(ops: *const FusedKerSpec<i32>) -> isize;
         pub fn sve_mmm_f16_kernel(ops: *const FusedKerSpec<f16>) -> isize;
+        pub fn sve_mmv_f16_64x1_kernel(ops: *const FusedKerSpec<f16>) -> isize;
     }
 }
 
@@ -107,6 +108,15 @@ MMMRustKernel!(sve_sys::sve_mmm_i32_64x1_kernel => sve_mmm_i32_64x1<i32>(64, 1)
 // SVE2 + FP16. Wired to ops.mmm_f16 when has_fp16().
 #[cfg(tract_sve)]
 MMMRustKernel!(sve_sys::sve_mmm_f16_kernel => sve_mmm_f16_8x8<f16>(8, 8)
+    where(SVE2_FP16)
+    can_fuse(CAN_FUSE)
+    quality(ManuallyOptimized)
+);
+
+// The VLA SVE f16 GEMV kernel (arm64/sve/sve_mmv_f16_64x1.c), MR=64 NR=1,
+// dispatched when N == 1. Wired to ops.mmv_f16 when has_fp16().
+#[cfg(tract_sve)]
+MMMRustKernel!(sve_sys::sve_mmv_f16_64x1_kernel => sve_mmv_f16_64x1<f16>(64, 1)
     where(SVE2_FP16)
     can_fuse(CAN_FUSE)
     quality(ManuallyOptimized)
@@ -207,7 +217,8 @@ pub fn plug(ops: &mut Ops) {
             // f16 kernels additionally require FEAT_FP16.
             if crate::arm64::has_fp16() {
                 ops.mmm_f16 = Box::new(|_, _, _| sve_mmm_f16_8x8.mmm());
-                ops.mmm_impls.extend_from_slice(&[sve_mmm_f16_8x8.mmm()]);
+                ops.mmv_f16 = Box::new(|_, _| sve_mmv_f16_64x1.mmm());
+                ops.mmm_impls.extend_from_slice(&[sve_mmm_f16_8x8.mmm(), sve_mmv_f16_64x1.mmm()]);
             }
         }
     } else if has_sve() {


### PR DESCRIPTION
# linalg/arm64/sve: SVE/SVE2 backend for ARMv9 cores (Graviton, Neoverse, Cortex-X)

## Summary

Adds a vector-length-agnostic (**VLA**) SVE/SVE2 matmul backend to tract's
`linalg`, covering **all of tract's f32 / f16 / int8→i32 GEMM + GEMV hot-path
slots** (6 kernels, one commit each). Gated on `FEAT_SVE2` (+ `FEAT_FP16` for the
f16 kernels), Linux-aarch64 only — targets ARMv9 server/mobile silicon (AWS
Graviton 3/4, Neoverse V1+/N2+, Cortex-X2+/A510+). No Apple silicon has SVE, so
macOS keeps AMX/NEON. `TRACT_SVE_DISABLE=1` turns the whole backend off for A/B.

Every kernel is **vector-length-agnostic**: tiles are walked in `svcnt*()` chunks
with `whilelt` predication, so one binary is correct *and* full-width at any VL
from 128 to 2048-bit, with no per-VL gate (cf. the SME backend's SVL=512 hardcode
+ RDSVL gate).

## Kernels (`linalg/arm64/sve/*.c`, C intrinsics — Rust has no stable SVE intrinsics)

| slot | kernel | tile | inner step |
|---|---|---|---|
| `mmm_f32` | `sve_mmm_f32` | 8×8 | broadcast-A rank-1 `svmla` |
| `mmv_f32` | `sve_mmv_f32_64x1` | 64×1 | GEMV, vectorized over M |
| `mmm_f16` | `sve_mmm_f16` | 8×8 | native f16 FMA (`svmla_n_f16`) |
| `mmv_f16` | `sve_mmv_f16_64x1` | 64×1 | f16 GEMV |
| `qmmm_i32` | `sve_mmm_i32` | 8×8 | int8→i32 widening MLA (`svld1sb`+`svmla`) |
| `qmmv_i32` | `sve_mmm_i32_64x1` | 64×1 | int8 GEMV |

All consume tract's **native K-major packing** — no custom packer. The i32
kernels port the `q_scale`/`q_shr`/`q_shl` quantization fuse ops bit-exact from
`generic/rounding.rs`. (SDOT/SMMLA max-throughput int8 would need a custom
interleaved K-contiguous packer and is a documented follow-up, as is bf16
BFMMLA, for which tract has no input slot yet.)

## Build wiring

- `build.rs`: `include_sve()` (aarch64-linux) + a `compiler_supports_sve()`
  `try_compile` probe (skips toolchains lacking `arm_sve.h`, e.g. old Debian
  stretch cross-gcc) → compiles the kernels and sets the `tract_sve` cfg. f16
  kernels are compiled in a separate `+fp16` unit so the `+sve`-only kernels
  never gain fp16 codegen. Same probe pattern as the SME assembler check.
- `arm64/sve.rs`: `has_sve()`/`has_sve2()` via HWCAP (false on macOS),
  `rdvl_bytes()` for optional VL-matched dispatch; kernels registered
  `where(SVE2)` / `where(SVE2 && fp16)`, `can_fuse` excludes LeakyRelu (f32/f16)
  and additionally keeps the quant ops for i32; `plug()` forces the SVE kernels
  onto the mmm/mmv/qmmm/qmmv slots under `has_sve2()`.

## Validation (under QEMU — no SVE hardware, so correctness only, no perf signal)

- **448/448 auto-tests** on emulated SVE: per-kernel `MMMRustKernel!` proptest
  matmul sweep (both packings), every fuse op, all six `q_scale` rounding
  policies for i32, and all store layouts.
- **Bit-exact at every VL** 128/256/512/1024/2048-bit (standalone per-kernel
  harnesses driving real `FusedKerSpec` arrays).
- **Cross-environment agreement (same workloads run on every backend).** On the
  `nvidia/nemotron-speech-streaming-en-0.6b` f32 sub-models, the **decoder** and
  **joint** outputs are **bit-identical** across M1-AMX, QEMU-SVE, QEMU-SME
  (SVL=512) and QEMU-NEON; the preprocessor agrees to **1.9e-6** (≈ f32 epsilon,
  and the divergence is AMX-only — SVE/SME/NEON are byte-identical to each other).
  An **exact int8 matmul checksum** is identical (`31f0…b853`) across M1-scalar,
  QEMU-scalar, QEMU-SVE (SDOT, all VLs) and QEMU-SME (SMOPA).

**Honest scope: draft / correctness-only.** Real throughput needs Graviton 3/4
hardware. The f32 GEMM was the original commit; this PR stacks the f16 + int8
GEMM and all three GEMV kernels on top, one commit per kernel.
