### PR TITLE
transformers: route fused ScaledMaskedSoftmax through an accurate vectorized exp

### DIFF
--- a/core/src/ops/nn/softmax/mod.rs
+++ b/core/src/ops/nn/softmax/mod.rs
@@ -31,6 +31,10 @@ pub enum SoftmaxExp {
     Libc,
     // https://nic.schraudolph.org/pubs/Schraudolph99.pdf
     FastCompact,
+    /// Accurate (~1-2 ulp) vectorized exp via the linalg `softmax2_accurate`
+    /// kernels: SIMD speed like FastCompact but true-softmax accuracy, and it
+    /// yields NaN (not a spurious 0) on fully-masked rows, matching libc.
+    Accurate,
 }
 
 #[derive(Debug, Clone, new, Hash, Default, PartialEq, Eq)]
@@ -239,6 +243,9 @@ impl Softmax {
                     }
                     SoftmaxExp::FastCompact => (tract_linalg::ops().softmax2_fastcompact_f16)()
                         .run_with_params(slice, max)?,
+                    SoftmaxExp::Accurate => {
+                        (tract_linalg::ops().softmax2_accurate_f16)().run_with_params(slice, max)?
+                    }
                 };
                 let rsum = sum.recip();
                 (tract_linalg::ops().mul_by_scalar_f16)().run_with_params(slice, rsum)?;
@@ -271,6 +278,9 @@ impl Softmax {
                     }
                     SoftmaxExp::FastCompact => (tract_linalg::ops().softmax2_fastcompact_f32)()
                         .run_with_params(slice, max)?,
+                    SoftmaxExp::Accurate => {
+                        (tract_linalg::ops().softmax2_accurate_f32)().run_with_params(slice, max)?
+                    }
                 };
                 let rsum = sum.recip();
                 (tract_linalg::ops().mul_by_scalar_f32)().run_with_params(slice, rsum)?;

--- a/linalg/src/generic/reduce.rs
+++ b/linalg/src/generic/reduce.rs
@@ -271,8 +271,10 @@ pub mod softmax_l2 {
         // 2ⁿ by exponent construction; n ∈ [-127, 127] thanks to the clamp.
         let pow2n = f32::from_bits((((n as i32) + 127) as u32) << 23);
         let e = y * pow2n;
-        // -inf / deep underflow → exact 0 (NaN propagates: `NaN < LO` is false).
-        if x < LO { 0.0 } else { e }
+        // Branchless underflow flush keeps the dataflow vectorizable:
+        // 0 when x < LO, else e (NaN propagates: `NaN < LO` is false).
+        let flush = -((x < LO) as i32) as u32;
+        f32::from_bits(e.to_bits() & !flush)
     }
 
     #[cfg(test)]

--- a/linalg/src/generic/reduce.rs
+++ b/linalg/src/generic/reduce.rs
@@ -158,6 +158,58 @@ pub mod softmax_l2 {
         }
     );
 
+    // Accurate (~1-2 ulp) softmax kernels: same map+reduce shape as the
+    // FastCompact ones above, but using `accurate_exp_f32` instead of the
+    // coarse Schraudolph approximation, and padding the SIMD tail with
+    // -inf (so masked/padding lanes contribute exactly 0 to the sum).
+    map_reduce_impl_wrap!(
+        f32,
+        SSoftMaxL2Accurate,
+        4,
+        4,
+        f32,
+        f32::NEG_INFINITY,
+        0.0,
+        fn run(x: &mut [f32], max: f32) -> f32 {
+            debug_assert!(x.len() % Self::nr() == 0);
+            debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
+            let mut sum = 0.;
+            for v in x.iter_mut() {
+                let y = accurate_exp_f32(*v - max);
+                *v = y;
+                sum += y;
+            }
+            sum
+        },
+        fn reduce_two(a: f32, b: f32) -> f32 {
+            a + b
+        }
+    );
+
+    map_reduce_impl_wrap!(
+        f16,
+        HSoftMaxL2Accurate,
+        8,
+        8,
+        f16,
+        f16::NEG_INFINITY,
+        f16::zero(),
+        fn run(x: &mut [f16], max: f16) -> f16 {
+            debug_assert!(x.len() % Self::nr() == 0);
+            debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
+            let mut sum = f16::zero();
+            for v in x.iter_mut() {
+                let y = f16::from_f32(accurate_exp_f32((*v - max).to_f32()));
+                *v = y;
+                sum += y;
+            }
+            sum
+        },
+        fn reduce_two(a: f16, b: f16) -> f16 {
+            a + b
+        }
+    );
+
     // ported from https://github.com/gnuradio/volk/blob/master/kernels/volk/volk_32f_expfast_32f.h
     // probably inspired from https://nic.schraudolph.org/pubs/Schraudolph99.pdf
     // not that the cast to u32 deals with negative right, while implem in volk code are wrong in some
@@ -172,6 +224,57 @@ pub mod softmax_l2 {
         f32::from_bits(((SLOPE * v) + OFFSET) as u32)
     }
 
+    /// Accurate (~1-2 ulp) vectorizable `exp`, used by the SSoftMaxL2Accurate /
+    /// HSoftMaxL2Accurate softmax kernels.
+    ///
+    /// Cephes-style range reduction `x = n*ln2 + r` (Cody-Waite two-part ln2)
+    /// followed by a degree-6 polynomial on `r` in `[-ln2/2, ln2/2]` and a
+    /// scaling by `2^n` via direct exponent construction. Branch-free apart
+    /// from one final `select`, so the caller's per-lane loop auto-vectorizes.
+    ///
+    /// Guarantees relied upon by softmax:
+    /// * `exp(0) == 1.0` exactly (the row max normalises cleanly);
+    /// * `exp(-inf) == 0.0` exactly and deep underflow flushes to `0.0`, so a
+    ///   fully-masked row sums to 0 and the dispatch's `0·(1/0)` yields `NaN`,
+    ///   matching the libc path and the numpy reference (rather than the
+    ///   spurious finite 0 the old `f32::MIN` padding produced).
+    ///
+    /// Softmax only ever evaluates `x = element - max ≤ 0`; the positive domain
+    /// is clamped purely for safety.
+    #[inline(always)]
+    pub fn accurate_exp_f32(x: f32) -> f32 {
+        const LOG2E: f32 = 1.44269504088896341f32;
+        // Cody-Waite split of ln2: C1 + C2 == ln2 to extra precision.
+        const C1: f32 = 0.693359375f32;
+        const C2: f32 = -2.12194440e-4f32;
+        const HI: f32 = 88.3762626647949f32;
+        const LO: f32 = -88.3762626647949f32;
+        // polynomial coefficients (Cephes expf)
+        const P0: f32 = 1.9875691500e-4f32;
+        const P1: f32 = 1.3981999507e-3f32;
+        const P2: f32 = 8.3334519073e-3f32;
+        const P3: f32 = 4.1665795894e-2f32;
+        const P4: f32 = 1.6666665459e-1f32;
+        const P5: f32 = 5.0000001201e-1f32;
+
+        let xc = x.clamp(LO, HI);
+        let n = (LOG2E * xc + 0.5).floor();
+        let g = xc - n * C1 - n * C2;
+        let z = g * g;
+        let mut y = P0;
+        y = y * g + P1;
+        y = y * g + P2;
+        y = y * g + P3;
+        y = y * g + P4;
+        y = y * g + P5;
+        y = y * z + g + 1.0;
+        // 2ⁿ by exponent construction; n ∈ [-127, 127] thanks to the clamp.
+        let pow2n = f32::from_bits((((n as i32) + 127) as u32) << 23);
+        let e = y * pow2n;
+        // -inf / deep underflow → exact 0 (NaN propagates: `NaN < LO` is false).
+        if x < LO { 0.0 } else { e }
+    }
+
     #[cfg(test)]
     #[macro_use]
     pub mod s {
@@ -183,5 +286,67 @@ pub mod softmax_l2 {
     pub mod h {
         use super::*;
         crate::softmax_l2_frame_tests!(true, f16, HSoftMaxL2);
+    }
+
+    #[cfg(test)]
+    mod accurate {
+        use super::{SSoftMaxL2Accurate, accurate_exp_f32};
+        use crate::frame::reduce::MapReduceKer;
+
+        // Non-tautological: the accurate kernel's exp is validated against libc
+        // exp (the FastCompact kernels are only ever compared against
+        // fast_compact itself, which can't catch divergence from true softmax).
+        #[test]
+        fn accurate_exp_matches_libc() {
+            // softmax only feeds x <= 0; sweep that domain densely.
+            let mut x = 0.0f32;
+            while x > -60.0 {
+                let got = accurate_exp_f32(x);
+                let want = x.exp();
+                let rel = (got - want).abs() / want;
+                assert!(rel < 2e-6, "x={x}: accurate={got} libc={want} rel={rel}");
+                x -= 0.0007;
+            }
+        }
+
+        #[test]
+        fn accurate_exp_edges() {
+            assert_eq!(accurate_exp_f32(0.0), 1.0); // row max normalises cleanly
+            assert_eq!(accurate_exp_f32(f32::NEG_INFINITY), 0.0); // fully-masked -> 0
+            assert_eq!(accurate_exp_f32(-1000.0), 0.0); // deep underflow flushes
+            assert!(accurate_exp_f32(f32::NAN).is_nan()); // NaN propagates
+        }
+
+        // A fully-masked row (every element -inf) must sum to exactly 0 -> the
+        // dispatch's 1/0 = inf, 0*inf = NaN, matching the libc path and the numpy
+        // reference. Driven through the frame (`red().run_with_params`) so the
+        // kernel always sees a correctly-aligned slice (the raw `K::run` has a
+        // debug_assert on alignment) and the SIMD tail is padded with
+        // `map_neutral` (= -inf, exp -> 0), not f32::MIN (exp -> ~1, which would
+        // make the row sum to a spurious nonzero and yield a finite 0). Length 6
+        // exercises both an aligned 4-lane chunk and a 2-lane padded tail.
+        #[test]
+        fn fully_masked_row_sums_to_zero() {
+            use crate::frame::reduce::MapReduce;
+            let op = SSoftMaxL2Accurate::red();
+            let mut row = vec![f32::NEG_INFINITY; 6];
+            // the max reduce returns f32::MIN (its neutral) for an all -inf row.
+            let sum = op.run_with_params(&mut row, f32::MIN).unwrap();
+            assert_eq!(sum, 0.0, "fully-masked row must sum to 0, got {sum}");
+            assert!(row.iter().all(|&v| v == 0.0));
+        }
+
+        // The SIMD tail is padded with `map_neutral`; it must be -inf so padding
+        // lanes contribute exp(-inf - max) = 0. With the old f32::MIN padding, a
+        // fully-masked row's lanes computed exp(f32::MIN - f32::MIN) = exp(0) ≈ 1,
+        // inflating the sum and turning the result into a spurious finite 0
+        // instead of NaN.
+        #[test]
+        fn map_neutral_is_neg_inf() {
+            assert_eq!(
+                <SSoftMaxL2Accurate as MapReduceKer<f32, f32>>::map_neutral(),
+                f32::NEG_INFINITY
+            );
+        }
     }
 }

--- a/linalg/src/generic/reduce.rs
+++ b/linalg/src/generic/reduce.rs
@@ -258,16 +258,16 @@ pub mod softmax_l2 {
         const P5: f32 = 5.0000001201e-1f32;
 
         let xc = x.clamp(LO, HI);
-        let n = (LOG2E * xc + 0.5).floor();
-        let g = xc - n * C1 - n * C2;
+        let n = xc.mul_add(LOG2E, 0.5).floor();
+        let g = (-n).mul_add(C2, (-n).mul_add(C1, xc));
         let z = g * g;
         let mut y = P0;
-        y = y * g + P1;
-        y = y * g + P2;
-        y = y * g + P3;
-        y = y * g + P4;
-        y = y * g + P5;
-        y = y * z + g + 1.0;
+        y = y.mul_add(g, P1);
+        y = y.mul_add(g, P2);
+        y = y.mul_add(g, P3);
+        y = y.mul_add(g, P4);
+        y = y.mul_add(g, P5);
+        y = y.mul_add(z, g + 1.0);
         // 2ⁿ by exponent construction; n ∈ [-127, 127] thanks to the clamp.
         let pow2n = f32::from_bits((((n as i32) + 127) as u32) << 23);
         let e = y * pow2n;

--- a/linalg/src/lib.rs
+++ b/linalg/src/lib.rs
@@ -113,6 +113,8 @@ pub struct Ops {
     /// a single 2-pass kernel. Called once per row by `core::ops::nn::RmsNorm`
     /// when the input is f32 and the axis is the last (contiguous) one.
     pub rms_norm_f32: Box<dyn Fn(&mut [f32], f32) + Send + Sync>,
+    pub softmax2_accurate_f16: Box<dyn Fn() -> Box<dyn reduce::MapReduce<f16, f16>> + Send + Sync>,
+    pub softmax2_accurate_f32: Box<dyn Fn() -> Box<dyn reduce::MapReduce<f32, f32>> + Send + Sync>,
 }
 
 impl Ops {
@@ -250,6 +252,8 @@ pub fn generic() -> Ops {
         softmax2_fastcompact_f16: Box::new(|| generic::reduce::softmax_l2::HSoftMaxL2::red()),
         softmax2_fastcompact_f32: Box::new(|| generic::reduce::softmax_l2::SSoftMaxL2::red()),
         rms_norm_f32: Box::new(generic::rms_norm::rms_norm_f32),
+        softmax2_accurate_f16: Box::new(|| generic::reduce::softmax_l2::HSoftMaxL2Accurate::red()),
+        softmax2_accurate_f32: Box::new(|| generic::reduce::softmax_l2::SSoftMaxL2Accurate::red()),
     };
     crate::generic::mmm::plug(&mut ops);
     ops

--- a/nnef/src/ops/core/softmax.rs
+++ b/nnef/src/ops/core/softmax.rs
@@ -39,6 +39,7 @@ pub fn deser_softmax(
     let exp: Option<String> = invocation.get_named_arg_as(builder, "exp")?;
     let exp = match exp.as_deref() {
         Some("fast_compact") => SoftmaxExp::FastCompact,
+        Some("accurate") => SoftmaxExp::Accurate,
         _ => SoftmaxExp::Libc,
     };
 
@@ -71,10 +72,10 @@ fn ser_softmax(
     let mut args = vec![("axes", ints(&op.axes))];
     let op_name = match op.kind {
         SoftmaxKind::Softmax(exp) => {
-            if exp == SoftmaxExp::FastCompact {
-                args.push(("exp", string("fast_compact")))
-            } else {
-                return Ok(None);
+            match exp {
+                SoftmaxExp::FastCompact => args.push(("exp", string("fast_compact"))),
+                SoftmaxExp::Accurate => args.push(("exp", string("accurate"))),
+                SoftmaxExp::Libc => return Ok(None),
             };
             "tract_core_softmax"
         }

--- a/transformers/src/ops/scaled_masked_softmax.rs
+++ b/transformers/src/ops/scaled_masked_softmax.rs
@@ -98,9 +98,14 @@ impl EvalOp for ScaledMaskedSoftmax {
             Add.eval(scaled.into(), mask.clone(), dt)?.into()
         };
 
-        let softmax_out = Softmax::new(softmax_axis, None, SoftmaxKind::Softmax(SoftmaxExp::Libc))
-            .eval(tvec![pre_softmax])?[0]
-            .clone();
+        // Accurate vectorized softmax: routes through the linalg SIMD
+        // `softmax2_accurate` kernels (true-softmax accuracy, unlike FastCompact)
+        // and yields NaN — not a spurious 0 — on fully-masked rows, matching the
+        // scalar libc path and the numpy reference.
+        let softmax_out =
+            Softmax::new(softmax_axis, None, SoftmaxKind::Softmax(SoftmaxExp::Accurate))
+                .eval(tvec![pre_softmax])?[0]
+                .clone();
 
         if self.post_softmax_mask {
             // Zero out positions where the bool mask is false.


### PR DESCRIPTION
## What

`ScaledMaskedSoftmax::eval` hard-coded `SoftmaxExp::Libc`, so the fused attention softmax always ran scalar libm `expf` and never reached the linalg SIMD softmax kernels — a real perf gap. This PR closes that gap **without** sacrificing accuracy, by adding an **accurate vectorizable `exp`** and routing the fused softmax through it.

> **History:** this PR originally just flipped `Libc → FastCompact`. CI (and a local full-suite run) showed that was wrong on two counts, so the approach was reworked — see below.

## Why not FastCompact

Switching the fused softmax to the existing `SoftmaxExp::FastCompact` (Schraudolph approximation) fails the `scaled_masked_softmax` / `sdpa` proptests two independent ways:

1. **Precision.** FastCompact's `exp` is ~0.5% off true softmax — outside the suite's `Approximate` tolerance (f32 rtol `5e-4`), producing 30%+ outliers. (The existing `softmax_l2` frame test only compares FastCompact against *itself*, so it never caught this.)
2. **Fully-masked rows → NaN mismatch.** On an all-`-inf` row the FastCompact kernel pads the SIMD tail with `f32::MIN` and computes `exp(f32::MIN - f32::MIN) ≈ 1`, so the row sums to a nonzero value and yields a finite `0` where the scalar libc path and the numpy reference both yield `NaN` (`0 * 1/0`).

This mirrors what ggml/llama.cpp concluded ([ggml-org/llama.cpp#7154](https://github.com/ggml-org/llama.cpp/pull/7154)): keep an *accurate* vectorized `expf` for softmax, reserve fast-approx `exp` for error-tolerant ops.

## What changed

- **linalg:** `accurate_exp_f32` — a Cephes-style range-reduced `exp` (Cody-Waite `ln2` split + degree-6 polynomial + `2^n` by exponent construction). Measured **max rel error ~1.9e-6 vs libc** over the softmax domain `[0, -60]`. `exp(0)==1` and `exp(-inf)==0` exactly; deep underflow flushes to `0`; `NaN` propagates.
- **linalg:** `SSoftMaxL2Accurate` / `HSoftMaxL2Accurate` map-reduce kernels, exposed as `softmax2_accurate_{f32,f16}`. They pad the SIMD tail with **`-inf`** (not `f32::MIN`), so masked/padding lanes contribute exactly `0` and a fully-masked row sums to `0` → `NaN`, matching libc and the reference.
- **core:** new `SoftmaxExp::Accurate` variant + dispatch (f32/f16).
- **nnef:** `exp = "accurate"` de/serialization round-trip.
- **transformers:** `ScaledMaskedSoftmax::eval` uses `SoftmaxExp::Accurate`.

`Libc` remains the default everywhere; `FastCompact` is untouched. This adds a third, accurate-but-vectorized option and points fused attention at it.

## Tests

- New linalg tests validate `accurate_exp_f32` **against libc** (not against itself) and cover the fully-masked degenerate row (sum == 0).
- `scaled_masked_softmax` + `sdpa` proptests (f16/f32 × raw/decluttered/optimized) pass on **native** and **wasm32-wasip1** (the job that originally failed).
- Full `tract-linalg` suite green; `tract-core` / `nnef` / `transformers` green; `cargo fmt` clean; no new clippy warnings on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
