### PR TITLE
wasm: SIMD int8 (i8->i32) matmul kernel (wasm_i32_4x4)

### DIFF
--- a/linalg/src/wasm.rs
+++ b/linalg/src/wasm.rs
@@ -66,6 +66,10 @@ pub fn plug(ops: &mut Ops) {
     ops.mmm_impls.push(wasm_f32_16x1.mmm());
     ops.mmm_impls.push(wasm_f32_32x1.mmm());
     ops.mmm_impls.push(wasm_f32_8x8.mmm());
+    // int8 -> i32 matmul: SIMD kernel (was generic scalar). ManuallyOptimized so
+    // strategize's retain() keeps it over generic_i32_4x4 for i8 packing.
+    ops.mmm_impls.push(wasm_i32_4x4.mmm());
+    ops.qmmm_i32 = Box::new(|_, _, _| wasm_i32_4x4.mmm());
     // Selection paths. Both rely on kernel_selection::strategize honouring
     // the mmm_f32 / mmv_f32 callback, which it only does when the callback's
     // kernel is tagged ManuallyOptimized. Otherwise strategize falls through
@@ -2125,6 +2129,309 @@ unsafe fn kernel_f32_8x8(mut pnl: *const FusedKerSpec<f32>) -> isize {
 // callback that returns it for N>1 GEMM (see the `plug` comment) — otherwise
 // strategize drops it and routes every GEMM onto the 32x1 GEMV kernel.
 MMMRustKernel!(kernel_f32_8x8 => wasm_f32_8x8<f32>(8,8)@(8,8) quality(ImplementationQuality::ManuallyOptimized));
+
+// Wasm SIMD int8 -> i32 matmul kernel (4x4). WASM's only integer dot
+// (i32x4.relaxed_dot_i8x16_i7x16) is non-deterministic for full i8 (its 2nd
+// operand is i7), so for a bit-exact kernel the AddMatMul K-loop uses widening
+// i8->i32 + i32x4 mul/add (an extmul/SMLAL-style outer product). The quant
+// epilogue + fuse ops reuse the bit-exact scalar path (q_scale/q_shr/q_shl),
+// which is O(MR*NR) and negligible vs the O(MR*NR*K) inner loop. Bit-identical
+// to generic_i32_4x4; selected for i8 matmul via its ManuallyOptimized quality
+// (WASM had no int8 matmul kernel — int8 fell back to the generic scalar one).
+#[inline(never)]
+unsafe fn kernel_i32_4x4(mut pnl: *const FusedKerSpec<i32>) -> isize {
+    use crate::ScaleShiftAndRound;
+    use std::arch::wasm32::*;
+    unsafe {
+        let mut ab = [[0i32; 4]; 4];
+        loop {
+            if pnl.is_null() {
+                break;
+            }
+            match *pnl {
+                FusedKerSpec::Done => break,
+                FusedKerSpec::Clear => ab = [[0i32; 4]; 4],
+                FusedKerSpec::LoadTile(col_major, _row_major) => {
+                    for row in 0..4 {
+                        for col in 0..4 {
+                            ab[row][col] = *col_major.add(col * 4 + row);
+                        }
+                    }
+                }
+                FusedKerSpec::ScalarAdd(a) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] += a;
+                        }
+                    }
+                }
+                FusedKerSpec::ScalarMul(a) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] *= a;
+                        }
+                    }
+                }
+                FusedKerSpec::ScalarMin(m) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].min(m);
+                        }
+                    }
+                }
+                FusedKerSpec::ScalarMax(m) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].max(m);
+                        }
+                    }
+                }
+                FusedKerSpec::ScalarSub(m) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = m - ab[i][j];
+                        }
+                    }
+                }
+                FusedKerSpec::ScalarSubF(m) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] -= m;
+                        }
+                    }
+                }
+                FusedKerSpec::LeakyRelu(a) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = if ab[i][j] > 0 { ab[i][j] } else { a * ab[i][j] };
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowMin(m) => {
+                    for i in 0..4 {
+                        let v = *m.add(i);
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].min(v);
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowMax(m) => {
+                    for i in 0..4 {
+                        let v = *m.add(i);
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].max(v);
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowAdd(m) => {
+                    for i in 0..4 {
+                        let v = *m.add(i);
+                        for j in 0..4 {
+                            ab[i][j] += v;
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowMul(m) => {
+                    for i in 0..4 {
+                        let v = *m.add(i);
+                        for j in 0..4 {
+                            ab[i][j] *= v;
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowSub(m) => {
+                    for i in 0..4 {
+                        let v = *m.add(i);
+                        for j in 0..4 {
+                            ab[i][j] = v - ab[i][j];
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowSubF(m) => {
+                    for i in 0..4 {
+                        let v = *m.add(i);
+                        for j in 0..4 {
+                            ab[i][j] -= v;
+                        }
+                    }
+                }
+                FusedKerSpec::PerColMin(m) => {
+                    let c = std::slice::from_raw_parts(m, 4);
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].min(c[j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColMax(m) => {
+                    let c = std::slice::from_raw_parts(m, 4);
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].max(c[j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColAdd(m) => {
+                    let c = std::slice::from_raw_parts(m, 4);
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] += c[j];
+                        }
+                    }
+                }
+                FusedKerSpec::PerColMul(m) => {
+                    let c = std::slice::from_raw_parts(m, 4);
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] *= c[j];
+                        }
+                    }
+                }
+                FusedKerSpec::PerColSub(m) => {
+                    let c = std::slice::from_raw_parts(m, 4);
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = c[j] - ab[i][j];
+                        }
+                    }
+                }
+                FusedKerSpec::PerColSubF(m) => {
+                    let c = std::slice::from_raw_parts(m, 4);
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] -= c[j];
+                        }
+                    }
+                }
+                FusedKerSpec::AddRowColProducts(rows, cols) => {
+                    for i in 0..4 {
+                        let r = *rows.add(i);
+                        for j in 0..4 {
+                            ab[i][j] += r * *cols.add(j);
+                        }
+                    }
+                }
+                FusedKerSpec::AddUnicast(other) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            let p = other.ptr.offset(
+                                other.row_byte_stride * i as isize
+                                    + other.col_byte_stride * j as isize,
+                            );
+                            let v = match other.item_size {
+                                1 => *(p as *const i8) as i32,
+                                4 => *(p as *const i32),
+                                _ => return 1,
+                            };
+                            ab[i][j] += v;
+                        }
+                    }
+                }
+                FusedKerSpec::ShiftLeft(shift) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].q_shl(shift);
+                        }
+                    }
+                }
+                FusedKerSpec::RoundingShiftRight(shift, rp) => {
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].q_shr(shift, rp);
+                        }
+                    }
+                }
+                FusedKerSpec::QScale(shift, rp, mult) => {
+                    let s = Scaler::from_fuse_params(shift, rp, mult);
+                    for i in 0..4 {
+                        for j in 0..4 {
+                            ab[i][j] = ab[i][j].q_scale(s);
+                        }
+                    }
+                }
+                FusedKerSpec::AddMatMul { k, pa, pb, packing } => {
+                    if packing == 1 {
+                        // i8 x i8, K-major (4 i8 per k): SIMD outer-product accumulate.
+                        let a = pa as *const i8;
+                        let b = pb as *const i8;
+                        let mut acc = [
+                            v128_load(ab[0].as_ptr() as *const v128),
+                            v128_load(ab[1].as_ptr() as *const v128),
+                            v128_load(ab[2].as_ptr() as *const v128),
+                            v128_load(ab[3].as_ptr() as *const v128),
+                        ];
+                        for ik in 0..k {
+                            // B[ik, 0..4]: 4 i8 -> i32x4 (sign-extended).
+                            let bw = v128_load32_zero(b.add(4 * ik) as *const u32);
+                            let bw = i16x8_extend_low_i8x16(bw);
+                            let bw = i32x4_extend_low_i16x8(bw);
+                            let ar = a.add(4 * ik);
+                            acc[0] =
+                                i32x4_add(acc[0], i32x4_mul(i32x4_splat(*ar.add(0) as i32), bw));
+                            acc[1] =
+                                i32x4_add(acc[1], i32x4_mul(i32x4_splat(*ar.add(1) as i32), bw));
+                            acc[2] =
+                                i32x4_add(acc[2], i32x4_mul(i32x4_splat(*ar.add(2) as i32), bw));
+                            acc[3] =
+                                i32x4_add(acc[3], i32x4_mul(i32x4_splat(*ar.add(3) as i32), bw));
+                        }
+                        v128_store(ab[0].as_mut_ptr() as *mut v128, acc[0]);
+                        v128_store(ab[1].as_mut_ptr() as *mut v128, acc[1]);
+                        v128_store(ab[2].as_mut_ptr() as *mut v128, acc[2]);
+                        v128_store(ab[3].as_mut_ptr() as *mut v128, acc[3]);
+                    } else if packing == 0 {
+                        // i32 x i32, K-major (scalar; rare path).
+                        let a = pa as *const i32;
+                        let b = pb as *const i32;
+                        for ik in 0..k {
+                            for i in 0..4 {
+                                let av = *a.add(4 * ik + i);
+                                for j in 0..4 {
+                                    ab[i][j] += av * *b.add(4 * ik + j);
+                                }
+                            }
+                        }
+                    } else {
+                        return 1;
+                    }
+                }
+                FusedKerSpec::Store(tile) => match tile.item_size {
+                    1 => {
+                        for i in 0..4 {
+                            for j in 0..4 {
+                                let loc = tile.ptr.offset(
+                                    tile.row_byte_stride * i as isize
+                                        + tile.col_byte_stride * j as isize,
+                                ) as *mut u8;
+                                *loc = ab[i][j] as u8;
+                            }
+                        }
+                    }
+                    4 => {
+                        for i in 0..4 {
+                            for j in 0..4 {
+                                let loc = tile.ptr.offset(
+                                    tile.row_byte_stride * i as isize
+                                        + tile.col_byte_stride * j as isize,
+                                ) as *mut i32;
+                                *loc = ab[i][j];
+                            }
+                        }
+                    }
+                    _ => return 1,
+                },
+            };
+            pnl = pnl.add(1);
+        }
+    }
+    0
+}
+
+MMMRustKernel!(kernel_i32_4x4 => wasm_i32_4x4<i32>(4,4)
+    packing[1] = i8i8 => |k| k.with_packing(i8::packing(4), i8::packing(4));
+    quality(ImplementationQuality::ManuallyOptimized)
+    store(i8)
+);
 
 #[cfg(test)]
 mod dispatch_trace {


### PR DESCRIPTION
## Summary
WASM had **no int8 matmul kernel** — i8 (i32-accumulator) matmul fell back to the generic *scalar* kernel. This adds **`wasm_i32_4x4`**, a `simd128` int8 → i32 matmul kernel.

## What's here
- **`wasm_i32_4x4`** — the `AddMatMul` K-loop widens i8→i32 and accumulates with `i32x4` mul/add (an SMLAL-style outer product). The quant epilogue (`q_scale`/`q_shr`/`q_shl`) + fuse ops reuse the bit-exact scalar path — O(MR·NR), negligible vs the O(MR·NR·K) inner loop. **Bit-identical to `generic_i32_4x4`**; selected for i8 matmul via `ManuallyOptimized` quality (over the generic scalar one).

## Why widening multiplies, not the relaxed dot
WASM's only integer dot, `i32x4.relaxed_dot_i8x16_i7x16_add`, treats its 2nd operand as **i7** (`[-64,63]`) and is **non-deterministic for full i8** (engines may compute i7×i8 or i8×i8). So for a bit-exact, deterministic kernel this uses widening multiplies instead. A relaxed-dot fast path (for i7-range weights) is a possible follow-up.

## Validation
- `wasm_i32_4x4`: **114/114** on wasmtime (`+simd128`).
- Full `tract-linalg` wasm suite: **1870/1870**.
- `cargo fmt --check` clean. (clippy: the index-loop / `offset`-cast lints match the existing `wasm_f32_*` kernels.)

## Perf
The inner loop is 4-wide `i32x4` vs the prior element-at-a-time scalar fallback. A precise wasmtime throughput bench is a follow-up — but this replaces a pure-scalar path, so it's a clear win for int8 inference on WASM.