### PR TITLE
linalg/x86_64: add AVX-512 f16 softmax_l2 kernel

### DIFF
--- a/linalg/benches/softmax.rs
+++ b/linalg/benches/softmax.rs
@@ -1,7 +1,7 @@
 use criterion::*;
 use tract_data::prelude::*;
 use tract_linalg::element_wise::ElementWiseKer;
-use tract_linalg::generic::reduce::softmax_l2::SSoftMaxL2;
+use tract_linalg::generic::reduce::softmax_l2::{HSoftMaxL2, SSoftMaxL2};
 use tract_linalg::reduce::{MapReduceKer, ReduceKer};
 
 #[inline(never)]
@@ -134,5 +134,31 @@ fn softmax_f32(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, softmax_f32);
+fn softmax_f16(c: &mut Criterion) {
+    let mut group = c.benchmark_group("softmax_f16");
+    // 1536 = 64*24 (multiple of avx512 f16 nr=64 and generic h nr=8).
+    const N: usize = 1536;
+    group.throughput(Throughput::Elements(N as u64));
+    let mut input = unsafe { Tensor::uninitialized_aligned::<f16>(&[N], 64).unwrap() };
+    let mut plain = input.try_as_plain_mut().unwrap();
+    let input = plain.as_slice_mut::<f16>().unwrap();
+    for (i, x) in input.iter_mut().enumerate() {
+        *x = f16::from_f32((i as f32 / 10.0).sin() * 5.0);
+    }
+    group.bench_function("loop2/generic", |b| {
+        b.iter(|| HSoftMaxL2::red().run_with_params(input, f16::from_f32(10.0)))
+    });
+    #[cfg(target_arch = "x86_64")]
+    if std::is_x86_feature_detected!("avx512f") {
+        group.bench_function("loop2/avx512", |b| {
+            b.iter(|| {
+                tract_linalg::x86_64_fma::softmax::x86_64_avx512_softmax2_fastcompact_f16_64n::red()
+                    .run_with_params(input, f16::from_f32(10.0))
+                    .unwrap()
+            });
+        });
+    }
+}
+
+criterion_group!(benches, softmax_f32, softmax_f16);
 criterion_main!(benches);

--- a/linalg/src/x86_64_fma.rs
+++ b/linalg/src/x86_64_fma.rs
@@ -1,6 +1,7 @@
 use crate::Ops;
 use crate::frame::element_wise::ElementWiseKer;
 use crate::frame::reduce::{MapReduceKer, ReduceKer};
+use crate::x86_64_fma::softmax::x86_64_avx512_softmax2_fastcompact_f16_64n;
 use crate::x86_64_fma::softmax::x86_64_fma_softmax2_fastcompact_f32_32n;
 
 pub mod mmm;
@@ -62,6 +63,7 @@ fn plug_avx512f(ops: &mut Ops) {
     ops.max_f32 = Box::new(|| max::x86_64_avx512_max_f32_64n::red());
     ops.softmax2_fastcompact_f32 =
         Box::new(|| softmax::x86_64_avx512_softmax2_fastcompact_f32_64n::red());
+    ops.softmax2_fastcompact_f16 = Box::new(|| x86_64_avx512_softmax2_fastcompact_f16_64n::red());
 
     ops.erf_f32 = Box::new(|| erf::x86_64_avx512_erf_f32_64n::ew());
 
@@ -70,7 +72,8 @@ fn plug_avx512f(ops: &mut Ops) {
          silu_f32, gelu_f32, \
          sigmoid_f16, tanh_f16, hardswish_f16, leaky_relu_f16, \
          silu_f16, gelu_f16, \
-         max_f32, softmax2_fastcompact_f32, erf_f32: x86_64/avx512f activated"
+         max_f32, softmax2_fastcompact_f32, softmax2_fastcompact_f16, erf_f32: \
+         x86_64/avx512f activated"
     );
 }
 

--- a/linalg/src/x86_64_fma/softmax.rs
+++ b/linalg/src/x86_64_fma/softmax.rs
@@ -1,3 +1,6 @@
+use crate::num_traits::Zero;
+use tract_data::internal::f16;
+
 map_reduce_impl_wrap!(
     f32,
     x86_64_fma_softmax2_fastcompact_f32_32n,
@@ -247,5 +250,149 @@ mod test_x86_64_avx512_softmax2_fastcompact_f32_64n {
         is_x86_feature_detected!("avx512f"),
         f32,
         x86_64_avx512_softmax2_fastcompact_f32_64n
+    );
+}
+
+// AVX-512 f16 softmax_l2: same fast-compact-exp algorithm as the FMA f32
+// kernel, with f16 <-> f32 conversion at the IO boundary. Each loop iteration
+// handles 64 f16 (128 bytes) through 4× (ymm f16 load -> vcvtph2ps -> zmm f32
+// compute -> vcvttps2dq -> vcvtps2ph -> ymm f16 store). The sum is accumulated
+// in f32 across the loop (higher precision than the generic HSoftMaxL2 which
+// accumulates in f16) and cast to f16 at return; the SuperApproximate test
+// tolerance covers the precision delta.
+// nr=64 (multiple of 4 ymm f16 loads); alignment_items=32 (64-byte aligned).
+map_reduce_impl_wrap!(
+    f16,
+    x86_64_avx512_softmax2_fastcompact_f16_64n,
+    64,
+    32,
+    f16,
+    f16::MIN,
+    f16::zero(),
+    #[inline(never)]
+    fn run(buf: &mut [f16], max: f16) -> f16 {
+        assert!(buf.len() % 64 == 0);
+        assert!(buf.len() > 0);
+        unsafe { x86_64_avx512_softmax2_fastcompact_f16_64n_run(buf, max) }
+    },
+    #[inline(never)]
+    fn reduce_two(a: f16, b: f16) -> f16 {
+        a + b
+    }
+);
+
+#[target_feature(enable = "avx512f")]
+unsafe fn x86_64_avx512_softmax2_fastcompact_f16_64n_run(
+    buf: &mut [tract_data::internal::f16],
+    max: tract_data::internal::f16,
+) -> tract_data::internal::f16 {
+    unsafe {
+        let len = buf.len();
+        let ptr = buf.as_ptr();
+        let max_f32: f32 = max.to_f32();
+        let mut acc = 0f32;
+        const MLN2: f32 = 0.6931471805f32;
+        const A: f32 = 8388608.0f32;
+        const B: f32 = 1065353216.0f32;
+        const C: f32 = 60801.0f32;
+        const SLOPE: f32 = A / MLN2;
+        const OFFSET: f32 = B - C;
+        std::arch::asm!("
+            vbroadcastss zmm0, xmm0
+            vmovaps zmm1, zmm0
+            vmovaps zmm2, zmm0
+            vmovaps zmm3, zmm0
+
+            vpxord       zmm28, zmm28, zmm28      // 0 (clamp floor)
+            vbroadcastss zmm29, xmm29             // max (f32)
+            vbroadcastss zmm30, xmm30             // slope
+            vbroadcastss zmm31, xmm31             // offset
+            2:
+                // load 4 ymm of f16 (16 f16 per ymm = 32 bytes), convert to zmm f32
+                vcvtph2ps zmm4, [{ptr}]
+                vcvtph2ps zmm5, [{ptr} + 32]
+                vcvtph2ps zmm6, [{ptr} + 64]
+                vcvtph2ps zmm7, [{ptr} + 96]
+
+                // subtract max
+                vsubps zmm4, zmm4, zmm29
+                vsubps zmm5, zmm5, zmm29
+                vsubps zmm6, zmm6, zmm29
+                vsubps zmm7, zmm7, zmm29
+
+                // OFFSET + SLOPE * (x - max)
+                vmovaps zmm8,  zmm31
+                vmovaps zmm9,  zmm31
+                vmovaps zmm10, zmm31
+                vmovaps zmm11, zmm31
+                vfmadd231ps zmm8,  zmm4, zmm30
+                vfmadd231ps zmm9,  zmm5, zmm30
+                vfmadd231ps zmm10, zmm6, zmm30
+                vfmadd231ps zmm11, zmm7, zmm30
+
+                // max(0, ...)
+                vmaxps zmm8,  zmm8,  zmm28
+                vmaxps zmm9,  zmm9,  zmm28
+                vmaxps zmm10, zmm10, zmm28
+                vmaxps zmm11, zmm11, zmm28
+
+                // fast-compact-exp trick: the truncated i32 has the same bit
+                // pattern as the f32 ~exp(x), so accumulate AS f32 + store as f16
+                vcvttps2dq zmm8,  zmm8
+                vcvttps2dq zmm9,  zmm9
+                vcvttps2dq zmm10, zmm10
+                vcvttps2dq zmm11, zmm11
+
+                vaddps zmm0, zmm0, zmm8
+                vaddps zmm1, zmm1, zmm9
+                vaddps zmm2, zmm2, zmm10
+                vaddps zmm3, zmm3, zmm11
+
+                // convert back to f16 and store (4th operand 0 = round to nearest even)
+                vcvtps2ph [{ptr}],      zmm8,  0
+                vcvtps2ph [{ptr} + 32], zmm9,  0
+                vcvtps2ph [{ptr} + 64], zmm10, 0
+                vcvtps2ph [{ptr} + 96], zmm11, 0
+
+                add {ptr}, 128
+                sub {len}, 64
+                jnz 2b
+
+            // reduce zmm0..3 to a scalar f32 in xmm0
+            vaddps zmm0, zmm0, zmm1
+            vaddps zmm2, zmm2, zmm3
+            vaddps zmm0, zmm0, zmm2
+            vextractf64x4 ymm1, zmm0, 1
+            vaddps ymm0, ymm0, ymm1
+            vextractf128 xmm1, ymm0, 1
+            vaddps xmm0, xmm0, xmm1
+            vpermilps xmm1, xmm0, 2 + (3 << 2)
+            vaddps xmm0, xmm0, xmm1
+            vpermilps xmm1, xmm0, 1
+            vaddps xmm0, xmm0, xmm1
+            ",
+        len = inout(reg) len => _,
+        ptr = inout(reg) ptr => _,
+        inout("zmm0") acc,
+        out("zmm1") _, out("zmm2") _, out("zmm3") _,
+        out("zmm4") _, out("zmm5") _, out("zmm6") _, out("zmm7") _,
+        out("zmm8") _, out("zmm9") _, out("zmm10") _, out("zmm11") _,
+        out("zmm28") _,
+        inout("zmm29") max_f32 => _,
+        inout("zmm30") SLOPE => _,
+        inout("zmm31") OFFSET => _,
+        );
+        f16::from_f32(acc)
+    }
+}
+
+#[cfg(test)]
+mod test_x86_64_avx512_softmax2_fastcompact_f16_64n {
+    use super::*;
+    use tract_data::internal::f16;
+    crate::softmax_l2_frame_tests!(
+        is_x86_feature_detected!("avx512f"),
+        f16,
+        x86_64_avx512_softmax2_fastcompact_f16_64n
     );
 }


### PR DESCRIPTION
## Summary
- New `x86_64_avx512_softmax2_fastcompact_f16_64n` kernel: AVX-512 (zmm, 16-wide) f16 softmax_l2 mirroring the f32 fast-compact-exp algorithm. Each loop iteration processes 64 f16 (128 bytes) through 4× (`vcvtph2ps` load → zmm f32 compute → `vcvtps2ph` store).
- Sum accumulates in f32 across the loop (higher precision than the generic `HSoftMaxL2` which accumulates in f16); cast to f16 at return. The `SuperApproximate` test tolerance covers the precision delta.
- Wires into `Ops::softmax2_fastcompact_f16` from `plug_avx512f`; non-AVX512 x86 keeps the generic scalar f16 path.

Bench (single-thread, Cascade Lake, throughput Gelem/s):
- `softmax_f16/loop2` generic: 0.075
- `softmax_f16/loop2` AVX-512: 8.4    (**112× generic**)

The headline reflects the generic baseline's per-element scalar f16 arithmetic plus a scalar `fast_compact_exp_f32` call. The AVX-512 path does the exp 16-wide in f32 and pays only the IO-boundary `vcvtph2ps`/`vcvtps2ph` conversions.

## Test plan
- [x] `cargo test --release -p tract-linalg` — 2672 passed, 0 failed (6 new f16 softmax tests via `softmax_l2_frame_tests!`)
- [x] `cargo bench --bench softmax softmax_f16` — numbers above
- [x] Non-AVX512 x86 hosts unchanged (fallback exercised via `avx512f` gating in `plug_avx512f`)

## Validation environment

x86_64 KVM guest, Ubuntu 24.04.4 LTS (kernel 6.18.5), rustc 1.94.1.

- CPU: Intel Xeon @ 2.80 GHz, family 6 / model 85 / stepping 7 (Cascade Lake-SP); 4 vCPU, 1 thread/core, 1 socket.
- AVX-512 features (all confirmed by `is_x86_feature_detected!`): f, vnni, dq, bw, vl, cd.
- Cache: L1d 32 KiB/core, L2 1 MiB/core, L3 33 MiB shared. 15 GiB RAM.
- Bench discipline: `RAYON_NUM_THREADS=1`, `taskset -c 0`, Criterion warm-up 5 s / measure 15 s, sample size 100.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtQweWhf8E1W7pEJMF6ywf)_
