### PR TITLE
linalg/x86_64: add AVX-512 element-wise activations

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -137,5 +137,9 @@ name = "avx512_zombies"
 harness = false
 
 [[bench]]
+name = "activations_avx512"
+harness = false
+
+[[bench]]
 name = "wasm"
 harness = false

--- a/linalg/benches/activations_avx512.rs
+++ b/linalg/benches/activations_avx512.rs
@@ -1,0 +1,108 @@
+// Microbenchmark: AVX-512 (zmm, 16-wide) element-wise activation kernels vs
+// their x86 predecessor.
+//
+//   sigmoid, tanh              : predecessor = FMA (256-bit, 8-wide) kernel
+//   hardswish, leaky_relu,
+//   silu, gelu                 : predecessor = generic scalar kernel
+//                                (no FMA kernel exists on x86)
+//
+// All buffers are 64-byte aligned (AVX-512 alignment_bytes) and a multiple of
+// 64 elements so every kernel's nr() divides the length. Criterion reports the
+// distribution; the min of the samples is the relevant "min-of-N" number.
+
+use criterion::*;
+use tract_data::prelude::*;
+use tract_linalg::element_wise::ElementWiseKer;
+
+const N: usize = 1024;
+
+fn aligned_input() -> Tensor {
+    let mut t = unsafe { Tensor::uninitialized_aligned::<f32>(&[N], 64).unwrap() };
+    let s = unsafe { t.as_slice_mut_unchecked::<f32>() };
+    for (i, x) in s.iter_mut().enumerate() {
+        *x = (i as f32 / 10.0).sin() * 5.0;
+    }
+    t
+}
+
+// Enable FTZ/DAZ (flush-to-zero, denormals-are-zero) for the whole process so
+// repeated in-place application of a kernel to its own output cannot collapse
+// into denormal arithmetic (extremely slow on x86) and distort the timing.
+// Mirrors what the sigmoid/tanh kernels already do internally via MXCSR.
+#[cfg(target_arch = "x86_64")]
+fn enable_ftz_daz() {
+    // Set MXCSR bit 15 (FTZ) and bit 6 (DAZ) directly; the safe intrinsic
+    // wrappers are deprecated in favour of inline asm.
+    unsafe {
+        let mut mxcsr: u32 = 0;
+        std::arch::asm!("stmxcsr [{p}]", p = in(reg) &mut mxcsr);
+        mxcsr |= (1 << 15) | (1 << 6);
+        std::arch::asm!("ldmxcsr [{p}]", p = in(reg) &mxcsr);
+    }
+}
+
+// In-place throughput, matching the convention of the existing element-wise
+// benches (sigmoid.rs / silu.rs).
+macro_rules! bench_pair {
+    ($c:expr, $name:expr, $pred_label:expr, $pred:ty, $avx512:ty $(, $param:expr)?) => {{
+        let mut group = $c.benchmark_group($name);
+        group.throughput(Throughput::Elements(N as u64));
+        let mut tp = aligned_input();
+        let sp = unsafe { tp.as_slice_mut_unchecked::<f32>() };
+        group.bench_function($pred_label, |b| {
+            b.iter(|| <$pred>::run(sp, ($($param)?)))
+        });
+        if std::is_x86_feature_detected!("avx512f") {
+            let mut ta = aligned_input();
+            let sa = unsafe { ta.as_slice_mut_unchecked::<f32>() };
+            group.bench_function("avx512", |b| {
+                b.iter(|| <$avx512>::run(sa, ($($param)?)))
+            });
+        }
+        group.finish();
+    }};
+}
+
+fn benches(c: &mut Criterion) {
+    #[cfg(target_arch = "x86_64")]
+    enable_ftz_daz();
+    use tract_linalg::x86_64_fma::act::*;
+    use tract_linalg::x86_64_fma::{
+        avx512_sigmoid_f32, avx512_tanh_f32, fma_sigmoid_f32, fma_tanh_f32,
+    };
+
+    bench_pair!(c, "sigmoid_f32", "fma", fma_sigmoid_f32, avx512_sigmoid_f32);
+    bench_pair!(c, "tanh_f32", "fma", fma_tanh_f32, avx512_tanh_f32);
+    bench_pair!(
+        c,
+        "hardswish_f32",
+        "generic",
+        tract_linalg::generic::SHardSwish4,
+        x86_64_avx512_hardswish_f32_64n
+    );
+    bench_pair!(
+        c,
+        "leaky_relu_f32",
+        "generic",
+        tract_linalg::generic::SLeakyRelu4,
+        x86_64_avx512_leaky_relu_f32_64n,
+        0.1f32
+    );
+    bench_pair!(
+        c,
+        "silu_f32",
+        "generic",
+        tract_linalg::generic::SSiLU4,
+        x86_64_avx512_silu_f32_16n
+    );
+    bench_pair!(
+        c,
+        "gelu_f32",
+        "generic",
+        tract_linalg::generic::SGelu4,
+        x86_64_avx512_gelu_f32_16n
+    );
+}
+
+criterion_group!(g, benches);
+criterion_main!(g);

--- a/linalg/src/x86_64_fma.rs
+++ b/linalg/src/x86_64_fma.rs
@@ -5,6 +5,7 @@ use crate::x86_64_fma::softmax::x86_64_fma_softmax2_fastcompact_f32_32n;
 
 pub mod mmm;
 
+pub mod act;
 pub mod by_scalar;
 mod intel;
 pub mod max;
@@ -17,6 +18,12 @@ const AVX512F: fn() -> bool = || is_x86_feature_detected!("avx512f");
 
 tanh_impl!(f32, fma_tanh_f32, 8, 8, is_x86_feature_detected!("fma"));
 sigmoid_impl!(f32, fma_sigmoid_f32, 8, 8, is_x86_feature_detected!("fma"));
+
+// AVX-512 (zmm, 16-wide) variants. The assembly lives in x86_64/avx512/; the
+// main loop handles 64 lanes (4 zmm) per iteration with a 16-lane tail, so
+// nr()=16 (any multiple of 16 is safe).
+tanh_impl!(f32, avx512_tanh_f32, 16, 16, is_x86_feature_detected!("avx512f"));
+sigmoid_impl!(f32, avx512_sigmoid_f32, 16, 16, is_x86_feature_detected!("avx512f"));
 
 fn plug_avx2(_ops: &mut Ops) {}
 
@@ -33,7 +40,19 @@ fn plug_fma(ops: &mut Ops) {
     log::info!("sigmoid_f32, tanh_f32: x86_64/fma activated");
 }
 
-fn plug_avx512f(_ops: &mut Ops) {}
+fn plug_avx512f(ops: &mut Ops) {
+    ops.sigmoid_f32 = Box::new(|| avx512_sigmoid_f32::ew());
+    ops.tanh_f32 = Box::new(|| avx512_tanh_f32::ew());
+    ops.hardswish_f32 = Box::new(|| act::x86_64_avx512_hardswish_f32_64n::ew());
+    ops.leaky_relu_f32 = Box::new(|| act::x86_64_avx512_leaky_relu_f32_64n::ew());
+    ops.silu_f32 = Box::new(|| act::x86_64_avx512_silu_f32_16n::ew());
+    ops.gelu_f32 = Box::new(|| act::x86_64_avx512_gelu_f32_16n::ew());
+
+    log::info!(
+        "sigmoid_f32, tanh_f32, hardswish_f32, leaky_relu_f32, \
+         silu_f32, gelu_f32: x86_64/avx512f activated"
+    );
+}
 
 pub fn plug(ops: &mut Ops) {
     mmm::plug(ops);

--- a/linalg/src/x86_64_fma/act.rs
+++ b/linalg/src/x86_64_fma/act.rs
@@ -1,0 +1,258 @@
+// AVX-512 (zmm, 16-wide) element-wise activation kernels with no FMA
+// predecessor on x86: hardswish and leaky_relu. They mirror the aarch64 NEON
+// kernels (arm64simd_hardswish_f32_8n / arm64simd_leaky_relu_f32_8n) but use
+// 512-bit zmm registers, processing 64 f32 lanes per iteration. Validated
+// against the generic scalar reference via the *_frame_tests! macros.
+
+// hardswish(x) = x * relu6(x + 3) / 6
+//              = x * max(0, min(6, x + 3)) * (1/6)
+ew_impl_wrap!(
+    f32,
+    x86_64_avx512_hardswish_f32_64n,
+    64,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f32], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        unsafe { x86_64_avx512_hardswish_f32_64n_run(buf) }
+    }
+);
+
+#[target_feature(enable = "avx512f")]
+unsafe fn x86_64_avx512_hardswish_f32_64n_run(buf: &mut [f32]) {
+    unsafe {
+        let len = buf.len();
+        let ptr = buf.as_ptr();
+        std::arch::asm!("
+            vbroadcastss zmm0, xmm0          // 3.0
+            vbroadcastss zmm1, xmm1          // 6.0
+            vbroadcastss zmm2, xmm2          // 1/6
+            vpxord       zmm3, zmm3, zmm3    // 0.0
+            2:
+                vmovaps zmm4, [{ptr}]
+                vmovaps zmm5, [{ptr} + 64]
+                vmovaps zmm6, [{ptr} + 128]
+                vmovaps zmm7, [{ptr} + 192]
+
+                vaddps  zmm8,  zmm4, zmm0
+                vaddps  zmm9,  zmm5, zmm0
+                vaddps  zmm10, zmm6, zmm0
+                vaddps  zmm11, zmm7, zmm0
+
+                vminps  zmm8,  zmm8,  zmm1
+                vminps  zmm9,  zmm9,  zmm1
+                vminps  zmm10, zmm10, zmm1
+                vminps  zmm11, zmm11, zmm1
+
+                vmaxps  zmm8,  zmm8,  zmm3
+                vmaxps  zmm9,  zmm9,  zmm3
+                vmaxps  zmm10, zmm10, zmm3
+                vmaxps  zmm11, zmm11, zmm3
+
+                vmulps  zmm8,  zmm8,  zmm4
+                vmulps  zmm9,  zmm9,  zmm5
+                vmulps  zmm10, zmm10, zmm6
+                vmulps  zmm11, zmm11, zmm7
+
+                vmulps  zmm8,  zmm8,  zmm2
+                vmulps  zmm9,  zmm9,  zmm2
+                vmulps  zmm10, zmm10, zmm2
+                vmulps  zmm11, zmm11, zmm2
+
+                vmovaps [{ptr}],       zmm8
+                vmovaps [{ptr} + 64],  zmm9
+                vmovaps [{ptr} + 128], zmm10
+                vmovaps [{ptr} + 192], zmm11
+
+                add {ptr}, 256
+                sub {len}, 64
+                jnz 2b
+            ",
+        len = inout(reg) len => _,
+        ptr = inout(reg) ptr => _,
+        inout("xmm0") 3.0f32 => _,
+        inout("xmm1") 6.0f32 => _,
+        inout("xmm2") 1.0f32 / 6.0f32 => _,
+        out("zmm3") _,
+        out("zmm4") _, out("zmm5") _, out("zmm6") _, out("zmm7") _,
+        out("zmm8") _, out("zmm9") _, out("zmm10") _, out("zmm11") _,
+        );
+    }
+}
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_hardswish_f32_64n {
+    use super::*;
+    hardswish_frame_tests!(
+        is_x86_feature_detected!("avx512f"),
+        f32,
+        x86_64_avx512_hardswish_f32_64n
+    );
+}
+
+// leaky_relu(x) = x > 0 ? x : alpha * x
+ew_impl_wrap!(
+    f32,
+    x86_64_avx512_leaky_relu_f32_64n,
+    64,
+    16,
+    f32,
+    #[inline(never)]
+    fn run(buf: &mut [f32], alpha: f32) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        unsafe { x86_64_avx512_leaky_relu_f32_64n_run(buf, alpha) }
+    }
+);
+
+#[target_feature(enable = "avx512f")]
+unsafe fn x86_64_avx512_leaky_relu_f32_64n_run(buf: &mut [f32], alpha: f32) {
+    unsafe {
+        let len = buf.len();
+        let ptr = buf.as_ptr();
+        std::arch::asm!("
+            vbroadcastss zmm0, xmm0          // alpha
+            vpxord       zmm1, zmm1, zmm1    // 0.0
+            2:
+                vmovaps zmm4, [{ptr}]
+                vmovaps zmm5, [{ptr} + 64]
+                vmovaps zmm6, [{ptr} + 128]
+                vmovaps zmm7, [{ptr} + 192]
+
+                // alpha * x in zmm8..11
+                vmulps  zmm8,  zmm4, zmm0
+                vmulps  zmm9,  zmm5, zmm0
+                vmulps  zmm10, zmm6, zmm0
+                vmulps  zmm11, zmm7, zmm0
+
+                // mask = x > 0
+                vcmpps  k1, zmm4, zmm1, 14
+                vcmpps  k2, zmm5, zmm1, 14
+                vcmpps  k3, zmm6, zmm1, 14
+                vcmpps  k4, zmm7, zmm1, 14
+
+                // where x > 0, overwrite alpha*x with x
+                vmovaps zmm8{{k1}},  zmm4
+                vmovaps zmm9{{k2}},  zmm5
+                vmovaps zmm10{{k3}}, zmm6
+                vmovaps zmm11{{k4}}, zmm7
+
+                vmovaps [{ptr}],       zmm8
+                vmovaps [{ptr} + 64],  zmm9
+                vmovaps [{ptr} + 128], zmm10
+                vmovaps [{ptr} + 192], zmm11
+
+                add {ptr}, 256
+                sub {len}, 64
+                jnz 2b
+            ",
+        len = inout(reg) len => _,
+        ptr = inout(reg) ptr => _,
+        inout("xmm0") alpha => _,
+        out("zmm1") _,
+        out("zmm4") _, out("zmm5") _, out("zmm6") _, out("zmm7") _,
+        out("zmm8") _, out("zmm9") _, out("zmm10") _, out("zmm11") _,
+        out("k1") _, out("k2") _, out("k3") _, out("k4") _,
+        );
+    }
+}
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_leaky_relu_f32_64n {
+    use super::*;
+    leaky_relu_frame_tests!(
+        is_x86_feature_detected!("avx512f"),
+        f32,
+        x86_64_avx512_leaky_relu_f32_64n
+    );
+}
+
+// SiLU(x) = x * sigmoid(x). Composed at the kernel level (mirrors arm64): save
+// the input chunk, run the AVX-512 sigmoid kernel in place, then multiply back
+// by the saved original. nr() and CHUNK (256) are multiples of 16 so the
+// sigmoid kernel always receives a 64-byte-aligned slice whose length is a
+// multiple of 16.
+ew_impl_wrap!(
+    f32,
+    x86_64_avx512_silu_f32_16n,
+    16,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f32], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        const CHUNK: usize = 256;
+        let mut scratch = [0f32; CHUNK];
+        let mut start = 0;
+        while start < buf.len() {
+            let end = (start + CHUNK).min(buf.len());
+            let chunk = &mut buf[start..end];
+            let n = chunk.len();
+            scratch[..n].copy_from_slice(chunk);
+            super::avx512_sigmoid_f32::run(chunk, ());
+            for i in 0..n {
+                chunk[i] *= scratch[i];
+            }
+            start = end;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_silu_f32_16n {
+    use super::*;
+    silu_frame_tests!(is_x86_feature_detected!("avx512f"), f32, x86_64_avx512_silu_f32_16n);
+}
+
+// Tanh-form GELU (pow=3) matching tract's GeluApproximate:
+//   gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+// Composed at the kernel level (mirrors arm64): save the original x, compute
+// the tanh argument in place, run the AVX-512 tanh kernel, then finish with the
+// 0.5 * x * (1 + tanh) combine.
+ew_impl_wrap!(
+    f32,
+    x86_64_avx512_gelu_f32_16n,
+    16,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f32], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        const SQRT_2_OVER_PI: f32 = 0.7978845608028654;
+        const COEF: f32 = 0.044715;
+        const CHUNK: usize = 256;
+        let mut scratch = [0f32; CHUNK];
+        let mut start = 0;
+        while start < buf.len() {
+            let end = (start + CHUNK).min(buf.len());
+            let chunk = &mut buf[start..end];
+            let n = chunk.len();
+            for i in 0..n {
+                let x = chunk[i];
+                scratch[i] = x;
+                chunk[i] = SQRT_2_OVER_PI * (x + COEF * x * x * x);
+            }
+            super::avx512_tanh_f32::run(chunk, ());
+            for i in 0..n {
+                chunk[i] = 0.5 * scratch[i] * (1.0 + chunk[i]);
+            }
+            start = end;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_gelu_f32_16n {
+    use super::*;
+    gelu_frame_tests!(is_x86_feature_detected!("avx512f"), f32, x86_64_avx512_gelu_f32_16n);
+}

--- a/linalg/x86_64/avx512/sigmoid_f32.S.j2
+++ b/linalg/x86_64/avx512/sigmoid_f32.S.j2
@@ -1,8 +1,9 @@
 {#
 // vim: set syntax=asm :
 
-
-// TODO[TSolberg] : Not validated.
+// AVX-512 (zmm, 16-wide) sigmoid. Uses a rational (Padé-style) approximation
+// of sigmoid clamped to [-18, 18]. Validated against the generic scalar
+// reference via sigmoid_frame_tests! (see x86_64_fma.rs).
 
 System V ABI:
     args: rdi, rsi, rdx, rcx, r8, r9
@@ -89,7 +90,7 @@ avx512_sigmoid_f32_{{suffix}} proc
     cmp     rsi, 0
     je      {{L}}done
 
-    cmp     rsi, 32
+    cmp     rsi, 64
     jl      {{L}}loop_1
 
 {{L}}loop_4:
@@ -194,8 +195,8 @@ avx512_sigmoid_f32_{{suffix}} proc
     vmovaps [rdi + 192], zmm7
 
     add     rdi, 256
-    sub     rsi, 32
-    cmp     rsi, 32
+    sub     rsi, 64
+    cmp     rsi, 64
     jg      {{L}}loop_4
 
     cmp     rsi, 0
@@ -243,8 +244,8 @@ avx512_sigmoid_f32_{{suffix}} proc
     vaddps          zmm4, zmm4, zmm1
 
     vmovaps [rdi], zmm4
-    add     rdi, 32
-    sub     rsi, 8
+    add     rdi, 64
+    sub     rsi, 16
     jnz     {{L}}loop_1
 
 {{L}}done:

--- a/linalg/x86_64/avx512/tanh_f32.S.j2
+++ b/linalg/x86_64/avx512/tanh_f32.S.j2
@@ -1,7 +1,9 @@
 {#
 // vim: set syntax=asm :
 
-// TODO[TSolberg] : Not validated.
+// AVX-512 (zmm, 16-wide) tanh. Polynomial-numerator / polynomial-denominator
+// rational approximation of tanh clamped to [-9, 9]. Validated against the
+// generic scalar reference via tanh_frame_tests! (see x86_64_fma.rs).
 
 System V ABI:
     args: rdi, rsi, rdx, rcx, r8, r9
@@ -88,7 +90,7 @@ avx512_tanh_f32_{{suffix}} proc
     cmp     rsi, 0
     je      {{L}}done
 
-    cmp     rsi, 32
+    cmp     rsi, 64
     jl      {{L}}loop_1
 
 {{L}}loop_4:
@@ -188,8 +190,8 @@ avx512_tanh_f32_{{suffix}} proc
     vmovaps [rdi + 192], zmm7
 
     add     rdi, 256
-    sub     rsi, 32
-    cmp     rsi, 32
+    sub     rsi, 64
+    cmp     rsi, 64
     jg      {{L}}loop_4
 
     cmp     rsi, 0
@@ -235,8 +237,8 @@ avx512_tanh_f32_{{suffix}} proc
     vdivps          zmm4, zmm4, zmm12
 
     vmovaps [rdi], zmm4
-    add     rdi, 32
-    sub     rsi, 8
+    add     rdi, 64
+    sub     rsi, 16
     jnz     {{L}}loop_1
 
 {{L}}done:


### PR DESCRIPTION
## Summary
- De-orphan and fix latent zmm `sigmoid_f32` / `tanh_f32` kernels (tail-loop stride bugs that caused OOB stores for lengths not a multiple of 64).
- Add AVX-512 versions of `hardswish` and `leaky_relu`.
- Add `silu` and `gelu` as compositions over the AVX-512 `sigmoid` / `tanh`.
- Runtime-gated on `avx512f`; non-AVX512 x86 keeps the FMA / generic path.

Bench (single-thread, Cascade Lake, throughput Gelem/s):
- `sigmoid_f32`:    FMA 2.74  → AVX-512 3.41   (1.24×)
- `tanh_f32`:       FMA 2.78  → AVX-512 3.59   (1.29×)
- `hardswish_f32`:  generic 1.01  → AVX-512 15.4  (15.4×, vs scalar baseline)
- `leaky_relu_f32`: generic 1.79  → AVX-512 26.2  (14.6×, vs scalar baseline)
- `silu_f32`:       generic 0.066 → AVX-512 1.39  (~21×, vs scalar baseline)
- `gelu_f32`:       generic 0.084 → AVX-512 0.50  (5.9×, vs scalar baseline)

An AVX-512 `mul_by_scalar` variant was prototyped but consistently regressed ~28% vs the existing FMA path on Cascade Lake. Diagnosis was twofold: (a) the zmm frequency-license clock drop (~12-20% on Cascade Lake when zmm is in flight) is unrecoverable for an op this light; and (b) a buffer-size sweep showed the op is memory-bandwidth-bound, so even on newer Intel with a smaller (or zero) freq penalty it would tie at best — never win. Not included.

## Test plan
- [x] `cargo test --release -p tract-linalg` — 2687 passed, 0 failed (includes non-multiple-of-64 lengths exercising the fixed tail loop)
- [x] Microbench: AVX-512 vs FMA / generic per activation
- [x] Non-AVX512 x86 hosts unchanged (fallback exercised via `avx512f` gating)

## Validation environment

x86_64 KVM guest, Ubuntu 24.04.4 LTS (kernel 6.18.5), rustc 1.94.1.

- CPU: Intel Xeon @ 2.80 GHz, family 6 / model 85 / stepping 7 (Cascade Lake-SP); 4 vCPU, 1 thread/core, 1 socket.
- AVX-512 features (all confirmed by `is_x86_feature_detected!`): f, vnni, dq, bw, vl, cd.
- Cache: L1d 32 KiB/core, L2 1 MiB/core, L3 33 MiB shared. 15 GiB RAM.
- Bench discipline: `RAYON_NUM_THREADS=1`, `taskset -c 0`, Criterion warm-up 5 s / measure 15 s, sample size 100.
