### PR TITLE
onnx: fix LayerNorm output dtype mismatch with F16 inputs

### DIFF
--- a/onnx/src/ops/nn/layer_norm.rs
+++ b/onnx/src/ops/nn/layer_norm.rs
@@ -182,11 +182,7 @@ impl Expansion for LayerNorm {
         } else {
             normalized_scaled
         };
-        let y = model.wire_node(
-            format!("{prefix}.cast_y"),
-            cast(fact.datum_type),
-            &y_internal,
-        )?;
+        let y = model.wire_node(format!("{prefix}.cast_y"), cast(fact.datum_type), &y_internal)?;
         let mut outputs = tvec!(y[0]);
         if self.mean_output.is_some() {
             outputs.push(reduced_mean_x[0]);

--- a/onnx/src/ops/nn/layer_norm.rs
+++ b/onnx/src/ops/nn/layer_norm.rs
@@ -161,20 +161,20 @@ impl Expansion for LayerNorm {
         let normalized =
             model.wire_node(format!("{prefix}.normalized"), mul(), &[d[0], inv_std_dev[0]])?;
         // NormalizedScaled = Mul(Normalized, Scale) Y = Add(NormalizedScaled, B)
-        let cast_normalized = model.wire_node(
-            format!("{prefix}.cast_normalized"),
-            cast(fact.datum_type),
-            &normalized,
-        )?;
+        // Keep `normalized` in self.datum_type (typically F32) through the
+        // scale/bias application, then cast back to fact.datum_type at the
+        // very end. Casting back too early causes a type mismatch with
+        // `cast_scale` / `cast_bias` (which are in self.datum_type), which
+        // breaks F16-input LayerNorm (output is F32 but fact says F16).
         let normalized_scaled = wire_with_rank_broadcast(
             format!("{prefix}.normalized_scaled"),
             model,
             mul(),
-            &[cast_normalized[0], cast_scale[0]],
+            &[normalized[0], cast_scale[0]],
         )?;
-        let y = if let Some(bias) = cast_bias {
+        let y_internal = if let Some(bias) = cast_bias {
             wire_with_rank_broadcast(
-                format!("{prefix}.y"),
+                format!("{prefix}.y_internal"),
                 model,
                 add(),
                 &[normalized_scaled[0], bias[0]],
@@ -182,6 +182,11 @@ impl Expansion for LayerNorm {
         } else {
             normalized_scaled
         };
+        let y = model.wire_node(
+            format!("{prefix}.cast_y"),
+            cast(fact.datum_type),
+            &y_internal,
+        )?;
         let mut outputs = tvec!(y[0]);
         if self.mean_output.is_some() {
             outputs.push(reduced_mean_x[0]);


### PR DESCRIPTION
The LayerNorm op's `wire` expansion casts `normalized` back to fact.datum_type *before* applying scale/bias, then multiplies that result with `cast_scale` (which is still in self.datum_type, F32).

With F16 inputs this becomes F16 × F32, whose output is downgraded to F32 by `mul()`. The inference rule then asserts
`outputs[0].datum_type == inputs[0].datum_type` (F16) against the actual F32 output, failing `into_typed()` with:

    Output mismatch after rewiring expansion for output #0:
    expected 1,256,384,F16 got 1,256,384,F32

Fix: defer the cast back to fact.datum_type until after all scale/bias operations. Now the expansion stays entirely in self.datum_type (F32) through normalized × scale + bias, and casts only the final result.

Behavior is unchanged for F32 inputs (the final cast is a no-op when fact.datum_type == self.datum_type).

Reproduced with sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 exported via `optimum.exporters.onnx.main_export(..., dtype="fp16")` and loaded with `into_optimized().into_runnable()`.