### PR TITLE
scan: decouple force_scan_external_state from seq concretization

### DIFF
--- a/core/src/transform.rs
+++ b/core/src/transform.rs
@@ -291,16 +291,16 @@ register_model_transform!("set_symbols", SetSymbolsConfig, |config| Ok(Box::new(
 )));
 
 /// Ad-hoc fix-up for NNEF artifacts exported before Scan grew the
-/// `external_state` flag (issue #2157). For every Scan in the model:
-/// 1. Substitute the scan-axis symbol on the Scan input with 1 across the
-///    whole model (caller is bound by the per-call seq=1 contract that
-///    external state management implies).
-/// 2. Set `external_state = true`.
+/// `external_state` flag (issue #2157). Sets `external_state = true` on every
+/// Scan, asserting that the caller plumbs initial state in and reads final
+/// state out each call. Apply only when the loaded model is known to use
+/// external state management, e.g. the parakeet decoder. Cheaper than
+/// re-exporting cached NNEF.
 ///
-/// After this transform, the standard declutter pipeline sees `iters == 1`
-/// on each Scan and `declutter_single_loop` inlines the body. Apply only
-/// when the loaded model is known to use external state management, e.g.
-/// the parakeet decoder. Cheaper than re-exporting cached NNEF.
+/// This does *not* touch the sequence dimension. Inlining the Scan body via
+/// `declutter_single_loop` additionally requires `iters == 1`, which is the
+/// caller's per-call contract — concretize it explicitly (e.g. `--set
+/// TARGETS__TIME=1`), separately from this flag.
 #[derive(Debug)]
 struct ForceScanExternalState;
 
@@ -310,22 +310,7 @@ impl ModelTransform for ForceScanExternalState {
     }
 
     fn transform(&self, model: &mut TypedModel) -> TractResult<()> {
-        use crate::ops::scan::{InputMapping, Scan};
-        let mut subs: HashMap<Symbol, TDim> = HashMap::new();
-        for node in &model.nodes {
-            let Some(scan) = node.op_as::<Scan>() else { continue };
-            for (slot, mapping) in scan.input_mapping.iter().enumerate() {
-                let InputMapping::Scan(info) = mapping else { continue };
-                let outer = node.inputs[slot];
-                let dim = &model.outlet_fact(outer)?.shape[info.axis];
-                if let TDim::Sym(s) = dim {
-                    subs.insert(s.clone(), TDim::Val(1));
-                }
-            }
-        }
-        if !subs.is_empty() {
-            *model = model.set_symbols(&subs)?;
-        }
+        use crate::ops::scan::Scan;
         for node in &mut model.nodes {
             if let Some(scan) = node.op_as_mut::<Scan>() {
                 scan.external_state = true;

--- a/harness/nemotron-speech-streaming-en-0.6b/ci.sh
+++ b/harness/nemotron-speech-streaming-en-0.6b/ci.sh
@@ -25,11 +25,13 @@ do
 			nnef_file=$MODEL.$m.nnef.tgz
 		fi
 		# Decoder is stepped one token per call by the caller (external state
-		# carry); force the Scan op into single-iter inlining so the LSTM body
-		# lands on the GPU instead of bouncing through CPU each step.
+		# carry): assert the external_state flag and concretize the seq symbol
+		# to 1 so the Scan inlines and the LSTM body lands on the GPU instead of
+		# bouncing through CPU each step. set_symbols RON must stay space-free
+		# ($extra_transforms is passed unquoted).
 		extra_transforms=""
 		if [ "$m" = "decoder" ]; then
-			extra_transforms="-t force_scan_external_state"
+			extra_transforms='-t force_scan_external_state -t set_symbols(values:{"TARGETS__TIME":1})'
 		fi
 		$CACHE_FILE \
 			$S3DIR/$nnef_file \

--- a/harness/parakeet-tdt-600m-v3/ci.sh
+++ b/harness/parakeet-tdt-600m-v3/ci.sh
@@ -22,13 +22,15 @@ do
 			nnef_file=nvidia--parakeet-tdt-0.6b-v3-f32f32.$m.nnef.tgz
 		fi
 		# decoder LSTM is externally state-managed (caller plumbs state_0/
-		# state_1 every run): force the external_state flag on Scans
-		# pre-optimisation so declutter_single_loop inlines them, and assert
-		# no Scan survives. Cached NNEF predates the flag — see #2157.
+		# state_1 every run) and stepped one token per call: assert the
+		# external_state flag on Scans (cached NNEF predates it — see #2157)
+		# and concretize the seq symbol to 1, so declutter_single_loop inlines
+		# them. Assert no Scan survives. set_symbols RON must stay space-free
+		# ($extra_transform is passed unquoted).
 		extra_transform=""
 		extra_assert=""
 		if [ "$m" = "decoder" ]; then
-			extra_transform="-t force_scan_external_state"
+			extra_transform='-t force_scan_external_state -t set_symbols(values:{"T":1})'
 			extra_assert="--assert-op-count Scan 0"
 		fi
 		$CACHE_FILE \


### PR DESCRIPTION
The transform conflated two concerns: flipping external_state (a fixup for NNEF artifacts predating the flag) and substituting the scan-axis symbol with 1 model-wide. The latter is the caller's per-call seq=1 contract, needed only for declutter_single_loop's separate iters==1 gate, not implied by external state. Keep the transform flag-only; harnesses now drive inlining with an explicit -t set_symbols (T / TARGETS__TIME = 1) alongside the flag.