### PR TITLE
tract-cuda: expose cuda-12XXX feature gates, default still cuda-13000

### DIFF
--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
       - run: |
           ROOT=. ./.travis/ci-system-setup.sh
-          cargo build -p tract-cli --profile opt-no-lto --no-default-features --features transformers,pulse
+          cargo build -p tract-cli --profile opt-no-lto --no-default-features --features transformers,pulse,cuda-13000
       - run: echo uname=$(uname) >> $GITHUB_ENV
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -86,11 +86,19 @@ case "$PLATFORM" in
 
     "aarch64-unknown-linux-gnu-stretch" | "armv7-unknown-linux-gnueabihf-stretch" | "x86_64-unknown-linux-gnu-stretch")
         INNER_PLATFORM=${PLATFORM%-stretch}
+        # aarch64 stretch bench targets Jetson-class boxes that ship with CUDA 12;
+        # the default CUDA 13 cudarc binding wouldn't run there (cudart symbol
+        # rename across the 12/13 boundary).  Force cuda-12000 for that build only.
+        CUDA_FEATURE_ENV=""
+        if [ "$PLATFORM" = "aarch64-unknown-linux-gnu-stretch" ]
+        then
+            CUDA_FEATURE_ENV="-e TRACT_CUDA_FEATURE=cuda-12000"
+        fi
         (cd .travis/docker-debian-stretch; docker build --tag debian-stretch .)
         docker run -v `pwd`:/tract -w /tract \
             -e CI=true \
             -e SKIP_QEMU_TEST=skip \
-            -e PLATFORM=$INNER_PLATFORM debian-stretch \
+            -e PLATFORM=$INNER_PLATFORM $CUDA_FEATURE_ENV debian-stretch \
             ./.travis/cross.sh
         sudo chown -R `whoami` .
         export RUSTC_TRIPLE=$INNER_PLATFORM
@@ -196,7 +204,16 @@ case "$PLATFORM" in
 
         cargo dinghy --platform $PLATFORM $DINGHY_TEST_ARGS check -p tract-ffi
         # keep lto for these two are they're going to devices.
-        cargo dinghy --platform $PLATFORM build --release -p tract-cli -p example-tensorflow-mobilenet-v2
+        if [ -n "$TRACT_CUDA_FEATURE" ]
+        then
+            cargo dinghy --platform $PLATFORM build --release \
+                --no-default-features \
+                --features "onnx,tf,pulse,pulse-opl,tflite,transformers,extra,$TRACT_CUDA_FEATURE" \
+                -p tract-cli
+            cargo dinghy --platform $PLATFORM build --release -p example-tensorflow-mobilenet-v2
+        else
+            cargo dinghy --platform $PLATFORM build --release -p tract-cli -p example-tensorflow-mobilenet-v2
+        fi
         ;;
 
     wasm32-wasi)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ walkdir = "2.3.2"
 zerofrom = "0.1.5"
 tract-api = { version = "=0.23.0-dev.4", path = 'api' }
 tract-core = { version = "0.23.0-pre", path = 'core' }
-tract-cuda = { version = "0.23.0-pre", path = 'cuda' }
+tract-cuda = { version = "0.23.0-pre", path = 'cuda', default-features = false }
 tract-data = { version = "0.23.0-pre", path = 'data' }
 tract-extra = { version = "0.23.0-pre", path = 'extra' }
 tract-gpu = { version = "0.23.0-pre", path = 'gpu' }

--- a/api/rs/Cargo.toml
+++ b/api/rs/Cargo.toml
@@ -34,7 +34,7 @@ serde_json.workspace = true
 tract-metal.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
-tract-cuda.workspace = true
+tract-cuda = { workspace = true, default-features = false }
 
 
 [dev-dependencies]
@@ -44,7 +44,23 @@ tempfile.workspace = true
 serde_json.workspace = true
 
 [features]
+default = ["cuda-13000"]
 complex = []
 # default = [ "dylib" ]
 # dylib = []
 # staticlib = []
+
+# CUDA driver-API selectors (linux/windows targets only). Pass-through to
+# tract-cuda. Exactly one must be active; the default pulls cuda-13000.
+cuda-12000 = ["tract-cuda/cuda-12000"]
+cuda-12010 = ["tract-cuda/cuda-12010"]
+cuda-12020 = ["tract-cuda/cuda-12020"]
+cuda-12030 = ["tract-cuda/cuda-12030"]
+cuda-12040 = ["tract-cuda/cuda-12040"]
+cuda-12050 = ["tract-cuda/cuda-12050"]
+cuda-12060 = ["tract-cuda/cuda-12060"]
+cuda-12080 = ["tract-cuda/cuda-12080"]
+cuda-12090 = ["tract-cuda/cuda-12090"]
+cuda-13000 = ["tract-cuda/cuda-13000"]
+cuda-13010 = ["tract-cuda/cuda-13010"]
+cuda-13020 = ["tract-cuda/cuda-13020"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -75,7 +75,7 @@ tract-metal.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 cudarc.workspace = true
-tract-cuda.workspace = true
+tract-cuda = { workspace = true, default-features = false }
 
 [features]
 default = [
@@ -86,6 +86,7 @@ default = [
   "tflite",
   "transformers",
   "extra",
+  "cuda-13000",
 ]
 apple-amx-ios = ["tract-linalg/apple-amx-ios"]
 onnx = ["tract-onnx", "tract-libcli/hir", "tract-libcli/onnx"]
@@ -97,3 +98,21 @@ tflite = ["tract-tflite"]
 transformers = ["tract-transformers", "tract-libcli/transformers"]
 conform = ["tract-tensorflow/conform"]
 multithread-mm = ["tract-linalg/multithread-mm"]
+
+# CUDA driver-API selectors (linux/windows targets only). Picking one binds
+# cudarc against the matching CUDA enum/struct layout; the resulting binary
+# runs on any driver whose API is >= the chosen one. Exactly one must be
+# active. The default pulls cuda-13000 in; cross-compiles aimed at older
+# drivers (e.g. aarch64 with CUDA 12) override with `--no-default-features`.
+cuda-12000 = ["tract-cuda/cuda-12000"]
+cuda-12010 = ["tract-cuda/cuda-12010"]
+cuda-12020 = ["tract-cuda/cuda-12020"]
+cuda-12030 = ["tract-cuda/cuda-12030"]
+cuda-12040 = ["tract-cuda/cuda-12040"]
+cuda-12050 = ["tract-cuda/cuda-12050"]
+cuda-12060 = ["tract-cuda/cuda-12060"]
+cuda-12080 = ["tract-cuda/cuda-12080"]
+cuda-12090 = ["tract-cuda/cuda-12090"]
+cuda-13000 = ["tract-cuda/cuda-13000"]
+cuda-13010 = ["tract-cuda/cuda-13010"]
+cuda-13020 = ["tract-cuda/cuda-13020"]

--- a/cuda/Cargo.toml
+++ b/cuda/Cargo.toml
@@ -41,7 +41,22 @@ proptest.workspace = true
 rand.workspace = true
 
 [features]
+# Pick exactly one cuda-XXXXX to bind cudarc against. Higher minor versions
+# bind more symbols; the resulting binary still runs against any CUDA driver
+# whose API version is >= the chosen one (the runtime check in utils.rs
+# enforces this).
+cuda-12000 = ["cudarc/cuda-12000"]
+cuda-12010 = ["cudarc/cuda-12010"]
+cuda-12020 = ["cudarc/cuda-12020"]
+cuda-12030 = ["cudarc/cuda-12030"]
+cuda-12040 = ["cudarc/cuda-12040"]
+cuda-12050 = ["cudarc/cuda-12050"]
+cuda-12060 = ["cudarc/cuda-12060"]
+cuda-12080 = ["cudarc/cuda-12080"]
+cuda-12090 = ["cudarc/cuda-12090"]
 cuda-13000 = ["cudarc/cuda-13000"]
+cuda-13010 = ["cudarc/cuda-13010"]
+cuda-13020 = ["cudarc/cuda-13020"]
 default = ["cuda-13000"]
 
 [[bench]]

--- a/cuda/src/utils.rs
+++ b/cuda/src/utils.rs
@@ -14,15 +14,60 @@ use crate::ops::GgmlQuantQ81Fact;
 static CULIBS_MISSING: OnceLock<Option<&'static str>> = OnceLock::new();
 static DEPENDENCIES_OK: OnceLock<()> = OnceLock::new();
 
-// Ensure exactly cuda-13000 is enabled.
-// Prevent accidental change of feature gate without
-// updating this required API version used for compatibility check.
-// please update the 3 references bellow if cudarc gate is updated to a newer version.
+/// CUDA Driver API version this build of tract-cuda is bound against. Used both
+/// for the runtime driver-version check (in `ensure_cuda_driver_compatible`)
+/// and for the per-version cubin cache path. Derived at compile time from the
+/// active `cuda-XXXXX` feature; cudarc binds to that same enum/struct layout,
+/// so the two must agree. Adding a new minor here means adding the matching
+/// cargo feature too.
+#[cfg(feature = "cuda-12000")]
+pub const REQUIRED_CUDA_API: i32 = 12000;
+#[cfg(feature = "cuda-12010")]
+pub const REQUIRED_CUDA_API: i32 = 12010;
+#[cfg(feature = "cuda-12020")]
+pub const REQUIRED_CUDA_API: i32 = 12020;
+#[cfg(feature = "cuda-12030")]
+pub const REQUIRED_CUDA_API: i32 = 12030;
+#[cfg(feature = "cuda-12040")]
+pub const REQUIRED_CUDA_API: i32 = 12040;
+#[cfg(feature = "cuda-12050")]
+pub const REQUIRED_CUDA_API: i32 = 12050;
+#[cfg(feature = "cuda-12060")]
+pub const REQUIRED_CUDA_API: i32 = 12060;
+#[cfg(feature = "cuda-12080")]
+pub const REQUIRED_CUDA_API: i32 = 12080;
+#[cfg(feature = "cuda-12090")]
+pub const REQUIRED_CUDA_API: i32 = 12090;
+#[cfg(feature = "cuda-13000")]
 pub const REQUIRED_CUDA_API: i32 = 13000;
-#[cfg(not(feature = "cuda-13000"))]
+#[cfg(feature = "cuda-13010")]
+pub const REQUIRED_CUDA_API: i32 = 13010;
+#[cfg(feature = "cuda-13020")]
+pub const REQUIRED_CUDA_API: i32 = 13020;
+
+// Exactly one cuda-XXXXX feature must be enabled. cudarc itself panics at its
+// build script if zero are enabled, but it does not catch the case of two
+// being enabled simultaneously — and a mismatch between REQUIRED_CUDA_API and
+// cudarc's actual binding would be a silent ABI hazard. Enumerate the
+// supported set explicitly so a duplicate triggers `REQUIRED_CUDA_API` re-def
+// at compile time.
+#[cfg(not(any(
+    feature = "cuda-12000",
+    feature = "cuda-12010",
+    feature = "cuda-12020",
+    feature = "cuda-12030",
+    feature = "cuda-12040",
+    feature = "cuda-12050",
+    feature = "cuda-12060",
+    feature = "cuda-12080",
+    feature = "cuda-12090",
+    feature = "cuda-13000",
+    feature = "cuda-13010",
+    feature = "cuda-13020",
+)))]
 compile_error!(
-    "Tract CUDA backend currently supports only cudarc feature 'cuda-13000'. \
-        Enabled in Cargo features.",
+    "Tract CUDA backend requires exactly one of the cuda-XXXXX features \
+     (cuda-12000..cuda-13020) to be enabled. Enable it in Cargo features.",
 );
 
 /// CUDA Driver API status code type (CUresult is an enum, but it's ABI-compatible with int).


### PR DESCRIPTION
REQUIRED_CUDA_API becomes cfg-derived (one of cuda-12000..cuda-13020) and the compile_error now requires exactly one to be enabled.  Workspace dep gains default-features=false so tract-cli can pick a version without fighting the default; tract-cli mirrors the pass-through features and pulls cuda-13000 into its own default, preserving today's behaviour.

aarch64-unknown-linux-gnu-stretch bench bundle now binds to cuda-12000 so the resulting binary runs on Jetson-class boxes (CUDA 12 driver + the v1/v2 cudart symbol rename across the 12/13 boundary makes the default cuda-13 binary non-portable there).  Other cross targets and the default cargo build are unchanged.