### PR TITLE
linalg/x86_64: add AVX-512 erf kernel

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -112,6 +112,10 @@ name = "activations_avx512_f16"
 harness = false
 
 [[bench]]
+name = "erf"
+harness = false
+
+[[bench]]
 bench = false
 name = "arm64simd"
 harness = false

--- a/linalg/benches/erf.rs
+++ b/linalg/benches/erf.rs
@@ -1,0 +1,38 @@
+// Microbenchmark: AVX-512 (zmm, 16-wide) erf kernel vs the generic scalar
+// SErf4 (no FMA predecessor exists on x86). All buffers are 64-byte aligned
+// (AVX-512 alignment_bytes) and a multiple of 64 elements so the kernel's
+// nr() = 64 divides the length.
+
+use criterion::*;
+use tract_data::prelude::*;
+use tract_linalg::element_wise::ElementWiseKer;
+
+const N: usize = 1024;
+
+fn aligned_input() -> Tensor {
+    let mut t = unsafe { Tensor::uninitialized_aligned::<f32>(&[N], 64).unwrap() };
+    let s = unsafe { t.as_slice_mut_unchecked::<f32>() };
+    for (i, x) in s.iter_mut().enumerate() {
+        *x = (i as f32 / 10.0).sin() * 5.0;
+    }
+    t
+}
+
+fn erf_f32(c: &mut Criterion) {
+    let mut g = c.benchmark_group("erf_f32");
+    g.throughput(Throughput::Elements(N as u64));
+    let mut tp = aligned_input();
+    let sp = unsafe { tp.as_slice_mut_unchecked::<f32>() };
+    g.bench_function("generic", |b| b.iter(|| tract_linalg::generic::SErf4::run(sp, ())));
+    if std::is_x86_feature_detected!("avx512f") {
+        let mut ta = aligned_input();
+        let sa = unsafe { ta.as_slice_mut_unchecked::<f32>() };
+        g.bench_function("avx512", |b| {
+            b.iter(|| tract_linalg::x86_64_fma::erf::x86_64_avx512_erf_f32_64n::run(sa, ()))
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(g, erf_f32);
+criterion_main!(g);

--- a/linalg/src/frame/erf.rs
+++ b/linalg/src/frame/erf.rs
@@ -1,0 +1,82 @@
+#[allow(unused_macros)]
+macro_rules! erf_impl {
+    ($ti: ident, $func: ident, $nr: expr, $alignment_items: expr, $cond: expr) => {
+        ew_impl!($ti, $func, $nr, $alignment_items);
+        #[cfg(test)]
+        paste! {
+            mod [<test_ $func>] {
+                use super::*;
+                erf_frame_tests!($cond, $ti, $func);
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+#[macro_use]
+pub mod test {
+    use crate::LADatum;
+    use crate::frame::element_wise::*;
+    use num_traits::{AsPrimitive, Float};
+    use proptest::test_runner::TestCaseResult;
+
+    #[macro_export]
+    macro_rules! erf_frame_tests {
+        ($cond:expr, $t: ty, $ker:ty) => {
+            proptest::proptest! {
+                #[test]
+                fn prop(xs in proptest::collection::vec(-5f32..5.0, 0..100)) {
+                    if $cond {
+                        $crate::frame::erf::test::test_erf::<$ker, $t>(&*xs).unwrap()
+                    }
+                }
+            }
+            #[test]
+            fn trivial() {
+                if $cond {
+                    $crate::frame::erf::test::test_erf::<$ker, $t>(&[
+                        -5f32, -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0, 5.0,
+                    ])
+                    .unwrap();
+                }
+            }
+            #[test]
+            fn zeros() {
+                if $cond {
+                    $crate::frame::erf::test::test_erf::<$ker, $t>(&[0.0; 16]).unwrap();
+                }
+            }
+        };
+    }
+
+    pub fn test_erf<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+        T: AsPrimitive<f32>,
+    {
+        let data = tract_data::prelude::tensor1(values);
+        let data = data.cast_to::<T>().unwrap();
+        let data = data.try_as_plain().unwrap().as_slice::<T>().unwrap();
+        crate::frame::element_wise::test::test_element_wise::<K, T, _>(data, |x: T| {
+            // Abramowitz & Stegun 7.1.26 six-coefficient approximation, mirroring
+            // generic/erf.rs::serf so the test reference matches the production scalar path.
+            const A1: f32 = 0.0705230784;
+            const A2: f32 = 0.0422820123;
+            const A3: f32 = 0.0092705272;
+            const A4: f32 = 0.0001520143;
+            const A5: f32 = 0.0002765672;
+            const A6: f32 = 0.0000430638;
+            let x: f32 = x.as_();
+            let signum = x.signum();
+            let abs = x.abs();
+            let y = A6 * abs;
+            let y = (A5 + y) * abs;
+            let y = (A4 + y) * abs;
+            let y = (A3 + y) * abs;
+            let y = (A2 + y) * abs;
+            let y = (A1 + y) * abs;
+            let y = 1.0 - (y + 1.0).powi(16).recip();
+            y.copysign(signum).as_()
+        })
+    }
+}

--- a/linalg/src/frame/mod.rs
+++ b/linalg/src/frame/mod.rs
@@ -8,6 +8,8 @@ pub mod unicast;
 #[macro_use]
 pub mod by_scalar;
 #[macro_use]
+pub mod erf;
+#[macro_use]
 pub mod gelu;
 #[macro_use]
 pub mod hardswish;

--- a/linalg/src/generic/erf.rs
+++ b/linalg/src/generic/erf.rs
@@ -49,3 +49,9 @@ impl ElementWiseKer<f32> for SErf4 {
         x.iter_mut().for_each(serf)
     }
 }
+
+#[cfg(test)]
+mod test_serf4 {
+    use super::*;
+    crate::erf_frame_tests!(true, f32, SErf4);
+}

--- a/linalg/src/x86_64_fma.rs
+++ b/linalg/src/x86_64_fma.rs
@@ -8,6 +8,7 @@ pub mod mmm;
 pub mod act;
 pub mod act_f16;
 pub mod by_scalar;
+pub mod erf;
 mod intel;
 pub mod max;
 pub mod panel_extract;
@@ -62,12 +63,14 @@ fn plug_avx512f(ops: &mut Ops) {
     ops.softmax2_fastcompact_f32 =
         Box::new(|| softmax::x86_64_avx512_softmax2_fastcompact_f32_64n::red());
 
+    ops.erf_f32 = Box::new(|| erf::x86_64_avx512_erf_f32_64n::ew());
+
     log::info!(
         "sigmoid_f32, tanh_f32, hardswish_f32, leaky_relu_f32, \
          silu_f32, gelu_f32, \
          sigmoid_f16, tanh_f16, hardswish_f16, leaky_relu_f16, \
          silu_f16, gelu_f16, \
-         max_f32, softmax2_fastcompact_f32: x86_64/avx512f activated"
+         max_f32, softmax2_fastcompact_f32, erf_f32: x86_64/avx512f activated"
     );
 }
 

--- a/linalg/src/x86_64_fma/erf.rs
+++ b/linalg/src/x86_64_fma/erf.rs
@@ -1,0 +1,204 @@
+// AVX-512 (zmm, 16-wide) error function kernel. Mirrors generic/erf.rs::serf
+// (Abramowitz & Stegun 7.1.26 six-coefficient polynomial) but runs the
+// polynomial via FMA chains over 4 zmm registers per iteration (64 lanes per
+// loop step). Validated against the generic scalar reference via
+// erf_frame_tests! at SuperApproximate tolerance.
+//
+// Algorithm (per lane):
+//   signum = sign(x);  abs = |x|
+//   y = a6
+//   y = y*abs + a5            (Horner FMA)
+//   y = y*abs + a4
+//   y = y*abs + a3
+//   y = y*abs + a2
+//   y = y*abs + a1
+//   y = y * abs               (final factor of abs)
+//   y = y + 1
+//   y = y^16                  (4 sequential squares)
+//   y = 1 / y                 (vdivps, full IEEE precision)
+//   y = 1 - y
+//   result = copysign(y, x)
+
+ew_impl_wrap!(
+    f32,
+    x86_64_avx512_erf_f32_64n,
+    64,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f32], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        unsafe { x86_64_avx512_erf_f32_64n_run(buf) }
+    }
+);
+
+#[target_feature(enable = "avx512f")]
+unsafe fn x86_64_avx512_erf_f32_64n_run(buf: &mut [f32]) {
+    unsafe {
+        let len = buf.len();
+        let ptr = buf.as_ptr();
+        const A1: f32 = 0.0705230784;
+        const A2: f32 = 0.0422820123;
+        const A3: f32 = 0.0092705272;
+        const A4: f32 = 0.0001520143;
+        const A5: f32 = 0.0002765672;
+        const A6: f32 = 0.0000430638;
+        // 0x7fffffff: positive-finite mask (clears sign bit). As f32 bits, this
+        // is NaN; we never use it as a numeric value — only as a bit mask via vandps.
+        const ABS_MASK: f32 = f32::from_bits(0x7fffffff);
+        const SIGN_MASK: f32 = f32::from_bits(0x80000000);
+        std::arch::asm!("
+            // broadcast constants (xmmN -> zmmN, broadcast across all 16 lanes)
+            vbroadcastss zmm0, xmm0           // a1
+            vbroadcastss zmm1, xmm1           // a2
+            vbroadcastss zmm2, xmm2           // a3
+            vbroadcastss zmm3, xmm3           // a4
+            vbroadcastss zmm4, xmm4           // a5
+            vbroadcastss zmm5, xmm5           // a6
+            vbroadcastss zmm6, xmm6           // 1.0
+            vbroadcastss zmm7, xmm7           // abs mask (0x7fffffff)
+            vbroadcastss zmm8, xmm8           // sign mask (0x80000000)
+            2:
+                // load 4 zmm of input
+                vmovaps zmm9,  [{ptr}]
+                vmovaps zmm10, [{ptr} + 64]
+                vmovaps zmm11, [{ptr} + 128]
+                vmovaps zmm12, [{ptr} + 192]
+
+                // sign[i] = x[i] & SIGN_MASK   (keeps only the sign bit)
+                vandps zmm13, zmm9,  zmm8
+                vandps zmm14, zmm10, zmm8
+                vandps zmm15, zmm11, zmm8
+                vandps zmm16, zmm12, zmm8
+
+                // abs[i] = x[i] & ABS_MASK     (clears the sign bit)
+                vandps zmm9,  zmm9,  zmm7
+                vandps zmm10, zmm10, zmm7
+                vandps zmm11, zmm11, zmm7
+                vandps zmm12, zmm12, zmm7
+
+                // y = a6 (in zmm17..20, 4 independent channels)
+                vmovaps zmm17, zmm5
+                vmovaps zmm18, zmm5
+                vmovaps zmm19, zmm5
+                vmovaps zmm20, zmm5
+
+                // y = y*abs + a5
+                vfmadd213ps zmm17, zmm9,  zmm4
+                vfmadd213ps zmm18, zmm10, zmm4
+                vfmadd213ps zmm19, zmm11, zmm4
+                vfmadd213ps zmm20, zmm12, zmm4
+
+                // y = y*abs + a4
+                vfmadd213ps zmm17, zmm9,  zmm3
+                vfmadd213ps zmm18, zmm10, zmm3
+                vfmadd213ps zmm19, zmm11, zmm3
+                vfmadd213ps zmm20, zmm12, zmm3
+
+                // y = y*abs + a3
+                vfmadd213ps zmm17, zmm9,  zmm2
+                vfmadd213ps zmm18, zmm10, zmm2
+                vfmadd213ps zmm19, zmm11, zmm2
+                vfmadd213ps zmm20, zmm12, zmm2
+
+                // y = y*abs + a2
+                vfmadd213ps zmm17, zmm9,  zmm1
+                vfmadd213ps zmm18, zmm10, zmm1
+                vfmadd213ps zmm19, zmm11, zmm1
+                vfmadd213ps zmm20, zmm12, zmm1
+
+                // y = y*abs + a1
+                vfmadd213ps zmm17, zmm9,  zmm0
+                vfmadd213ps zmm18, zmm10, zmm0
+                vfmadd213ps zmm19, zmm11, zmm0
+                vfmadd213ps zmm20, zmm12, zmm0
+
+                // y = y * abs  (final factor)
+                vmulps zmm17, zmm17, zmm9
+                vmulps zmm18, zmm18, zmm10
+                vmulps zmm19, zmm19, zmm11
+                vmulps zmm20, zmm20, zmm12
+
+                // y = y + 1
+                vaddps zmm17, zmm17, zmm6
+                vaddps zmm18, zmm18, zmm6
+                vaddps zmm19, zmm19, zmm6
+                vaddps zmm20, zmm20, zmm6
+
+                // y^16: square 4 times
+                vmulps zmm17, zmm17, zmm17
+                vmulps zmm18, zmm18, zmm18
+                vmulps zmm19, zmm19, zmm19
+                vmulps zmm20, zmm20, zmm20
+
+                vmulps zmm17, zmm17, zmm17
+                vmulps zmm18, zmm18, zmm18
+                vmulps zmm19, zmm19, zmm19
+                vmulps zmm20, zmm20, zmm20
+
+                vmulps zmm17, zmm17, zmm17
+                vmulps zmm18, zmm18, zmm18
+                vmulps zmm19, zmm19, zmm19
+                vmulps zmm20, zmm20, zmm20
+
+                vmulps zmm17, zmm17, zmm17
+                vmulps zmm18, zmm18, zmm18
+                vmulps zmm19, zmm19, zmm19
+                vmulps zmm20, zmm20, zmm20
+
+                // y = 1 / y      (full-precision reciprocal, matches generic .recip())
+                vdivps zmm21, zmm6, zmm17
+                vdivps zmm22, zmm6, zmm18
+                vdivps zmm23, zmm6, zmm19
+                vdivps zmm24, zmm6, zmm20
+
+                // y = 1 - y
+                vsubps zmm21, zmm6, zmm21
+                vsubps zmm22, zmm6, zmm22
+                vsubps zmm23, zmm6, zmm23
+                vsubps zmm24, zmm6, zmm24
+
+                // copysign: stamp the original sign bit onto the (positive) result
+                vorps zmm21, zmm21, zmm13
+                vorps zmm22, zmm22, zmm14
+                vorps zmm23, zmm23, zmm15
+                vorps zmm24, zmm24, zmm16
+
+                // store
+                vmovaps [{ptr}],       zmm21
+                vmovaps [{ptr} + 64],  zmm22
+                vmovaps [{ptr} + 128], zmm23
+                vmovaps [{ptr} + 192], zmm24
+
+                add {ptr}, 256
+                sub {len}, 64
+                jnz 2b
+            ",
+            len = inout(reg) len => _,
+            ptr = inout(reg) ptr => _,
+            inout("xmm0") A1 => _,
+            inout("xmm1") A2 => _,
+            inout("xmm2") A3 => _,
+            inout("xmm3") A4 => _,
+            inout("xmm4") A5 => _,
+            inout("xmm5") A6 => _,
+            inout("xmm6") 1f32 => _,
+            inout("xmm7") ABS_MASK => _,
+            inout("xmm8") SIGN_MASK => _,
+            out("zmm9")  _, out("zmm10") _, out("zmm11") _, out("zmm12") _,
+            out("zmm13") _, out("zmm14") _, out("zmm15") _, out("zmm16") _,
+            out("zmm17") _, out("zmm18") _, out("zmm19") _, out("zmm20") _,
+            out("zmm21") _, out("zmm22") _, out("zmm23") _, out("zmm24") _,
+        );
+    }
+}
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_erf_f32_64n {
+    use super::*;
+    crate::erf_frame_tests!(is_x86_feature_detected!("avx512f"), f32, x86_64_avx512_erf_f32_64n);
+}


### PR DESCRIPTION
## Summary
- New `x86_64_avx512_erf_f32_64n` kernel: AVX-512 (zmm, 16-wide) erf mirroring `generic/erf.rs::serf` (Abramowitz & Stegun 7.1.26 six-coefficient approximation), processing 64 lanes per iteration through 4 zmm registers + FMA Horner chains, final `1/(y+1)^16` via `vdivps` (full IEEE precision).
- Wires into `Ops::erf_f32` from `plug_avx512f`; non-AVX512 x86 keeps the generic scalar path (which the compiler typically auto-vectorizes to FMA).
- New `linalg/src/frame/erf.rs` with `erf_frame_tests!` macro (mirrors `frame/hardswish.rs` structure) so both the generic `SErf4` and the AVX-512 kernel share one proptest reference.

Bench (single-thread, Cascade Lake, throughput Gelem/s):
- `erf_f32` generic (compiler auto-vectorized to FMA): 0.81
- `erf_f32` AVX-512:                                  3.27   (4.05× generic)

The 4× headline reflects the bench host's auto-vectorized generic baseline (compiler emits FMA from the polynomial chain at `-O3`). On pre-FMA x86 the gap is much wider, since the compiler can't autovec the chain.

## Test plan
- [x] `cargo test --release -p tract-linalg` — 2672 passed, 0 failed (6 new erf tests: 3 generic + 3 AVX-512)
- [x] `cargo bench --bench erf` — numbers above
- [x] Non-AVX512 x86 hosts unchanged (fallback exercised via `avx512f` gating in `plug_avx512f`)

## Validation environment

x86_64 KVM guest, Ubuntu 24.04.4 LTS (kernel 6.18.5), rustc 1.94.1.

- CPU: Intel Xeon @ 2.80 GHz, family 6 / model 85 / stepping 7 (Cascade Lake-SP); 4 vCPU, 1 thread/core, 1 socket.
- AVX-512 features (all confirmed by `is_x86_feature_detected!`): f, vnni, dq, bw, vl, cd.
- Cache: L1d 32 KiB/core, L2 1 MiB/core, L3 33 MiB shared. 15 GiB RAM.
- Bench discipline: `RAYON_NUM_THREADS=1`, `taskset -c 0`, Criterion warm-up 5 s / measure 15 s, sample size 100.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtQweWhf8E1W7pEJMF6ywf)_
