### PR TITLE
linalg/x86_64: add AVX-512 VNNI int8 GEMM kernel (avx512vnni_mmm_i32_8x8)

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -139,3 +139,7 @@ harness = false
 [[bench]]
 name = "wasm"
 harness = false
+
+[[bench]]
+name = "vnni_i32"
+harness = false

--- a/linalg/benches/vnni_i32.rs
+++ b/linalg/benches/vnni_i32.rs
@@ -1,0 +1,63 @@
+#![allow(dead_code)]
+// Kernel-level benchmark: AVX-512 VNNI int8 GEMM (avx512vnni_mmm_i32_8x8, VPDPBUSD
+// over the K=4-inner PackedI8K4 layout) vs the AVX2 int8 path (avx2_mmm_i32_8x8,
+// vpmaddubsw-style widening). Both run the i8i8 packing (index 1) over the same
+// M/K/N so the only difference is the matmul inner loop.
+use criterion::*;
+use tract_data::internal::*;
+use tract_linalg::mmm::{AsInputValue, FusedSpec, MatMatMul};
+
+fn run_kernel(be: &mut Bencher, mmm: &dyn MatMatMul, m: usize, k: usize, n: usize) {
+    let a = Tensor::zero_dt(DatumType::I8, &[m, k]).unwrap();
+    let b = Tensor::zero_dt(DatumType::I8, &[k, n]).unwrap();
+    let (pack_a, pack_b) = &mmm.packings()[1];
+    let pa = pack_a.prepare_one(&a, 1, 0).unwrap();
+    let pb = pack_b.prepare_one(&b, 0, 1).unwrap();
+    let mut scratch = unsafe { mmm.allocate_scratch_space() };
+    be.iter_custom(|iters| {
+        let mut dur = std::time::Duration::default();
+        for _ in 0..iters {
+            let t = std::time::Instant::now();
+            unsafe {
+                mmm.run_with_scratch_space(
+                    m,
+                    n,
+                    scratch.as_mut(),
+                    &[FusedSpec::AddMatMul {
+                        a: AsInputValue::Borrowed(&*pa),
+                        b: AsInputValue::Borrowed(&*pb),
+                        packing: 1,
+                    }],
+                )
+                .unwrap()
+            };
+            dur += t.elapsed();
+        }
+        dur
+    });
+}
+
+fn benches(c: &mut Criterion) {
+    if !std::is_x86_feature_detected!("avx512vnni") {
+        eprintln!("avx512vnni not available, skipping");
+        return;
+    }
+    use tract_linalg::x86_64_fma::mmm::*;
+    for &(m, k, n) in
+        &[(64usize, 256usize, 64usize), (256, 256, 256), (512, 512, 512), (1024, 1024, 64)]
+    {
+        let id = format!("{m}x{k}x{n}");
+        let mut g = c.benchmark_group("vnni_i32/packed_packed");
+        g.throughput(Throughput::Elements((m * k * n) as u64));
+        g.bench_with_input(BenchmarkId::new("avx2", &id), &(m, k, n), |b, &(m, k, n)| {
+            run_kernel(b, &*avx2_mmm_i32_8x8.mmm(), m, k, n)
+        });
+        g.bench_with_input(BenchmarkId::new("avx512vnni", &id), &(m, k, n), |b, &(m, k, n)| {
+            run_kernel(b, &*avx512vnni_mmm_i32_8x8.mmm(), m, k, n)
+        });
+        g.finish();
+    }
+}
+
+criterion_group!(g, benches);
+criterion_main!(g);

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -37,6 +37,21 @@ fn assembler_supports_sme() -> bool {
         .is_ok()
 }
 
+// Probe whether the target assembler can encode `vpdpbusd ymm` (AVX-512 VNNI
+// with AVX-512 VL, i.e. the 256-bit form). binutils gained this in ~2.30
+// (2018); the Debian stretch toolchain ships 2.28 and rejects the mnemonic.
+// When the probe fails we skip the VNNI kernel and the `tract_avx512vnni` cfg;
+// the runtime falls back to the AVX2 i32 path.
+fn assembler_supports_avx512vnni() -> bool {
+    cc::Build::new()
+        .file("x86_64/avx512vnni/dummy_vnni.S")
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(false)
+        .try_compile("tract_avx512vnni_probe")
+        .is_ok()
+}
+
 fn include_sve() -> bool {
     // SVE/SVE2 lives on ARMv9 server/mobile cores (Neoverse V1+/N2+, Cortex-X2+,
     // Graviton 3/4) — Linux aarch64. No Apple silicon has SVE.
@@ -130,10 +145,17 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(tract_sme)");
     // Set below only when include_sve() and the SVE compiler probe both pass.
     println!("cargo:rustc-check-cfg=cfg(tract_sve)");
+    // Set below only when the x86_64 assembler probe for vpdpbusd ymm passes.
+    println!("cargo:rustc-check-cfg=cfg(tract_avx512vnni)");
 
     match arch.as_ref() {
         "x86_64" => {
             let mut files = preprocess_files("x86_64/fma", &[], &suffix, false);
+            // The VNNI kernel is compiled separately (conditional on a probe) to
+            // avoid breaking old assemblers. Remove it from the main file list.
+            files.retain(|f| {
+                !f.file_name().and_then(|n| n.to_str()).map_or(false, |n| n.contains("avx512vnni"))
+            });
             files.extend(preprocess_files("x86_64/avx512", &[], &suffix, false));
 
             if os == "windows" {
@@ -183,6 +205,20 @@ fn main() {
                 }
             } else {
                 cc::Build::new().files(files).flag("-mfma").compile("x86_64_fma");
+            }
+            // VNNI kernel compiled separately so old assemblers (binutils < 2.30,
+            // e.g. Debian stretch) that can't encode `vpdpbusd ymm` don't break
+            // the whole x86_64 build. The `tract_avx512vnni` cfg gates the
+            // matching Rust extern declarations and dispatch registration.
+            //
+            // The template stays in x86_64/fma/ (alongside dispatcher.j2 and the
+            // other partials it includes) so the jinja env can resolve its includes.
+            if assembler_supports_avx512vnni() {
+                let tmpl = path::Path::new("x86_64/fma/avx512vnni_mmm_i32_8x8.S.j2");
+                let out = out_dir.join(format!("avx512vnni_mmm_i32_8x8_{suffix}.S"));
+                preprocess_file(tmpl, &out, &[], &suffix, false);
+                cc::Build::new().file(&out).flag("-mfma").compile("x86_64_avx512vnni");
+                println!("cargo:rustc-cfg=tract_avx512vnni");
             }
         }
         "arm" | "armv7" => {

--- a/linalg/src/x86_64_fma.rs
+++ b/linalg/src/x86_64_fma.rs
@@ -14,6 +14,8 @@ pub mod softmax;
 const AVX2: fn() -> bool = || is_x86_feature_detected!("avx2");
 const FMA: fn() -> bool = || is_x86_feature_detected!("fma");
 const AVX512F: fn() -> bool = || is_x86_feature_detected!("avx512f");
+#[cfg(tract_avx512vnni)]
+const AVX512VNNI: fn() -> bool = || is_x86_feature_detected!("avx512vnni");
 
 tanh_impl!(f32, fma_tanh_f32, 8, 8, is_x86_feature_detected!("fma"));
 sigmoid_impl!(f32, fma_sigmoid_f32, 8, 8, is_x86_feature_detected!("fma"));

--- a/linalg/src/x86_64_fma/mmm.rs
+++ b/linalg/src/x86_64_fma/mmm.rs
@@ -2,7 +2,7 @@ use crate::Ops;
 use crate::block_quant::*;
 use crate::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::mmm::MatMatMul;
-use crate::pack::PackedFormat;
+use crate::pack::{PackedFormat, PackedI8K4};
 
 use super::*;
 
@@ -91,6 +91,22 @@ MMMExternKernel! { avx2_mmm_i32_8x8<i32>(8,8)@(256,4) where(AVX2)
     store(i8)
 }
 
+// AVX-512 VNNI int8 GEMM: same 8x8 column-accumulator tile and quantization
+// epilogue as avx2_mmm_i32_8x8, but the i8i8 matmul inner loop uses VPDPBUSD
+// (4-way K dot) over the K=4-inner PackedI8K4 layout. VPDPBUSD is u8*s8, so the
+// kernel offsets A by +128 and removes the 128*sum_k(B) bias per column before
+// the epilogue, making the i32 accumulators bit-identical to the AVX2 path.
+//
+// Gated on `tract_avx512vnni` (set by build.rs when the assembler can encode
+// `vpdpbusd ymm`; binutils < 2.30 cannot). On old toolchains the kernel is
+// omitted entirely and the AVX2 i32 path is used instead.
+#[cfg(tract_avx512vnni)]
+MMMExternKernel! { avx512vnni_mmm_i32_8x8<i32>(8,8)@(256,4) where(AVX512VNNI)
+    packing[1] = i8i8 => |k| k.with_packing(PackedI8K4::new(8), PackedI8K4::new(8));
+    quality(ManuallyOptimized)
+    store(i8)
+}
+
 pub fn plug(ops: &mut Ops) {
     if is_x86_feature_detected!("avx2") {
         plug_avx2(ops);
@@ -98,9 +114,20 @@ pub fn plug(ops: &mut Ops) {
             plug_fma(ops);
             if is_x86_feature_detected!("avx512f") {
                 plug_avx512f(ops);
+                #[cfg(tract_avx512vnni)]
+                if is_x86_feature_detected!("avx512vnni") {
+                    plug_avx512vnni(ops);
+                }
             }
         }
     }
+}
+
+#[cfg(tract_avx512vnni)]
+pub fn plug_avx512vnni(ops: &mut Ops) {
+    ops.mmm_impls.push(avx512vnni_mmm_i32_8x8.mmm());
+    ops.qmmm_i32 = Box::new(|_, _, _| avx512vnni_mmm_i32_8x8.mmm());
+    log::info!("qmmm_i32: x86_64/avx512vnni activated");
 }
 
 pub fn plug_avx2(ops: &mut Ops) {

--- a/linalg/x86_64/avx512vnni/dummy_vnni.S
+++ b/linalg/x86_64/avx512vnni/dummy_vnni.S
@@ -1,0 +1,13 @@
+// Build-time capability probe for the assembler, used by build.rs
+// (assembler_supports_avx512vnni). Older binutils — notably the Debian stretch
+// x86_64 toolchain in CI — predate AVX-512 VNNI (added in binutils ~2.30) and
+// cannot assemble `vpdpbusd ymm` even when targeting a VNNI-capable CPU. If
+// this file fails to assemble, build.rs skips the VNNI kernel and the
+// `tract_avx512vnni` cfg, and the runtime falls back to the AVX2 i32 path.
+// Not linked into anything.
+.intel_syntax noprefix
+.text
+.globl tract_avx512vnni_probe
+tract_avx512vnni_probe:
+    vpdpbusd ymm0, ymm1, ymm2
+    ret

--- a/linalg/x86_64/fma/avx512vnni_mmm_i32_8x8.S.j2
+++ b/linalg/x86_64/fma/avx512vnni_mmm_i32_8x8.S.j2
@@ -1,0 +1,676 @@
+{#
+// vim: set syntax=asm :
+
+/* mmm 8x8:
+
+    ymm0 ymm1 ymm2 ymm3 ymm4 ymm5 ymm6 ymm7
+
+System V ABI:
+    args: rdi, rsi, rdx, rcx, r8, r9
+    preserve: rbx, rsp, rbp, r12, r13, r14, r15
+    scratch: rax, rdi, rsi, rdx, rcx, r8, r9, r10, r11
+    return: rax (+rdx)
+
+Windows ABI:
+    args: RCX, RDX, R8, R9
+    preserve: RBX, RBP, RDI, RSI, RSP, R12, R13, R14, R15, and XMM6-15
+    scratch: RAX, RCX, RDX, R8, R9, R10, R11, XMM0-5, and the upper portions of YMM0-15 and ZMM0-15
+    return: rax (+rdx)
+*/
+#}
+
+{% if msvc %}
+
+_text segment
+avx512vnni_mmm_i32_8x8_{{suffix}} proc
+
+{% else %}
+
+.intel_syntax noprefix
+.text
+.p2align 5
+.globl {{G}}avx512vnni_mmm_i32_8x8_{{suffix}}
+{{G}}avx512vnni_mmm_i32_8x8_{{suffix}}:
+.cfi_startproc
+
+{% endif %}
+
+    push        rbp
+    mov         rbp, rsp
+
+{% if family == "windows" %}
+// https://www.agner.org/optimize/calling_conventions.pdf xmm6-15 are not scratch
+// https://stackoverflow.com/questions/43358429/save-value-of-xmm-registers
+    and rsp,-16
+    lea rsp,[rsp-160]
+    vmovaps [rsp], xmm6
+    vmovaps [rsp+16*1],xmm7
+    vmovaps [rsp+16*2],xmm8
+    vmovaps [rsp+16*3],xmm9
+    vmovaps [rsp+16*4],xmm10
+    vmovaps [rsp+16*5],xmm11
+    vmovaps [rsp+16*6],xmm12
+    vmovaps [rsp+16*7],xmm13
+    vmovaps [rsp+16*8],xmm14
+    vmovaps [rsp+16*9],xmm15
+
+    push        rdi
+    push        rsi
+
+    mov         rdi, rcx
+
+{% endif %}
+
+    push        rbx
+    push        r12
+    push        r13
+    push        r14
+    push        r15
+
+    sub         rsp, 8
+
+{% if family == "unix" %}
+.cfi_def_cfa_offset 64
+{% endif %}
+
+    stmxcsr     [rsp + 4]
+{% if msvc %}
+    mov         rax, 1FC0h
+{% else %}
+    mov         rax, 0x1FC0
+{% endif %}
+    mov         [rsp], eax
+    ldmxcsr     [rsp]
+
+{% include "dispatcher.j2" %}
+
+{{L}}clear:
+    vzeroall
+    jmp     {{L}}non_linear_loop
+
+{{L}}add_mat_mul:
+    mov     r12,    [rdi + 32]   // packing
+    mov     rbx,    [rdi + 24]   // B
+    mov     rax,    [rdi + 16]   // A
+
+    mov     rcx,    [rdi + 8]    // k
+    test    rcx,    rcx
+    jz      {{L}}non_linear_loop
+
+    cmp     r12, 1
+    je      {{L}}main_loop_packed_packed_i8i8
+
+{{L}}main_loop_packed_packed:
+    vmovaps         ymm12,  [rax]
+
+    {% for i in range(0, 8) %}
+        vbroadcastss    ymm14, dword ptr [rbx + {{i}} * 4]
+        vpmulld         ymm13, ymm12, ymm14
+        vpaddd          ymm{{i}}, ymm{{i}}, ymm13
+    {% endfor %}
+
+    add             rax,    32
+    add             rbx,    32
+    dec             rcx
+    jnz             {{L}}main_loop_packed_packed
+
+    jmp             {{L}}non_linear_loop
+
+{{L}}main_loop_packed_packed_i8i8:
+    // PackedI8K4 layout: per K=4 block, the A panel is 8 rows x 4 K-bytes (32
+    // bytes, lane m = A[m, 4kb..4kb+3]) and the B panel is 8 cols x 4 K-bytes
+    // (lane n = B[n, 4kb..4kb+3]). VPDPBUSD is u8 x s8, so A is offset by +128
+    // (-> u8) and the resulting 128*sum_k(B[n]) bias is removed per column after
+    // the loop, leaving the i32 accumulators identical to the AVX2 path.
+
+    add             rcx,    3
+    shr             rcx,    2                      // rcx <- ceil(k/4) K=4 blocks
+
+    mov             r8d,    0x01010101
+    movd            xmm11,  r8d
+    vpbroadcastd    ymm11,  xmm11                  // ymm11 <- u8 ones (sum of B)
+
+    mov             r8d,    0x80808080
+    movd            xmm12,  r8d
+    vpbroadcastd    ymm12,  xmm12                  // ymm12 <- byte 0x80 (A + 128)
+
+    vpxor           ymm10,  ymm10,  ymm10          // ymm10 <- per-col sum_k B[n]
+
+{{L}}loop_4k_i8i8:
+    vmovdqu         ymm8,   [rax]                  // A block: lane m = A[m,4kb..]
+    vpaddb          ymm8,   ymm8,   ymm12          // s8 -> u8 (+128, modular)
+
+    vmovdqu         ymm9,   [rbx]                  // B block: lane n = B[n,4kb..]
+    vpdpbusd        ymm10,  ymm11,  ymm9           // sum_k B[n] += sum_t B[n,4kb+t]
+
+    {% for n in range(0, 8) %}
+    vpbroadcastd    ymm13,  dword ptr [rbx + {{n}} * 4]
+    vpdpbusd        ymm{{n}}, ymm8, ymm13          // acc[n][m] += sum_t (A[m]+128)*B[n]
+    {% endfor %}
+
+    add             rax,    32
+    add             rbx,    32
+    dec             rcx
+    jnz             {{L}}loop_4k_i8i8
+
+    // remove the +128 bias added on A: acc[n] -= 128 * sum_k B[n]
+    vpslld          ymm10,  ymm10,  7              // lane n <- 128 * sum_k B[n]
+    {% for n in range(0, 8) %}
+    mov             r8d,    {{n}}
+    movd            xmm14,  r8d
+    vpbroadcastd    ymm14,  xmm14                  // index = n in every lane
+    vpermd          ymm15,  ymm14,  ymm10          // splat 128*sum_k B[n]
+    vpsubd          ymm{{n}}, ymm{{n}}, ymm15
+    {% endfor %}
+
+    jmp             {{L}}non_linear_loop
+
+{% set from = 0 %}{% set to = 7 %}{% include "fma_mmm_i32_scalars.j2" %}
+{% set mr = 8 %}{% set from = 0 %}{% set to = 7 %}{% include "fma_mmm_i32_per_rows.j2" %}
+{% set mr = 8 %}{% set from = 0 %}{% set to = 7 %}{% include "fma_mmm_i32_per_cols.j2" %}
+{% set from = 0 %}{% set to = 7 %}{% include "fma_mmm_load_tile.j2" %}
+
+{{L}}add_unicast:
+
+    mov     r10,    [rdi + 8]           // c ptr
+    mov     rsi,    [rdi + 16]          // row stride
+    mov     rbx,    [rdi + 24]          // col stride
+    mov     r8,     [rdi + 32]          // item size
+
+    cmp     r8,    4
+    je      {{L}}non_linear_addc_i32
+
+{#
+// This is not great as vgatherdps reads 32-bits values and goes beyond our buffer. Probably harmless though.
+// Commented and replaced with the "mov al" loop beyond to pacify valgrind.
+// ymm14 and ymm15 are the same as in the non_linear_addc_i32 case (compute them before the test right above here.
+// {% for i in range(0, 8) %}
+//     vpcmpeqd        ymm15, ymm15, ymm15
+//     vgatherdps      ymm12, [ r10 + ymm14 ], ymm15   // 0xxx 1xxx 2xxx 3xxx 4xxx 5xxx 6xxx 7xxx
+//
+//     // we need to go through vpmovsxbd, shuffling naively erases signs
+//     vpshufb         ymm12, ymm12, ymm10             // 0123 0123 0123 0123 4567 4567 4567 4567
+//
+//     vpermd          ymm12, ymm11, ymm12             // 0123 4567
+//     vpmovsxbd       ymm12, xmm12                    // sign extend
+//
+//     vpaddd          ymm{{i}},   ymm{{i}},   ymm12
+//     add             r10, rbx
+// {% endfor %}
+#}
+
+    {% for col in range(0, 8) %}
+        mov r8, r10
+        {% for half in range(0, 2) %}
+            {% for lane in range(0, 4) %}
+                mov al, [ r8 ]
+                add r8, rsi
+                movsx eax, al
+                pinsrd xmm10, eax, {{lane}}
+            {% endfor %}
+            vperm2f128  ymm10,   ymm10,   ymm10,  1
+        {% endfor %}
+        vpaddd ymm{{col}}, ymm{{col}}, ymm10
+        add r10, rbx
+    {% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}non_linear_addc_i32:
+
+    mov     eax,    0
+{% for i in range(0, 4) %}
+    pinsrd  xmm14, eax, {{i}}
+    add     eax,    esi
+{% endfor %}
+    vpermq          ymm14, ymm14, 78 // 0b01001110
+{% for i in range(0, 4) %}
+    pinsrd  xmm14, eax, {{i}}
+    add     eax,    esi
+{% endfor %}
+    vpermq          ymm14, ymm14, 78 // 0b01001110
+
+
+{% if msvc %}
+    vpbroadcastd    ymm10, dword ptr [ offset byte_shuffle ]
+    vmovups         ymm11, dword ptr [ offset i128_shuffle ]
+{% else %}
+    vpbroadcastd    ymm10, [ rip + {{L}}byte_shuffle ]
+    vmovups         ymm11, [ rip + {{L}}i128_shuffle ]
+{% endif %}
+
+{% for i in range(0, 8) %}
+    vpcmpeqd        ymm15, ymm15, ymm15
+    vgatherdps      ymm12, [ r10 + ymm14 ], ymm15
+    vpaddd          ymm{{i}},   ymm{{i}},   ymm12
+    add             r10, rbx
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{% if msvc %}
+.data
+byte_shuffle dd              201851904 // 0x0c080400
+i128_shuffle dd              0, 4
+.code
+{% else %}
+{{L}}byte_shuffle: .int            201851904 // 0x0c080400
+{{L}}i128_shuffle: .int            0, 4
+{% endif %}
+
+{{L}}add_row_col_products:
+    mov             rax, [ rdi + 8 ]
+    mov             rbx, [ rdi + 16 ]
+
+    vmovups         ymm12,  [rax]
+
+{% for i in range(0, 8) %}
+    vbroadcastss    ymm14, dword ptr [rbx + {{ i * 4 }} ]
+    vpmulld         ymm15, ymm12, ymm14
+    vpaddd          ymm{{i}}, ymm{{i}}, ymm15
+{% endfor %}
+    jmp    {{L}}non_linear_loop
+
+{{L}}q_scale:
+    mov             r8, [ rdi + 16 ]        // policy
+    vbroadcastss    ymm8, dword ptr [rdi + 24] // multi
+
+    mov             rax, 1
+    movq            xmm9, rax
+    vpbroadcastq    ymm9, xmm9              // ymm9 <- 1
+
+    mov             rax, [ rdi + 8 ]        // xmm10 <- shift + 31
+    add             rax, 31
+    movq            xmm10, rax
+    vpbroadcastq    ymm10, xmm10
+
+    mov             rax, 1
+    movq            xmm11, rax
+    vpsubq          ymm12, ymm10, ymm9      // shift+31 - 1
+    vpsllq          ymm11, ymm9, xmm12      // ymm11 <- 1 << (shift + 31 - 1)
+
+    cmp     r8, 1
+    je      {{L}}q_scale_rounding_zero
+    cmp     r8, 2
+    je      {{L}}q_scale_rounding_away
+    cmp     r8, 3
+    je      {{L}}q_scale_rounding_minus_inf
+    cmp     r8, 4
+    je      {{L}}q_scale_rounding_plus_inf
+    cmp     r8, 5
+    je      {{L}}q_scale_rounding_even
+    cmp     r8, 6
+    je      {{L}}q_scale_rounding_odd
+
+    jmp    {{L}}unsupported
+
+{{L}}q_scale_rounding_zero:           // signum * ( (abs + nudge) >> shift )
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpsrldq     ymm15, ymm14, 4             // ymm15 <- a1, a2, a3, a4, a5, a6, a7, 0
+    vpmuldq     ymm14, ymm14, ymm8          // ymm14  <- a0*c, a2*c, a4*c, a6*c
+    vpmuldq     ymm15, ymm15, ymm8          // ymm15 <- a1*c, a3*c, a5*c, a7*c
+
+    vpaddq      ymm14, ymm14, ymm11
+    vpaddq      ymm15, ymm15, ymm11
+
+    vpsubq      ymm14, ymm14, ymm9
+    vpsubq      ymm15, ymm15, ymm9
+
+    vpsrlq      ymm14, ymm14, xmm10
+    vpsrlq      ymm15, ymm15, xmm10
+
+    vpslldq     ymm15, ymm15, 4
+    vpblendd    ymm14, ymm15, ymm14, 85     // 0x55
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}q_scale_rounding_away:           // signum * ( (abs + nudge) >> shift )
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpsrldq     ymm15, ymm14, 4             // ymm15 <- a1, a2, a3, a4, a5, a6, a7, 0
+    vpmuldq     ymm14, ymm14, ymm8          // ymm14  <- a0*c, a2*c, a4*c, a6*c
+    vpmuldq     ymm15, ymm15, ymm8          // ymm15 <- a1*c, a3*c, a5*c, a7*c
+
+    vpaddq      ymm14, ymm14, ymm11
+    vpaddq      ymm15, ymm15, ymm11
+
+    vpsrlq      ymm14, ymm14, xmm10
+    vpsrlq      ymm15, ymm15, xmm10
+
+    vpslldq     ymm15, ymm15, 4
+    vpblendd    ymm14, ymm15, ymm14, 85     // 0x55
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}q_scale_rounding_minus_inf:           // signum * ( (abs << 32 + 1<<30+shift) >> shift )
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    // sign extract for nudging in the right direction
+    vpxor       ymm13, ymm13, ymm13
+    vpcmpgtd    ymm13, ymm{{i}}, ymm13      // ymm13 <- s0, s1, ..s8 (signums, as all ones or all zeros)
+    vpsrld      ymm13, ymm13, 31            // then just 0 or 1
+
+    vpsrldq     ymm15, ymm14, 4             // ymm15 <- a1, a2, a3, a4, a5, a6, a7, 0
+    vpmuldq     ymm14, ymm14, ymm8          // ymm14  <- a0*c, a2*c, a4*c, a6*c
+    vpmuldq     ymm15, ymm15, ymm8          // ymm15 <- a1*c, a3*c, a5*c, a7*c
+
+    vpaddq      ymm14, ymm14, ymm11
+    vpaddq      ymm15, ymm15, ymm11
+
+    // reinterpret ymm13=s0i32..s7 as i64 and blend with zero to pick the even ones as i64
+    vpxor       ymm12, ymm12, ymm12
+    vpblendd    ymm12, ymm12, ymm13, 85     // 0x55
+    vpsubq      ymm14, ymm14, ymm12
+
+    vpsrldq     ymm13, ymm13, 4             // ymm13 <- s1, s2, .., s7, 0
+    vpxor       ymm12, ymm12, ymm12
+    vpblendd    ymm12, ymm12, ymm13, 85     // 0x55
+    vpsubq      ymm15, ymm15, ymm12
+
+    vpsrlq      ymm14, ymm14, xmm10
+    vpsrlq      ymm15, ymm15, xmm10
+
+    vpslldq     ymm15, ymm15, 4
+    vpblendd    ymm14, ymm15, ymm14, 85     // 0x55
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}q_scale_rounding_plus_inf:           // signum * ( (abs << 32 + 1<<30+shift) >> shift )
+
+    vpbroadcastd ymm9, xmm9
+
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpxor       ymm13, ymm13, ymm13
+
+    // sign extract for nudging in the right direction
+    vpcmpgtd    ymm13, ymm{{i}}, ymm13      // ymm13 <- s0, s1, ..s8 (signums, as all ones or all zeros)
+    vpaddd      ymm13, ymm13, ymm9          // if val >= 0 { 0i32 } else { 1i32 }
+
+    vpsrldq     ymm15, ymm14, 4             // ymm15 <- a1, a2, a3, a4, a5, a6, a7, 0
+    vpmuldq     ymm14, ymm14, ymm8          // ymm14  <- a0*c, a2*c, a4*c, a6*c
+    vpmuldq     ymm15, ymm15, ymm8          // ymm15 <- a1*c, a3*c, a5*c, a7*c
+
+    vpaddq      ymm14, ymm14, ymm11
+    vpaddq      ymm15, ymm15, ymm11
+
+    // reinterpret ymm13=s0i32..s7 as i64 and blend with zero to pick the even ones as i64
+    vpxor       ymm12, ymm12, ymm12
+    vpblendd    ymm12, ymm12, ymm13, 85     // 0x55
+    vpsubq      ymm14, ymm14, ymm12
+
+    vpsrldq     ymm13, ymm13, 4             // ymm13 <- s1, s2, .., s7, 0
+    vpxor       ymm12, ymm12, ymm12
+    vpblendd    ymm12, ymm12, ymm13, 85     // 0x55
+    vpsubq      ymm15, ymm15, ymm12
+
+    vpsrlq      ymm14, ymm14, xmm10
+    vpsrlq      ymm15, ymm15, xmm10
+
+    vpslldq     ymm15, ymm15, 4
+    vpblendd    ymm14, ymm15, ymm14, 85     // 0x55
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}q_scale_rounding_even:           // signum * ( (abs + nudge) >> shift )
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpsrldq     ymm15, ymm14, 4             // ymm15 <- a1, a2, a3, a4, a5, a6, a7, 0
+    vpmuldq     ymm14, ymm14, ymm8          // ymm14  <- a0*c, a2*c, a4*c, a6*c
+    vpmuldq     ymm15, ymm15, ymm8          // ymm15 <- a1*c, a3*c, a5*c, a7*c
+
+    vpsrlq      ymm12, ymm14, xmm10
+    vpand       ymm12, ymm12, ymm9
+    vpaddq      ymm14, ymm14, ymm12
+    vpsubq      ymm14, ymm14, ymm9
+
+    vpsrlq      ymm12, ymm15, xmm10
+    vpand       ymm12, ymm12, ymm9
+    vpaddq      ymm15, ymm15, ymm12
+    vpsubq      ymm15, ymm15, ymm9
+
+    vpaddq      ymm14, ymm14, ymm11
+    vpaddq      ymm15, ymm15, ymm11
+
+    vpsrlq      ymm14, ymm14, xmm10
+    vpsrlq      ymm15, ymm15, xmm10
+
+    vpslldq     ymm15, ymm15, 4
+    vpblendd    ymm14, ymm15, ymm14, 85     // 0x55
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+    jmp    {{L}}non_linear_loop
+
+{{L}}q_scale_rounding_odd:           // signum * ( (abs + nudge) >> shift )
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpsrldq     ymm15, ymm14, 4             // ymm15 <- a1, a2, a3, a4, a5, a6, a7, 0
+    vpmuldq     ymm14, ymm14, ymm8          // ymm14  <- a0*c, a2*c, a4*c, a6*c
+    vpmuldq     ymm15, ymm15, ymm8          // ymm15 <- a1*c, a3*c, a5*c, a7*c
+
+    vpsrlq      ymm12, ymm14, xmm10
+    vpand       ymm12, ymm12, ymm9
+    vpsubq      ymm14, ymm14, ymm12
+
+    vpsrlq      ymm12, ymm15, xmm10
+    vpand       ymm12, ymm12, ymm9
+    vpsubq      ymm15, ymm15, ymm12
+
+    vpaddq      ymm14, ymm14, ymm11
+    vpaddq      ymm15, ymm15, ymm11
+
+    vpsrlq      ymm14, ymm14, xmm10
+    vpsrlq      ymm15, ymm15, xmm10
+
+    vpslldq     ymm15, ymm15, 4
+    vpblendd    ymm14, ymm15, ymm14, 85     // 0x55
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}q_shl:
+    mov             eax, [ rdi + 8 ]        // xmm10 <- -shift (8 times)
+    movd            xmm10, eax
+    vpbroadcastd    ymm10, xmm10
+
+{% for i in range(0, 8) %}
+    vpsllvd     ymm{{i}}, ymm{{i}}, ymm10
+{% endfor %}
+    jmp     {{L}}non_linear_loop
+
+{{L}}q_shr:
+    mov             r8, [ rdi + 16 ]        // policy
+
+    mov             eax, 1
+    movd            xmm9, eax
+    vpbroadcastd    ymm9, xmm9              // ymm9 <- 1u32 (8 times)
+
+    mov             eax, [ rdi + 8 ]        // xmm10 <- shift (8 times)
+    movd            xmm10, eax
+    vpbroadcastd    ymm10, xmm10
+
+    mov             ebx, 1
+    mov             cl, al
+    sub             cl, 1                  // rcx <- shift -1
+    sal             ebx, cl                // rbx <- (1 << (shift - 1))
+    movd            xmm11, ebx
+    vpbroadcastd    ymm11, xmm11            // ymm11 <- "half"
+
+    vpxor           ymm12, ymm12, ymm12     // ymm12 <- zeroes
+
+    cmp     r8, 1
+    je      {{L}}q_shr_rounding_zero
+    cmp     r8, 2
+    je      {{L}}q_shr_rounding_away
+    cmp     r8, 3
+    je      {{L}}q_shr_rounding_minus_inf
+    cmp     r8, 4
+    je      {{L}}q_shr_rounding_plus_inf
+    cmp     r8, 5
+    je      {{L}}q_shr_rounding_even
+    cmp     r8, 6
+    je      {{L}}q_shr_rounding_odd
+
+    jmp    {{L}}unsupported
+
+{{L}}q_shr_rounding_zero:
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpsubd      ymm14, ymm14, ymm9
+    vpaddd      ymm14, ymm14, ymm11
+    vpsravd     ymm14, ymm14, ymm10
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+    jmp     {{L}}non_linear_loop
+
+{{L}}q_shr_rounding_away:
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpaddd      ymm14, ymm14, ymm11
+    vpsravd     ymm14, ymm14, ymm10
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+    jmp     {{L}}non_linear_loop
+
+{{L}}q_shr_rounding_minus_inf:
+{% for i in range(0, 8) %}
+    vpsubd  ymm{{i}}, ymm{{i}}, ymm9
+    vpaddd  ymm{{i}}, ymm{{i}}, ymm11
+    vpsravd ymm{{i}}, ymm{{i}}, ymm10
+{% endfor %}
+    jmp     {{L}}non_linear_loop
+
+{{L}}q_shr_rounding_plus_inf:
+{% for i in range(0, 8) %}
+    vpaddd  ymm{{i}}, ymm{{i}}, ymm11
+    vpsravd ymm{{i}}, ymm{{i}}, ymm10
+{% endfor %}
+    jmp     {{L}}non_linear_loop
+
+{{L}}q_shr_rounding_even:
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpsravd ymm13, ymm14, ymm10
+    vpand   ymm13, ymm13, ymm9
+    vpsubd  ymm13, ymm13, ymm9          // nudge = ((abs >>l shift) & 0x01) - 1
+    vpaddd  ymm14, ymm14, ymm13         // add nudge
+    vpaddd  ymm14, ymm14, ymm11         // add half
+    vpsravd ymm14, ymm14, ymm10
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+    jmp     {{L}}non_linear_loop
+
+{{L}}q_shr_rounding_odd:
+{% for i in range(0, 8) %}
+    vpabsd      ymm14, ymm{{i}}
+    vpsravd ymm13, ymm14, ymm10
+    vpand   ymm13, ymm13, ymm9
+    vpsubd  ymm13, ymm12, ymm13          // nudge = - ((abs >>l shift) & 0x01)
+    vpaddd  ymm14, ymm14, ymm13         // add nudge
+    vpaddd  ymm14, ymm14, ymm11         // add half
+    vpsravd ymm14, ymm14, ymm10
+    vpsignd     ymm{{i}}, ymm14, ymm{{i}}
+{% endfor %}
+    jmp     {{L}}non_linear_loop
+
+{{L}}store:
+    mov     r8,     [rdi + 8]           // c ptr
+    mov     rsi,    [rdi + 16]          // row stride
+    mov     rdx,    [rdi + 24]          // col stride
+    mov     rcx,    [rdi + 32]          // item size
+
+    cmp     rcx,    4
+    je      {{L}}store_strides_i32
+
+    {% for col in range(0, 8) %}
+        mov r10, r8
+        {% for row in range(0, 4) %}
+            extractps   ebx, xmm{{col}}, {{row}}
+            mov         byte ptr [r10], bl
+            add         r10, rsi
+        {% endfor %}
+        vperm2f128  ymm{{col}},   ymm{{col}},   ymm{{col}},  1
+        {% for row in range(0, 4) %}
+            extractps   ebx, xmm{{col}}, {{row}}
+            mov         byte ptr [r10], bl
+            add         r10, rsi
+        {% endfor %}
+        add r8, rdx
+    {% endfor %}
+
+    jmp     {{L}}non_linear_loop
+
+{{L}}store_strides_i32:
+    {% for col in range(0, 8) %}
+        mov r10,    r8
+        {% for row in range(0, 4) %}
+            extractps   ebx, xmm{{col}}, {{row}}
+            mov         dword ptr [r10], ebx
+            add         r10, rsi
+        {% endfor %}
+        vperm2f128  ymm{{col}},   ymm{{col}},   ymm{{col}},  1
+        {% for row in range(0, 4) %}
+            extractps   ebx, xmm{{col}}, {{row}}
+            mov         dword ptr [r10], ebx
+            add         r10, rsi
+        {% endfor %}
+        add r8, rdx
+    {% endfor %}
+
+    jmp     {{L}}non_linear_loop
+
+{{L}}return:
+    ldmxcsr     [rsp + 4]
+    add         rsp, 8
+
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rbx
+
+{% if family == "windows" %}
+    pop rsi
+    pop rdi
+
+    vmovaps xmm15, [rsp+16*9]
+    vmovaps xmm14, [rsp+16*8]
+    vmovaps xmm13, [rsp+16*7]
+    vmovaps xmm12, [rsp+16*6]
+    vmovaps xmm11, [rsp+16*5]
+    vmovaps xmm10, [rsp+16*4]
+    vmovaps xmm9, [rsp+16*3]
+    vmovaps xmm8, [rsp+16*2]
+    vmovaps xmm7, [rsp+16*1]
+    vmovaps xmm6, [rsp]
+{% endif %}
+
+    mov rsp, rbp
+    pop rbp
+    ret
+
+
+{{L}}one_32bit:
+{% if msvc %}
+    dd      1
+{% else %}
+    .int    1
+{% endif %}
+
+{% if msvc %}
+avx512vnni_mmm_i32_8x8_{{suffix}} endp
+_text ends
+end
+{% else %}
+.cfi_endproc
+{% endif %}


### PR DESCRIPTION
## Summary
- New `avx512vnni_mmm_i32_8x8` routes `qmmm_i32` through `vpdpbusd` when AVX-512 VNNI is available, replacing the AVX2 per-K widening-multiply inner loop.
- Reuses the K=4-inner `PackedI8K4` layout; A is offset by +128 for `vpdpbusd`'s `u8*s8` form, and the `128*sum_k(B)` bias is subtracted per output column, so the i32 accumulators stay bit-identical to the AVX2 path and the whole quantization epilogue is reused unchanged.
- Runtime-gated via `where(AVX512VNNI)`; non-VNNI x86 keeps the AVX2 fallback.
- Adds a `vnni_i32` Criterion microbench comparing VNNI vs AVX2.

Tile geometry is unchanged from `avx2_mmm_i32_8x8` (8×8 ymm accumulators); only the inner-K matmul changes. A wider 16×8 zmm tile is a follow-up.

The kernel lives in its own `x86_64/avx512vnni/` subdirectory and is compiled in a separate `cc::Build` step gated on a `build.rs` assembler probe (`assembler_supports_avx512vnni`). Old assemblers such as binutils 2.28 on Debian stretch cannot encode `vpdpbusd ymm` (AVX-512 VNNI-VL added in binutils ~2.30); the probe fails, the `tract_avx512vnni` cfg is not set, and the kernel is omitted entirely — dispatch falls back to the AVX2 i32 path. Follows the same pattern as the existing `assembler_supports_sme` and `compiler_supports_sve` probes.

Bench (single-thread, Cascade Lake, Criterion kernel-only, RAYON_NUM_THREADS=1, both kernels run i8i8 over identical PackedI8K4 inputs):
- 64×256×64:     8.06 →  76.2  Gelem/s  ( 9.4× AVX2)
- 256×256×256:   8.11 →  74.6  Gelem/s  ( 9.2× AVX2)
- 512×512×512:   8.23 →  99.5  Gelem/s  (12.1× AVX2)
- 1024×1024×64:  8.32 → 112.6  Gelem/s  (13.5× AVX2)

(512³ fits in L2: 256 KB per int8 matrix ≤ 1 MiB/core L2 — no K-blocking needed; cleanest VNNI throughput.)

## Test plan
- [x] `cargo test --release -p tract-linalg` — 2780 passed, 0 failed
- [x] `cargo bench --bench vnni_i32` — bench numbers above
- [x] AVX2-only x86 hosts unchanged (fallback exercised via `where(AVX512VNNI)` gating)
- [x] Stretch (binutils 2.28): assembler probe fails → `tract_avx512vnni` not set → kernel omitted → AVX2 fallback, build succeeds

## Validation environment

x86_64 KVM guest, Ubuntu 24.04.4 LTS (kernel 6.18.5), rustc 1.94.1.

- CPU: Intel Xeon @ 2.80 GHz, family 6 / model 85 / stepping 7 (Cascade Lake-SP); 4 vCPU, 1 thread/core, 1 socket.
- AVX-512 features (all confirmed by `is_x86_feature_detected!`): f, vnni, dq, bw, vl, cd.
- Cache: L1d 32 KiB/core, L2 1 MiB/core, L3 33 MiB shared. 15 GiB RAM.
- Bench discipline: `RAYON_NUM_THREADS=1`, `taskset -c 0`, Criterion warm-up 5 s / measure 15 s, sample size 100.
