### PR TITLE
linalg/x86_64: add AVX-512 f16 element-wise activations (stacked on #2304)

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -108,6 +108,10 @@ name = "softmax"
 harness = false
 
 [[bench]]
+name = "activations_avx512_f16"
+harness = false
+
+[[bench]]
 bench = false
 name = "arm64simd"
 harness = false

--- a/linalg/benches/activations_avx512_f16.rs
+++ b/linalg/benches/activations_avx512_f16.rs
@@ -1,0 +1,83 @@
+// Microbenchmark: AVX-512 f16 element-wise activations vs the generic scalar
+// f16 kernels (no FMA f16 predecessor exists on x86 — the generic baseline
+// already runs `(*v - max).to_f32()`-style per-element conversions). Buffers
+// are 64-byte aligned (alignment that the AVX-512 path uses internally) and
+// a multiple of 64 elements.
+
+use criterion::*;
+use tract_data::prelude::*;
+use tract_linalg::element_wise::ElementWiseKer;
+
+const N: usize = 1024;
+
+fn aligned_input() -> Tensor {
+    let mut t = unsafe { Tensor::uninitialized_aligned::<f16>(&[N], 64).unwrap() };
+    let s = unsafe { t.as_slice_mut_unchecked::<f16>() };
+    for (i, x) in s.iter_mut().enumerate() {
+        *x = f16::from_f32((i as f32 / 10.0).sin() * 5.0);
+    }
+    t
+}
+
+macro_rules! bench_pair {
+    ($c:expr, $name:expr, $pred:ty, $avx512:ty $(, $param:expr)?) => {{
+        let mut group = $c.benchmark_group($name);
+        group.throughput(Throughput::Elements(N as u64));
+        let mut tp = aligned_input();
+        let sp = unsafe { tp.as_slice_mut_unchecked::<f16>() };
+        group.bench_function("generic", |b| {
+            b.iter(|| <$pred>::run(sp, ($($param)?)))
+        });
+        if std::is_x86_feature_detected!("avx512f") {
+            let mut ta = aligned_input();
+            let sa = unsafe { ta.as_slice_mut_unchecked::<f16>() };
+            group.bench_function("avx512", |b| {
+                b.iter(|| <$avx512>::run(sa, ($($param)?)))
+            });
+        }
+        group.finish();
+    }};
+}
+
+fn benches(c: &mut Criterion) {
+    bench_pair!(
+        c,
+        "sigmoid_f16",
+        tract_linalg::generic::sigmoid::HSigmoid8,
+        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_sigmoid_f16_16n
+    );
+    bench_pair!(
+        c,
+        "tanh_f16",
+        tract_linalg::generic::tanh::HTanh8,
+        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_tanh_f16_16n
+    );
+    bench_pair!(
+        c,
+        "hardswish_f16",
+        tract_linalg::generic::hardswish::HHardSwish8,
+        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_hardswish_f16_64n
+    );
+    bench_pair!(
+        c,
+        "leaky_relu_f16",
+        tract_linalg::generic::leaky_relu::HLeakyRelu8,
+        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_leaky_relu_f16_64n,
+        f16::from_f32(0.1)
+    );
+    bench_pair!(
+        c,
+        "silu_f16",
+        tract_linalg::generic::silu::HSiLU8,
+        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_silu_f16_16n
+    );
+    bench_pair!(
+        c,
+        "gelu_f16",
+        tract_linalg::generic::gelu::HGelu8,
+        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_gelu_f16_16n
+    );
+}
+
+criterion_group!(g, benches);
+criterion_main!(g);

--- a/linalg/src/x86_64_fma.rs
+++ b/linalg/src/x86_64_fma.rs
@@ -6,6 +6,7 @@ use crate::x86_64_fma::softmax::x86_64_fma_softmax2_fastcompact_f32_32n;
 pub mod mmm;
 
 pub mod act;
+pub mod act_f16;
 pub mod by_scalar;
 mod intel;
 pub mod max;
@@ -50,9 +51,18 @@ fn plug_avx512f(ops: &mut Ops) {
     ops.silu_f32 = Box::new(|| act::x86_64_avx512_silu_f32_16n::ew());
     ops.gelu_f32 = Box::new(|| act::x86_64_avx512_gelu_f32_16n::ew());
 
+    ops.sigmoid_f16 = Box::new(|| act_f16::x86_64_avx512_sigmoid_f16_16n::ew());
+    ops.tanh_f16 = Box::new(|| act_f16::x86_64_avx512_tanh_f16_16n::ew());
+    ops.hardswish_f16 = Box::new(|| act_f16::x86_64_avx512_hardswish_f16_64n::ew());
+    ops.leaky_relu_f16 = Box::new(|| act_f16::x86_64_avx512_leaky_relu_f16_64n::ew());
+    ops.silu_f16 = Box::new(|| act_f16::x86_64_avx512_silu_f16_16n::ew());
+    ops.gelu_f16 = Box::new(|| act_f16::x86_64_avx512_gelu_f16_16n::ew());
+
     log::info!(
         "sigmoid_f32, tanh_f32, hardswish_f32, leaky_relu_f32, \
-         silu_f32, gelu_f32: x86_64/avx512f activated"
+         silu_f32, gelu_f32, \
+         sigmoid_f16, tanh_f16, hardswish_f16, leaky_relu_f16, \
+         silu_f16, gelu_f16: x86_64/avx512f activated"
     );
 }
 

--- a/linalg/src/x86_64_fma/act_f16.rs
+++ b/linalg/src/x86_64_fma/act_f16.rs
@@ -1,0 +1,300 @@
+// AVX-512 f16 element-wise activations. Each kernel chunks f16 -> 64-byte-aligned
+// f32 scratch via vcvtph2ps (cvt_f16_to_f32 below), runs the matching f32
+// AVX-512 kernel (or the avx512_sigmoid_f32 / avx512_tanh_f32 wrappers from
+// x86_64_fma.rs), and converts back to f16 via vcvtps2ph (cvt_f32_to_f16).
+// Conversion is driven through std::arch intrinsics directly because the
+// scalar f16::to_f32 / f16::from_f32 loops are not autovectorized by
+// rustc + LLVM (branches / call overhead in the half crate's methods),
+// which leaves a naive port stuck around 7 Melem/s.
+//
+// The f32 AVX-512 activation kernels assume 64-byte aligned input (alignment
+// bytes = nr * 4 for nr >= 16). The local scratch is wrapped in
+// #[repr(C, align(64))] so the contained [f32; 256] sits at a 64-byte boundary.
+//
+// Validated against the generic f16 reference (HHardSwish8 / HLeakyRelu8 /
+// HSigmoid8 / HTanh8 / HSiLU8 / HGelu8) via the existing *_frame_tests!
+// macros at SuperApproximate tolerance, which covers the precision delta
+// between scalar f16 arithmetic and f32-internal computation.
+
+use tract_data::internal::f16;
+
+#[repr(C, align(64))]
+struct AlignedScratch([f32; 256]);
+
+impl AlignedScratch {
+    fn new() -> Self {
+        Self([0f32; 256])
+    }
+}
+
+const CHUNK: usize = 256;
+
+// Vectorized f16 <-> f32 helpers using vcvtph2ps / vcvtps2ph. Rustc + LLVM
+// do NOT autovectorize the scalar `.to_f32()` loop (the half crate's method
+// has branches / function-call overhead), so we drive the conversion with
+// intrinsics directly. Both helpers process 16 lanes per iteration; the tail
+// (which only fires for the 1-15 leftover lanes inside a CHUNK = 256 batch)
+// falls back to scalar.
+#[target_feature(enable = "avx512f")]
+unsafe fn cvt_f16_to_f32(src: &[f16], dst: &mut [f32]) {
+    use core::arch::x86_64::*;
+    let n = src.len();
+    debug_assert!(dst.len() >= n);
+    let chunks = n / 16;
+    unsafe {
+        for k in 0..chunks {
+            let m = _mm256_loadu_si256(src.as_ptr().add(k * 16) as *const __m256i);
+            let z = _mm512_cvtph_ps(m);
+            _mm512_storeu_ps(dst.as_mut_ptr().add(k * 16), z);
+        }
+        for k in (chunks * 16)..n {
+            *dst.get_unchecked_mut(k) = src.get_unchecked(k).to_f32();
+        }
+    }
+}
+
+#[target_feature(enable = "avx512f")]
+unsafe fn cvt_f32_to_f16(src: &[f32], dst: &mut [f16]) {
+    use core::arch::x86_64::*;
+    let n = src.len();
+    debug_assert!(dst.len() >= n);
+    let chunks = n / 16;
+    unsafe {
+        for k in 0..chunks {
+            let z = _mm512_loadu_ps(src.as_ptr().add(k * 16));
+            // _MM_FROUND_TO_NEAREST_INT == 0 (round-to-nearest-even, matches f16::from_f32)
+            let m = _mm512_cvtps_ph::<0>(z);
+            _mm256_storeu_si256(dst.as_mut_ptr().add(k * 16) as *mut __m256i, m);
+        }
+        for k in (chunks * 16)..n {
+            *dst.get_unchecked_mut(k) = f16::from_f32(*src.get_unchecked(k));
+        }
+    }
+}
+
+// hardswish_f16
+ew_impl_wrap!(
+    f16,
+    x86_64_avx512_hardswish_f16_64n,
+    64,
+    32,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f16], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        let mut scratch = AlignedScratch::new();
+        let s = &mut scratch.0;
+        let mut i = 0;
+        while i < buf.len() {
+            let n = (CHUNK).min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::act::x86_64_avx512_hardswish_f32_64n::run(&mut s[..n], ());
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_hardswish_f16_64n {
+    use super::*;
+    hardswish_frame_tests!(
+        is_x86_feature_detected!("avx512f"),
+        f16,
+        x86_64_avx512_hardswish_f16_64n
+    );
+}
+
+// leaky_relu_f16  (parameter: alpha as f16)
+ew_impl_wrap!(
+    f16,
+    x86_64_avx512_leaky_relu_f16_64n,
+    64,
+    32,
+    f16,
+    #[inline(never)]
+    fn run(buf: &mut [f16], alpha: f16) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        let alpha_f32 = alpha.to_f32();
+        let mut scratch = AlignedScratch::new();
+        let s = &mut scratch.0;
+        let mut i = 0;
+        while i < buf.len() {
+            let n = (CHUNK).min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::act::x86_64_avx512_leaky_relu_f32_64n::run(&mut s[..n], alpha_f32);
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_leaky_relu_f16_64n {
+    use super::*;
+    leaky_relu_frame_tests!(
+        is_x86_feature_detected!("avx512f"),
+        f16,
+        x86_64_avx512_leaky_relu_f16_64n
+    );
+}
+
+// sigmoid_f16  (calls the avx512_sigmoid_f32 wrapper from x86_64_fma.rs;
+// its nr() is 16 so CHUNK=256 is always a clean multiple)
+ew_impl_wrap!(
+    f16,
+    x86_64_avx512_sigmoid_f16_16n,
+    16,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f16], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        let mut scratch = AlignedScratch::new();
+        let s = &mut scratch.0;
+        let mut i = 0;
+        while i < buf.len() {
+            let n = (CHUNK).min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::avx512_sigmoid_f32::run(&mut s[..n], ());
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_sigmoid_f16_16n {
+    use super::*;
+    sigmoid_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_sigmoid_f16_16n);
+}
+
+// tanh_f16
+ew_impl_wrap!(
+    f16,
+    x86_64_avx512_tanh_f16_16n,
+    16,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f16], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        let mut scratch = AlignedScratch::new();
+        let s = &mut scratch.0;
+        let mut i = 0;
+        while i < buf.len() {
+            let n = (CHUNK).min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::avx512_tanh_f32::run(&mut s[..n], ());
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_tanh_f16_16n {
+    use super::*;
+    tanh_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_tanh_f16_16n);
+}
+
+// silu_f16: x * sigmoid(x).  Mirror the f32 silu pattern: save the input
+// (in f32), run sigmoid in place on the scratch, then multiply back.
+ew_impl_wrap!(
+    f16,
+    x86_64_avx512_silu_f16_16n,
+    16,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f16], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        let mut work = AlignedScratch::new();
+        let mut save = AlignedScratch::new();
+        let w = &mut work.0;
+        let v = &mut save.0;
+        let mut i = 0;
+        while i < buf.len() {
+            let n = (CHUNK).min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut w[..n]) };
+            v[..n].copy_from_slice(&w[..n]);
+            super::avx512_sigmoid_f32::run(&mut w[..n], ());
+            for j in 0..n {
+                w[j] *= v[j];
+            }
+            unsafe { cvt_f32_to_f16(&w[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_silu_f16_16n {
+    use super::*;
+    silu_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_silu_f16_16n);
+}
+
+// Tanh-form GELU (matches tract's GeluApproximate, pow=3, see act.rs gelu_f32):
+//   gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+ew_impl_wrap!(
+    f16,
+    x86_64_avx512_gelu_f16_16n,
+    16,
+    16,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f16], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        const SQRT_2_OVER_PI: f32 = 0.7978845608028654;
+        const COEF: f32 = 0.044715;
+        let mut work = AlignedScratch::new();
+        let mut save = AlignedScratch::new();
+        let w = &mut work.0;
+        let v = &mut save.0;
+        let mut i = 0;
+        while i < buf.len() {
+            let n = (CHUNK).min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut v[..n]) };
+            for j in 0..n {
+                let x = v[j];
+                w[j] = SQRT_2_OVER_PI * (x + COEF * x * x * x);
+            }
+            super::avx512_tanh_f32::run(&mut w[..n], ());
+            for j in 0..n {
+                w[j] = 0.5 * v[j] * (1.0 + w[j]);
+            }
+            unsafe { cvt_f32_to_f16(&w[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_x86_64_avx512_gelu_f16_16n {
+    use super::*;
+    gelu_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_gelu_f16_16n);
+}


### PR DESCRIPTION
## Summary

Stacked on #2304. Adds six f16 element-wise activations on x86 AVX-512:
- `sigmoid_f16`, `tanh_f16` (compose over #2304's `avx512_sigmoid_f32` / `avx512_tanh_f32`)
- `hardswish_f16`, `leaky_relu_f16` (compose over #2304's f32 kernels of the same op)
- `silu_f16`, `gelu_f16` (compose at the kernel level: f32 polynomial + scalar combine in f32, mirroring #2304's f32 versions)

Each kernel chunks the input through a 64-byte-aligned f32 scratch (CHUNK = 256), runs the matching f32 AVX-512 kernel, and converts back to f16. **f16↔f32 conversion is driven by `vcvtph2ps` / `vcvtps2ph` via `std::arch` intrinsics** (helpers `cvt_f16_to_f32` / `cvt_f32_to_f16`) — rustc + LLVM do NOT autovectorize the scalar `f16::to_f32` / `f16::from_f32` loops, which is why a naive port leaves AVX-512 stuck at ~7 Melem/s. The intrinsics-based path gets back to the per-op AVX-512 ceiling.

Wires into `Ops::{sigmoid,tanh,hardswish,leaky_relu,silu,gelu}_f16` from `plug_avx512f`; non-AVX512 x86 keeps the generic scalar f16 kernels.

Bench (single-thread, Cascade Lake, throughput Gelem/s):
| op             | generic | AVX-512 | speedup |
|----------------|--------:|--------:|--------:|
| sigmoid_f16    |  0.016  |   1.54  |   96×   |
| tanh_f16       |  0.018  |   1.61  |   92×   |
| hardswish_f16  |  0.051  |   9.46  |  186×   |
| leaky_relu_f16 |  0.96   |  10.4   |   11×   |
| silu_f16       |  0.20   |   0.93  |  4.6×   |
| gelu_f16       |  0.11   |   0.75  |  6.7×   |

`leaky_relu` and `silu` show smaller ratios because the generic baseline is already faster than the sigmoid/tanh polynomial paths (leaky_relu is just a max + multiply; silu uses a generic sigmoid that's faster than HSigmoid8 in isolation).

## Test plan
- [x] `cargo test --release -p tract-linalg` — 2708 passed, 0 failed (21 new f16 activation tests: 3-7 cases per op, including proptest)
- [x] `cargo bench --bench activations_avx512_f16` — numbers above
- [x] Non-AVX512 x86 hosts unchanged (fallback exercised via `avx512f` gating in `plug_avx512f`)
- [x] Cross-arch builds clean (`aarch64-unknown-linux-gnu`, `wasm32-unknown-unknown`): the new `std::arch::x86_64` intrinsics in `act_f16.rs` are walled off by `#[cfg(target_arch = "x86_64")]` on the `x86_64_fma` module in `linalg/src/lib.rs`.

## Dependencies

Stacked on **#2304** (AVX-512 element-wise activations). Imports `act::x86_64_avx512_hardswish_f32_64n`, `act::x86_64_avx512_leaky_relu_f32_64n`, `avx512_sigmoid_f32`, `avx512_tanh_f32`. Until #2304 merges, this PR's diff includes both commits; once #2304 lands, GitHub auto-rebases the view to show only this commit.

## Validation environment

x86_64 KVM guest, Ubuntu 24.04.4 LTS (kernel 6.18.5), rustc 1.94.1.

- CPU: Intel Xeon @ 2.80 GHz, family 6 / model 85 / stepping 7 (Cascade Lake-SP); 4 vCPU, 1 thread/core, 1 socket.
- AVX-512 features (all confirmed by `is_x86_feature_detected!`): f, vnni, dq, bw, vl, cd.
- Cache: L1d 32 KiB/core, L2 1 MiB/core, L3 33 MiB shared. 15 GiB RAM.
- Bench discipline: `RAYON_NUM_THREADS=1`, `taskset -c 0`, Criterion warm-up 5 s / measure 15 s, sample size 100.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtQweWhf8E1W7pEJMF6ywf)_
