### PR TITLE
arm64 SDOT int8 matmul kernel (FEAT_DotProd) + PackedI8K4 packing

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -84,6 +84,10 @@ name = "mm_for_asr_am"
 harness = false
 
 [[bench]]
+name = "qmmm_i8"
+harness = false
+
+[[bench]]
 name = "hardswish"
 harness = false
 

--- a/linalg/arm64/arm64simd/arm64simd_mmm_i32_8x8_dot.S.j2
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_i32_8x8_dot.S.j2
@@ -1,0 +1,235 @@
+// vim: ft=arm
+
+// C tile regs:
+// - x19-x29 to preserve (but x19, x28, x29 not used) 
+// - d8..d15 to preserve
+// - v16 to v31, no need to preserve
+// 
+//      v16[0] v18[0] v20[0] v22[0] v24[0] v26[0] v28[0] v30[0]
+//      v16[1] v18[1] 
+//      v16[2] v18[2] 
+//      v16[3] v18[3]
+//                     
+//      v17[0] v19[0] v21[0] v23[0] v25[0] v27[0] v29[0] v31[0]
+//      v17[1] v19[1] 
+//      v17[2] v19[2] 
+//      v17[3] v19[3] 
+
+// no preservation either for v0-v7...
+// packed A buffering (2x8 values): alternating v0, v1 with v2, v3
+// packed B buffering (2x8 values): alternating v4, v5 with v6, v7
+
+.text
+.align 4
+
+.cpu generic+fp+simd+dotprod
+.global {{G}}arm64simd_mmm_i32_8x8_dot_{{suffix}}
+{{G}}arm64simd_mmm_i32_8x8_dot_{{suffix}}:
+
+/*
+    prfm        pldl1keep, [x1]
+    prfm        pldl1keep, [x2]
+*/
+    stp         x20, x21, [sp, #-16]!
+    stp         x22, x23, [sp, #-16]!
+    stp         x24, x25, [sp, #-16]!
+    stp         x26, x27, [sp, #-16]!
+
+    stp         d8, d9, [sp, #-16]!
+    stp         d10, d11, [sp, #-16]!
+    stp         d12, d13, [sp, #-16]!
+    stp         d14, d15, [sp, #-16]!
+
+{% include "dispatcher.j2" %}
+
+.add_mat_mul:
+    ldp         x2, x4, [x0, #24]   // b, packing
+    ldp         x3, x1, [x0, #8]    // k, a
+
+    cmp         x3, #0
+    beq         .non_linear_loop
+
+    cmp         x4, #1
+    beq         .packed_packed_loop_1_i8i8
+
+.packed_packed_loop_1:
+
+    ld1	        { v0.4s, v1.4s }, [ x1 ], #32
+    ld1	        { v4.4s, v5.4s }, [ x2 ], #32
+
+    mla         v16.4s, v0.4s, v4.s[0]
+    mla         v17.4s, v1.4s, v4.s[0]
+    mla         v18.4s, v0.4s, v4.s[1]
+    mla         v19.4s, v1.4s, v4.s[1]
+
+    mla         v20.4s, v0.4s, v4.s[2]
+    mla         v21.4s, v1.4s, v4.s[2]
+    mla         v22.4s, v0.4s, v4.s[3]
+    mla         v23.4s, v1.4s, v4.s[3]
+
+    mla         v24.4s, v0.4s, v5.s[0]
+    mla         v25.4s, v1.4s, v5.s[0]
+    mla         v26.4s, v0.4s, v5.s[1]
+    mla         v27.4s, v1.4s, v5.s[1]
+
+    mla         v28.4s, v0.4s, v5.s[2]
+    mla         v29.4s, v1.4s, v5.s[2]
+    mla         v30.4s, v0.4s, v5.s[3]
+    mla         v31.4s, v1.4s, v5.s[3]
+
+    subs        x3, x3, #1
+    bne .packed_packed_loop_1
+
+    b .non_linear_loop
+
+.packed_packed_loop_1_i8i8:
+    // PackedI8K4 (K=4-inner, r=8): per 4-K block, A is m0-3 (v0) / m4-7 (v1),
+    // B is n0-3 (v4) / n4-7 (v5), each lane a 4xi8 group. SDOT by-element dots
+    // a B column's 4 K against all 4 m rows of an A half. Same v16..v31 tile
+    // layout as the SMLAL kernel: v[16 + n*2 + m_half] = C[m_half*4..][n].
+    ld1         { v0.16b, v1.16b }, [ x1 ], #32
+    ld1         { v4.16b, v5.16b }, [ x2 ], #32
+
+    sdot        v16.4s, v0.16b, v4.4b[0]
+    sdot        v17.4s, v1.16b, v4.4b[0]
+    sdot        v18.4s, v0.16b, v4.4b[1]
+    sdot        v19.4s, v1.16b, v4.4b[1]
+    sdot        v20.4s, v0.16b, v4.4b[2]
+    sdot        v21.4s, v1.16b, v4.4b[2]
+    sdot        v22.4s, v0.16b, v4.4b[3]
+    sdot        v23.4s, v1.16b, v4.4b[3]
+
+    sdot        v24.4s, v0.16b, v5.4b[0]
+    sdot        v25.4s, v1.16b, v5.4b[0]
+    sdot        v26.4s, v0.16b, v5.4b[1]
+    sdot        v27.4s, v1.16b, v5.4b[1]
+    sdot        v28.4s, v0.16b, v5.4b[2]
+    sdot        v29.4s, v1.16b, v5.4b[2]
+    sdot        v30.4s, v0.16b, v5.4b[3]
+    sdot        v31.4s, v1.16b, v5.4b[3]
+
+    subs        x3, x3, #4
+    bgt .packed_packed_loop_1_i8i8
+
+    b .non_linear_loop
+
+{% set from = 16 %}{% set to = 31 %}{% include "arm64simd_mmm_i32_scalars.j2" %}
+{% set mr = 8 %}{% set from = 16 %}{% set to = 31 %}{% include "arm64simd_mmm_i32_per_rows.j2" %}
+{% set mr = 8 %}{% set from = 16 %}{% set to = 31 %}{% include "arm64simd_mmm_i32_per_cols.j2" %}
+{% set from = 16 %}{% set to = 31 %}{% include "arm64simd_mmm_load_tile.j2" %}
+
+.add_unicast:
+    ldp         x5, x6, [x0, #8]
+    ldp         x7, x8, [x0, #24]
+
+    cmp         x8, #4
+    beq         non_linear_addc_i32
+
+    {% for col in range(8, 16) %}
+        mov x4, x5
+        {% for reg in range(0, 2) %}
+            {% for lane in range(0, 4) %}
+                ld1 {v0.b}[{{lane}}], [ x4 ], x6
+            {% endfor %}
+            sshll v0.8h, v0.8b, 0
+            sshll v0.4s, v0.4h, 0
+            add v{{ col * 2 + reg }}.4s, v{{ col * 2 + reg }}.4s, v0.4s
+        {% endfor %}
+        add x5, x5, x7
+    {% endfor %}
+
+    b           .non_linear_loop
+
+non_linear_addc_i32:
+    {% for col in range(8, 16) %}
+        mov x4, x5
+        {% for reg in range(0, 2) %}
+            {% for lane in range(0, 4) %}
+                ld1 {v0.s}[{{lane}}], [ x4 ], x6
+            {% endfor %}
+            add v{{ col * 2 + reg }}.4s, v{{ col * 2 + reg }}.4s, v0.4s
+        {% endfor %}
+        add x5, x5, x7
+    {% endfor %}
+
+    b           .non_linear_loop
+
+.add_row_col_products:
+    ldr     x2, [x0, #8]
+    ldr     x3, [x0, #16]
+
+    ld1         { v0.4s, v1.4s }, [ x2 ]
+    ld1         { v4.4s, v5.4s }, [ x3 ]
+
+    xtn         v0.4h, v0.4s
+    xtn         v1.4h, v1.4s
+    xtn         v4.4h, v4.4s
+    xtn         v5.4h, v5.4s
+
+    smlal        v16.4s, v0.4h, v4.h[0]
+    smlal        v17.4s, v1.4h, v4.h[0]
+    smlal        v18.4s, v0.4h, v4.h[1]
+    smlal        v19.4s, v1.4h, v4.h[1]
+    smlal        v20.4s, v0.4h, v4.h[2]
+    smlal        v21.4s, v1.4h, v4.h[2]
+    smlal        v22.4s, v0.4h, v4.h[3]
+    smlal        v23.4s, v1.4h, v4.h[3]
+
+    smlal        v24.4s, v0.4h, v5.h[0]
+    smlal        v25.4s, v1.4h, v5.h[0]
+    smlal        v26.4s, v0.4h, v5.h[1]
+    smlal        v27.4s, v1.4h, v5.h[1]
+    smlal        v28.4s, v0.4h, v5.h[2]
+    smlal        v29.4s, v1.4h, v5.h[2]
+    smlal        v30.4s, v0.4h, v5.h[3]
+    smlal        v31.4s, v1.4h, v5.h[3]
+
+    b           .non_linear_loop
+
+    {% include "arm64simd_mmm_i32_scale_q16_q31.j2" %}
+
+.store:
+    ldp         x5, x6, [x0, #8]            // c base ptr, rsc
+    ldp         x7, x8, [x0, #24]           // csc, item_size
+
+    cmp         x8, #4
+    beq         .store_strides_i32
+
+    {% for col in range(8, 16) %}
+        mov x4, x5
+        {% for reg in range(0, 2) %}
+            {% for lane in range(0, 4) %}
+                st1 { v{{ col * 2 + reg }}.b }[{{ lane * 4 }}], [ x4 ], x6
+            {% endfor %}
+        {% endfor %}
+        add x5, x5, x7
+    {% endfor %}
+
+    b           .non_linear_loop
+
+.store_strides_i32:
+    {% for col in range(8, 16) %}
+        mov x4, x5
+        {% for reg in range(0, 2) %}
+            {% for lane in range(0, 4) %}
+                st1 { v{{ col * 2 + reg }}.s }[{{lane}}], [ x4 ], x6
+            {% endfor %}
+        {% endfor %}
+        add x5, x5, x7
+    {% endfor %}
+
+    b           .non_linear_loop
+
+.return:
+    ldp         d14, d15, [sp], #16
+    ldp         d12, d13, [sp], #16
+    ldp         d10, d11, [sp], #16
+    ldp         d8, d9, [sp], #16
+
+    ldp         x26, x27, [sp], #16
+    ldp         x24, x25, [sp], #16
+    ldp         x22, x23, [sp], #16
+    ldp         x20, x21, [sp], #16
+
+    ret
+

--- a/linalg/arm64/arm64simd/dummy_dotprod.S
+++ b/linalg/arm64/arm64simd/dummy_dotprod.S
@@ -1,0 +1,13 @@
+// Build-time capability probe for the assembler, used by build.rs
+// (assembler_supports_dotprod). Older binutils — notably the Debian stretch
+// aarch64 cross-toolchain in CI — predate FEAT_DotProd and cannot assemble
+// `sdot` even with `.cpu generic+fp+simd+dotprod`. If this file fails to
+// assemble, build.rs skips the SDOT kernel and the `tract_arm64_dotprod` cfg,
+// and the runtime falls back to the SMLAL 8x8 i32 kernel. Not linked into
+// anything.
+.cpu generic+fp+simd+dotprod
+.text
+.globl tract_dotprod_probe
+tract_dotprod_probe:
+    sdot v0.4s, v1.16b, v2.4b[0]
+    ret

--- a/linalg/benches/qmmm_i8.rs
+++ b/linalg/benches/qmmm_i8.rs
@@ -1,0 +1,56 @@
+// int8 -> i32 GEMM (qmmm_i32) microbench. A/B the SME SMOPA kernel vs the NEON
+// fallback by running twice: default (SME) vs TRACT_SME_DISABLE=1 (arm64simd 8x8).
+extern crate criterion;
+use criterion::*;
+use tract_data::internal::*;
+use tract_linalg::mmm::{AsInputValue, FusedSpec};
+
+use DatumType::I32;
+
+fn qmmm(be: &mut criterion::Bencher, &(m, k, n): &(usize, usize, usize)) {
+    unsafe {
+        let mmm = tract_linalg::ops().mmm(I32, Some(m), Some(k), Some(n)).unwrap();
+        // packing index 1 == i8i8 for both sme_qmmm_i32_32x32 and arm64simd_mmm_i32_8x8.
+        let a = Tensor::zero::<i8>(&[m, k]).unwrap();
+        let b = Tensor::zero::<i8>(&[k, n]).unwrap();
+        let packing = &mmm.packings()[1];
+        let pa = packing.0.prepare_one(&a, 1, 0).unwrap();
+        let pb = packing.1.prepare_one(&b, 0, 1).unwrap();
+        let mut c = Tensor::zero::<i32>(&[m, n]).unwrap();
+        be.iter(move || {
+            mmm.run(
+                m,
+                n,
+                &[
+                    FusedSpec::AddMatMul {
+                        a: AsInputValue::Borrowed(&*pa),
+                        b: AsInputValue::Borrowed(&*pb),
+                        packing: 1,
+                    },
+                    FusedSpec::Store(mmm.c_view(Some(0), Some(1)).wrap(&c.view_mut())),
+                ],
+            )
+        });
+    }
+}
+
+fn bench(c: &mut Criterion) {
+    let mut g = c.benchmark_group("qmmm_i8");
+    g.sample_size(20);
+    for &shape in &[
+        (256usize, 256usize, 256usize),
+        (512, 512, 512),
+        (1024, 1024, 1024),
+        (128, 768, 768),
+        (384, 768, 768),
+        (64, 2048, 2048),
+    ] {
+        let (m, k, n) = shape;
+        g.throughput(Throughput::Elements((m * k * n) as u64));
+        g.bench_function(format!("{m}x{k}x{n}"), |be| qmmm(be, &shape));
+    }
+    g.finish();
+}
+
+criterion::criterion_group!(benches, bench);
+criterion::criterion_main!(benches);

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -37,6 +37,22 @@ fn assembler_supports_sme() -> bool {
         .is_ok()
 }
 
+// Probe whether the target assembler can encode FEAT_DotProd `sdot` (the
+// indexed int8 form used by arm64simd_mmm_i32_8x8_dot). Old binutils — notably
+// the Debian stretch aarch64 cross-toolchain in CI — predate FEAT_DotProd and
+// reject `.cpu ...+dotprod` / `sdot` outright. When the probe fails we skip the
+// SDOT kernel and the `tract_arm64_dotprod` cfg; the runtime falls back to the
+// SMLAL 8x8 i32 kernel.
+fn assembler_supports_dotprod() -> bool {
+    cc::Build::new()
+        .file("arm64/arm64simd/dummy_dotprod.S")
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(false)
+        .try_compile("tract_dotprod_probe")
+        .is_ok()
+}
+
 fn include_sve() -> bool {
     // SVE/SVE2 lives on ARMv9 server/mobile cores (Neoverse V1+/N2+, Cortex-X2+,
     // Graviton 3/4) — Linux aarch64. No Apple silicon has SVE.
@@ -130,6 +146,8 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(tract_sme)");
     // Set below only when include_sve() and the SVE compiler probe both pass.
     println!("cargo:rustc-check-cfg=cfg(tract_sve)");
+    // Set below only when the aarch64 assembler probe for `sdot` passes.
+    println!("cargo:rustc-check-cfg=cfg(tract_arm64_dotprod)");
 
     match arch.as_ref() {
         "x86_64" => {
@@ -197,13 +215,30 @@ fn main() {
             cc::Build::new().files(files).flag("-marm").flag("-mfpu=neon").compile("armv7neon");
         }
         "aarch64" => {
-            let files = preprocess_files(
+            let mut files = preprocess_files(
                 "arm64/arm64simd",
                 &[("core", vec!["a53", "a55", "gen"])],
                 &suffix,
                 false,
             );
+            // The SDOT kernel is compiled separately (conditional on a probe) so
+            // old assemblers (binutils < 2.30, e.g. Debian stretch) that can't
+            // encode `sdot` don't break the whole arm64simd build. Remove it
+            // from the main file list.
+            files.retain(|f| {
+                !f.file_name().and_then(|n| n.to_str()).map_or(false, |n| n.contains("_dot"))
+            });
             cc::Build::new().files(files).compile("arm64simd");
+            // The template stays in arm64/arm64simd/ (alongside the jinja partials
+            // it includes) so the env can resolve its includes. The
+            // `tract_arm64_dotprod` cfg gates the matching Rust extern + dispatch.
+            if assembler_supports_dotprod() {
+                let tmpl = path::Path::new("arm64/arm64simd/arm64simd_mmm_i32_8x8_dot.S.j2");
+                let out = out_dir.join(format!("arm64simd_mmm_i32_8x8_dot_{suffix}.S"));
+                preprocess_file(tmpl, &out, &[], &suffix, false);
+                cc::Build::new().file(&out).compile("arm64simd_dot");
+                println!("cargo:rustc-cfg=tract_arm64_dotprod");
+            }
             if include_amx() {
                 let files = preprocess_files("arm64/apple_amx", &[], &suffix, false);
                 cc::Build::new().files(files).compile("appleamx");

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -189,6 +189,40 @@ pub fn has_fp16() -> bool {
         || *HAS_FP16
 }
 
+// FEAT_DotProd (SDOT/UDOT), ARMv8.2. TRACT_DOTPROD_DISABLE=1 forces it off so
+// callers can A/B the SDOT kernel against the SMLAL 8x8 fallback on one binary.
+#[cfg(target_os = "macos")]
+pub fn has_dotprod() -> bool {
+    // Every Apple arm64 CPU (M1+/A11+) implements FEAT_DotProd.
+    std::env::var_os("TRACT_DOTPROD_DISABLE").is_none()
+}
+
+#[cfg(target_os = "linux")]
+pub fn has_dotprod() -> bool {
+    if std::env::var_os("TRACT_DOTPROD_DISABLE").is_some() {
+        return false;
+    }
+    // HWCAP_ASIMDDP = 1 << 20 on aarch64.
+    const HWCAP_ASIMDDP: u64 = 1 << 20;
+    const AT_HWCAP: u64 = 16;
+    unsafe extern "C" {
+        fn getauxval(t: u64) -> u64;
+    }
+    unsafe { (getauxval(AT_HWCAP) & HWCAP_ASIMDDP) != 0 }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "ios")))]
+pub fn has_dotprod() -> bool {
+    false
+}
+
+#[cfg(target_os = "ios")]
+pub fn has_dotprod() -> bool {
+    // A11+ (iPhone10,1+) implement FEAT_DotProd.
+    std::env::var_os("TRACT_DOTPROD_DISABLE").is_none()
+        && IPHONE_MODEL_MAJOR.map(|it| it >= 10).unwrap_or(false)
+}
+
 #[target_feature(enable = "fp16")]
 #[inline]
 pub unsafe fn add_f16(a: f16, b: f16) -> f16 {
@@ -351,7 +385,19 @@ pub fn plug(ops: &mut Ops) {
         arm64fp16::plug(ops);
     }
 
-    ops.qmmm_i32 = Box::new(|_, _, _| arm64simd_mmm_i32_8x8.mmm());
+    // SDOT (~4x the SMLAL 8x8) when FEAT_DotProd is present, else the SMLAL 8x8 fallback.
+    // The SDOT kernel only exists when the assembler could encode `sdot`
+    // (`tract_arm64_dotprod`, set by build.rs); otherwise always use the SMLAL 8x8.
+    #[cfg(tract_arm64_dotprod)]
+    if has_dotprod() {
+        ops.qmmm_i32 = Box::new(|_, _, _| arm64simd_mmm_i32_8x8_dot.mmm());
+    } else {
+        ops.qmmm_i32 = Box::new(|_, _, _| arm64simd_mmm_i32_8x8.mmm());
+    }
+    #[cfg(not(tract_arm64_dotprod))]
+    {
+        ops.qmmm_i32 = Box::new(|_, _, _| arm64simd_mmm_i32_8x8.mmm());
+    }
     ops.qmmv_i32 = Box::new(|_, _| arm64simd_mmm_i32_64x1.mmm());
     ops.mmv_f32 = match *KIND {
         Kind::CortexA53 => Box::new(|_, _| arm64simd_mmm_f32_64x1_a53.mmm()),

--- a/linalg/src/arm64/arm64simd.rs
+++ b/linalg/src/arm64/arm64simd.rs
@@ -84,6 +84,21 @@ MMMExternKernel!(arm64simd_mmm_i32_8x8<i32>(8, 8)@(16, 16)
    store(i8)
 );
 
+// SDOT (FEAT_DotProd) variant: 4-K reduction per instruction (~4x the SMLAL
+// 8x8 above). Uses the K=4-inner PackedI8K4 packing; identical v16..v31 tile
+// layout, so it reuses all the i32 fuse/store/q_scale machinery.
+//
+// Gated on `tract_arm64_dotprod` (set by build.rs when the assembler can encode
+// `sdot`; binutils < 2.30 cannot). On old toolchains the kernel is omitted and
+// dispatch falls back to the SMLAL 8x8 i32 kernel.
+#[cfg(tract_arm64_dotprod)]
+MMMExternKernel!(arm64simd_mmm_i32_8x8_dot<i32>(8, 8)@(16, 16)
+   where(super::has_dotprod)
+   packing[1] = i8i8 => |k| k.with_packing(crate::pack::PackedI8K4::new(8), crate::pack::PackedI8K4::new(8));
+   quality(ManuallyOptimized)
+   store(i8)
+);
+
 MMMExternKernel!(arm64simd_mmm_i32_64x1<i32>(64, 1)@(16, 1)
    packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 64,16), PackedFormat::new(DatumType::I8, 1, 1));
    quality(ManuallyOptimized)
@@ -112,6 +127,8 @@ pub fn plug(ops: &mut Ops) {
         arm64simd_mmm_i32_8x8.mmm(),
         arm64simd_mmm_i32_64x1.mmm(),
     ]);
+    #[cfg(tract_arm64_dotprod)]
+    ops.mmm_impls.push(arm64simd_mmm_i32_8x8_dot.mmm());
     panel_extract::plug(ops);
 }
 


### PR DESCRIPTION
Adds an int8 → i32 matmul kernel using **SDOT** (`FEAT_DotProd`, ARMv8.2) — ~4× the SMLAL `8x8` kernel at the matmul level — plus the `PackedI8K4` (K=4-inner) packing it consumes and the matmul/conv lowering to route it.

> **Stacked on #2277.** The first commit here is #2277 (the int8 matmul *dispatch* fix). Without it, 2D int8 matmuls select the `64x1` GEMV kernel and this SDOT kernel is never chosen. Please review/merge #2277 first; this rebases cleanly once it lands.

## What's here

- **`arm64simd_mmm_i32_8x8_dot`** — SDOT i8→i32 8×8 kernel, gated on `has_dotprod()` (`TRACT_DOTPROD_DISABLE=1` forces the SMLAL fallback for A/B). Same `v16..v31` tile layout as the SMLAL `8x8`, so it reuses all the i32 fuse/store/q_scale machinery.
- **`PackedI8K4`** — K=4-inner packing (`out[(k/4)·r·4 + m·4 + (k%4)]`, `k_alignment=4`); one-pass `KOut4Writer` + a cache-friendly `pack_view`.
- **Lowering** — `OptMatMulPack` / einsum / conv-im2col generalized from `PackedFormat` to `Box<dyn MMMInputFormat>` so `PackedI8K4` flows through matmul and conv; `QSumB` reads the K=4 layout. `PackedFormat` paths stay byte-identical (monomorphic, no `dyn` on the hot path).

## Validation

- Bit-exact vs the SMLAL kernel (concrete + dynamic-shape int8 models, M1 + M4).
- `cargo test -p tract-core`: 244/244 · `cargo test -p tract-linalg`: 3817/3817 · `cargo fmt --check` clean · no new clippy warnings.

## Performance (Apple M4, e2e)

On top of #2277 (which selects the SMLAL `8x8`), SDOT adds:

| model | SMLAL `8x8` | SDOT `8x8_dot` | |
|---|---|---|---|
| all-MiniLM-L6-v2 (int8, seq=128) | 44.4 ms | 24.8 ms | **1.79×** |
| InceptionV1 (int8) | 51.6 ms | 28.4 ms | **1.82×** |

Combined with #2277 (vs the pre-fix `64x1` GEMV): MiniLM 50.5→24.8 ms (2.04×), InceptionV1 53.6→28.4 ms (1.89×).

(`UDOT` skipped: tract normalises activations to i8, so the u8 path is redundant.)