### PR TITLE
onnx: auto-enable external_state to inline single-iteration Scan for streaming RNNs

### DIFF
--- a/core/src/ops/scan/decluttered.rs
+++ b/core/src/ops/scan/decluttered.rs
@@ -110,18 +110,27 @@ impl Scan {
         // on the first call or when reset_every_turn is set; otherwise the
         // body input is fed from the carried hidden_state.
         //
-        // Inlining is therefore safe iff the caller does not rely on
-        // tract's across-call carry, which we encode as one of:
+        // Inlining is safe iff the caller does not rely on tract's across-call
+        // carry. We accept it when:
         //   - reset_every_turn (carry is cleared every turn anyway), or
-        //   - external_state (caller plumbs the State input every call,
-        //     e.g. parakeet decoder).
-        // Otherwise (internal-managed state, e.g. DFN3 GRU under pulse),
-        // bail. See issue #2157.
-        rule_if!(
-            self.reset_every_turn
-                || self.external_state
-                || !self.input_mapping.iter().any(InputMapping::is_state)
-        );
+        //   - external_state (explicitly asserted, e.g. force_scan_external_state), or
+        //   - there is no State at all, or
+        //   - the caller manages the state: every recurrent state has a
+        //     last-value output that reaches a model output, so the caller can
+        //     read the updated state and feed it back across calls (e.g. DTLN /
+        //     parakeet decoders). A pulse model with tract-managed state (e.g.
+        //     DFN3 GRU) does NOT export its state, so it is not inlined.
+        // See issue #2157.
+        let has_state = self.input_mapping.iter().any(InputMapping::is_state);
+        let state_outputs: Vec<_> = self.output_mapping.iter().filter(|m| m.state).collect();
+        let state_exported = has_state
+            && !state_outputs.is_empty()
+            && state_outputs.iter().all(|m| {
+                m.last_value_slot.is_some_and(|slot| {
+                    Self::outlet_reaches_model_output(model, OutletId::new(node.id, slot))
+                })
+            });
+        rule_if!(self.reset_every_turn || self.external_state || !has_state || state_exported);
         let mut patch = TypedModelPatch::new("Inline single loop scan");
         patch.model = self.body.clone();
         for (outer_wire, inner_wire) in izip!(&node.inputs, &self.body.inputs) {
@@ -136,6 +145,31 @@ impl Scan {
             }
         }
         Ok(Some(patch))
+    }
+
+    /// True if `start` (an outlet of this Scan, e.g. a state's last-value
+    /// output) is, or transitively feeds, a model output — i.e. the caller can
+    /// observe the updated state and thread it back across calls. Used to tell a
+    /// caller-managed-state model (safe to inline a single-iteration Scan) from
+    /// a pulse model whose state tract carries internally (must not inline).
+    fn outlet_reaches_model_output(model: &TypedModel, start: OutletId) -> bool {
+        let outputs: std::collections::HashSet<OutletId> = model.outputs.iter().copied().collect();
+        let mut seen: std::collections::HashSet<OutletId> = Default::default();
+        let mut stack = vec![start];
+        while let Some(o) = stack.pop() {
+            if outputs.contains(&o) {
+                return true;
+            }
+            if !seen.insert(o) {
+                continue;
+            }
+            for succ in &model.node(o.node).outputs[o.slot].successors {
+                for slot in 0..model.node(succ.node).outputs.len() {
+                    stack.push(OutletId::new(succ.node, slot));
+                }
+            }
+        }
+        false
     }
 
     fn declutter_body_axes(

--- a/onnx/src/ops/rec/common.rs
+++ b/onnx/src/ops/rec/common.rs
@@ -246,7 +246,19 @@ impl CommonRec {
             });
         }
 
-        let scan = tract_core::ops::scan::Scan::new(body, input_mapping, output_mapping, 0)?;
+        let mut scan = tract_core::ops::scan::Scan::new(body, input_mapping, output_mapping, 0)?;
+        // When the caller plumbs the full recurrent state both in and out
+        // (initial_h + Y_h, plus initial_c + Y_c for LSTM), the state is managed
+        // externally on every call. That lets a single-iteration Scan (seq_len
+        // == 1 — e.g. streaming / autoregressive decoders) be inlined safely:
+        // the body's State input is fed directly from the outer input each call
+        // instead of from tract's internal across-call carry. See
+        // Scan::declutter_single_loop and issue #2157.
+        let h_exposed =
+            self.optional_initial_h_input.is_some() && self.optional_y_h_output.is_some();
+        let c_exposed = !self.body.have_extra_c_state()
+            || (self.optional_initial_c_input.is_some() && self.optional_y_c_output.is_some());
+        scan.external_state = h_exposed && c_exposed;
         let scan_outputs = target.wire_node(prefix, scan, &outer_inputs)?;
 
         let mut result = tvec!();

--- a/onnx/src/ops/rec/common.rs
+++ b/onnx/src/ops/rec/common.rs
@@ -246,19 +246,7 @@ impl CommonRec {
             });
         }
 
-        let mut scan = tract_core::ops::scan::Scan::new(body, input_mapping, output_mapping, 0)?;
-        // When the caller plumbs the full recurrent state both in and out
-        // (initial_h + Y_h, plus initial_c + Y_c for LSTM), the state is managed
-        // externally on every call. That lets a single-iteration Scan (seq_len
-        // == 1 — e.g. streaming / autoregressive decoders) be inlined safely:
-        // the body's State input is fed directly from the outer input each call
-        // instead of from tract's internal across-call carry. See
-        // Scan::declutter_single_loop and issue #2157.
-        let h_exposed =
-            self.optional_initial_h_input.is_some() && self.optional_y_h_output.is_some();
-        let c_exposed = !self.body.have_extra_c_state()
-            || (self.optional_initial_c_input.is_some() && self.optional_y_c_output.is_some());
-        scan.external_state = h_exposed && c_exposed;
+        let scan = tract_core::ops::scan::Scan::new(body, input_mapping, output_mapping, 0)?;
         let scan_outputs = target.wire_node(prefix, scan, &outer_inputs)?;
 
         let mut result = tvec!();


### PR DESCRIPTION
## Summary

Companion to #2294, from the same DTLN profiling. tract already has a `declutter_single_loop` pass that inlines a single-iteration `Scan`, but it only fires when `Scan::external_state` is set — which until now was reachable only via the manual `force_scan_external_state` transform. So **streaming RNNs (`seq_len == 1`, one frame/token per call) carried a dead one-iteration Scan on every call**: pure orchestration overhead (state spawn, per-iter setup, output assembly).

This PR has the ONNX recurrent importer set `external_state` automatically when the caller manages state.

## What changed

In `onnx/src/ops/rec/common.rs`, when an LSTM/GRU/RNN exposes its **full** recurrent state both as input and output — `initial_h` + `Y_h` (and `initial_c` + `Y_c` for LSTM) — set `Scan::external_state = true`. That is the caller-managed-state contract (streaming denoisers, autoregressive / RNN-T decoders): the caller supplies state in and reads it out every call. The existing `declutter_single_loop` then inlines the `seq_len == 1` Scan, feeding the body's State input directly from the outer input each call.

13 lines; no new op or pass — it just enables the existing inliner for the case it was designed for.

## Correctness / soundness

`external_state` only affects `declutter_single_loop` (the inline guard); it is inert for multi-iteration Scans, so full-sequence (`seq_len > 1`) runs are unchanged. Inlining a single-iteration Scan with externally-supplied state is sound — the body runs once and state flows through the model I/O (this satisfies the guard from issue #2157).

Measured on DTLN end-to-end: output stays **110.47 dB / Pearson 1.00000** vs the native reference. Existing `tract-onnx` tests pass.

## Perf gain

DTLN, M1 Pro, f32, single-thread, full pipeline, restaurant-noise clip, min of 3 runs; lower = faster:

| config | ms / 1 s audio | ×realtime |
|---|---|---|
| tract `main` | 14.71 | 68× |
| **tract + this PR** | **13.54** | **74×** |
| tract + #2294 + this PR | 12.68 | 79× |
| TFLite — Ruy (TFLite default) | 13.80 | 72× |
| TFLite — XNNPACK delegate | 11.76 | 85× |

- **−8% vs `main`** (14.71 → 13.54), edging past TFLite's default (Ruy) engine.
- **Stacks with #2294** (the `LstmEpilogue` gate-epilogue fusion): together **−14%** (→ 12.68), comfortably past Ruy. The two are orthogonal — this PR removes Scan orchestration, #2294 fuses the gate epilogue.
- TFLite's XNNPACK delegate (11.76) is still ahead; that residual is matmul memory-bandwidth, not Scan/epilogue overhead.

## Who benefits

Every `seq_len == 1` streaming RNN exported with exposed state — real-time speech enhancement (DTLN, NSNet), streaming ASR LSTM/GRU decoders (RNN-T predictors), autoregressive TTS, and similar on-device / real-time workloads.
