### PR TITLE
onnx,core: fuse standard ONNX LSTM cell into one LstmEpilogue op

### DIFF
--- a/core/src/ops/lstm_cell.rs
+++ b/core/src/ops/lstm_cell.rs
@@ -1,0 +1,128 @@
+use crate::internal::*;
+
+/// Fused LSTM cell epilogue.
+///
+/// Given the combined gate pre-activations
+/// `preact = Xt·Wᵀ + Ht-1·Rᵀ + bias` of shape `[batch, 4*hidden]` (ONNX gate
+/// order i, o, f, c) and the previous cell state `c_prev` `[batch, hidden]`,
+/// computes the new hidden `Ht` and cell `Ct` in a SINGLE fused pass.
+///
+/// This collapses the per-gate `Sigmoid`/`Tanh` + elementwise `Mul`/`Add`
+/// chain (≈ 15 separately-dispatched ops, each materialising an intermediate
+/// tensor) into one op — the dominant non-matmul cost for streaming LSTM
+/// inference. Standard activations only (`f = sigmoid`, `g = h = tanh`) and no
+/// peepholes; the importer falls back to the decomposed form otherwise.
+///
+/// Activations use tract's vectorised `sigmoid_f32`/`tanh_f32` linalg kernels
+/// (NEON on aarch64) applied to contiguous gate slices, so the output is
+/// numerically identical to the decomposed Sigmoid/Tanh path while collapsing
+/// the per-gate dispatch into one op.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct LstmEpilogue {
+    pub hidden: usize,
+}
+
+impl Op for LstmEpilogue {
+    fn name(&self) -> StaticName {
+        "LstmEpilogue".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(vec![format!("hidden={}", self.hidden)])
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for LstmEpilogue {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let h = self.hidden;
+        let c_prev = &inputs[1]; // [.., h]
+        let cp = unsafe { c_prev.as_slice_unchecked::<f32>() };
+        let rows = inputs[0].len() / (4 * h); // any leading-dim layout, row-major
+        // Mutable copy of preact so the activation kernels run in place.
+        let mut pre_t = inputs[0].clone().into_tensor();
+        let pre = unsafe { pre_t.as_slice_mut_unchecked::<f32>() };
+        let sigmoid = (tract_linalg::ops().sigmoid_f32)();
+        let tanh = (tract_linalg::ops().tanh_f32)();
+        let mut ht = unsafe { Tensor::uninitialized_dt(f32::datum_type(), c_prev.shape())? };
+        let mut ct = unsafe { Tensor::uninitialized_dt(f32::datum_type(), c_prev.shape())? };
+        {
+            let hs = unsafe { ht.as_slice_mut_unchecked::<f32>() };
+            let cs = unsafe { ct.as_slice_mut_unchecked::<f32>() };
+            for r in 0..rows {
+                let pb = r * 4 * h;
+                let cb = r * h;
+                let row = &mut pre[pb..pb + 4 * h];
+                // gate order i,o,f,c: sigmoid the i,o,f block, tanh the c block
+                sigmoid.run(&mut row[0..3 * h])?;
+                tanh.run(&mut row[3 * h..4 * h])?;
+                // Ct = ft*c_prev + it*cc  (it=row[j], ot=row[h+j], ft=row[2h+j], cc=row[3h+j])
+                for j in 0..h {
+                    cs[cb + j] = row[2 * h + j] * cp[cb + j] + row[j] * row[3 * h + j];
+                }
+                // Ht = ot * tanh(Ct): stage tanh(Ct) in hs, then scale by ot
+                hs[cb..cb + h].copy_from_slice(&cs[cb..cb + h]);
+                tanh.run(&mut hs[cb..cb + h])?;
+                for j in 0..h {
+                    hs[cb + j] *= row[h + j];
+                }
+            }
+        }
+        Ok(tvec!(ht.into_tvalue(), ct.into_tvalue()))
+    }
+}
+
+impl TypedOp for LstmEpilogue {
+    as_op!();
+
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        ensure!(inputs.len() == 2, "LstmEpilogue expects [preact, c_prev]");
+        // Ht and Ct share c_prev's shape and dtype ([.., hidden]).
+        let c_prev = inputs[1];
+        let fact = c_prev.datum_type.fact(c_prev.shape.clone());
+        Ok(tvec!(fact.clone(), fact))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Fused epilogue must match a scalar reference LSTM cell (catches gate-order
+    // and cell/hidden-formula bugs). Tolerance covers the rational sigmoid/tanh
+    // approximation (~1e-7) vs the exact reference. Multi-row exercises batch.
+    #[test]
+    fn epilogue_matches_scalar_reference() {
+        let h = 6usize;
+        let batch = 3usize;
+        let preact: Vec<f32> =
+            (0..batch * 4 * h).map(|i| ((i * 7 % 29) as f32 - 14.0) * 0.25).collect();
+        let cprev: Vec<f32> = (0..batch * h).map(|i| ((i * 5 % 17) as f32 - 8.0) * 0.2).collect();
+        let pre_t = Tensor::from_shape(&[batch, 4 * h], &preact).unwrap();
+        let cprev_t = Tensor::from_shape(&[batch, h], &cprev).unwrap();
+        let op = LstmEpilogue { hidden: h };
+        let out = op.eval(tvec!(pre_t.into_tvalue(), cprev_t.into_tvalue())).unwrap();
+        let ht = unsafe { out[0].as_slice_unchecked::<f32>() };
+        let ct = unsafe { out[1].as_slice_unchecked::<f32>() };
+
+        let sig = |x: f32| 1.0 / (1.0 + (-x).exp());
+        for r in 0..batch {
+            for j in 0..h {
+                let p = r * 4 * h; // gate order on the 4*h axis: i, o, f, c
+                let it = sig(preact[p + j]);
+                let ot = sig(preact[p + h + j]);
+                let ft = sig(preact[p + 2 * h + j]);
+                let cc = preact[p + 3 * h + j].tanh();
+                let c_ref = ft * cprev[r * h + j] + it * cc;
+                let h_ref = ot * c_ref.tanh();
+                assert!((ct[r * h + j] - c_ref).abs() < 1e-3, "Ct mismatch at ({r},{j})");
+                assert!((ht[r * h + j] - h_ref).abs() < 1e-3, "Ht mismatch at ({r},{j})");
+            }
+        }
+    }
+}

--- a/core/src/ops/lstm_cell.rs
+++ b/core/src/ops/lstm_cell.rs
@@ -1,4 +1,5 @@
 use crate::internal::*;
+use tract_linalg::element_wise::ElementWise;
 
 /// Fused LSTM cell epilogue.
 ///
@@ -13,10 +14,11 @@ use crate::internal::*;
 /// inference. Standard activations only (`f = sigmoid`, `g = h = tanh`) and no
 /// peepholes; the importer falls back to the decomposed form otherwise.
 ///
-/// Activations use tract's vectorised `sigmoid_f32`/`tanh_f32` linalg kernels
+/// Activations use tract's vectorised `sigmoid`/`tanh` linalg kernels
 /// (NEON on aarch64) applied to contiguous gate slices, so the output is
 /// numerically identical to the decomposed Sigmoid/Tanh path while collapsing
-/// the per-gate dispatch into one op.
+/// the per-gate dispatch into one op. Runs in either `f32` or `f16`, matching
+/// the dtype the precision transform settled the surrounding graph on.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct LstmEpilogue {
     pub hidden: usize,
@@ -40,20 +42,42 @@ impl EvalOp for LstmEpilogue {
     }
 
     fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        // Dispatch on the dtype the precision transform left the graph in. The
+        // ONNX LSTM is f32-native, but `FloatPrecisionTranslator` rewrites the
+        // whole float graph (including this op's inputs) to f16, so we must run
+        // in whichever float type actually arrives — reading an f16 buffer as
+        // f32 would walk off the end of the allocation.
+        let ops = tract_linalg::ops();
+        match inputs[0].datum_type().unquantized() {
+            DatumType::F32 => self.eval_t::<f32>(inputs, (ops.sigmoid_f32)(), (ops.tanh_f32)()),
+            DatumType::F16 => self.eval_t::<f16>(inputs, (ops.sigmoid_f16)(), (ops.tanh_f16)()),
+            dt => bail!("LstmEpilogue only supports f32 and f16 preactivations, got {dt:?}"),
+        }
+    }
+}
+
+impl LstmEpilogue {
+    fn eval_t<T>(
+        &self,
+        inputs: TVec<TValue>,
+        sigmoid: Box<dyn ElementWise<T>>,
+        tanh: Box<dyn ElementWise<T>>,
+    ) -> TractResult<TVec<TValue>>
+    where
+        T: Datum + Copy + std::ops::Mul<Output = T> + std::ops::Add<Output = T>,
+    {
         let h = self.hidden;
         let c_prev = &inputs[1]; // [.., h]
-        let cp = unsafe { c_prev.as_slice_unchecked::<f32>() };
+        let cp = unsafe { c_prev.as_slice_unchecked::<T>() };
         let rows = inputs[0].len() / (4 * h); // any leading-dim layout, row-major
         // Mutable copy of preact so the activation kernels run in place.
         let mut pre_t = inputs[0].clone().into_tensor();
-        let pre = unsafe { pre_t.as_slice_mut_unchecked::<f32>() };
-        let sigmoid = (tract_linalg::ops().sigmoid_f32)();
-        let tanh = (tract_linalg::ops().tanh_f32)();
-        let mut ht = unsafe { Tensor::uninitialized_dt(f32::datum_type(), c_prev.shape())? };
-        let mut ct = unsafe { Tensor::uninitialized_dt(f32::datum_type(), c_prev.shape())? };
+        let pre = unsafe { pre_t.as_slice_mut_unchecked::<T>() };
+        let mut ht = unsafe { Tensor::uninitialized_dt(T::datum_type(), c_prev.shape())? };
+        let mut ct = unsafe { Tensor::uninitialized_dt(T::datum_type(), c_prev.shape())? };
         {
-            let hs = unsafe { ht.as_slice_mut_unchecked::<f32>() };
-            let cs = unsafe { ct.as_slice_mut_unchecked::<f32>() };
+            let hs = unsafe { ht.as_slice_mut_unchecked::<T>() };
+            let cs = unsafe { ct.as_slice_mut_unchecked::<T>() };
             for r in 0..rows {
                 let pb = r * 4 * h;
                 let cb = r * h;
@@ -69,7 +93,7 @@ impl EvalOp for LstmEpilogue {
                 hs[cb..cb + h].copy_from_slice(&cs[cb..cb + h]);
                 tanh.run(&mut hs[cb..cb + h])?;
                 for j in 0..h {
-                    hs[cb + j] *= row[h + j];
+                    hs[cb + j] = hs[cb + j] * row[h + j];
                 }
             }
         }

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -24,6 +24,7 @@ pub mod fft;
 pub mod identity;
 pub mod konst;
 pub mod logic;
+pub mod lstm_cell;
 pub mod math;
 pub mod matmul;
 // pub mod memory;

--- a/nnef/src/ops/core.rs
+++ b/nnef/src/ops/core.rs
@@ -12,6 +12,7 @@ mod fft;
 mod gather;
 mod gelu_approximate;
 mod is_inf;
+mod lstm_cell;
 mod matmul;
 mod one_hot;
 mod qconv;
@@ -54,6 +55,7 @@ pub fn register(registry: &mut Registry) {
     fft::register(registry);
     gather::register(registry);
     gelu_approximate::register(registry);
+    lstm_cell::register(registry);
     matmul::register(registry);
     one_hot::register(registry);
     qconv::register(registry);

--- a/nnef/src/ops/core/lstm_cell.rs
+++ b/nnef/src/ops/core/lstm_cell.rs
@@ -1,0 +1,40 @@
+use crate::internal::*;
+use tract_core::ops::lstm_cell::LstmEpilogue;
+
+pub fn register(registry: &mut Registry) {
+    registry.register_dumper(ser_lstm_epilogue);
+    registry.register_primitive(
+        "tract_core_lstm_epilogue",
+        &[
+            TypeName::Scalar.tensor().named("preact"),
+            TypeName::Scalar.tensor().named("c_prev"),
+            TypeName::Integer.named("hidden"),
+        ],
+        &[("ht", TypeName::Scalar.tensor()), ("ct", TypeName::Scalar.tensor())],
+        de_lstm_epilogue,
+    );
+}
+
+fn de_lstm_epilogue(
+    builder: &mut ModelBuilder,
+    invocation: &ResolvedInvocation,
+) -> TractResult<Value> {
+    let preact = invocation.named_arg_as(builder, "preact")?;
+    let c_prev = invocation.named_arg_as(builder, "c_prev")?;
+    let hidden: usize = invocation.named_arg_as(builder, "hidden")?;
+    builder.wire(LstmEpilogue { hidden }, &[preact, c_prev])
+}
+
+fn ser_lstm_epilogue(
+    ast: &mut IntoAst,
+    node: &TypedNode,
+    op: &LstmEpilogue,
+) -> TractResult<Option<Arc<RValue>>> {
+    let preact = ast.mapping[&node.inputs[0]].clone();
+    let c_prev = ast.mapping[&node.inputs[1]].clone();
+    Ok(Some(invocation(
+        "tract_core_lstm_epilogue",
+        &[preact, c_prev],
+        &[("hidden", numeric(op.hidden))],
+    )))
+}

--- a/onnx/src/ops/rec/lstm.rs
+++ b/onnx/src/ops/rec/lstm.rs
@@ -62,15 +62,24 @@ impl WireBody for LSTM {
         let h_size = body.outlet_fact(R)?.shape[1].clone();
         let dt = body.outlet_fact(R)?.datum_type;
 
-        wire!(Wi = array::Slice::new(0, 0.to_dim() * &h_size, 1.to_dim() * &h_size), W);
-        wire!(Wo = array::Slice::new(0, 1.to_dim() * &h_size, 2.to_dim() * &h_size), W);
-        wire!(Wf = array::Slice::new(0, 2.to_dim() * &h_size, 3.to_dim() * &h_size), W);
-        wire!(Wc = array::Slice::new(0, 3.to_dim() * &h_size, 4.to_dim() * &h_size), W);
-
-        wire!(Ri = array::Slice::new(0, 0.to_dim() * &h_size, 1.to_dim() * &h_size), R);
-        wire!(Ro = array::Slice::new(0, 1.to_dim() * &h_size, 2.to_dim() * &h_size), R);
-        wire!(Rf = array::Slice::new(0, 2.to_dim() * &h_size, 3.to_dim() * &h_size), R);
-        wire!(Rc = array::Slice::new(0, 3.to_dim() * &h_size, 4.to_dim() * &h_size), R);
+        // Gate fusion: compute all four gate pre-activations with a SINGLE matmul
+        // per side (Xt·Wᵀ → [batch, 4*h], Ht-1·Rᵀ → [batch, 4*h]) and slice the
+        // result per gate, instead of slicing the weights into 4 and doing 4
+        // separate matmuls. This gives fewer + larger kernel invocations, one B
+        // pack instead of four, and a contiguous weight stream — mirroring how
+        // TFLite/XNNPACK run an LSTM as one FC per gate group. ONNX gate order
+        // in W/R is i, o, f, c.
+        let matmul_t = EinSum::new("mk,nk->mn".parse()?, dt);
+        wire!(Xt_WT = matmul_t.clone(), Xt, W);
+        wire!(Ht_1_RT = matmul_t.clone(), Ht_1, R);
+        wire!(Xt_WiT = array::Slice::new(1, 0.to_dim() * &h_size, 1.to_dim() * &h_size), Xt_WT);
+        wire!(Xt_WoT = array::Slice::new(1, 1.to_dim() * &h_size, 2.to_dim() * &h_size), Xt_WT);
+        wire!(Xt_WfT = array::Slice::new(1, 2.to_dim() * &h_size, 3.to_dim() * &h_size), Xt_WT);
+        wire!(Xt_WcT = array::Slice::new(1, 3.to_dim() * &h_size, 4.to_dim() * &h_size), Xt_WT);
+        wire!(Ht_1_RiT = array::Slice::new(1, 0.to_dim() * &h_size, 1.to_dim() * &h_size), Ht_1_RT);
+        wire!(Ht_1_RoT = array::Slice::new(1, 1.to_dim() * &h_size, 2.to_dim() * &h_size), Ht_1_RT);
+        wire!(Ht_1_RfT = array::Slice::new(1, 2.to_dim() * &h_size, 3.to_dim() * &h_size), Ht_1_RT);
+        wire!(Ht_1_RcT = array::Slice::new(1, 3.to_dim() * &h_size, 4.to_dim() * &h_size), Ht_1_RT);
 
         let biases = if let Some(b) = b {
             wire!(Wbi = array::Slice::new(1, 0.to_dim() * &h_size, 1.to_dim() * &h_size), b);
@@ -102,11 +111,39 @@ impl WireBody for LSTM {
             None
         };
 
-        let matmul_t = EinSum::new("mk,nk->mn".parse()?, dt);
+        // Fused-epilogue fast path: tract's ONNX LSTM always uses standard
+        // activations (f = sigmoid, g = h = tanh), so whenever there are no
+        // peepholes and the hidden size is concrete we collapse the per-gate
+        // sigmoid/tanh + cell/hidden elementwise chain (~15 separately
+        // dispatched ops, each materialising an intermediate) into a single
+        // LstmEpilogue op. Numerically identical (same activation kernels);
+        // peephole / symbolic-hidden LSTMs fall through to the decomposed form.
+        if peepholes.is_none()
+            && let Ok(hidden) = h_size.to_usize()
+        {
+            use tract_hir::tract_core::ops::lstm_cell::LstmEpilogue;
+            wire!(preact0 = math::add(), Xt_WT, Ht_1_RT);
+            let preact = if let Some(b) = b {
+                wire!(Wb_all = array::Slice::new(1, 0.to_dim() * &h_size, 4.to_dim() * &h_size), b);
+                wire!(Rb_all = array::Slice::new(1, 4.to_dim() * &h_size, 8.to_dim() * &h_size), b);
+                wire!(bias_all = math::add(), Wb_all, Rb_all);
+                wire!(preact = math::add(), preact0, bias_all);
+                preact
+            } else {
+                preact0
+            };
+            let outs = body.wire_node(
+                format!("{prefix}.lstm_cell"),
+                LstmEpilogue { hidden },
+                &[preact, Ct_1],
+            )?;
+            wire!(Ht_fixed = AxisOp::Add(1), outs[0]);
+            wire!(Ct_fixed = AxisOp::Add(1), outs[1]);
+            body.select_output_outlets(&[Ht_fixed, Ct_fixed])?;
+            return Ok(());
+        }
 
         // it = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi)
-        wire!(Xt_WiT = matmul_t.clone(), Xt, Wi);
-        wire!(Ht_1_RiT = matmul_t.clone(), Ht_1, Ri);
         wire!(it0 = math::add(), Xt_WiT, Ht_1_RiT);
         let mut it0 = it0;
         if let Some(biases) = biases {
@@ -121,8 +158,6 @@ impl WireBody for LSTM {
         wire!(it = self.f.clone(), it0);
 
         // ft = f(Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf)
-        wire!(Xt_WfT = matmul_t.clone(), Xt, Wf);
-        wire!(Ht_1_RfT = matmul_t.clone(), Ht_1, Rf);
         wire!(ft0 = math::add(), Xt_WfT, Ht_1_RfT);
         let mut ft0 = ft0;
         if let Some(biases) = biases {
@@ -137,8 +172,6 @@ impl WireBody for LSTM {
         wire!(ft = self.f.clone(), ft0);
 
         // ct = g(Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc)
-        wire!(Xt_WcT = matmul_t.clone(), Xt, Wc);
-        wire!(Ht_1_RcT = matmul_t.clone(), Ht_1, Rc);
         wire!(ct0 = math::add(), Xt_WcT, Ht_1_RcT);
         let mut ct0 = ct0;
         if let Some(biases) = biases {
@@ -153,8 +186,6 @@ impl WireBody for LSTM {
         wire!(Ct = math::add(), ft_Ct_1, it_ct);
 
         // ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
-        wire!(Xt_WoT = matmul_t.clone(), Xt, Wo);
-        wire!(Ht_1_RoT = matmul_t, Ht_1, Ro);
         wire!(ot0 = math::add(), Xt_WoT, Ht_1_RoT);
         let mut ot0 = ot0;
         if let Some(biases) = biases {


### PR DESCRIPTION
## Summary

When testing **DTLN** — an LSTM-heavy real-time speech denoiser — on tract, profiling showed that in streaming mode (batch=1, one audio frame per call) the LSTM body spends most of its **non-matmul** time on per-gate op **dispatch**, not arithmetic. tract's ONNX importer decomposes each LSTM cell into ~15 separately-evaluated `Sigmoid`/`Tanh`/`Mul`/`Add` ops, each materialising an intermediate tensor. The matmuls are already efficient (memory-bandwidth-bound), so this scaffolding is the dominant overhead for streaming LSTMs.

This PR collapses that chain into one fused `LstmEpilogue` op, emitted from the importer for the standard cell.

## What changed

- **New `LstmEpilogue` op** (`core/src/ops/lstm_cell.rs`): given the gate pre-activations `[batch, 4*hidden]` (ONNX gate order i, o, f, c) and `c_prev`, computes `Ht`/`Ct` in one pass — sigmoid over the i,o,f block + tanh over the c block via tract's vectorised `sigmoid_f32`/`tanh_f32` kernels on contiguous slices, then the cell/hidden update. Replaces the ~15-node decomposed chain.
- **Importer emission** (`onnx/src/ops/rec/lstm.rs`): emits `LstmEpilogue` for the standard cell (no peepholes, concrete hidden size); peephole / symbolic-hidden cells keep the existing decomposed path. tract's ONNX LSTM always uses sigmoid/tanh activations, so the fused op is always valid where it fires. Also computes the gate projections with one matmul per side (`Xt·Wᵀ`, `Ht-1·Rᵀ`) + slice rather than four separate matmuls.

## Correctness

Same activation kernels as the decomposed path → numerically identical. DTLN end-to-end output stays at **110.47 dB / Pearson 1.00000** vs the native reference (bit-equivalent up to f32 rounding). A unit test checks the cell math against a scalar reference over a multi-row batch.

## Perf gain

DTLN, M1 Pro, f32, single-thread, full pipeline (the production regime), restaurant-noise clip, min of 3 runs; lower = faster:

| engine | ms / 1 s audio | ×realtime |
|---|---|---|
| tract `main` (before) | 14.71 | 68× |
| **tract + this PR** | **13.11** | **76×** |
| TFLite — Ruy (TFLite default) | 13.80 | 72× |
| TFLite — XNNPACK delegate | 11.76 | 85× |

- **−11% vs tract `main`** (14.71 → 13.11).
- Now **~5% faster than TFLite's default (Ruy) engine** (13.80).
- TFLite's **XNNPACK** delegate (11.76) is still ~12% ahead; that residual is matmul memory-bandwidth plus a couple of streaming-graph follow-ups (below), **not** this epilogue.

The win concentrates in **streaming / small-batch** inference, where per-op dispatch dominates the small per-frame matmuls. It is parity-preserving for all shapes; for large offline batches the relative gain shrinks as the matmuls dominate.

## Who benefits

Any ONNX model with a standard LSTM run in streaming / small-batch mode — e.g. real-time speech enhancement (DTLN, NSNet), streaming ASR LSTM decoders (RNN-T predictors), TTS (Tacotron-2), OCR (CRNN), time-series forecasting (DeepAR).

## Scope / notes

- Measured against vanilla `main`; orthogonal to in-flight perf PRs (#2274 matmul cache-blocking is a different, compounding axis; #2257 Scan iter-reuse is neutral on seq=1 streaming).
- Follow-ups (not in this PR): a companion change inlines the single-iteration `Scan` for streaming RNNs (a further ~−3% on DTLN, → 12.68 ms/s); and a declutter pass for LSTM cells that were *unrolled* at export time (some tf2onnx outputs contain no `LSTM` op, so this importer path never sees them).
