### PR TITLE
pulse/MultiBroadcastTo: linearity-checked per-pulse size for stream axis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "tract"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "boow",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "tract-api"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "boow",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "tract-cli"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "box_drawing",
  "clap",
@@ -4680,7 +4680,7 @@ dependencies = [
 
 [[package]]
 name = "tract-core"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "tract-cuda"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "criterion",
@@ -4736,7 +4736,7 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "criterion",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "tract-extra"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "approx",
  "criterion",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "tract-ffi"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "flate2",
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "tract-gpu"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "derive-new",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "derive-new",
  "env_logger",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "tract-libcli"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "box_drawing",
  "clap",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "byteorder",
  "cc",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "tract-metal"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "criterion",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "byteorder",
  "erased-serde",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef-resources"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "nom 8.0.0",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "bytes",
  "criterion",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "dyn-eq",
  "env_logger",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "tract-proxy"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "anyhow",
  "boow",
@@ -4991,14 +4991,14 @@ dependencies = [
 
 [[package]]
 name = "tract-proxy-sys"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "bindgen 0.72.1",
 ]
 
 [[package]]
 name = "tract-pulse"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "downcast-rs",
  "dyn-eq",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "tract-pulse-opl"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "downcast-rs",
  "dyn-eq",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "tract-tensorflow"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "bytes",
  "criterion",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "tract-tflite"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "derive-new",
  "flatbuffers",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "tract-transformers"
-version = "0.23.0"
+version = "0.23.1-pre"
 dependencies = [
  "float-ord",
  "tract-nnef",

--- a/pulse/src/lib.rs
+++ b/pulse/src/lib.rs
@@ -293,4 +293,66 @@ mod tests {
         // downstream meet point.  Now it should pulsify without error.
         let _pulse = PulsedModel::new(&model, t, &2.to_dim()).expect("pulsification");
     }
+
+    /// `MultiBroadcastTo` pulsifier baseline: a target shape that grows
+    /// linearly with the streaming symbol (`1 + S/2` -- the canonical
+    /// `shape_of(stride-2 conv)` pattern) gets the per-pulse increment
+    /// `P/2` after the boundary-subtract trick. Locks in the existing
+    /// linear contract so the non-linear fallback below cannot regress
+    /// it.
+    #[test]
+    fn test_multi_broadcast_to_pulsifier_linear_axis() {
+        use tract_pulse_opl::tract_core::ops::array::MultiBroadcastTo;
+
+        let mut model = TypedModel::default();
+        let s = model.symbols.sym("S");
+        let linear: TDim = 1.to_dim() + s.to_dim() / 2;
+        let target_shape: ShapeFact = tvec![1.to_dim(), linear, 4.to_dim()].into();
+
+        let a = model.add_source("a", f32::fact(dims![1, s.to_dim(), 4].as_ref())).unwrap();
+        let out = model.wire_node("bc", MultiBroadcastTo::new(target_shape), &[a]).unwrap();
+        model.select_output_outlets(&out).unwrap();
+
+        let pulse = PulsedModel::new(&model, s, &4.to_dim()).expect("pulsification");
+        let out_fact = pulse.output_fact(0).unwrap();
+        // `1 + S/2` at S=P=4 is 3, at S=0 it is 1. The trick yields
+        // `3 - 1 = 2` per pulse; the linearity probe at S=8 gives delta
+        // 4, matching `2 * 2`, so we stay on the linear path.
+        assert_eq!(
+            out_fact.shape[1],
+            2.to_dim(),
+            "linear streaming axis must keep the boundary-subtract delta; got fact: {out_fact:?}",
+        );
+    }
+
+    /// Non-linear target shape (`min(2, S + 2)`, which equals 2 for every
+    /// `S >= 0`): the boundary-subtract collapses `full - base` to 0 even
+    /// though the full per-pulse shape is 2. Pre-fix that produced a
+    /// 0-volume PulsedFact that poisoned every downstream consumer (most
+    /// visibly: a Scan body's State input reading the GRU `h_0` tile,
+    /// surfacing as `Clashing resolution for expression. 2=2 != 0` on the
+    /// runtime warmup turn). The fallback keeps the full value when the
+    /// `substitute(S→0) == substitute(S→P) == substitute(S→2P)` probe
+    /// confirms the axis is not actually streaming.
+    #[test]
+    fn test_multi_broadcast_to_pulsifier_non_linear_axis() {
+        use tract_pulse_opl::tract_core::ops::array::MultiBroadcastTo;
+
+        let mut model = TypedModel::default();
+        let s = model.symbols.sym("S");
+        let non_linear: TDim = (s.to_dim() + 2.to_dim()).mini(2.to_dim());
+        let target_shape: ShapeFact = tvec![1.to_dim(), non_linear, 1.to_dim()].into();
+
+        let a = model.add_source("a", f32::fact(dims![1, s.to_dim(), 1].as_ref())).unwrap();
+        let out = model.wire_node("bc", MultiBroadcastTo::new(target_shape), &[a]).unwrap();
+        model.select_output_outlets(&out).unwrap();
+
+        let pulse = PulsedModel::new(&model, s, &4.to_dim()).expect("pulsification");
+        let out_fact = pulse.output_fact(0).unwrap();
+        assert_eq!(
+            out_fact.shape[1],
+            2.to_dim(),
+            "non-linear streaming axis must keep the full value, not the collapsed delta; got fact: {out_fact:?}",
+        );
+    }
 }

--- a/pulse/src/ops/array/broadcast.rs
+++ b/pulse/src/ops/array/broadcast.rs
@@ -23,14 +23,7 @@ fn pulsify(
                 .enumerate()
                 .map(|(i, dim)| {
                     if i == axis {
-                        // Remove the constant boundary term so that per-pulse output size
-                        // matches the actual pulsed output of any upstream strided conv.
-                        // E.g. shape_of(stride-2 conv) = 1 + S/2:
-                        //   substitute(S→P) = 1 + P/2  (wrong)
-                        //   substitute(S→P) - substitute(S→0) = P/2  (correct)
-                        let full = dim.substitute(symbol, pulse)?;
-                        let base = dim.substitute(symbol, &TDim::Val(0))?;
-                        Ok(full - base)
+                        pulsified_stream_axis_dim(dim, symbol, pulse)
                     } else {
                         dim.substitute(symbol, pulse)
                     }
@@ -43,6 +36,54 @@ fn pulsify(
     } else {
         Ok(None)
     }
+}
+
+/// Compute the per-pulse size for a `MultiBroadcastTo` target axis whose
+/// shape mentions the streaming symbol.
+///
+/// The canonical pattern emitted by ONNX `Expand` / `BroadcastTo` against
+/// a `shape_of(streaming)` chain is a *linear* dim of the form
+/// `pulse_growth(S) + boundary` with `pulse_growth(0) = 0`, e.g. a
+/// stride-2 conv's output length `1 + S/2`. For that pattern the per-pulse
+/// increment is `dim(P) - dim(0)` and we use it as the pulse-axis size.
+///
+/// When the expression is constant over `[0, P]` or non-linear in `S`,
+/// the same subtraction can collapse `full - base` to `0` while `full`
+/// itself is a positive valid shape. That happens for chunked-batch
+/// expressions like `1 + -1*min(2, -1+(8·S)/5) + (8·S)/5` (which equals
+/// `max(2, (8·S)/5 - 1)`), where every `S ∈ {0, P, 2P}` resolves to the
+/// same lower bound. The consumer of such an axis (a Scan body state
+/// init, an elementwise meet point) reads the *full* per-pulse shape,
+/// not an empty delta — emitting a `0`-volume PulsedFact poisons every
+/// downstream fact.
+///
+/// Heuristic: probe at `S=0`, `S=P`, and `S=2P`. Use the linear
+/// subtraction iff the delta is strictly positive and `delta(2P) ==
+/// 2·delta(P)` (provably linear over the probe interval). Otherwise
+/// fall back to `dim(P)`.
+fn pulsified_stream_axis_dim(dim: &TDim, symbol: &Symbol, pulse: &TDim) -> TractResult<TDim> {
+    let full = dim.substitute(symbol, pulse)?;
+    let base = dim.substitute(symbol, &TDim::Val(0))?;
+    let delta = full.clone() - base.clone();
+    // Constant on `[0, P]` — this axis is not actually streaming on this
+    // pulse window. Use the full value so downstream facts stay
+    // non-degenerate.
+    if delta == 0.to_dim() {
+        return Ok(full);
+    }
+    // Confirm linearity by sampling at `2P`. Only worthwhile when `P` is
+    // a concrete positive integer; for symbolic `pulse` the trick falls
+    // back to the existing behavior (treat as linear).
+    if let Some(pulse_v) = pulse.as_i64()
+        && pulse_v > 0
+    {
+        let double = dim.substitute(symbol, &TDim::Val(pulse_v * 2))?;
+        let delta_double = double - base;
+        if delta_double != delta.clone() * 2 {
+            return Ok(full);
+        }
+    }
+    Ok(delta)
 }
 
 /// Concat with pulse along concat axis


### PR DESCRIPTION
## Summary

The `MultiBroadcastTo` pulsifier sizes the streaming axis as `dim(P) - dim(0)` to peel off the constant boundary term
that shows up on linear streaming shapes (the canonical `shape_of(stride-2 conv) = 1 + S/2` pattern). The subtraction
is sound for any `pulse_growth(S) + boundary` expression with `pulse_growth(0) = 0`. When the target expression is
non-linear or constant on the probe interval, the same subtraction can collapse `full - base` to `0` while `full`
itself is a positive valid shape: a `0`-volume `PulsedFact` then poisons every downstream consumer.

Concrete trigger seen in the wild: a DPRNN intra-block whose state-init tile-batch dim is `1 + -1*min(2, -1+(8*S)/5)
+ (8*S)/5` (equals `max(2, (8*S)/5 - 1)`). For every `S ∈ {0, P, 2P}` the expression resolves to the lower bound `2`,
so the pre-fix subtraction yields `0` and the GRU state-init wire pulsifies to shape `[1, 0, 64]`. The Scan body's
State source fact (set at load time from the same symbolic expression) folds to `[1, 2, 64]` in its own declutter
pass, and the runtime warmup turn bails with `Clashing resolution for expression. 2=2 != 0`.

## Fix

Promote the inline subtraction to `pulsified_stream_axis_dim` with an explicit linearity probe at `S=0`, `S=P`, and
`S=2P`:

- `delta == 0` (constant on `[0, P]`)  →  fall back to `full`.
- non-linear (`delta(2P) != 2·delta(P)`)  →  fall back to `full`.
- strictly positive linear delta  →  use `delta` (unchanged from the existing code).

For a symbolic `pulse` value the probe at `2P` is skipped and the existing behavior is preserved.

## Test

- `tests::test_multi_broadcast_to_pulsifier_linear_axis` (new): target shape `[1, 1 + S/2, 4]` with `pulse = 4` keeps
   the linear `delta = 2`, locking in the `shape_of(stride-2 conv)` contract.
- `tests::test_multi_broadcast_to_pulsifier_non_linear_axis` (new): target shape `[1, min(2, S + 2), 1]` with
   `pulse = 4` keeps the full value `2`. Pre-fix this asserted shape would have been `0`.

Both tests verified to fail against `main`'s `Ok(full - base)` and pass on this branch.