### PR TITLE
test-rt/suite-onnx: gate test_convtranspose_autopad_same to since:18

### DIFF
--- a/test-rt/suite-onnx/node.txt
+++ b/test-rt/suite-onnx/node.txt
@@ -728,7 +728,7 @@ test_attention_4d_with_qk_matmul_softmax_expanded since:24
 test_averagepool_2d_ceil_last_window_starts_on_pad since:24
 test_conv_with_autopad_same
 test_convinteger_without_padding
-test_convtranspose_autopad_same
+test_convtranspose_autopad_same since:18
 test_convtranspose_group_2 since:24
 test_convtranspose_group_2_image_3 since:24
 test_gelu_default_1_expanded since:24


### PR DESCRIPTION
The onnx 1.9.0 backend fixture uses auto_pad=SAME_LOWER with an expected output that pre-dates onnx PR #3440 (April 2021), where the spec and test data were corrected to match the implementation (ONNXRuntime + tract). From opset 18 onward the fixture uses SAME_UPPER and matches.

Direct evidence: passes on v1_13_0 and v1_19_1, fails on v1_9_0.