### PR TITLE
onnx: add LpNormalization, MeanVarianceNormalization, GroupNormalization, RotaryEmbedding op handlers

### DIFF
--- a/onnx/src/ops/nn/group_norm.rs
+++ b/onnx/src/ops/nn/group_norm.rs
@@ -1,0 +1,167 @@
+use crate::model::ParsingContext;
+use crate::pb::NodeProto;
+use tract_core::ops::cast::cast;
+use tract_hir::internal::*;
+use tract_hir::ops::logic::wire_with_rank_broadcast;
+use tract_hir::ops::math::{add, mul, rsqrt, square, sub};
+use tract_hir::ops::nn::{Reduce, Reducer};
+
+pub fn group_normalization(
+    ctx: &ParsingContext,
+    node: &NodeProto,
+) -> TractResult<(Box<dyn InferenceOp>, Vec<String>)> {
+    let epsilon = node.get_attr_opt("epsilon")?.unwrap_or(1e-5);
+    let num_groups: usize = node.get_attr("num_groups")?;
+    // Before opset 21, `scale`/`bias` are per-group (shape [num_groups]); from opset 21 on they
+    // are per-channel (shape [C]), matching the other normalization operators.
+    let per_channel_affine = ctx.onnx_operator_set_version >= 21;
+    Ok((expand(GroupNorm { epsilon, num_groups, per_channel_affine }), vec![]))
+}
+
+#[derive(Debug, Clone, new)]
+struct GroupNorm {
+    epsilon: f32,
+    num_groups: usize,
+    per_channel_affine: bool,
+}
+
+// Broadcast a 1-D parameter [K] to rank `target_rank` with K on axis 1: [1, K, 1, .., 1].
+fn broadcast_to_channel_axis(
+    model: &mut TypedModel,
+    base: &str,
+    outlet: OutletId,
+    target_rank: usize,
+) -> TractResult<OutletId> {
+    let mut wire = model.wire_node(format!("{base}.ax0"), AxisOp::Add(0), &[outlet])?;
+    for ax in 2..target_rank {
+        wire = model.wire_node(format!("{base}.ax{ax}"), AxisOp::Add(ax), &wire)?;
+    }
+    Ok(wire[0])
+}
+
+impl Expansion for GroupNorm {
+    fn name(&self) -> StaticName {
+        "GroupNorm".into()
+    }
+
+    fn rules<'r, 'p: 'r, 's: 'r>(
+        &'s self,
+        s: &mut Solver<'r>,
+        inputs: &'p [TensorProxy],
+        outputs: &'p [TensorProxy],
+    ) -> InferenceResult {
+        check_input_arity(inputs, 3)?;
+        check_output_arity(outputs, 1)?;
+        s.equals(&inputs[0].datum_type, &inputs[1].datum_type)?;
+        s.equals(&inputs[0].datum_type, &inputs[2].datum_type)?;
+        s.equals(&inputs[0].datum_type, &outputs[0].datum_type)?;
+        s.equals(&inputs[0].shape, &outputs[0].shape)?;
+        Ok(())
+    }
+
+    fn wire(
+        &self,
+        prefix: &str,
+        model: &mut TypedModel,
+        inputs: &[OutletId],
+    ) -> TractResult<TVec<OutletId>> {
+        let fact = model.outlet_fact(inputs[0])?.clone();
+        let rank = fact.rank();
+        let dt = fact.datum_type;
+        ensure!(rank >= 2, "GroupNormalization expects rank >= 2, got {rank}");
+        let c = fact.shape[1].clone();
+        let groups = self.num_groups.to_dim();
+        let channels_per_group = c.clone().div_ceil(self.num_groups as u64);
+
+        // Per the ONNX spec (`stash_type`, default 1=FLOAT), mean/variance are computed in f32;
+        // this matters for f16/bf16 inputs. Cast in, normalize in f32, cast back before the affine.
+        let stash = DatumType::F32;
+        let x = model.wire_node(format!("{prefix}.cast_in"), cast(stash), &inputs[0..1])?;
+
+        // Split the channel axis: (N, C, *spatial) -> (N, G, C/G, *spatial), rank + 1.
+        let grouped = model.wire_node(
+            format!("{prefix}.split"),
+            AxisOp::Reshape(1, tvec![c.clone()], tvec![groups.clone(), channels_per_group.clone()]),
+            &x,
+        )?;
+
+        // Normalize each group over C/G and all spatial dims (axes 2..=rank in the split tensor).
+        let red_axes: Vec<i64> = (2..=rank as i64).collect();
+        let mean = Reduce::new(Some(red_axes.clone()), true, Reducer::Mean).wire(
+            &format!("{prefix}.mean"),
+            model,
+            &grouped,
+        )?;
+        let diff = wire_with_rank_broadcast(
+            format!("{prefix}.diff"),
+            model,
+            sub(),
+            &[grouped[0], mean[0]],
+        )?;
+        let sq = model.wire_node(format!("{prefix}.sq"), square(), &diff)?;
+        let var = Reduce::new(Some(red_axes), true, Reducer::Mean).wire(
+            &format!("{prefix}.var"),
+            model,
+            &sq,
+        )?;
+        let eps = model.add_const(
+            format!("{prefix}.eps"),
+            tensor0(self.epsilon).cast_to_dt(stash)?.into_owned(),
+        )?;
+        let var_eps =
+            wire_with_rank_broadcast(format!("{prefix}.var_eps"), model, add(), &[var[0], eps])?;
+        let inv = model.wire_node(format!("{prefix}.rsqrt"), rsqrt(), &var_eps)?;
+        let normed_f32 =
+            wire_with_rank_broadcast(format!("{prefix}.normed"), model, mul(), &[diff[0], inv[0]])?;
+        // Back to the input dtype before the (dtype-native) scale/bias affine.
+        let normed = model.wire_node(format!("{prefix}.cast_out"), cast(dt), &normed_f32)?;
+
+        let merge = |model: &mut TypedModel, name: String, wire: &[OutletId]| {
+            model.wire_node(
+                name,
+                AxisOp::Reshape(
+                    1,
+                    tvec![groups.clone(), channels_per_group.clone()],
+                    tvec![c.clone()],
+                ),
+                wire,
+            )
+        };
+
+        if self.per_channel_affine {
+            // scale/bias are [C]: merge back to (N, C, *spatial), then apply per-channel affine.
+            let merged = merge(model, format!("{prefix}.merge"), &normed)?;
+            let scale =
+                broadcast_to_channel_axis(model, &format!("{prefix}.scale"), inputs[1], rank)?;
+            let scaled = wire_with_rank_broadcast(
+                format!("{prefix}.scaled"),
+                model,
+                mul(),
+                &[merged[0], scale],
+            )?;
+            let bias =
+                broadcast_to_channel_axis(model, &format!("{prefix}.bias"), inputs[2], rank)?;
+            wire_with_rank_broadcast(prefix, model, add(), &[scaled[0], bias])
+        } else {
+            // scale/bias are [num_groups]: apply on the grouped tensor, then merge back.
+            let gr_rank = rank + 1;
+            let scale =
+                broadcast_to_channel_axis(model, &format!("{prefix}.scale"), inputs[1], gr_rank)?;
+            let scaled = wire_with_rank_broadcast(
+                format!("{prefix}.scaled"),
+                model,
+                mul(),
+                &[normed[0], scale],
+            )?;
+            let bias =
+                broadcast_to_channel_axis(model, &format!("{prefix}.bias"), inputs[2], gr_rank)?;
+            let biased = wire_with_rank_broadcast(
+                format!("{prefix}.biased"),
+                model,
+                add(),
+                &[scaled[0], bias],
+            )?;
+            merge(model, prefix.to_string(), &biased)
+        }
+    }
+}

--- a/onnx/src/ops/nn/lp_norm.rs
+++ b/onnx/src/ops/nn/lp_norm.rs
@@ -1,0 +1,61 @@
+use crate::model::ParsingContext;
+use crate::pb::NodeProto;
+use tract_hir::internal::*;
+use tract_hir::ops::logic::wire_with_rank_broadcast;
+
+pub fn lp_normalization(
+    _ctx: &ParsingContext,
+    node: &NodeProto,
+) -> TractResult<(Box<dyn InferenceOp>, Vec<String>)> {
+    let axis = node.get_attr_opt("axis")?.unwrap_or(-1);
+    let p: i64 = node.get_attr_opt("p")?.unwrap_or(2);
+    ensure!(p == 1 || p == 2, "LpNormalization only supports p=1 or p=2, got p={p}");
+    Ok((expand(LpNorm { axis, p }), vec![]))
+}
+
+#[derive(Debug, Clone, new)]
+struct LpNorm {
+    axis: i64,
+    p: i64,
+}
+
+impl Expansion for LpNorm {
+    fn name(&self) -> StaticName {
+        "LpNorm".into()
+    }
+
+    fn rules<'r, 'p: 'r, 's: 'r>(
+        &'s self,
+        s: &mut Solver<'r>,
+        inputs: &'p [TensorProxy],
+        outputs: &'p [TensorProxy],
+    ) -> InferenceResult {
+        check_input_arity(inputs, 1)?;
+        check_output_arity(outputs, 1)?;
+        s.equals(&inputs[0].datum_type, &outputs[0].datum_type)?;
+        s.equals(&inputs[0].shape, &outputs[0].shape)?;
+        Ok(())
+    }
+
+    fn wire(
+        &self,
+        prefix: &str,
+        model: &mut TypedModel,
+        inputs: &[OutletId],
+    ) -> TractResult<TVec<OutletId>> {
+        let rank = model.outlet_fact(inputs[0])?.rank() as i64;
+        let axis = if self.axis < 0 { self.axis + rank } else { self.axis };
+        // Lp norm along `axis`, keeping the reduced dim so it broadcasts against the input.
+        let reducer = if self.p == 1 {
+            tract_hir::ops::nn::Reducer::L1
+        } else {
+            tract_hir::ops::nn::Reducer::L2
+        };
+        let norm = tract_hir::ops::nn::Reduce::new(Some(vec![axis]), true, reducer).wire(
+            &format!("{prefix}.norm"),
+            model,
+            &inputs[0..1],
+        )?;
+        wire_with_rank_broadcast(prefix, model, tract_hir::ops::math::div(), &[inputs[0], norm[0]])
+    }
+}

--- a/onnx/src/ops/nn/mod.rs
+++ b/onnx/src/ops/nn/mod.rs
@@ -12,12 +12,16 @@ mod batch_norm;
 mod conv_transpose;
 mod dropout;
 mod gelu;
+mod group_norm;
 mod instance_norm;
 mod layer_norm;
+mod lp_norm;
 mod lrn;
 mod mish;
+mod mvn;
 mod reduce;
 mod rms_norm;
+mod rotary_embedding;
 
 pub fn arg_max_min(
     _ctx: &ParsingContext,
@@ -48,14 +52,17 @@ pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("GlobalAveragePool", |_, _| Ok((expand(ops::nn::GlobalAvgPool), vec![])));
     reg.insert("GlobalLpPool", global_lp_pool);
     reg.insert("GlobalMaxPool", |_, _| Ok((expand(ops::nn::GlobalMaxPool), vec![])));
+    reg.insert("GroupNormalization", group_norm::group_normalization);
     reg.insert("Hardmax", layer_hard_max);
     reg.insert("HardSigmoid", hard_sigmoid);
     reg.insert("InstanceNormalization", instance_norm::instance_normalization);
     reg.insert("LayerNormalization", layer_norm::layer_norm);
     reg.insert("LeakyRelu", leaky_relu);
+    reg.insert("LpNormalization", lp_norm::lp_normalization);
     reg.insert("LogSoftmax", layer_log_soft_max);
     reg.insert("LRN", lrn::lrn);
     reg.insert("MaxPool", max_pool);
+    reg.insert("MeanVarianceNormalization", mvn::mean_variance_normalization);
     reg.insert("ParametricSoftplus", parametric_softplus);
     reg.insert("QLinearConv", conv_qlinear);
     reg.insert("PRelu", |_, _| Ok((expand(Prelu), vec![])));
@@ -80,6 +87,7 @@ pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("HardSwish", |_, _| Ok((ops::nn::hard_swish().into_hir(), vec![])));
     reg.insert("Mish", |_, _| Ok((expand(mish::Mish), vec![])));
     reg.insert("RMSNormalization", rms_norm::rms_normalization);
+    reg.insert("RotaryEmbedding", rotary_embedding::rotary_embedding);
     reg.insert("Softmax", layer_soft_max);
     reg.insert("Swish", |_, _| Ok((tract_core::ops::nn::silu::silu().into_hir(), vec![])));
     reg.insert("Softplus", |_, _| Ok((expand(ops::activations::Softplus), vec![])));

--- a/onnx/src/ops/nn/mvn.rs
+++ b/onnx/src/ops/nn/mvn.rs
@@ -1,0 +1,83 @@
+use crate::model::ParsingContext;
+use crate::pb::NodeProto;
+use tract_hir::internal::*;
+use tract_hir::ops::logic::wire_with_rank_broadcast;
+use tract_hir::ops::math::{add, div, sqrt, square, sub};
+use tract_hir::ops::nn::{Reduce, Reducer};
+
+// ONNX MeanVarianceNormalization is defined as a function:
+//   mean   = ReduceMean(X, axes)
+//   var    = ReduceMean(X^2, axes) - mean^2
+//   Y      = (X - mean) / (Sqrt(var) + 1e-9)
+// Note epsilon (1e-9) is added *outside* the square root, and is fixed (not an attribute).
+const EPSILON: f32 = 1e-9;
+
+pub fn mean_variance_normalization(
+    _ctx: &ParsingContext,
+    node: &NodeProto,
+) -> TractResult<(Box<dyn InferenceOp>, Vec<String>)> {
+    let axes = node.get_attr_opt_vec("axes")?.unwrap_or_else(|| vec![0, 2, 3]);
+    Ok((expand(MeanVarianceNorm { axes }), vec![]))
+}
+
+#[derive(Debug, Clone, new)]
+struct MeanVarianceNorm {
+    axes: Vec<i64>,
+}
+
+impl Expansion for MeanVarianceNorm {
+    fn name(&self) -> StaticName {
+        "MeanVarianceNorm".into()
+    }
+
+    fn rules<'r, 'p: 'r, 's: 'r>(
+        &'s self,
+        s: &mut Solver<'r>,
+        inputs: &'p [TensorProxy],
+        outputs: &'p [TensorProxy],
+    ) -> InferenceResult {
+        check_input_arity(inputs, 1)?;
+        check_output_arity(outputs, 1)?;
+        s.equals(&inputs[0].datum_type, &outputs[0].datum_type)?;
+        s.equals(&inputs[0].shape, &outputs[0].shape)?;
+        Ok(())
+    }
+
+    fn wire(
+        &self,
+        prefix: &str,
+        model: &mut TypedModel,
+        inputs: &[OutletId],
+    ) -> TractResult<TVec<OutletId>> {
+        let input_fact = model.outlet_fact(inputs[0])?.clone();
+        let rank = input_fact.rank() as i64;
+        let dt = input_fact.datum_type;
+        let axes: Vec<i64> = self.axes.iter().map(|&a| if a < 0 { a + rank } else { a }).collect();
+
+        let mean = Reduce::new(Some(axes.clone()), true, Reducer::Mean).wire(
+            &format!("{prefix}.mean"),
+            model,
+            &inputs[0..1],
+        )?;
+        let x_sq = model.wire_node(format!("{prefix}.sq"), square(), &inputs[0..1])?;
+        let ex_sq = Reduce::new(Some(axes), true, Reducer::Mean).wire(
+            &format!("{prefix}.ex_sq"),
+            model,
+            &x_sq,
+        )?;
+        let mean_sq = model.wire_node(format!("{prefix}.mean_sq"), square(), &mean)?;
+        let var = model.wire_node(format!("{prefix}.var"), sub(), &[ex_sq[0], mean_sq[0]])?;
+        let std = model.wire_node(format!("{prefix}.std"), sqrt(), &var)?;
+        let eps = model
+            .add_const(format!("{prefix}.eps"), tensor0(EPSILON).cast_to_dt(dt)?.into_owned())?;
+        let std_eps =
+            wire_with_rank_broadcast(format!("{prefix}.std_eps"), model, add(), &[std[0], eps])?;
+        let centered = wire_with_rank_broadcast(
+            format!("{prefix}.centered"),
+            model,
+            sub(),
+            &[inputs[0], mean[0]],
+        )?;
+        wire_with_rank_broadcast(prefix, model, div(), &[centered[0], std_eps[0]])
+    }
+}

--- a/onnx/src/ops/nn/rotary_embedding.rs
+++ b/onnx/src/ops/nn/rotary_embedding.rs
@@ -1,0 +1,211 @@
+use crate::model::ParsingContext;
+use crate::pb::NodeProto;
+use tract_core::ops::array::{Gather, Slice, TypedConcat};
+use tract_core::ops::math::{add, mul, sub};
+use tract_hir::internal::*;
+use tract_hir::ops::logic::wire_with_rank_broadcast;
+
+// ONNX RotaryEmbedding (opset 23). Mirrors onnx/reference/ops/op_rotary_embedding.py:
+//   * normalize input to [batch, seq, heads, head_size]
+//   * gather cos/sin caches by position_ids (when provided)
+//   * rotate the first `rotary_embedding_dim` channels (NeoX halves, or GPT-J interleaved pairs)
+//   * concatenate the untouched tail back and restore the original layout
+pub fn rotary_embedding(
+    _ctx: &ParsingContext,
+    node: &NodeProto,
+) -> TractResult<(Box<dyn InferenceOp>, Vec<String>)> {
+    let interleaved = node.get_attr_opt::<i64>("interleaved")?.unwrap_or(0) != 0;
+    let num_heads = node.get_attr_opt::<i64>("num_heads")?.unwrap_or(0) as usize;
+    let rotary_embedding_dim =
+        node.get_attr_opt::<i64>("rotary_embedding_dim")?.unwrap_or(0) as usize;
+    Ok((expand(RotaryEmbedding { interleaved, num_heads, rotary_embedding_dim }), vec![]))
+}
+
+#[derive(Debug, Clone, new)]
+struct RotaryEmbedding {
+    interleaved: bool,
+    num_heads: usize,
+    rotary_embedding_dim: usize,
+}
+
+impl Expansion for RotaryEmbedding {
+    fn name(&self) -> StaticName {
+        "RotaryEmbedding".into()
+    }
+
+    fn rules<'r, 'p: 'r, 's: 'r>(
+        &'s self,
+        s: &mut Solver<'r>,
+        inputs: &'p [TensorProxy],
+        outputs: &'p [TensorProxy],
+    ) -> InferenceResult {
+        ensure!(
+            inputs.len() == 3 || inputs.len() == 4,
+            "RotaryEmbedding expects 3 or 4 inputs, got {}",
+            inputs.len()
+        );
+        check_output_arity(outputs, 1)?;
+        // Output keeps the input tensor's type and shape.
+        s.equals(&inputs[0].datum_type, &outputs[0].datum_type)?;
+        s.equals(&inputs[0].shape, &outputs[0].shape)?;
+        Ok(())
+    }
+
+    fn wire(
+        &self,
+        prefix: &str,
+        model: &mut TypedModel,
+        inputs: &[OutletId],
+    ) -> TractResult<TVec<OutletId>> {
+        let in_fact = model.outlet_fact(inputs[0])?.clone();
+        let in_rank = in_fact.rank();
+        ensure!(in_rank == 3 || in_rank == 4, "RotaryEmbedding expects rank 3 or 4, got {in_rank}");
+        let has_position_ids = inputs.len() == 4;
+        let two = 2usize.to_dim();
+
+        // 1. Normalize input to [batch, seq, heads, head_size].
+        let x = if in_rank == 4 {
+            // [B, N, S, H] -> [B, S, N, H]
+            model.wire_node(format!("{prefix}.to_bsnh"), AxisOp::Move(1, 2), &[inputs[0]])?[0]
+        } else {
+            // [B, S, hidden] -> [B, S, N, H]
+            ensure!(self.num_heads > 0, "RotaryEmbedding with a 3D input requires num_heads");
+            let hidden = in_fact.shape[2].clone();
+            let head_size = hidden.clone().div_ceil(self.num_heads as u64);
+            model.wire_node(
+                format!("{prefix}.split_heads"),
+                AxisOp::Reshape(2, tvec![hidden], tvec![self.num_heads.to_dim(), head_size]),
+                &[inputs[0]],
+            )?[0]
+        };
+
+        let head_size = model.outlet_fact(x)?.shape[3].clone();
+        let rotary_dim = if self.rotary_embedding_dim == 0 {
+            head_size.clone()
+        } else {
+            self.rotary_embedding_dim.to_dim()
+        };
+        let half = rotary_dim.clone().div_ceil(2);
+
+        // 2. Split off the rotary part (and the pass-through tail when partial).
+        let x_rotate = model.wire_node(
+            format!("{prefix}.rotary"),
+            Slice::new(3, 0, rotary_dim.clone()),
+            &[x],
+        )?[0];
+        let passthrough = if rotary_dim != head_size {
+            Some(
+                model.wire_node(
+                    format!("{prefix}.passthrough"),
+                    Slice::new(3, rotary_dim.clone(), head_size.clone()),
+                    &[x],
+                )?[0],
+            )
+        } else {
+            None
+        };
+
+        // 3. Prepare cos/sin as [B, S, 1, half] (gathering by position_ids if present).
+        let mut prep = |tag: &str, cache: usize| -> TractResult<OutletId> {
+            let gathered = if has_position_ids {
+                model.wire_node(
+                    format!("{prefix}.{tag}_gather"),
+                    Gather::new(0),
+                    &[inputs[cache], inputs[3]],
+                )?[0]
+            } else {
+                inputs[cache]
+            };
+            Ok(model.wire_node(format!("{prefix}.{tag}_unsqueeze"), AxisOp::Add(2), &[gathered])?
+                [0])
+        };
+        let cos = prep("cos", 1)?;
+        let sin = prep("sin", 2)?;
+
+        // 4. Extract the two rotated components.
+        let (x1, x2) = if self.interleaved {
+            // [.., rotary_dim] -> [.., half, 2], then take the even/odd lanes.
+            let pairs = model.wire_node(
+                format!("{prefix}.pairs"),
+                AxisOp::Reshape(3, tvec![rotary_dim.clone()], tvec![half.clone(), two.clone()]),
+                &[x_rotate],
+            )?[0];
+            let even = model.wire_node(format!("{prefix}.even"), Slice::new(4, 0, 1), &[pairs])?[0];
+            let x1 = model.wire_node(format!("{prefix}.even_sq"), AxisOp::Rm(4), &[even])?[0];
+            let odd = model.wire_node(format!("{prefix}.odd"), Slice::new(4, 1, 2), &[pairs])?[0];
+            let x2 = model.wire_node(format!("{prefix}.odd_sq"), AxisOp::Rm(4), &[odd])?[0];
+            (x1, x2)
+        } else {
+            let x1 = model.wire_node(
+                format!("{prefix}.x1"),
+                Slice::new(3, 0, half.clone()),
+                &[x_rotate],
+            )?[0];
+            let x2 = model.wire_node(
+                format!("{prefix}.x2"),
+                Slice::new(3, half.clone(), rotary_dim.clone()),
+                &[x_rotate],
+            )?[0];
+            (x1, x2)
+        };
+
+        // 5. real = cos*x1 - sin*x2 ; imag = sin*x1 + cos*x2
+        let cos_x1 =
+            wire_with_rank_broadcast(format!("{prefix}.cos_x1"), model, mul(), &[cos, x1])?[0];
+        let sin_x2 =
+            wire_with_rank_broadcast(format!("{prefix}.sin_x2"), model, mul(), &[sin, x2])?[0];
+        let real =
+            wire_with_rank_broadcast(format!("{prefix}.real"), model, sub(), &[cos_x1, sin_x2])?[0];
+        let sin_x1 =
+            wire_with_rank_broadcast(format!("{prefix}.sin_x1"), model, mul(), &[sin, x1])?[0];
+        let cos_x2 =
+            wire_with_rank_broadcast(format!("{prefix}.cos_x2"), model, mul(), &[cos, x2])?[0];
+        let imag =
+            wire_with_rank_broadcast(format!("{prefix}.imag"), model, add(), &[sin_x1, cos_x2])?[0];
+
+        // 6. Reassemble the rotated channels.
+        let rotated = if self.interleaved {
+            let real5 = model.wire_node(format!("{prefix}.real_unsq"), AxisOp::Add(4), &[real])?[0];
+            let imag5 = model.wire_node(format!("{prefix}.imag_unsq"), AxisOp::Add(4), &[imag])?[0];
+            let interleaved = model.wire_node(
+                format!("{prefix}.interleave"),
+                TypedConcat::new(4),
+                &[real5, imag5],
+            )?[0];
+            model.wire_node(
+                format!("{prefix}.merge_pairs"),
+                AxisOp::Reshape(3, tvec![half.clone(), two.clone()], tvec![rotary_dim.clone()]),
+                &[interleaved],
+            )?[0]
+        } else {
+            model.wire_node(
+                format!("{prefix}.concat_halves"),
+                TypedConcat::new(3),
+                &[real, imag],
+            )?[0]
+        };
+
+        // 7. Re-attach the pass-through tail.
+        let out_bsnh = if let Some(pt) = passthrough {
+            model.wire_node(format!("{prefix}.concat_tail"), TypedConcat::new(3), &[rotated, pt])?
+                [0]
+        } else {
+            rotated
+        };
+
+        // 8. Restore the original layout.
+        let out = if in_rank == 4 {
+            // [B, S, N, H] -> [B, N, S, H]
+            model.wire_node(prefix.to_string(), AxisOp::Move(2, 1), &[out_bsnh])?
+        } else {
+            let hidden = in_fact.shape[2].clone();
+            let head_size = hidden.clone().div_ceil(self.num_heads as u64);
+            model.wire_node(
+                prefix.to_string(),
+                AxisOp::Reshape(2, tvec![self.num_heads.to_dim(), head_size], tvec![hidden]),
+                &[out_bsnh],
+            )?
+        };
+        Ok(out)
+    }
+}

--- a/test-rt/suite-onnx/node.txt
+++ b/test-rt/suite-onnx/node.txt
@@ -231,6 +231,9 @@ test_less.*
 test_log
 test_log_example
 test_logsoftmax.*
+test_l1normalization.*
+test_l2normalization.*
+test_lpnormalization.*
 test_lrn
 test_lrn_default
 test_lstm_batchwise
@@ -276,6 +279,7 @@ test_mod_uint32 not-nnef
 test_mod_uint64 not-nnef
 test_mod_uint8 not-nnef
 test_mul.*
+test_mvn
 test_mvn_expanded
 test_neg
 test_negative_log_likelihood_loss_input_shape_is_NCd1d2d3d4d5_none_no_weight_expanded
@@ -778,7 +782,9 @@ test_gelu_tanh_1 since:24
 test_gelu_tanh_1_expanded since:24
 test_gelu_tanh_2 since:24
 test_gelu_tanh_2_expanded since:24
+test_group_normalization_epsilon
 test_group_normalization_epsilon_expanded
+test_group_normalization_example
 test_group_normalization_example_expanded
 test_isnan_float16 since:24
 test_maxpool_2d_ceil_output_size_reduce_by_one since:24
@@ -825,14 +831,7 @@ test_rms_normalization_4d_axis_negative_4 since:24
 test_rms_normalization_4d_axis_negative_4_expanded since:24
 test_rms_normalization_default_axis since:24
 test_rms_normalization_default_axis_expanded since:24
-test_rotary_embedding_3d_input_expanded since:24
-test_rotary_embedding_expanded since:24
-test_rotary_embedding_interleaved_expanded since:24
-test_rotary_embedding_no_position_ids_expanded since:24
-test_rotary_embedding_no_position_ids_interleaved_expanded since:24
-test_rotary_embedding_no_position_ids_rotary_dim_expanded since:24
-test_rotary_embedding_with_interleaved_rotary_dim_expanded since:24
-test_rotary_embedding_with_rotary_dim_expanded since:24
+test_rotary_embedding.* since:24
 test_scatter_elements_with_duplicate_indices
 test_swish since:24
 test_swish_expanded since:24


### PR DESCRIPTION
## Summary
Adds ONNX importer handlers for four inference-relevant operators that tract could already compute as decomposed subgraphs but had no single-node binding for — continuing the recent Attention/RMSNorm/Gelu/Swish/Mish additions:

- **LpNormalization** (opset 1) — `Reduce<L1|L2>` over `axis`, then divide
- **MeanVarianceNormalization** (opset 13) — standard function decomposition (epsilon outside the sqrt)
- **GroupNormalization** (opset 18 & 21) — channel-split normalization; opset-aware affine (`[num_groups]` pre-21, `[C]` from 21) and honors `stash_type` (f32 reduction for f16/bf16 inputs)
- **RotaryEmbedding** (opset 23) — full reference algorithm: 3D/4D input, optional `position_ids`, partial `rotary_embedding_dim`, NeoX and GPT-J (`interleaved`) layouts

All lower to existing tract primitives — importer coverage, no new kernels.

## Tests
- Corresponding ONNX backend node tests enabled in `test-rt/suite-onnx/node.txt`, green on `default` + `unoptimized` runtimes (GroupNorm at both the opset-18 and opset-21 affine paths; all 8 RoPE variants). Full node suite: **4428 passed / 0 failed**.
- Spot-checked end-to-end against ONNX `ReferenceEvaluator` on small multi-op graphs, including dynamic (symbolic) batch/sequence shapes; RoPE bit-exact.

## Note
tract resolves ops by name regardless of domain; this PR targets the standardized `ai.onnx` operators. The `com.microsoft` RoPE variant has a different input order and is intentionally out of scope here.