### PR TITLE
DEBUG: instrument unicast OOB site

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ inherits="release"
 lto=false
 
 [profile.release]
-# debug = true
+debug = true
 lto = true
 
 [profile.bench]

--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -808,12 +808,33 @@ impl EvalOp for OptBinUnicast {
             let iterating_shape = a.shape()[..first_non_unary_axis].to_vec();
             for it_coords in tract_ndarray::indices(iterating_shape) {
                 let mut view = TensorView::at_prefix(&a, it_coords.slice())?;
-                debug_assert_eq!(view.shape(), &b_view.shape()[it_coords.slice().len()..]);
+                if view.shape() != &b_view.shape()[it_coords.slice().len()..] {
+                    eprintln!(
+                        "[optbin-instr] OptBinUnicast::eval shape mismatch: binop={} \
+                         a.shape={:?} b.shape={:?} first_non_unary_axis={} \
+                         it_coords={:?} view.shape={:?} b_inner={:?}",
+                        self.binop.name(),
+                        a.shape(),
+                        b_view.shape(),
+                        first_non_unary_axis,
+                        it_coords.slice(),
+                        view.shape(),
+                        &b_view.shape()[it_coords.slice().len()..],
+                    );
+                }
                 (self.eval_fn)(&mut view, &b_view)?;
             }
         } else {
             let mut view = a.view();
-            debug_assert_eq!(view.shape(), b_view.shape());
+            if view.shape() != b_view.shape() {
+                eprintln!(
+                    "[optbin-instr] OptBinUnicast::eval (no-iter) shape mismatch: binop={} \
+                     a.shape={:?} b.shape={:?}",
+                    self.binop.name(),
+                    a.shape(),
+                    b_view.shape(),
+                );
+            }
             (self.eval_fn)(&mut view, &b_view)?;
         }
 

--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -803,36 +803,56 @@ impl EvalOp for OptBinUnicast {
         let first_non_unary_axis =
             b_shape.iter().enumerate().take_while(|&(_, &dim)| dim == 1).map(|(i, _)| i + 1).last();
 
+        // [optbin-instr] entry trace — always print so we know which OptBinUnicast invocation
+        // is running. Cheap, fires once per eval, lets us correlate with [unicast-instr].
+        eprintln!(
+            "[optbin-instr] OptBinUnicast::eval ENTRY binop={} a.shape={:?} b.shape={:?} \
+             first_non_unary_axis={:?}",
+            self.binop.name(),
+            a.shape(),
+            b_view.shape(),
+            first_non_unary_axis,
+        );
+
         if let Some(first_non_unary_axis) = first_non_unary_axis {
             // Iterate on outter dimensions and evaluate with unicast subviews
             let iterating_shape = a.shape()[..first_non_unary_axis].to_vec();
             for it_coords in tract_ndarray::indices(iterating_shape) {
                 let mut view = TensorView::at_prefix(&a, it_coords.slice())?;
-                if view.shape() != &b_view.shape()[it_coords.slice().len()..] {
+                let view_len: usize = view.shape().iter().product();
+                let b_view_len: usize = b_view.shape().iter().product();
+                if view.shape() != &b_view.shape()[it_coords.slice().len()..]
+                    || view_len != b_view_len
+                {
                     eprintln!(
-                        "[optbin-instr] OptBinUnicast::eval shape mismatch: binop={} \
-                         a.shape={:?} b.shape={:?} first_non_unary_axis={} \
-                         it_coords={:?} view.shape={:?} b_inner={:?}",
+                        "[optbin-instr] iter-mismatch: binop={} a.shape={:?} b.shape={:?} \
+                         K={} it_coords={:?} view.shape={:?} view_len={} b_inner={:?} b_view_len={}",
                         self.binop.name(),
                         a.shape(),
                         b_view.shape(),
                         first_non_unary_axis,
                         it_coords.slice(),
                         view.shape(),
+                        view_len,
                         &b_view.shape()[it_coords.slice().len()..],
+                        b_view_len,
                     );
                 }
                 (self.eval_fn)(&mut view, &b_view)?;
             }
         } else {
             let mut view = a.view();
-            if view.shape() != b_view.shape() {
+            let view_len: usize = view.shape().iter().product();
+            let b_view_len: usize = b_view.shape().iter().product();
+            if view.shape() != b_view.shape() || view_len != b_view_len {
                 eprintln!(
-                    "[optbin-instr] OptBinUnicast::eval (no-iter) shape mismatch: binop={} \
-                     a.shape={:?} b.shape={:?}",
+                    "[optbin-instr] no-iter-mismatch: binop={} a.shape={:?} b.shape={:?} \
+                     view_len={} b_view_len={}",
                     self.binop.name(),
                     a.shape(),
                     b_view.shape(),
+                    view_len,
+                    b_view_len,
                 );
             }
             (self.eval_fn)(&mut view, &b_view)?;

--- a/linalg/src/frame/unicast.rs
+++ b/linalg/src/frame/unicast.rs
@@ -67,6 +67,17 @@ where
         K::name()
     }
     fn run(&self, a: &mut [T], b: &[T]) -> TractResult<()> {
+        if a.len() != b.len() {
+            eprintln!(
+                "[unicast-instr] LEN MISMATCH at Unicast::run kernel={} a.len={} b.len={} nr={} alignment_bytes={}",
+                K::name(),
+                a.len(),
+                b.len(),
+                K::nr(),
+                K::alignment_bytes(),
+            );
+            eprintln!("[unicast-instr] backtrace:\n{}", std::backtrace::Backtrace::force_capture());
+        }
         unicast_with_alignment(a, b, |a, b| K::run(a, b), K::nr(), K::alignment_bytes())
     }
 }
@@ -115,7 +126,25 @@ where
             buffers.1.ensure(nr * T::datum_type().size_of(), alignment_bytes);
             let tmp_a = std::slice::from_raw_parts_mut(buffers.0.buffer as *mut T, nr);
             let tmp_b = std::slice::from_raw_parts_mut(buffers.1.buffer as *mut T, nr);
+            let outer_a_len = a.len();
+            let outer_b_len = b.len();
             let mut compute_via_temp_buffer = |a: &mut [T], b: &[T]| {
+                if a.len() > tmp_a.len() || b.len() > tmp_b.len() {
+                    eprintln!(
+                        "[unicast-instr] OOB IMMINENT in compute_via_temp_buffer: \
+                         sub_a.len={} sub_b.len={} tmp.len={} (nr) outer_a.len={} outer_b.len={} alignment_bytes={}",
+                        a.len(),
+                        b.len(),
+                        nr,
+                        outer_a_len,
+                        outer_b_len,
+                        alignment_bytes,
+                    );
+                    eprintln!(
+                        "[unicast-instr] backtrace:\n{}",
+                        std::backtrace::Backtrace::force_capture()
+                    );
+                }
                 tmp_a[..a.len()].copy_from_slice(a);
                 tmp_b[..b.len()].copy_from_slice(b);
                 f(tmp_a, tmp_b);


### PR DESCRIPTION
linalg/src/frame/unicast.rs:
  - Unicast::run entry: eprintln + force_capture backtrace when a.len() != b.len() (the precondition the panic suggests is being violated upstream)
  - compute_via_temp_buffer closure: eprintln + backtrace when sub_a or sub_b exceeds the nr-sized tmp buffer (the line-120 site that panics on the cuda-lovelace runner)

Cargo.toml: release profile debug = true so the artifact has symbols and force_capture() backtraces resolve to source lines.

force_capture() works regardless of RUST_BACKTRACE env, so the diagnostics fire even without changing the workflow.

Throwaway branch — do not merge.