### PR TITLE
ci/large_models: add pr_number workflow_dispatch input

### DIFF
--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron:  '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional PR number to test (from fork ok). Leave empty to run on selected branch."
+        required: false
+        type: number
 
 env:
   LARGE_MODELS: true
@@ -13,8 +18,33 @@ permissions:
   contents: read
 
 jobs:
-  cli: 
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      test_ref: ${{ steps.set.outputs.test_ref }}
+    steps:
+      - id: set
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const prInput = context.payload.inputs?.pr_number ?? context.payload.pull_request?.number;
+            let ref;
+            if (prInput) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(prInput),
+              });
+              ref = pr.data.head.sha;
+            } else {
+              ref = process.env.GITHUB_SHA;
+            }
+            core.info(`test_ref: ${ref}`);
+            core.setOutput('test_ref', ref);
+
+  cli:
     name: Build tract on ${{ matrix.os }}
+    needs: prepare
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,6 +52,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ needs.prepare.outputs.test_ref }}
+          fetch-depth: 0
           persist-credentials: false
       - run: |
           ROOT=. ./.travis/ci-system-setup.sh
@@ -33,6 +65,7 @@ jobs:
           path: ./target/opt-no-lto/tract
 
   foundation-llms:
+    needs: prepare
     runs-on: ubuntu-latest
     outputs:
       models: ${{steps.set-matrix.outputs.models}}
@@ -55,7 +88,7 @@ jobs:
 
   foundation-llm:
     name: ${{ matrix.os }} / ${{matrix.rt}} / ${{ matrix.model }} / ${{ matrix.q }}
-    needs: [ cli, foundation-llms ]
+    needs: [ prepare, cli, foundation-llms ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -86,6 +119,8 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
+        fetch-depth: 0
         persist-credentials: false
     - name: Configure AWS Credentials
       continue-on-error: true
@@ -119,7 +154,7 @@ jobs:
 
   parakeet-tdt-600m-v3:
     name: ${{matrix.os}} / Parakeet TDT 600m v3
-    needs: [ cli ]
+    needs: [ prepare, cli ]
     strategy:
       matrix:
         os: [ macOS, cuda-lovelace ]
@@ -131,6 +166,8 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
+        fetch-depth: 0
         persist-credentials: false
     - run: echo uname=$(uname) >> $GITHUB_ENV
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -148,7 +185,7 @@ jobs:
 
   nemotron-speech-streaming-en-06b:
     name: ${{matrix.os}} / Nemotron speech streaming en 0.6b
-    needs: [ cli ]
+    needs: [ prepare, cli ]
     strategy:
       matrix:
         os: [ macOS, cuda-lovelace ]
@@ -160,6 +197,8 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
+        fetch-depth: 0
         persist-credentials: false
     - run: echo uname=$(uname) >> $GITHUB_ENV
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
Mirrors full.yml + cross-platform.yml. The workflow already runs on `pull_request:`; this adds the manual dispatch path for testing a specific PR (including from a fork) from the Actions tab. A new `prepare` job derives `test_ref` from the `pr_number` input or from the triggering pull_request, and every job now checks out at that ref.