### PR TITLE
tract-cli, tract-libcli: make cudarc + tract-cuda truly optional

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -74,8 +74,8 @@ float-ord.workspace = true
 tract-metal.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
-cudarc.workspace = true
-tract-cuda = { workspace = true, default-features = false }
+cudarc = { workspace = true, optional = true }
+tract-cuda = { workspace = true, optional = true }
 
 [features]
 default = [
@@ -99,20 +99,27 @@ transformers = ["tract-transformers", "tract-libcli/transformers"]
 conform = ["tract-tensorflow/conform"]
 multithread-mm = ["tract-linalg/multithread-mm"]
 
+# Marker feature implicitly enabled by every cuda-XXXXX selector below.
+# Use to gate cudarc-specific code paths in tract-cli. Not meant to be
+# enabled directly — always pick a concrete cuda-XXXXX so cudarc has an
+# API version to bind against.
+cuda = []
+
 # CUDA driver-API selectors (linux/windows targets only). Picking one binds
 # cudarc against the matching CUDA enum/struct layout; the resulting binary
 # runs on any driver whose API is >= the chosen one. Exactly one must be
 # active. The default pulls cuda-13000 in; cross-compiles aimed at older
-# drivers (e.g. aarch64 with CUDA 12) override with `--no-default-features`.
-cuda-12000 = ["tract-cuda/cuda-12000"]
-cuda-12010 = ["tract-cuda/cuda-12010"]
-cuda-12020 = ["tract-cuda/cuda-12020"]
-cuda-12030 = ["tract-cuda/cuda-12030"]
-cuda-12040 = ["tract-cuda/cuda-12040"]
-cuda-12050 = ["tract-cuda/cuda-12050"]
-cuda-12060 = ["tract-cuda/cuda-12060"]
-cuda-12080 = ["tract-cuda/cuda-12080"]
-cuda-12090 = ["tract-cuda/cuda-12090"]
-cuda-13000 = ["tract-cuda/cuda-13000"]
-cuda-13010 = ["tract-cuda/cuda-13010"]
-cuda-13020 = ["tract-cuda/cuda-13020"]
+# drivers (e.g. aarch64 with CUDA 12) override with `--no-default-features`
+# plus an explicit cuda-12XXX.
+cuda-12000 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12000"]
+cuda-12010 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12010"]
+cuda-12020 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12020"]
+cuda-12030 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12030"]
+cuda-12040 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12040"]
+cuda-12050 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12050"]
+cuda-12060 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12060"]
+cuda-12080 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12080"]
+cuda-12090 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-12090"]
+cuda-13000 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-13000"]
+cuda-13010 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-13010"]
+cuda-13020 = ["cuda", "dep:cudarc", "dep:tract-cuda", "tract-libcli/cuda", "tract-cuda/cuda-13020"]

--- a/cli/src/bench.rs
+++ b/cli/src/bench.rs
@@ -33,7 +33,7 @@ pub fn handle(
     limits.warmup(&params.req_runnable()?, &inputs)?;
 
     let (iters, dur) = {
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
         let _profiler =
             sub_matches.get_flag("cuda-gpu-trace").then(cudarc::driver::safe::Profiler::new);
         limits.bench(&params.req_runnable()?, &inputs)?

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -11,7 +11,7 @@ use tract_core::ops::matmul::optimized::{OptMatMul, ProtoFusedSpec};
 use tract_core::ops::matmul::pack::DynPackedExoticFact;
 use tract_core::ops::scan::OptScan;
 #[allow(unused_imports)]
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
 use tract_cuda::utils::ensure_cuda_runtime_dependencies;
 use tract_hir::internal::*;
 use tract_itertools::Itertools;
@@ -146,17 +146,17 @@ pub fn handle(
 
             #[cfg(not(any(target_os = "macos", target_os = "ios")))]
             {
-                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
                 ensure_cuda_runtime_dependencies("GPU profiling called on non-GPU device")?;
             }
 
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
             let is_cuda = matches.get_flag("cuda");
-            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+            #[cfg(not(all(any(target_os = "linux", target_os = "windows"), feature = "cuda")))]
             let is_cuda = false;
 
             if is_cuda {
-                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
                 tract_cuda::with_cuda_stream(|s| {
                     s.enable_profiling();
                     Ok(())
@@ -164,7 +164,7 @@ pub fn handle(
             }
 
             let before_node: Box<dyn Fn(usize)> = if is_cuda {
-                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
                 {
                     Box::new(|node_id| {
                         tract_cuda::with_cuda_stream(|s| {
@@ -174,7 +174,10 @@ pub fn handle(
                         .ok();
                     })
                 }
-                #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+                #[cfg(not(all(
+                    any(target_os = "linux", target_os = "windows"),
+                    feature = "cuda"
+                )))]
                 Box::new(|_| {})
             } else {
                 Box::new(|_| {})
@@ -186,7 +189,7 @@ pub fn handle(
                     &[(usize, String)],
                 ) -> TractResult<()>,
             > = if is_cuda {
-                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
                 {
                     Box::new(|dg, prefix| {
                         tract_cuda::with_cuda_stream(|s| {
@@ -209,7 +212,10 @@ pub fn handle(
                         })
                     })
                 }
-                #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+                #[cfg(not(all(
+                    any(target_os = "linux", target_os = "windows"),
+                    feature = "cuda"
+                )))]
                 Box::new(|_, _| Ok(()))
             } else {
                 Box::new(|_, _| Ok(()))
@@ -254,12 +260,20 @@ pub fn handle(
     }
 
     if sub_matches.contains_id("memory-arena") {
-        #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+        #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
         {
             ensure_cuda_runtime_dependencies(
                 "Memory arena is only enabled for MacOS / iOS devices or CUDA devices",
             )?;
         }
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "ios",
+            all(any(target_os = "linux", target_os = "windows"), feature = "cuda")
+        )))]
+        bail!(
+            "Memory arena requires CUDA (Linux/Windows with cuda-* feature) or Metal (macOS/iOS)"
+        );
         crate::memory_arena::dump_metrics(
             &params.req_typed_model(),
             &plan_options_from_subcommand(sub_matches)?,

--- a/libcli/Cargo.toml
+++ b/libcli/Cargo.toml
@@ -35,8 +35,8 @@ tract-transformers = { workspace = true, optional = true }
 tract-metal = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
-cudarc.workspace = true
-tract-cuda.workspace = true
+cudarc = { workspace = true, optional = true }
+tract-cuda = { workspace = true, optional = true }
 
 [features]
 default = ["transformers"]
@@ -45,3 +45,8 @@ hir = []
 onnx = ["tract-onnx"]
 complex = ["tract-core/complex"]
 transformers = ["tract-transformers"]
+# Marker / dependency selector for cudarc-backed code paths
+# (`--cuda-gpu-trace`).  Enabled transitively by tract-cli's cuda-XXXXX
+# features.  Always pulled together — picking one selects the cudarc API
+# binding; this feature wires the optional dep in.
+cuda = ["dep:cudarc", "dep:tract-cuda"]

--- a/libcli/src/lib.rs
+++ b/libcli/src/lib.rs
@@ -14,7 +14,7 @@ pub mod time;
 
 use tract_core::internal::*;
 #[allow(unused_imports)]
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
 use tract_cuda::utils::ensure_cuda_runtime_dependencies;
 
 pub fn capture_gpu_trace<F>(matches: &clap::ArgMatches, func: F) -> TractResult<()>
@@ -45,7 +45,7 @@ where
             bail!("`--metal-gpu-trace` present but it is only available on MacOS and iOS")
         }
     } else if matches.get_flag("cuda-gpu-trace") {
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
         {
             ensure_cuda_runtime_dependencies(
                 "`--cuda-gpu-trace` present but no CUDA installation has been found",
@@ -53,9 +53,12 @@ where
             let _prof = cudarc::driver::safe::Profiler::new()?;
             func()
         }
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(all(any(target_os = "linux", target_os = "windows"), feature = "cuda")))]
         {
-            bail!("`--cuda-gpu-trace` present but it is only available on Linux and Windows")
+            bail!(
+                "`--cuda-gpu-trace` present but tract was not built with CUDA support \
+                 (re-build on Linux/Windows with one of the cuda-XXXXX features)"
+            )
         }
     } else {
         func()

--- a/test-rt/test-cuda/Cargo.toml
+++ b/test-rt/test-cuda/Cargo.toml
@@ -27,7 +27,7 @@ log.workspace = true
 tract-core.workspace = true
 tract-onnx-opl.workspace = true
 infra = { path = "../infra" }
-tract-cuda.workspace = true
+tract-cuda = { workspace = true, features = ["cuda-13000"] }
 tract-gpu.workspace = true
 suite-onnx = { path = "../suite-onnx" }
 suite-unit = { path = "../suite-unit" }


### PR DESCRIPTION
The 'without-default-features' job in full.yml (cargo check -p tract-cli --no-default-features) regressed after the cuda-12XXX split: cudarc and tract-cuda were still pulled in unconditionally on linux/windows targets, so stripping the cuda-13000 default left cudarc with no API-version feature and its build script panicked.

Make both deps optional in tract-cli and tract-libcli, and have each cuda-XXXXX feature pull them in (dep:cudarc + dep:tract-cuda + tract-cuda/cuda-XXXXX + tract-libcli/cuda).  Adds a marker 'cuda' feature so cudarc-touching code in bench.rs / dump.rs / libcli/lib.rs can gate cleanly.

test-cuda explicitly opts into cuda-13000 (workspace dep has default-features=false now), so 'cargo test -p tract-cuda -p test-cuda' keeps building.