### PR TITLE
cuda/diag_gather: GPU kernel for the rel-pos skew gather

### DIFF
--- a/cuda/src/kernels/array/diag_gather.rs
+++ b/cuda/src/kernels/array/diag_gather.rs
@@ -1,0 +1,207 @@
+use crate::context::{TractCudaStream, cuda_context};
+use crate::kernels::launch_args::TractLaunchArgs;
+use crate::kernels::{LibraryName, MAX_THREADS, get_cuda_view};
+use anyhow::ensure;
+use cudarc::driver::{CudaStream, LaunchConfig, PushKernelArg};
+use std::fmt;
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DiagGather;
+
+impl fmt::Display for DiagGather {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl DiagGather {
+    pub fn is_supported_dt(dt: DatumType) -> bool {
+        matches!(dt, DatumType::F32 | DatumType::F16)
+    }
+
+    pub fn kernel_name(&self, dt: DatumType) -> TractResult<String> {
+        ensure!(Self::is_supported_dt(dt), "Unsupported dt {:?} for cuda diag_gather op", dt);
+        let tname = DeviceTensor::tname(dt)?;
+        Ok(format!("diag_gather_{tname}"))
+    }
+
+    pub fn eval(
+        &self,
+        stream: &TractCudaStream,
+        input: &DeviceTensor,
+        offset: i64,
+        out_len: usize,
+    ) -> TractResult<DeviceTensor> {
+        let rank = input.rank();
+        ensure!(rank >= 2);
+        let mut out_shape: TVec<usize> = input.shape().into();
+        out_shape[rank - 1] = out_len;
+        let output = unsafe { DeviceTensor::uninitialized_dt(input.datum_type(), &out_shape)? };
+        self.dispatch_eval(stream, input, offset, out_len, &output)?;
+        stream.synchronize()?;
+        Ok(output)
+    }
+
+    pub fn dispatch_eval(
+        &self,
+        stream: &TractCudaStream,
+        input: &DeviceTensor,
+        offset: i64,
+        out_len: usize,
+        output: &DeviceTensor,
+    ) -> TractResult<()> {
+        let rank = input.rank();
+        ensure!(rank >= 2);
+        ensure!(output.rank() == rank);
+        ensure!(output.datum_type() == input.datum_type());
+        let in_shape = input.shape();
+        let out_shape = output.shape();
+        // Output shares all leading axes with input, only the last differs.
+        ensure!(in_shape[..rank - 2] == out_shape[..rank - 2]);
+        ensure!(in_shape[rank - 2] == out_shape[rank - 2]);
+        ensure!(out_shape[rank - 1] == out_len);
+        // i64 -> i32 down-cast: model widths are well under i32::MAX in practice.
+        let offset_i32: i32 = offset.try_into().context("DiagGather offset overflows i32")?;
+        let out_len_i32: i32 = out_len.try_into().context("DiagGather out_len overflows i32")?;
+
+        // Flatten the (rank-2) leading axes into one batch axis.  Assumes the
+        // leading block is plain row-major (encoder use: rank-4 BxHxTxR with
+        // natural strides), so the batch stride is `t_q * (R or out_len)`.
+        let in_strides = input.strides();
+        let out_strides = output.strides();
+        let batch: usize = in_shape[..rank - 2].iter().product();
+        let t_q = in_shape[rank - 2];
+        let r_in = in_shape[rank - 1];
+        let in_stride_b: i32 = if rank >= 3 { (t_q * r_in) as i32 } else { 0 };
+        let in_stride_i = in_strides[rank - 2] as i32;
+        let in_stride_r = in_strides[rank - 1] as i32;
+        let out_stride_b: i32 = if rank >= 3 { (t_q * out_len) as i32 } else { 0 };
+        let out_stride_i = out_strides[rank - 2] as i32;
+        let out_stride_k = out_strides[rank - 1] as i32;
+
+        let i_view = get_cuda_view(input);
+        let o_view = get_cuda_view(output);
+
+        let func = cuda_context()
+            .load_pipeline(LibraryName::Array, self.kernel_name(input.datum_type())?)?;
+
+        let mut launch_args = TractLaunchArgs::new(stream, &func);
+        launch_args.push_view(&i_view);
+        launch_args.push_view(&o_view);
+        launch_args.push::<i32>(offset_i32);
+        launch_args.push::<i32>(batch as i32);
+        launch_args.push::<i32>(t_q as i32);
+        launch_args.push::<i32>(r_in as i32);
+        launch_args.push::<i32>(out_len_i32);
+        launch_args.push::<i32>(in_stride_b);
+        launch_args.push::<i32>(in_stride_i);
+        launch_args.push::<i32>(in_stride_r);
+        launch_args.push::<i32>(out_stride_b);
+        launch_args.push::<i32>(out_stride_i);
+        launch_args.push::<i32>(out_stride_k);
+
+        // Grid: x = out_len cols, y = T_q rows, z = batch.  Threads per block
+        // along x = min(out_len, 256) rounded down to multiple of 32.
+        let block_x = out_len.min(MAX_THREADS).max(32);
+        let grid_x = out_len.div_ceil(block_x);
+        let cfg = LaunchConfig {
+            grid_dim: (grid_x as _, t_q as _, batch as _),
+            block_dim: (block_x as _, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        launch_args.launch(cfg)
+    }
+}
+
+pub fn cuda_diag_gather_dispatch(
+    input: &DeviceTensor,
+    offset: i64,
+    out_len: usize,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    crate::with_cuda_stream(|stream| {
+        DiagGather.dispatch_eval(stream, input, offset, out_len, output)
+    })
+}
+
+crate::register_cuda_op!(tract_transformers::ops::diag_gather::DiagGather, |source, node, op| {
+    rule_if!(DiagGather::is_supported_dt(source.node_input_facts(node.id)?[0].datum_type));
+    Ok(Some(Box::new(tract_gpu::ops::diag_gather::GpuDiagGather::new(
+        op.offset.clone(),
+        op.out_len.clone(),
+        "Cuda",
+        cuda_diag_gather_dispatch,
+    ))))
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tract_core::internal::Tensor;
+    use tract_gpu::tensor::IntoDevice;
+    use tract_transformers::ops::diag_gather as cpu_dg;
+
+    fn run_against_cpu(shape: &[usize], offset: i64, out_len: usize) -> TractResult<()> {
+        use tract_core::plan::TurnState;
+        crate::with_cuda_stream(|stream| {
+            let len: usize = shape.iter().product();
+            let data: Vec<f32> = (0..len).map(|i| i as f32).collect();
+            let cpu_in = Tensor::from_shape(shape, &data)?;
+            let cuda_in = cpu_in.clone().into_device()?;
+
+            // CPU DiagGather only implements eval_with_session (it resolves
+            // TDims against the session's resolved_symbols); pass an empty
+            // TurnState since the TDims here are already concrete.
+            let cpu_op =
+                cpu_dg::DiagGather { offset: (offset as i64).to_dim(), out_len: out_len.to_dim() };
+            let session = TurnState::default();
+            let cpu_out = cpu_op.eval_with_session(0, &session, tvec![cpu_in.into_tvalue()])?[0]
+                .clone()
+                .into_tensor();
+            let cuda_out = DiagGather.eval(stream, &cuda_in, offset, out_len)?;
+            cpu_out
+                .close_enough(&cuda_out.to_host()?.into_tensor(), Approximation::Exact)
+                .with_context(|| format!("shape={shape:?} offset={offset} out_len={out_len}"))
+        })
+    }
+
+    #[test]
+    fn test_diag_gather_skew_basic() -> TractResult<()> {
+        // Classic skew-trick shape: [B*H, T, 2T-1] -> [B*H, T, T] with offset = T-1.
+        let t = 4;
+        run_against_cpu(&[2, t, 2 * t - 1], (t - 1) as i64, t)
+    }
+
+    #[test]
+    fn test_diag_gather_rank4_encoder_like() -> TractResult<()> {
+        // Mirrors the encoder shape: [B, H, T_q, R].
+        let t = 14;
+        run_against_cpu(&[1, 8, t, 2 * t - 1], (t - 1) as i64, t)
+    }
+
+    #[test]
+    fn test_diag_gather_out_of_bounds_zero_fill() -> TractResult<()> {
+        // out_len > R so some `r = offset + k - i` fall outside [0, R) and
+        // must be zero-filled (matches CPU contract).
+        let r = 5;
+        let t = 4;
+        run_against_cpu(&[1, t, r], 1, 8)
+    }
+
+    #[test]
+    fn test_diag_gather_partial_overlap() -> TractResult<()> {
+        // offset = 0: row i reads input[..., i, -i..-i+out_len], so the
+        // first `i` columns of each row are out of bounds and zeroed.
+        let t = 4;
+        let r = 6;
+        run_against_cpu(&[1, t, r], 0, t)
+    }
+
+    #[test]
+    fn test_diag_gather_rank2() -> TractResult<()> {
+        // Smallest valid rank: no leading batch axes.
+        run_against_cpu(&[5, 9], 4, 5)
+    }
+}

--- a/cuda/src/kernels/array/mod.rs
+++ b/cuda/src/kernels/array/mod.rs
@@ -1,11 +1,14 @@
 mod cast;
 mod copy;
+mod diag_gather;
 mod dispatch;
 mod rotate_half;
 
 pub use cast::Cast;
 pub use cast::cuda_cast_dispatch;
 pub use copy::Memcpy;
+pub use diag_gather::DiagGather;
+pub use diag_gather::cuda_diag_gather_dispatch;
 pub use dispatch::cuda_copy_nd_dispatch;
 pub use rotate_half::RotateHalf;
 pub use rotate_half::cuda_rotate_half_dispatch;
@@ -24,6 +27,12 @@ pub fn all_functions() -> Vec<String> {
                 tract_gpu::tensor::DeviceTensor::SUPPORTED_DT.into_iter().map(move |dt2| (dt1, dt2))
             })
             .flat_map(|(dt1, dt2)| Cast.kernel_name(dt1, dt2).into_iter()),
+    );
+
+    functions.extend(
+        tract_gpu::tensor::DeviceTensor::SUPPORTED_DT
+            .into_iter()
+            .flat_map(|dt| DiagGather.kernel_name(dt).into_iter()),
     );
 
     functions.into_iter().collect()

--- a/cuda/src/kernels/cu/array.cu
+++ b/cuda/src/kernels/cu/array.cu
@@ -219,3 +219,35 @@ INSTANTIATE_CAST_FROM(u64, uint64_t)
 // Rotate half: only float types
 INSTANTIATE_ROTATE_HALF(f32, float)
 INSTANTIATE_ROTATE_HALF(f16, __half)
+
+// Diagonal gather (Transformer-XL rel-pos skew, folded):
+//   out[..., i, k] = in[..., i, offset + k - i], 0 on out-of-bounds.
+// Leading axes are flattened by the host into one batch axis.  Each thread
+// owns one (b, i, k) output element — bandwidth-bound, no shared memory.
+#define INSTANTIATE_DIAG_GATHER(name, T)                                       \
+    extern "C" __global__ void diag_gather_##name(                             \
+        const T *input, T *output, const int32_t offset,                       \
+        const int32_t batch, const int32_t t_q, const int32_t r_in,            \
+        const int32_t out_len, const int32_t in_stride_b,                      \
+        const int32_t in_stride_i, const int32_t in_stride_r,                  \
+        const int32_t out_stride_b, const int32_t out_stride_i,                \
+        const int32_t out_stride_k) {                                          \
+        const int32_t k = blockIdx.x * blockDim.x + threadIdx.x;               \
+        if (k >= out_len)                                                      \
+            return;                                                            \
+        const int32_t i = blockIdx.y;                                          \
+        const int32_t b = blockIdx.z;                                          \
+        const int32_t r = offset + k - i;                                      \
+        T *out_ptr = output + b * out_stride_b + i * out_stride_i +            \
+                     k * out_stride_k;                                         \
+        if (r >= 0 && r < r_in) {                                              \
+            const T *in_ptr =                                                  \
+                input + b * in_stride_b + i * in_stride_i + r * in_stride_r;   \
+            *out_ptr = *in_ptr;                                                \
+        } else {                                                               \
+            *out_ptr = (T)0;                                                   \
+        }                                                                      \
+    }
+
+INSTANTIATE_DIAG_GATHER(f32, float)
+INSTANTIATE_DIAG_GATHER(f16, __half)

--- a/gpu/src/ops/diag_gather.rs
+++ b/gpu/src/ops/diag_gather.rs
@@ -1,0 +1,98 @@
+use crate::tensor::{DeviceTensor, DeviceTensorExt};
+use derive_new::new;
+use tract_core::internal::*;
+
+/// `out[..., i, k] = in[..., i, offset + k - i]`, with zero-fill on
+/// out-of-bounds reads. Mirrors `tract_transformers::ops::diag_gather::DiagGather`.
+///
+/// `offset` and `out_len` are TDim because the rel-pos table width and the
+/// query-axis length may both be symbolic upstream; both are resolved against
+/// `session.resolved_symbols` at eval time.
+pub type DispatchDiagGatherFn =
+    fn(input: &DeviceTensor, offset: i64, out_len: usize, output: &DeviceTensor) -> TractResult<()>;
+
+#[derive(Clone, new)]
+pub struct GpuDiagGather {
+    pub offset: TDim,
+    pub out_len: TDim,
+    pub backend_name: &'static str,
+    pub dispatch: DispatchDiagGatherFn,
+}
+
+impl std::fmt::Debug for GpuDiagGather {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}DiagGather", self.backend_name)
+    }
+}
+
+impl PartialEq for GpuDiagGather {
+    fn eq(&self, other: &Self) -> bool {
+        self.backend_name == other.backend_name
+            && self.offset == other.offset
+            && self.out_len == other.out_len
+    }
+}
+impl Eq for GpuDiagGather {}
+
+impl std::hash::Hash for GpuDiagGather {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.backend_name.hash(state);
+        self.offset.hash(state);
+        self.out_len.hash(state);
+    }
+}
+
+impl Op for GpuDiagGather {
+    fn name(&self) -> StaticName {
+        format!("{}DiagGather", self.backend_name).into()
+    }
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(vec![format!("offset={}, out_len={}", self.offset, self.out_len)])
+    }
+    op_as_typed_op!();
+}
+
+impl EvalOp for GpuDiagGather {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval_with_session(
+        &self,
+        node_id: usize,
+        session: &TurnState,
+        inputs: TVec<TValue>,
+    ) -> TractResult<TVec<TValue>> {
+        let input_val = args_1!(inputs);
+        let input = input_val.to_device_tensor()?;
+        let offset = self.offset.eval(&session.resolved_symbols).to_i64()?;
+        let out_len = self.out_len.eval(&session.resolved_symbols).to_usize()?;
+        let mut out_shape: TVec<usize> = input.shape().into();
+        let rank = out_shape.len();
+        ensure!(rank >= 2);
+        out_shape[rank - 1] = out_len;
+        let output = crate::session_handler::make_tensor_for_node(
+            session,
+            node_id,
+            input.datum_type(),
+            &out_shape,
+        )?;
+        (self.dispatch)(input, offset, out_len, &output)?;
+        Ok(tvec!(output.into_tensor().into_tvalue()))
+    }
+}
+
+impl TypedOp for GpuDiagGather {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        crate::utils::facts_to_device_facts(inputs, |facts| {
+            ensure!(facts.len() == 1);
+            let mut shape: TVec<TDim> = facts[0].shape.to_tvec();
+            ensure!(shape.len() >= 2);
+            let rank = shape.len();
+            shape[rank - 1] = self.out_len.clone();
+            Ok(tvec!(facts[0].datum_type.fact(&shape)))
+        })
+        .with_context(|| format!("Error while computing facts for {:?}", self.name()))
+    }
+    as_op!();
+}

--- a/gpu/src/ops/mod.rs
+++ b/gpu/src/ops/mod.rs
@@ -5,6 +5,7 @@ pub mod cast;
 pub mod change_axes;
 pub mod concat;
 pub mod copy_based;
+pub mod diag_gather;
 pub mod dyn_kv_cache;
 pub mod element_wise;
 pub mod gelu_approximate;

--- a/metal/src/kernels/array/array_ops.metal
+++ b/metal/src/kernels/array/array_ops.metal
@@ -241,6 +241,57 @@ typedef decltype(rotate_half_nd2<float>) rotate_half_nd2_t;
         "array_ops::rotate_half_nd2_" #tname)]] [[kernel]] rotate_half_nd2_t   \
         rotate_half_nd2<type>;
 
+// Diagonal gather (Transformer-XL rel-pos skew, folded):
+//   out[..., i, k] = in[..., i, offset + k - i], 0 on out-of-bounds.
+// Leading axes are flattened by the host into one batch axis.  Each thread
+// owns one (b, i, k) output element.
+//
+// params layout: [offset, t_q, r_in, out_len,
+//                 in_stride_b, in_stride_i, in_stride_r,
+//                 out_stride_b, out_stride_i, out_stride_k]
+template <typename T>
+[[kernel]] void diag_gather(device const void *input_b [[buffer(0)]],
+                            device void *output_b [[buffer(1)]],
+                            constant const int32_t *params [[buffer(2)]],
+                            uint3 tpig [[thread_position_in_grid]]) {
+    const int32_t k = (int32_t)tpig.x;
+    const int32_t i = (int32_t)tpig.y;
+    const int32_t b = (int32_t)tpig.z;
+
+    const int32_t offset = params[0];
+    const int32_t t_q = params[1];
+    const int32_t r_in = params[2];
+    const int32_t out_len = params[3];
+    const int32_t in_stride_b = params[4];
+    const int32_t in_stride_i = params[5];
+    const int32_t in_stride_r = params[6];
+    const int32_t out_stride_b = params[7];
+    const int32_t out_stride_i = params[8];
+    const int32_t out_stride_k = params[9];
+
+    if (k >= out_len || i >= t_q)
+        return;
+
+    device const T *input = (device const T *)input_b;
+    device T *output = (device T *)output_b;
+
+    const int32_t out_idx = b * out_stride_b + i * out_stride_i + k * out_stride_k;
+    const int32_t r = offset + k - i;
+    if (r >= 0 && r < r_in) {
+        const int32_t in_idx = b * in_stride_b + i * in_stride_i + r * in_stride_r;
+        output[out_idx] = input[in_idx];
+    } else {
+        output[out_idx] = (T)0;
+    }
+}
+
+typedef decltype(diag_gather<float>) diag_gather_t;
+
+#define INSTANTIATE_DIAG_GATHER(tname, type)                                   \
+    template [[host_name(                                                      \
+        "array_ops::diag_gather_" #tname)]] [[kernel]] diag_gather_t           \
+        diag_gather<type>;
+
 // Copy kernels: only u8/u16/u32/u64 (copy is type-size based)
 INSTANTIATE_COPY(u8, uint8_t)
 INSTANTIATE_COPY(u16, uint16_t)
@@ -276,3 +327,7 @@ INSTANTIATE_CAST_FROM(u64, uint64_t)
 // Rotate half: only float types
 INSTANTIATE_ROTATE_HALF_OP(f32, float)
 INSTANTIATE_ROTATE_HALF_OP(f16, half)
+
+// Diagonal gather: f32 and f16 only.
+INSTANTIATE_DIAG_GATHER(f32, float)
+INSTANTIATE_DIAG_GATHER(f16, half)

--- a/metal/src/kernels/array/diag_gather.rs
+++ b/metal/src/kernels/array/diag_gather.rs
@@ -1,0 +1,201 @@
+use crate::encoder::EncoderExt;
+use crate::{LibraryName, MetalStream};
+use anyhow::{Context, ensure};
+use metal::MTLSize;
+use std::fmt;
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DiagGather;
+
+impl fmt::Display for DiagGather {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl DiagGather {
+    pub fn is_supported_dt(dt: DatumType) -> bool {
+        matches!(dt, DatumType::F32 | DatumType::F16)
+    }
+
+    pub fn kernel_name(&self, dt: DatumType) -> TractResult<String> {
+        ensure!(Self::is_supported_dt(dt), "Unsupported dt {:?} for metal diag_gather op", dt);
+        let tname = DeviceTensor::tname(dt)?;
+        Ok(format!("array_ops::diag_gather_{tname}"))
+    }
+
+    pub fn eval(
+        &self,
+        stream: &MetalStream,
+        input: &DeviceTensor,
+        offset: i64,
+        out_len: usize,
+    ) -> TractResult<DeviceTensor> {
+        let rank = input.rank();
+        ensure!(rank >= 2);
+        let mut out_shape: TVec<usize> = input.shape().into();
+        out_shape[rank - 1] = out_len;
+        let output = unsafe { DeviceTensor::uninitialized_dt(input.datum_type(), &out_shape)? };
+        self.dispatch_eval(stream, input, offset, out_len, &output)?;
+        stream.wait_until_completed()?;
+        Ok(output)
+    }
+
+    pub fn dispatch_eval(
+        &self,
+        stream: &MetalStream,
+        input: &DeviceTensor,
+        offset: i64,
+        out_len: usize,
+        output: &DeviceTensor,
+    ) -> TractResult<()> {
+        stream.retain_tensor(input);
+        stream.retain_tensor(output);
+
+        let rank = input.rank();
+        ensure!(rank >= 2);
+        ensure!(output.rank() == rank);
+        ensure!(output.datum_type() == input.datum_type());
+        let in_shape = input.shape();
+        let out_shape = output.shape();
+        ensure!(in_shape[..rank - 2] == out_shape[..rank - 2]);
+        ensure!(in_shape[rank - 2] == out_shape[rank - 2]);
+        ensure!(out_shape[rank - 1] == out_len);
+
+        let offset_i32: i32 = offset.try_into().context("DiagGather offset overflows i32")?;
+        let out_len_i32: i32 = out_len.try_into().context("DiagGather out_len overflows i32")?;
+
+        // Flatten the (rank-2) leading axes into one batch axis.  Assumes the
+        // leading block is plain row-major (encoder use: rank-4 BxHxTxR with
+        // natural strides), so the batch stride is `t_q * (R or out_len)`.
+        let in_strides = input.strides();
+        let out_strides = output.strides();
+        let batch: usize = in_shape[..rank - 2].iter().product();
+        let t_q = in_shape[rank - 2];
+        let r_in = in_shape[rank - 1];
+        let in_stride_b: i32 = if rank >= 3 { (t_q * r_in) as i32 } else { 0 };
+        let in_stride_i = in_strides[rank - 2] as i32;
+        let in_stride_r = in_strides[rank - 1] as i32;
+        let out_stride_b: i32 = if rank >= 3 { (t_q * out_len) as i32 } else { 0 };
+        let out_stride_i = out_strides[rank - 2] as i32;
+        let out_stride_k = out_strides[rank - 1] as i32;
+
+        let params: [i32; 10] = [
+            offset_i32,
+            t_q as i32,
+            r_in as i32,
+            out_len_i32,
+            in_stride_b,
+            in_stride_i,
+            in_stride_r,
+            out_stride_b,
+            out_stride_i,
+            out_stride_k,
+        ];
+
+        let pipeline =
+            stream.load_pipeline(LibraryName::ArrayOps, &self.kernel_name(input.datum_type())?)?;
+        let command_buffer = stream.command_buffer();
+        command_buffer.encode(|encoder| {
+            encoder.set_compute_pipeline_state(&pipeline);
+            encoder.set_metal_tensor(0, input, metal::MTLResourceUsage::Read);
+            encoder.set_metal_tensor(1, output, metal::MTLResourceUsage::Write);
+            encoder.set_slice(2, &params);
+            let grid_size = MTLSize {
+                width: out_len as _,
+                height: t_q as _,
+                depth: batch as _,
+            };
+            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
+            encoder.dispatch_thread_groups(grid_size, group_size);
+        });
+        Ok(())
+    }
+}
+
+pub fn metal_diag_gather_dispatch(
+    input: &DeviceTensor,
+    offset: i64,
+    out_len: usize,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    crate::with_metal_stream(|stream| {
+        DiagGather.dispatch_eval(stream, input, offset, out_len, output)
+    })
+}
+
+crate::register_metal_op!(
+    tract_transformers::ops::diag_gather::DiagGather,
+    |source, node, op| {
+        rule_if!(DiagGather::is_supported_dt(source.node_input_facts(node.id)?[0].datum_type));
+        Ok(Some(Box::new(tract_gpu::ops::diag_gather::GpuDiagGather::new(
+            op.offset.clone(),
+            op.out_len.clone(),
+            "Metal",
+            metal_diag_gather_dispatch,
+        ))))
+    }
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::with_borrowed_metal_stream;
+    use tract_core::internal::Tensor;
+    use tract_core::plan::TurnState;
+    use tract_gpu::tensor::IntoDevice;
+    use tract_transformers::ops::diag_gather as cpu_dg;
+
+    fn run_against_cpu(shape: &[usize], offset: i64, out_len: usize) -> TractResult<()> {
+        with_borrowed_metal_stream(|stream| {
+            let len: usize = shape.iter().product();
+            let data: Vec<f32> = (0..len).map(|i| i as f32).collect();
+            let cpu_in = Tensor::from_shape(shape, &data)?;
+            let metal_in = cpu_in.clone().into_device()?;
+
+            let cpu_op =
+                cpu_dg::DiagGather { offset: (offset as i64).to_dim(), out_len: out_len.to_dim() };
+            let session = TurnState::default();
+            let cpu_out = cpu_op.eval_with_session(0, &session, tvec![cpu_in.into_tvalue()])?[0]
+                .clone()
+                .into_tensor();
+            let metal_out = DiagGather.eval(stream, &metal_in, offset, out_len)?;
+            cpu_out
+                .close_enough(&metal_out.to_host()?.into_tensor(), Approximation::Exact)
+                .with_context(|| format!("shape={shape:?} offset={offset} out_len={out_len}"))
+        })
+    }
+
+    #[test]
+    fn test_diag_gather_skew_basic() -> TractResult<()> {
+        let t = 4;
+        run_against_cpu(&[2, t, 2 * t - 1], (t - 1) as i64, t)
+    }
+
+    #[test]
+    fn test_diag_gather_rank4_encoder_like() -> TractResult<()> {
+        let t = 14;
+        run_against_cpu(&[1, 8, t, 2 * t - 1], (t - 1) as i64, t)
+    }
+
+    #[test]
+    fn test_diag_gather_out_of_bounds_zero_fill() -> TractResult<()> {
+        let r = 5;
+        let t = 4;
+        run_against_cpu(&[1, t, r], 1, 8)
+    }
+
+    #[test]
+    fn test_diag_gather_partial_overlap() -> TractResult<()> {
+        let t = 4;
+        let r = 6;
+        run_against_cpu(&[1, t, r], 0, t)
+    }
+
+    #[test]
+    fn test_diag_gather_rank2() -> TractResult<()> {
+        run_against_cpu(&[5, 9], 4, 5)
+    }
+}

--- a/metal/src/kernels/array/diag_gather.rs
+++ b/metal/src/kernels/array/diag_gather.rs
@@ -103,11 +103,7 @@ impl DiagGather {
             encoder.set_metal_tensor(0, input, metal::MTLResourceUsage::Read);
             encoder.set_metal_tensor(1, output, metal::MTLResourceUsage::Write);
             encoder.set_slice(2, &params);
-            let grid_size = MTLSize {
-                width: out_len as _,
-                height: t_q as _,
-                depth: batch as _,
-            };
+            let grid_size = MTLSize { width: out_len as _, height: t_q as _, depth: batch as _ };
             let group_size = MTLSize { width: 1, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
         });
@@ -126,18 +122,15 @@ pub fn metal_diag_gather_dispatch(
     })
 }
 
-crate::register_metal_op!(
-    tract_transformers::ops::diag_gather::DiagGather,
-    |source, node, op| {
-        rule_if!(DiagGather::is_supported_dt(source.node_input_facts(node.id)?[0].datum_type));
-        Ok(Some(Box::new(tract_gpu::ops::diag_gather::GpuDiagGather::new(
-            op.offset.clone(),
-            op.out_len.clone(),
-            "Metal",
-            metal_diag_gather_dispatch,
-        ))))
-    }
-);
+crate::register_metal_op!(tract_transformers::ops::diag_gather::DiagGather, |source, node, op| {
+    rule_if!(DiagGather::is_supported_dt(source.node_input_facts(node.id)?[0].datum_type));
+    Ok(Some(Box::new(tract_gpu::ops::diag_gather::GpuDiagGather::new(
+        op.offset.clone(),
+        op.out_len.clone(),
+        "Metal",
+        metal_diag_gather_dispatch,
+    ))))
+});
 
 #[cfg(test)]
 mod tests {

--- a/metal/src/kernels/array/mod.rs
+++ b/metal/src/kernels/array/mod.rs
@@ -1,11 +1,14 @@
 mod cast;
 mod copy;
+mod diag_gather;
 mod dispatch;
 mod rotate_half;
 
 pub use cast::Cast;
 pub use cast::metal_cast_dispatch;
 pub use copy::Memcpy;
+pub use diag_gather::DiagGather;
+pub use diag_gather::metal_diag_gather_dispatch;
 pub use dispatch::metal_copy_nd_dispatch;
 pub use rotate_half::RotateHalf;
 pub use rotate_half::metal_rotate_half_dispatch;
@@ -30,6 +33,12 @@ pub fn all_functions() -> Vec<String> {
                 tract_gpu::tensor::DeviceTensor::SUPPORTED_DT.into_iter().map(move |dt2| (dt1, dt2))
             })
             .flat_map(|(dt1, dt2)| Cast.kernel_name(dt1, dt2).into_iter()),
+    );
+
+    functions.extend(
+        tract_gpu::tensor::DeviceTensor::SUPPORTED_DT
+            .into_iter()
+            .flat_map(|dt| DiagGather.kernel_name(dt).into_iter()),
     );
 
     functions.into_iter().collect()


### PR DESCRIPTION
Replaces 24 CPU DiagGather nodes in the nemotron-streaming encoder with a CUDA kernel.  Output index (b, i, k) maps to input (b, i, offset+k-i) with zero-fill on out-of-bounds — one thread per output cell, no shared memory, embarrassingly parallel.

Leading axes are flattened into a single batch dim under the assumption of a row-major leading block (matches the encoder; the rank-2 / rank-4 unit tests and the encoder bundle compare with --approx very confirm).