### PR TITLE
Fix int8 matmul kernel selection picking the 64x1 GEMV for 2D matmuls

### DIFF
--- a/core/src/ops/einsum/kernel_selection.rs
+++ b/core/src/ops/einsum/kernel_selection.rs
@@ -53,8 +53,14 @@ pub fn strategize(model: &TypedModel, node: &TypedNode, op: &EinSumMatMul) -> Tr
         return Ok(single_strat(it));
     }
     if op.n.as_i64().is_some_and(|n| n > 1) {
-        let it =
-            impls.into_iter().max_by_key(|(m, _, pe)| (pe.is_none(), m.nr() * m.mr())).unwrap();
+        // For a 2D matmul (n > 1) a GEMV kernel (nr == 1) is a poor fit: it
+        // processes one output column per pass. Demote nr == 1 so it never wins
+        // the `nr * mr` tie against a square tile (e.g. i8 64x1 vs 8x8 both have
+        // nr*mr == 64). Ordering among nr > 1 kernels is left untouched.
+        let it = impls
+            .into_iter()
+            .max_by_key(|(m, _, pe)| (pe.is_none(), m.nr() > 1, m.nr() * m.mr()))
+            .unwrap();
         return Ok(single_strat(it));
     }
     let mut grouped_by_left_packing = Vec::<(&dyn MMMInputFormat, Vec<_>)>::new();
@@ -79,7 +85,21 @@ pub fn strategize(model: &TypedModel, node: &TypedNode, op: &EinSumMatMul) -> Tr
             (p, best_for_mmv, best_for_mmm)
         })
         .max_by_key(|(_, mmv, mmm)| {
-            (mmv.0.nr() == 1 && mmm.0.nr() > 1, mmv.2.is_none(), mmm.0.mr(), mmm.0.nr())
+            // When no group offers the ideal (true GEMV nr==1 + true matrix nr>1)
+            // pair, still prefer a group whose matrix-role kernel is a real matrix
+            // (nr > 1) over a GEMV-only group. Without this, int8 — whose GEMV
+            // (64x1), SMLAL (8x8) and SDOT (8x8_dot) kernels each use a different
+            // packing, so no single group is ideal — falls through to `mmm.mr` and
+            // picks the 64x1 GEMV even for symbolic (dynamic) n. f32/f16/block-quant
+            // are unaffected: they have a packing group that IS ideal (e.g. f32
+            // 32x1/32x3, q40 32x1/32x3), so the first key already decides.
+            (
+                mmv.0.nr() == 1 && mmm.0.nr() > 1,
+                mmv.2.is_none(),
+                mmm.0.nr() > 1,
+                mmm.0.mr(),
+                mmm.0.nr(),
+            )
         })
         .unwrap();
 
@@ -117,7 +137,11 @@ pub fn list_impls(
         .mmm_impls()
         .iter()
         .filter(|mmm| {
-            op.acceptable_accumulators().contains(&mmm.internal_type())
+            // Only consider kernels runnable on this CPU: e.g. the SDOT i8 kernel
+            // carries a FEAT_DotProd platform predicate, and must not be selected on
+            // a CPU that would trap on the instruction.
+            mmm.is_supported_here()
+                && op.acceptable_accumulators().contains(&mmm.internal_type())
                 && mmm.stores().contains(&op.operating_dt.unquantized())
         })
         .flat_map(move |mmm| {

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -76,6 +76,10 @@ pub trait MatMatMul: Debug + dyn_clone::DynClone + Send + Sync + std::any::Any {
     fn quality(&self) -> ImplementationQuality;
     fn dynamic_boost(&self) -> isize;
 
+    /// Whether this kernel is runnable on the current CPU (platform feature
+    /// gate, e.g. FEAT_DotProd for the SDOT i8 kernel).
+    fn is_supported_here(&self) -> bool;
+
     #[allow(clippy::type_complexity)]
     fn packings(&self) -> &[(Box<dyn MMMInputFormat>, Box<dyn MMMInputFormat>)];
 
@@ -143,6 +147,10 @@ impl<K: MatMatMulKer> MatMatMul for K {
 
     fn dynamic_boost(&self) -> isize {
         MatMatMulKer::dynamic_boost(self)
+    }
+
+    fn is_supported_here(&self) -> bool {
+        MatMatMulKer::is_supported_here(self)
     }
 
     fn packings(&self) -> &[(Box<dyn MMMInputFormat>, Box<dyn MMMInputFormat>)] {


### PR DESCRIPTION
## Problem

`einsum::kernel_selection::strategize` selects `arm64simd_mmm_i32_64x1` — a GEMV kernel (`nr=1`) — for *every* 2D int8 matmul on arm64, instead of a square matrix kernel. The GEMV kernel processes one output column per pass.

Quantized matmul (i8 inputs, i32 accumulator) skips the `ops().mmm()` fast path (it requires `operating_dt == input dt`, here i32 ≠ i8) and reaches two tie-breaks that don't distinguish a GEMV kernel from a matrix kernel:

- **concrete `n > 1`**: `max_by_key((pe.is_none(), nr*mr))` — the i8 candidates `64x1` and `8x8` both have `nr*mr == 64`, so `max_by_key` returns the last one (`64x1`).
- **symbolic `n`** (dynamic shapes, the common ONNX-export case): the i8 kernels use distinct packings, so no group forms a (GEMV + matrix) `VecVsMat` pair; the fallback then orders by `mmm.mr`, and `64x1` (mr=64) wins.

f32/f16/block-quant are unaffected — each has a packing group that forms a proper GEMV+matrix pair (e.g. f32 `32x1/32x3`, Apple AMX `32x1/32x32`), so the first tie-break key already selects correctly.

## Fix

- concrete `n>1`: demote `nr == 1` so a square tile wins the tie.
- symbolic `n`: prefer a group whose matrix-role kernel is a real matrix (`nr > 1`).
- filter `list_impls` by `is_supported_here()` (added to the `MatMatMul` trait) so platform-gated kernels are never selected on a CPU that would trap — previously such kernels were candidates, avoided only by the `64x1` tie.

## Validation

- Bit-exact output vs the previous kernel (concrete and dynamic-shape int8 models, `max|diff| = 0`).
- `cargo test -p tract-core`: 244/244. `cargo test -p tract-linalg`: 3703/3703.
- f32 dynamic-`n` verified unchanged (still AMX `32x1/32x32`).

## Impact (Apple M4, e2e)

With the int8 kernels currently in tree (`8x8` SMLAL), choosing the proper matrix kernel instead of the `64x1` GEMV is a modest e2e win:

| model | before (`64x1`) | after (`8x8`) | |
|---|---|---|---|
| all-MiniLM-L6-v2 (int8, seq=128) | 49.3 ms | 44.4 ms | 1.11× |
| InceptionV1 (int8) | 54.9 ms | 51.6 ms | 1.07× |

More importantly, the fix lets faster int8 kernels be *selected at all* for 2D matmuls. With a FEAT_DotProd SDOT kernel (downstream), the same fix yields ~2× e2e on these models.