### PR TITLE
docs: address Julien's review remarks (i-iv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ let model = tract::onnx()?
 let result = model.run([input.tract()?])?;
 ```
 
-The `tract` crate (`api/rs/src/lib.rs`) is the authoritative public API. The
+The [`tract`](https://crates.io/crates/tract) crate (`api/rs/src/lib.rs`) is the authoritative public API. The
 internal crates (`tract-core`, `tract-nnef`, `tract-onnx`, ...) are not
 stable surface and shouldn't be depended on directly.
+
+For Python, see the [`tract`](https://pypi.org/project/tract/) package on PyPI.
 
 ## Examples
 
@@ -53,10 +55,24 @@ targets today:
 | [`face_detection_yolov8onnx_example`](examples/face_detection_yolov8onnx_example) / [`face_similarity_arcface_onnx`](examples/face_similarity_arcface_onnx) | Modern object detection / face recognition |
 | [`wasm-model-bench`](examples/wasm-model-bench) | Running tract in the browser |
 
-Deeper technical material lives under [`doc/`](doc/) (start at
-[`doc/intro.md`](doc/intro.md)). The Sonos engineering
-[blog](https://tech-blog.sonos.com/posts/optimising-a-neural-network-for-inference/)
+## Resources
+
+Technical documentation lives under [`doc/`](doc/) (start at [`doc/intro.md`](doc/intro.md));
+the [`doc/cli-recipe.md`](doc/cli-recipe.md) page collects practical CLI recipes.
+The Sonos engineering [blog](https://tech-blog.sonos.com/posts/optimising-a-neural-network-for-inference/)
 has a long-form post on tract internals.
+
+## Python
+
+tract is also available as the [`tract`](https://pypi.org/project/tract/) package on PyPI,
+built on top of the same Rust core:
+
+```sh
+pip install tract
+```
+
+The API mirrors the Rust pipeline: load a model, set input facts, optimise, then run.
+Documentation: [sonos.github.io/tract](https://sonos.github.io/tract). Source lives in [`api/py/`](api/py/).
 
 ## Backends
 

--- a/doc/cli-recipe.md
+++ b/doc/cli-recipe.md
@@ -237,3 +237,22 @@ The log displays "Checked output #0, ok." (among other information).
 
 [generate_io.py here](/onnx/test_cases/transformer-mlm/generate_io.py) contains an example building a
 testcase for a BERT model from huggingface for inspiration.
+
+## Saving outputs
+
+The `--save-outputs` (long form `--save-outputs-npz`) flag on the `run` subcommand writes the
+model outputs to an `.npz` file after execution. This is the easiest way to capture a reference
+output for a given input, which can then be used with `--assert-output-bundle` in a later run.
+
+```sh
+# capture outputs from a first run
+tract -O model.onnx run --input-from-bundle inputs.npz --save-outputs reference.npz
+
+# replay and assert on a subsequent run (e.g. after a code change)
+tract -O model.onnx run --input-from-bundle inputs.npz --assert-output-bundle reference.npz
+```
+
+Output tensors are keyed by their model output name (or `output_N` if unnamed).
+
+There is also `--save-outputs-nnef` which writes each output tensor as a separate `.dat` file
+in a folder, in NNEF layout — useful for inspecting individual tensors with external tools.


### PR DESCRIPTION
(i) Quick start: link the tract crate to crates.io; add one-line pointer to
    the Python package for Python users.
(ii) Add ## Python section with PyPI install snippet, docs URL, and pointer
     to api/py/.
(iii) Move the doc/blog pointer out of the Examples section into its own
     ## Resources section; add cli-recipe.md to the pointer list.
(iv) Add --save-outputs / --save-outputs-nnef section to doc/cli-recipe.md
     with a capture-then-assert workflow example.