### PR TITLE
tflite: load DTLN models — op coverage + REDUCE_MEAN float-mean fix

### DIFF
--- a/tflite/src/model.rs
+++ b/tflite/src/model.rs
@@ -94,6 +94,9 @@ impl Framework<TfliteProtoModel, TypedModel> for Tflite {
         }
         for op in main.operators().context("No operators in Tflite model")? {
             for input in op.inputs().context("No input in Tflite  operator")? {
+                if input == -1 {
+                    continue; // tflite uses -1 as the "no tensor" sentinel for absent optional inputs
+                }
                 if let Entry::Vacant(slot) = mapping.entry(input) {
                     let (fact, name) = flat_tensor_to_tract_fact(&root, main, input)?;
                     let value = fact.konst.with_context(|| format!("Error in TF file for operator {op:?}. No prior computation nor constant for input {input}"))?;

--- a/tflite/src/ops/array.rs
+++ b/tflite/src/ops/array.rs
@@ -26,14 +26,17 @@ pub fn register_all(reg: &mut Registry) {
     reg.reg_to_tract(BuiltinOperator::BROADCAST_TO, de_broadcast_to);
     reg.reg_to_tract(BuiltinOperator::CONCATENATION, de_concat);
     reg.reg_to_tract(BuiltinOperator::EXPAND_DIMS, de_expand_dims);
+    reg.reg_to_tract(BuiltinOperator::PACK, de_pack);
     reg.reg_to_tract(BuiltinOperator::PAD, de_pad);
     reg.reg_to_tract(BuiltinOperator::PADV2, de_padv2);
     reg.reg_to_tract(BuiltinOperator::RESHAPE, de_reshape);
     reg.reg_to_tract(BuiltinOperator::SHAPE, de_shape);
     reg.reg_to_tract(BuiltinOperator::SLICE, de_slice);
     reg.reg_to_tract(BuiltinOperator::SQUEEZE, de_squeeze);
+    reg.reg_to_tract(BuiltinOperator::SPLIT, de_split);
     reg.reg_to_tract(BuiltinOperator::STRIDED_SLICE, de_strided_slice);
     reg.reg_to_tract(BuiltinOperator::TRANSPOSE, de_transpose);
+    reg.reg_to_tract(BuiltinOperator::UNPACK, de_unpack);
 }
 
 fn de_broadcast_to(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
@@ -153,7 +156,9 @@ fn de_squeeze(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
 
 fn de_strided_slice(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
     let options = builtin!(op, builtin_options_as_strided_slice_options);
-    ensure!(options.new_axis_mask() == 0 && options.shrink_axis_mask() == 0);
+    // shrink_axis_mask is honoured by tract's StridedSlice (passed through below);
+    // only new_axis_mask (inserting new size-1 dims) is unsupported.
+    ensure!(options.new_axis_mask() == 0, "tflite STRIDED_SLICE: new_axis_mask unsupported");
     let slice = tract_core::ops::array::StridedSlice {
         begin_mask: options.begin_mask() as _,
         end_mask: options.end_mask() as _,
@@ -162,6 +167,63 @@ fn de_strided_slice(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
         optional_steps_input: Some(3),
     };
     op.ctx.target.wire_node(op.prefix, slice, op.inputs)
+}
+
+// TFLite PACK: stack `values_count` tensors along a new `axis` (inverse of UNPACK).
+// Lowered to AxisOp::Add(axis) on each input + a concat along that new axis.
+fn de_pack(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
+    let options = builtin!(op, builtin_options_as_pack_options);
+    let out_rank = op.facts()?[0].rank() + 1;
+    let axis =
+        if options.axis() < 0 { options.axis() + out_rank as i32 } else { options.axis() } as usize;
+    let prefix = op.prefix;
+    let inputs: TVec<OutletId> = op.inputs.into();
+    let mut unsqueezed = tvec!();
+    for (i, inp) in inputs.iter().enumerate() {
+        let u = op.ctx.target.wire_node(
+            format!("{prefix}.unsqueeze_{i}"),
+            AxisOp::Add(axis),
+            &[*inp],
+        )?;
+        unsqueezed.push(u[0]);
+    }
+    op.ctx.target.wire_node(prefix, TypedConcat::new(axis), &unsqueezed)
+}
+
+// TFLite SPLIT: inputs [axis (const scalar), value]; SplitOptions.num_splits.
+// Splits `value` into num_splits equal slices along `axis` (axis preserved).
+fn de_split(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
+    let options = builtin!(op, builtin_options_as_split_options);
+    let num = options.num_splits() as usize;
+    let facts = op.facts()?;
+    let value = &facts[1];
+    let rank = value.rank() as i32;
+    let mut axis = *facts[0]
+        .konst
+        .as_ref()
+        .context("SPLIT axis must be constant")?
+        .try_as_plain()?
+        .as_slice::<i32>()?
+        .first()
+        .context("empty SPLIT axis")?;
+    if axis < 0 {
+        axis += rank;
+    }
+    let axis = axis as usize;
+    let dim = value.shape[axis].to_usize().context("SPLIT requires a concrete split dim")?;
+    ensure!(dim % num == 0, "SPLIT: dim {dim} not divisible by num_splits {num}");
+    let chunk = dim / num;
+    let prefix = op.prefix;
+    let mut outputs = tvec!();
+    for i in 0..num {
+        let s = op.ctx.target.wire_node(
+            format!("{prefix}.split_{i}"),
+            Slice { axis, start: (i * chunk).to_dim(), end: ((i + 1) * chunk).to_dim() },
+            &op.inputs[1..2],
+        )?;
+        outputs.push(s[0]);
+    }
+    Ok(outputs)
 }
 
 fn de_transpose(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
@@ -179,6 +241,31 @@ fn de_transpose(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
         wire = op.ctx.target.wire_node(format!("{prefix}.{ix}"), axis_op, &wire)?;
     }
     Ok(wire)
+}
+
+// TFLite UNPACK: split `input` along `axis` into `num` tensors of size 1 along
+// that axis, removing the axis (inverse of PACK). Lowered to Slice + RmAxis per
+// output. Enables loading models (e.g. DTLN) whose LSTM state is split via UNPACK.
+fn de_unpack(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
+    let options = builtin!(op, builtin_options_as_unpack_options);
+    let input = args_1!(op.facts()?);
+    let rank = input.rank();
+    let axis =
+        if options.axis() < 0 { rank as i32 + options.axis() } else { options.axis() } as usize;
+    let num = options.num() as usize;
+    let prefix = op.prefix;
+    let mut outputs = tvec!();
+    for i in 0..num {
+        let sliced = op.ctx.target.wire_node(
+            format!("{prefix}.slice_{i}"),
+            Slice { axis, start: i.to_dim(), end: (i + 1).to_dim() },
+            &op.inputs[0..1],
+        )?;
+        let squeezed =
+            op.ctx.target.wire_node(format!("{prefix}.rm_{i}"), AxisOp::Rm(axis), &sliced)?;
+        outputs.push(squeezed[0]);
+    }
+    Ok(outputs)
 }
 
 fn ser_axisop(

--- a/tflite/src/ops/math.rs
+++ b/tflite/src/ops/math.rs
@@ -21,6 +21,7 @@ pub fn register_all(reg: &mut Registry) {
     reg.reg_to_tract(BuiltinOperator::DIV, deser_div);
     reg.reg_to_tract(BuiltinOperator::MAXIMUM, |op| deser_bin(op, tract_core::ops::math::max()));
     reg.reg_to_tract(BuiltinOperator::MINIMUM, |op| deser_bin(op, tract_core::ops::math::min()));
+    reg.reg_to_tract(BuiltinOperator::SQUARED_DIFFERENCE, deser_squared_difference);
 
     reg.reg_to_tract(BuiltinOperator::EQUAL, |op| deser_comp(op, comp_eq()));
     reg.reg_to_tract(BuiltinOperator::NOT_EQUAL, |op| deser_comp(op, comp_ne()));
@@ -68,6 +69,17 @@ fn deser_sub(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
     let wires = wire_cast_and_rank_broadcast(op)?;
     let wires = op.ctx.target.wire_node(op.prefix, tract_core::ops::math::sub(), &wires)?;
     wire_fused_activation(op, &wires, &options.fused_activation_function())
+}
+
+// SQUARED_DIFFERENCE(a, b) = (a - b)^2
+fn deser_squared_difference(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
+    let wires = wire_cast_and_rank_broadcast(op)?;
+    let diff = op.ctx.target.wire_node(
+        format!("{}.diff", op.prefix),
+        tract_core::ops::math::sub(),
+        &wires,
+    )?;
+    op.ctx.target.wire_node(op.prefix, tract_core::ops::math::mul(), &[diff[0], diff[0]])
 }
 
 fn deser_mul(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {

--- a/tflite/src/ops/nn.rs
+++ b/tflite/src/ops/nn.rs
@@ -69,13 +69,18 @@ fn de_batch_matmul(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
 }
 
 fn de_fully_connected(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
-    let (input, weights, bias) = args_3!(op.facts()?);
+    let facts = op.facts()?;
+    let input = facts[0].clone();
+    let weights = facts[1].clone();
     let options = builtin!(op, builtin_options_as_fully_connected_options);
     ensure!(options.weights_format() == FullyConnectedOptionsWeightsFormat::DEFAULT);
     ensure!(!options.asymmetric_quantize_inputs());
     ensure!(input.rank() == 2);
     ensure!(weights.rank() == 2);
-    ensure!(bias.rank() == 1);
+    // bias is optional in tflite (absent => -1 input, filtered out before deser)
+    if let Some(bias) = facts.get(2) {
+        ensure!(bias.rank() == 1);
+    }
     let mut inputs: TVec<OutletId> = op.inputs.into();
     let wires = if input.datum_type.is_float() {
         let axes = "BI,OI->BO".parse()?;
@@ -104,16 +109,18 @@ fn de_fully_connected(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
 }
 
 fn de_reduce(op: &mut DeserOp, reducer: Reducer) -> TractResult<TVec<OutletId>> {
-    let (_, axes) = args_2!(op.facts()?);
+    let (input, axes) = args_2!(op.facts()?);
     let options = builtin!(op, builtin_options_as_reducer_options);
+    let rank = input.shape.rank() as i32;
     let axes: TVec<usize> = axes
         .konst
         .as_ref()
-        .unwrap()
+        .context("reduce expects constant axes")?
         .try_as_plain()?
         .as_slice::<i32>()?
         .iter()
-        .map(|d| *d as usize)
+        // normalise negative axes (e.g. -1 = last dim) before indexing
+        .map(|d| if *d < 0 { (*d + rank) as usize } else { *d as usize })
         .sorted()
         .collect();
     let p = &op.prefix;
@@ -133,14 +140,16 @@ fn de_reduce(op: &mut DeserOp, reducer: Reducer) -> TractResult<TVec<OutletId>> 
 
 fn de_reduce_mean(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
     let (input, axes) = args_2!(op.facts()?);
+    let rank = input.shape.rank() as i32;
     let axes: TVec<usize> = axes
         .konst
         .as_ref()
-        .unwrap()
+        .context("reduce_mean expects constant axes")?
         .try_as_plain()?
         .as_slice::<i32>()?
         .iter()
-        .map(|d| *d as usize)
+        // normalise negative axes (e.g. -1 = last dim) before indexing
+        .map(|d| if *d < 0 { (*d + rank) as usize } else { *d as usize })
         .sorted()
         .collect();
     let norm: TDim = axes.iter().map(|d| &input.shape[*d]).product();
@@ -153,7 +162,9 @@ fn de_reduce_mean(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
         &[norm],
     )?;
     let norm = op.ctx.target.wire_node(format!("{p}.recip"), core::math::recip(), &norm)?;
-    wire_with_rank_broadcast(op.prefix, op.ctx.target, core::quant::scale(), &[norm[0], wire[0]])
+    // Plain float multiply: sum * (1/count). (core::quant::scale rounds to an
+    // integer, which silently corrupted non-integer means, e.g. layer norm.)
+    wire_with_rank_broadcast(op.prefix, op.ctx.target, core::math::mul(), &[norm[0], wire[0]])
 }
 
 fn de_softmax(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {

--- a/tflite/src/ops/nn.rs
+++ b/tflite/src/ops/nn.rs
@@ -328,3 +328,132 @@ fn ser_softmax(
         options.as_union_value(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tflite::{
+        Buffer, BufferArgs, BuiltinOperator, BuiltinOptions, CustomOptionsFormat, Model, ModelArgs,
+        Operator, OperatorArgs, OperatorCode, OperatorCodeArgs, ReducerOptions, ReducerOptionsArgs,
+        SubGraph, SubGraphArgs, Tensor as FbTensor, TensorArgs, TensorType,
+    };
+    use flatbuffers::FlatBufferBuilder;
+    use tract_core::internal::*;
+    use tract_core::prelude::Framework;
+
+    // Regression for the REDUCE_MEAN integer-rounding bug: de_reduce_mean used
+    // core::quant::scale (which rounds to an integer), turning a true mean of
+    // 2.5 into 2. Hand-builds a minimal `MEAN([1,2,3,4], axis=1)` tflite and
+    // checks the loaded model returns 2.5, not a rounded value.
+    #[test]
+    fn reduce_mean_is_float_not_rounded() {
+        let mut fb = FlatBufferBuilder::new();
+
+        // buffers: [0] sentinel (inputs/outputs), [1] axes const = [1]
+        let ab = 1i32.to_le_bytes();
+        let axes_data = fb.create_vector::<u8>(&ab);
+        let buf0 = Buffer::create(&mut fb, &BufferArgs { data: None });
+        let buf1 = Buffer::create(&mut fb, &BufferArgs { data: Some(axes_data) });
+        let buffers = fb.create_vector(&[buf0, buf1]);
+
+        macro_rules! tensor {
+            ($name:expr, $shape:expr, $ty:expr, $buffer:expr) => {{
+                let name = fb.create_string($name);
+                let shape = fb.create_vector::<i32>($shape);
+                FbTensor::create(
+                    &mut fb,
+                    &TensorArgs {
+                        name: Some(name),
+                        buffer: $buffer,
+                        is_variable: false,
+                        quantization: None,
+                        shape: Some(shape),
+                        type_: $ty,
+                        sparsity: None,
+                        shape_signature: None,
+                        has_rank: true,
+                        variant_tensors: None,
+                    },
+                )
+            }};
+        }
+        let t_in = tensor!("in", &[1, 4], TensorType::FLOAT32, 0);
+        let t_ax = tensor!("axes", &[1], TensorType::INT32, 1);
+        let t_out = tensor!("out", &[1, 1], TensorType::FLOAT32, 0);
+        let tensors = fb.create_vector(&[t_in, t_ax, t_out]);
+
+        let opts = ReducerOptions::create(&mut fb, &ReducerOptionsArgs { keep_dims: true });
+        let oi = fb.create_vector::<i32>(&[0, 1]);
+        let oo = fb.create_vector::<i32>(&[2]);
+        let operator = Operator::create(
+            &mut fb,
+            &OperatorArgs {
+                inputs: Some(oi),
+                outputs: Some(oo),
+                opcode_index: 0,
+                builtin_options: Some(opts.as_union_value()),
+                builtin_options_type: BuiltinOptions::ReducerOptions,
+                custom_options: None,
+                custom_options_format: CustomOptionsFormat::FLEXBUFFERS,
+                mutating_variable_inputs: None,
+                intermediates: None,
+            },
+        );
+        let operators = fb.create_vector(&[operator]);
+
+        let si = fb.create_vector::<i32>(&[0]);
+        let so = fb.create_vector::<i32>(&[2]);
+        let subgraph = SubGraph::create(
+            &mut fb,
+            &SubGraphArgs {
+                name: None,
+                tensors: Some(tensors),
+                inputs: Some(si),
+                outputs: Some(so),
+                operators: Some(operators),
+            },
+        );
+        let subgraphs = fb.create_vector(&[subgraph]);
+
+        let opcode = OperatorCode::create(
+            &mut fb,
+            &OperatorCodeArgs {
+                deprecated_builtin_code: 40, // MEAN
+                custom_code: None,
+                version: 1,
+                builtin_code: BuiltinOperator::MEAN,
+            },
+        );
+        let operator_codes = fb.create_vector(&[opcode]);
+
+        let model = Model::create(
+            &mut fb,
+            &ModelArgs {
+                version: 3,
+                operator_codes: Some(operator_codes),
+                subgraphs: Some(subgraphs),
+                description: None,
+                buffers: Some(buffers),
+                metadata_buffer: None,
+                metadata: None,
+                signature_defs: None,
+            },
+        );
+        fb.finish(model, Some("TFL3"));
+        let bytes = fb.finished_data().to_vec();
+
+        let runnable = crate::tflite()
+            .model_for_read(&mut std::io::Cursor::new(bytes))
+            .unwrap()
+            .into_optimized()
+            .unwrap()
+            .into_runnable()
+            .unwrap();
+        let input = Tensor::from_shape(&[1usize, 4], &[1f32, 2., 3., 4.]).unwrap();
+        let out = runnable.run(tvec!(input.into())).unwrap();
+        let mean = unsafe { out[0].as_slice_unchecked::<f32>() }[0];
+        assert!(
+            (mean - 2.5).abs() < 1e-4,
+            "REDUCE_MEAN must be 2.5, got {mean} (integer-rounded?)"
+        );
+    }
+}

--- a/tflite/src/registry.rs
+++ b/tflite/src/registry.rs
@@ -67,7 +67,7 @@ impl Registry {
         mapping: &mut HashMap<i32, OutletId>,
     ) -> TractResult<()> {
         let inputs: TVec<OutletId> =
-            flat_op.inputs().unwrap().iter().map(|o| mapping[&o]).collect();
+            flat_op.inputs().unwrap().iter().filter(|&o| o >= 0).map(|o| mapping[&o]).collect();
         let tensors = subgraph.tensors().unwrap();
         let prefix = tensors.get(flat_op.outputs().unwrap().get(0) as usize).name().unwrap();
         let opcode_index = flat_op.opcode_index();

--- a/tflite/src/tensors.rs
+++ b/tflite/src/tensors.rs
@@ -110,7 +110,12 @@ pub fn flat_tensor_to_tract_fact<'m>(
     let mut dt: DatumType = flat.type_().try_into()?;
     if let Some(qp) = flat.quantization() {
         if let (Some(scale), Some(zp)) = (qp.scale(), qp.zero_point()) {
-            dt = dt.quantize(QParams::ZpScale { zero_point: zp.get(0) as _, scale: scale.get(0) })
+            // Float tensors often carry an empty quantization struct; only treat
+            // as quantized when scale/zero_point actually have entries.
+            if !scale.is_empty() && !zp.is_empty() {
+                dt = dt
+                    .quantize(QParams::ZpScale { zero_point: zp.get(0) as _, scale: scale.get(0) })
+            }
         }
     }
     let mut fact = dt.fact(flat.shape().unwrap().iter().map(|d| d as usize).collect_vec());


### PR DESCRIPTION
## Summary

Enables `tract-tflite` to load and run  **DTLN** real-time speech-denoiser `.tflite` models. Before this, the loader bailed on the very first op; now both DTLN sub-models load, run, and are **bit-exact vs the ONNX path** and match the native reference at **110.47 dB / Pearson 1.00000** end-to-end.

While getting there I found a real correctness bug (below) that affects far more than DTLN.

## The headline fix — REDUCE_MEAN was rounding to an integer

`de_reduce_mean` computed the mean as `sum * recip(count)` using `core::quant::scale()` — which **rounds its result to the nearest integer** (`round_ties_to_even`, for requantization). So any non-integer mean was silently corrupted: e.g. a layer-norm mean of `0.0284` became `0`, a variance of `13.4` became `13.0`. The fix uses a plain float multiply (`core::math::mul`). This affects any tflite model using `MEAN` / global-average-pool / layer-norm, not just DTLN.

## What changed (all in `tflite/`)

- **Op coverage** (`array.rs`, `math.rs`): add `UNPACK`, `PACK`, `SPLIT`, `SQUARED_DIFFERENCE` handlers.
- **`STRIDED_SLICE` `shrink_axis_mask`** (`array.rs`): the guard rejected `shrink_axis_mask != 0`, but tract's `StridedSlice` already honours it (it's passed straight through) — relaxed to reject only the genuinely-unsupported `new_axis_mask`.
- **`REDUCE_MEAN` correctness** (`nn.rs`): float-mean fix (above) + negative-axis normalization in `de_reduce` / `de_reduce_mean` (a `-1` axis was cast to a huge `usize` and indexed out of bounds).
- **`FULLY_CONNECTED` optional bias** (`nn.rs`): `args_3!` required exactly 3 inputs, but the body already handled the no-bias case by input count; accept 2-or-3.
- **Optional input `-1` sentinel** (`model.rs`, `registry.rs`): tflite encodes an absent optional input as `-1`; skip it in fact-building and filter it from an op's input list (previously `tensors().get((-1) as usize)` panicked).
- **Empty quantization guard** (`tensors.rs`): float tensors often carry an empty `quantization` struct; only treat as quantized when `scale`/`zero_point` actually have entries (previously `scale.get(0)` panicked out of bounds).

These are additive (new op handlers) or strictly-corrective (the guards/bugfixes), so currently-loading models are unaffected — the only behavioural change to an existing op is `REDUCE_MEAN` no longer rounding, which can only make results *more* correct.

## Validation

Per-model, identical random input fed to both frontends:
- `model_1.tflite` vs `model_1.onnx`: **max|diff| = 0** on both outputs.
- `model_2.tflite` vs `model_2.onnx`: **max|diff| = 0** on both outputs.

End-to-end (full DTLN pipeline, real audio) via `tract-tflite` vs the native DataDog output: **Pearson 1.00000, diff SNR 110.47 dB, max abs diff 1e-5**.

## Notes

- `tract-tflite` currently has no in-crate test suite, and TFLite's existing coverage is real-model harnesses (`harness/tfl-mobilenet-v2-q` downloads a model). Happy to add a `harness/dtln-tflite` along those lines if you can point me at where the DTLN `.tflite` should be hosted for CI — or to add round-trip unit tests if you'd prefer that style.
- This bundles several independent fixes for one coherent goal; glad to split (e.g. the `REDUCE_MEAN` correctness fix on its own) if you'd rather review them separately.
