### PR TITLE
patch transform: stop folding inputs; add select_inputs

### DIFF
--- a/core/src/model/graph.rs
+++ b/core/src/model/graph.rs
@@ -172,6 +172,24 @@ where
         Ok(self)
     }
 
+    /// Set model inputs by node name — mirror of [`Self::select_outputs_by_name`].
+    /// Removed inputs become dangling Source nodes; declutter prunes them.
+    pub fn select_inputs_by_name(
+        &mut self,
+        inputs: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> TractResult<()> {
+        self.set_input_names(inputs)
+    }
+
+    /// Set model inputs by node name and return `self`.
+    pub fn with_inputs_by_name(
+        mut self,
+        inputs: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> TractResult<Self> {
+        self.select_inputs_by_name(inputs)?;
+        Ok(self)
+    }
+
     /// Get the `ix`-th input tensor type information.
     pub fn input_fact(&self, ix: usize) -> TractResult<&F> {
         let input = self.input_outlets()?[ix];

--- a/core/src/transform.rs
+++ b/core/src/transform.rs
@@ -362,6 +362,28 @@ register_model_transform!("select_outputs", SelectOutputsConfig, |config| Ok(Box
     SelectOutputsTransform(config)
 )));
 
+#[derive(Debug, serde::Deserialize, Default)]
+pub struct SelectInputsConfig {
+    pub inputs: Vec<String>,
+}
+
+#[derive(Debug)]
+struct SelectInputsTransform(SelectInputsConfig);
+
+impl ModelTransform for SelectInputsTransform {
+    fn name(&self) -> StaticName {
+        "select_inputs".into()
+    }
+
+    fn transform(&self, model: &mut TypedModel) -> TractResult<()> {
+        model.select_inputs_by_name(self.0.inputs.iter())
+    }
+}
+
+register_model_transform!("select_inputs", SelectInputsConfig, |config| Ok(Box::new(
+    SelectInputsTransform(config)
+)));
+
 inventory::submit! {
     ModelTransformFactory {
         name: "f32_to_f16",

--- a/examples/nemo-nemotron-asr/src/main.rs
+++ b/examples/nemo-nemotron-asr/src/main.rs
@@ -20,6 +20,7 @@ fn concretize_batch(mut model: Model) -> anyhow::Result<Model> {
 fn remove_length_input(mut model: Model) -> anyhow::Result<Model> {
     model
         .transform(r#"{"name":"patch","body":"length = tract_core_shape_of(input_signal)[1];"}"#)?;
+    model.transform(r#"{"name":"select_inputs","inputs":["input_signal"]}"#)?;
     Ok(model)
 }
 

--- a/examples/nemo-nemotron-streaming-asr/src/main.rs
+++ b/examples/nemo-nemotron-streaming-asr/src/main.rs
@@ -108,6 +108,7 @@ impl NemotronModels {
         pp.transform(
             r#"{"name":"patch","body":"length = tract_core_shape_of(input_signal)[1];"}"#,
         )?;
+        pp.transform(r#"{"name":"select_inputs","inputs":["input_signal"]}"#)?;
         pp.transform(r#"{"name":"select_outputs","outputs":["processed_signal"]}"#)?;
         pp.transform(Pulse::new(config.preproc_pulse.to_string()).symbol("INPUT_SIGNAL__TIME"))?;
         let pp_delay = pp.property("pulse.delay")?.as_slice::<i64>()?[0].to_owned() as usize;
@@ -125,6 +126,7 @@ impl NemotronModels {
         enc.transform(
             r#"{"name":"patch","body":"length = tract_core_shape_of(audio_signal)[2];"}"#,
         )?;
+        enc.transform(r#"{"name":"select_inputs","inputs":["audio_signal"]}"#)?;
         enc.transform(r#"{"name":"select_outputs","outputs":["outputs"]}"#)?;
         enc.transform(Pulse::new(config.encoder_pulse.to_string()).symbol("AUDIO_SIGNAL__TIME"))?;
         let enc_delay = enc.property("pulse.delay")?.as_slice::<i64>()?[0].to_owned() as usize;

--- a/harness/nemotron-speech-streaming-en-0.6b/ci.sh
+++ b/harness/nemotron-speech-streaming-en-0.6b/ci.sh
@@ -41,6 +41,7 @@ model_prefix=$MODELS/$S3DIR/$MODEL
 $TRACT_RUN $model_prefix.preprocessor.nnef.tgz \
 	-t 'concretize_symbols(values: {"BATCH": 1})' \
 	-t 'patch(body: "length = tract_core_shape_of(input_signal)[1];")' \
+	-t 'select_inputs(inputs: ["input_signal"])' \
 	-t 'select_outputs(outputs: ["processed_signal"])' \
 	dump -q \
 	--assert-op-count Iff 0
@@ -49,6 +50,7 @@ $TRACT_RUN $model_prefix.preprocessor.nnef.tgz \
 $TRACT_RUN $model_prefix.preprocessor.nnef.tgz \
 	-t 'concretize_symbols(values: {"BATCH": 1})' \
 	-t 'patch(body: "length = tract_core_shape_of(input_signal)[1];")' \
+	-t 'select_inputs(inputs: ["input_signal"])' \
 	-t 'select_outputs(outputs: ["processed_signal"])' \
 	-t 'pulse(symbol: Some("INPUT_SIGNAL__TIME"), pulse: "4800")' \
 	dump -q
@@ -61,6 +63,7 @@ $TRACT_RUN $model_prefix.encoder.p1.nnef.tgz \
 	--nnef-tract-transformers \
 	-t 'concretize_symbols(values: {"BATCH": 1})' \
 	-t 'patch(body: "length = tract_core_shape_of(audio_signal)[2];")' \
+	-t 'select_inputs(inputs: ["audio_signal"])' \
 	-t 'select_outputs(outputs: ["outputs"])' \
 	-t 'pulse(symbol: Some("AUDIO_SIGNAL__TIME"), pulse: "112")' \
 	dump -q
@@ -72,6 +75,7 @@ $TRACT_RUN $model_prefix.encoder.p1.nnef.tgz \
 	--nnef-tract-transformers \
 	-t 'concretize_symbols(values: {"BATCH": 1})' \
 	-t 'patch(body: "length = tract_core_shape_of(audio_signal)[2];")' \
+	-t 'select_inputs(inputs: ["audio_signal"])' \
 	-t 'select_outputs(outputs: ["outputs"])' \
 	-t 'pulse(symbol: Some("AUDIO_SIGNAL__TIME"), pulse: "112")' \
 	run \

--- a/nnef/src/transform.rs
+++ b/nnef/src/transform.rs
@@ -87,7 +87,6 @@ impl ModelTransform for PatchTransform {
         // Build the TypedModelPatch
         let mut patch = TypedModelPatch { model: patch_model, taps, ..TypedModelPatch::default() };
 
-        let mut inputs_to_remove = vec![];
         let mut new_output_names = vec![];
 
         for (i, lhs_name) in lhs_names.iter().enumerate() {
@@ -124,15 +123,19 @@ impl ModelTransform for PatchTransform {
                         &[wire],
                     )?[0];
                 }
+                // Shunt consumers of the input outlet to the new wire.  Like
+                // `TypedModelPatch::shunt_outside` we do NOT touch
+                // `model.inputs` — the original input stays in the list as
+                // a disconnected Source.  Use `select_inputs(...)` after the
+                // patch to drop it explicitly.
                 patch.shunt_outside(model, input_outlet, wire)?;
-                inputs_to_remove.push(input_outlet);
             } else if self.0.new_outputs.contains(lhs_name) {
                 new_output_names.push(lhs_name.clone());
             } else {
                 let is_intermediate = i < lhs_names.len() - 1;
                 if !is_intermediate {
                     bail!(
-                        "Wire '{}' is not a model input and not declared in new_outputs",
+                        "Wire '{}' is not a model input/intermediate and not declared in new_outputs",
                         lhs_name
                     );
                 }
@@ -141,9 +144,6 @@ impl ModelTransform for PatchTransform {
 
         patch.apply(model)?;
 
-        for inp in &inputs_to_remove {
-            model.inputs.retain(|o| o != inp);
-        }
         for name in &new_output_names {
             let node_id = model.node_id_by_name(name)?;
             model.outputs.push(OutletId::new(node_id, 0));


### PR DESCRIPTION
`TypedModelPatch::shunt_outside` leaves the shunted node in the graph, but the NNEF `patch` transform also implicitly removed model inputs whose name appeared on the LHS.  That hidden side-effect made `patch` do two things at once: substitute a wire, and trim the interface.  Drop the trimming.

Add a sibling `select_inputs(inputs: [...])` transform shaped like `select_outputs`.  The pulse pipeline now reads:

  -t 'patch(body: "length = tract_core_shape_of(input_signal)[1];")' \
  -t 'select_inputs(inputs: ["input_signal"])'              \
  -t 'select_outputs(outputs: ["processed_signal"])'        \
  -t 'pulse(symbol: ..., pulse: ...)'

Discarded Sources stay in the graph until declutter prunes them.

Wire-up: `Graph::select_inputs_by_name` (mirror of `select_outputs_by_name`) + `with_inputs_by_name` + transform registration.  Updated harness/nemotron + nemo-nemotron-asr + nemo-nemotron-streaming-asr to add the explicit `select_inputs` step.