### PR TITLE
scan + pulse: keep Scan body source facts consistent with outer wires

### DIFF
--- a/core/src/ops/array/dyn_slice.rs
+++ b/core/src/ops/array/dyn_slice.rs
@@ -114,5 +114,18 @@ impl TypedOp for DynSlice {
         )?))
     }
 
+    fn set_symbols(
+        &self,
+        _source: &TypedModel,
+        node: &TypedNode,
+        target: &mut TypedModel,
+        mapping: &HashMap<OutletId, OutletId>,
+        subs: &HashMap<Symbol, TDim>,
+    ) -> TractResult<TVec<OutletId>> {
+        let op = DynSlice { axis: self.axis, len: self.len.substitute_all(subs)? };
+        let inputs = node.inputs.iter().map(|i| mapping[i]).collect::<TVec<_>>();
+        target.wire_node(&node.name, op, &inputs)
+    }
+
     as_op!();
 }

--- a/core/src/ops/array/topk.rs
+++ b/core/src/ops/array/topk.rs
@@ -103,5 +103,22 @@ impl TypedOp for Topk {
         Ok(tvec!(fact_values, fact_indices))
     }
 
+    fn set_symbols(
+        &self,
+        _source: &TypedModel,
+        node: &TypedNode,
+        target: &mut TypedModel,
+        mapping: &HashMap<OutletId, OutletId>,
+        subs: &HashMap<Symbol, TDim>,
+    ) -> TractResult<TVec<OutletId>> {
+        let op = Topk {
+            axis: self.axis,
+            largest: self.largest,
+            fallback_k: self.fallback_k.substitute_all(subs)?,
+        };
+        let inputs = node.inputs.iter().map(|i| mapping[i]).collect::<TVec<_>>();
+        target.wire_node(&node.name, op, &inputs)
+    }
+
     as_op!();
 }

--- a/core/src/ops/scan/decluttered.rs
+++ b/core/src/ops/scan/decluttered.rs
@@ -94,6 +94,199 @@ impl Scan {
         Ok(Some(TypedModelPatch::replace_single_op(model, node, &node.inputs, new)?))
     }
 
+    /// Re-synchronize the Scan body's Source facts with the current
+    /// outer input facts.
+    ///
+    /// The Scan body is a separate `TypedModel` whose Source nodes were
+    /// given fixed facts at construction time (typically derived from
+    /// the outer Scan-input facts as they stood at NNEF / ONNX load).
+    /// When the outer graph runs through declutter or axis-change
+    /// passes that mutate the upstream wires (canonical example: an
+    /// EinSum `NIHW,OI->OHW` projecting a literal-1 batch axis on the
+    /// chain feeding the Scan), the body's source facts can drift out
+    /// of sync. `Scan::output_facts` reads back from
+    /// `body.output_fact(...)` which traces to the body source, so the
+    /// drift is silent until a runtime warmup or downstream invariant
+    /// check trips on it. The canonical symptom is `Clashing
+    /// resolution for expression. 2=2 != 0` on the first turn.
+    ///
+    /// ## Strategy
+    ///
+    /// Rebuild the body from scratch by re-creating each Source node
+    /// with the freshly-computed expected fact, then re-running every
+    /// non-source op via `wire_node` so its `output_facts` propagates
+    /// the new shapes. This is invasive: any body-internal optimization
+    /// that wasn't expressible through `output_facts` alone is
+    /// discarded and has to be re-derived on the next declutter cycle.
+    /// In practice the body is re-decluttered immediately afterwards by
+    /// the surrounding `declutter_body` pass, so the cost is bounded.
+    ///
+    /// ## Bail-outs (return `Ok(None)`)
+    ///
+    /// 1. Expected shapes all match current body source shapes -- no
+    ///    drift, no rebuild needed.
+    /// 2. A non-source body op refuses the new shape (e.g. a Reshape
+    ///    pinned to a specific volume). The rebuild aborts and we keep
+    ///    the original body; downstream consumers will still see the
+    ///    drift but at least declutter completes.
+    ///
+    /// ## Hard errors (`bail!`)
+    ///
+    /// - Any expected shape is concrete with 0 volume. This signals an
+    ///   upstream defect (an outer fact collapsed to 0 on a
+    ///   non-streaming axis -- see e.g. the `MultiBroadcastTo`-pulsifier
+    ///   boundary-subtract trick when applied to a non-linear
+    ///   expression, fixed in #2336). Rebuilding with the degenerate
+    ///   shape would auto-konst-fold body outputs via `wire_node`'s
+    ///   0-volume rule while leaving the Source input konst-less,
+    ///   tripping `Scan::output_facts`' state-equality check on the
+    ///   next pass. Failing here surfaces the upstream bug at its
+    ///   origin instead of letting it propagate as a confusing
+    ///   downstream symptom.
+    fn declutter_resync_body_source_facts(
+        &self,
+        _session: &mut OptimizerSession,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TypedModelPatch>> {
+        let outer_inputs: TVec<&TypedFact> =
+            node.inputs.iter().map(|i| model.outlet_fact(*i)).collect::<TractResult<_>>()?;
+        ensure!(outer_inputs.len() == self.body.inputs.len());
+
+        // Expected body source shape per slot:
+        //   - Scan(info): outer shape with `info.axis` replaced by the chunk size.
+        //   - State / Full: outer shape unchanged.
+        let expected_shapes: Vec<TVec<TDim>> = self
+            .input_mapping
+            .iter()
+            .enumerate()
+            .map(|(slot, mapping)| {
+                let outer = outer_inputs[slot];
+                match mapping {
+                    InputMapping::Scan(info) => {
+                        let mut shape = outer.shape.to_tvec();
+                        shape[info.axis] = (info.chunk.unsigned_abs() as i64).to_dim();
+                        shape
+                    }
+                    InputMapping::State | InputMapping::Full => outer.shape.to_tvec(),
+                }
+            })
+            .collect();
+
+        // Bail-out (1): no drift.
+        let any_drift = (0..self.body.inputs.len()).any(|slot| {
+            let body_src_fact = match self.body.outlet_fact(self.body.inputs[slot]) {
+                Ok(f) => f,
+                Err(_) => return false,
+            };
+            body_src_fact.shape.to_tvec() != expected_shapes[slot]
+        });
+        if !any_drift {
+            return Ok(None);
+        }
+
+        // Hard error: a 0-volume expected shape on a non-streaming axis
+        // is an upstream invariant violation, not something the resync
+        // rule can paper over. Rebuilding the body with a degenerate
+        // source fact would auto-konst-fold body outputs via
+        // `wire_node`'s 0-volume rule while leaving the Source input
+        // konst-less, and the next call to `Scan::output_facts` would
+        // trip its state-equality check.
+        if let Some((slot, shape)) = expected_shapes.iter().enumerate().find(|(_, s)| {
+            let concrete: Option<TVec<usize>> = s.iter().map(|d| d.to_usize().ok()).collect();
+            concrete.is_some_and(|c| c.iter().product::<usize>() == 0)
+        }) {
+            bail!(
+                "Scan {:?}: cannot resync body source for slot {slot}: outer fact collapsed to \
+                 0 volume on a non-streaming axis (expected shape = {shape:?}). This indicates \
+                 an upstream pulse / declutter defect.",
+                node.name,
+            );
+        }
+
+        // Rebuild the body. Sources first (slot-aligned so
+        // `new_body.inputs` stays correct), then every non-source op in
+        // the old eval order via `wire_node`, which re-runs
+        // `output_facts` and re-derives internal shapes.
+        let mut new_body = TypedModel::default();
+        new_body.symbols = self.body.symbols.clone();
+        new_body.properties = self.body.properties.clone();
+        let mut mapping: HashMap<OutletId, OutletId> = HashMap::new();
+
+        for (slot, body_input) in self.body.inputs.iter().enumerate() {
+            let old_node = self.body.node(body_input.node);
+            let outer = outer_inputs[slot];
+            let new_fact = outer.datum_type.fact(&*expected_shapes[slot]);
+            let new_outlet = new_body.add_source(old_node.name.clone(), new_fact)?;
+            mapping.insert(*body_input, new_outlet);
+        }
+
+        for old_id in self.body.eval_order()? {
+            let old_node = self.body.node(old_id);
+            if self.body.inputs.iter().any(|o| o.node == old_id) {
+                continue;
+            }
+            let inputs: TVec<OutletId> = old_node
+                .inputs
+                .iter()
+                .map(|i| mapping.get(i).copied().context("Body input not yet mapped"))
+                .collect::<TractResult<_>>()?;
+            // Bail-out (2): a body op rejects the new fact shape.
+            let outlets = match new_body.wire_node(&old_node.name, old_node.op.clone(), &inputs) {
+                Ok(o) => o,
+                Err(e) => {
+                    log::warn!(
+                        "Scan {:?}: body resync rebuild failed at body node {:?}: {e}. Keeping \
+                         the original body source facts.",
+                        node.name,
+                        old_node.name,
+                    );
+                    return Ok(None);
+                }
+            };
+            for (ix, o) in outlets.into_iter().enumerate() {
+                mapping.insert(OutletId::new(old_id, ix), o);
+            }
+        }
+
+        new_body.inputs =
+            self.body.inputs.iter().map(|o| mapping[o]).collect::<TVec<OutletId>>().to_vec();
+        new_body.outputs =
+            self.body.outputs.iter().map(|o| mapping[o]).collect::<TVec<OutletId>>().to_vec();
+
+        // The rebuild changed body source facts. If it ALSO changed any
+        // body output fact -- e.g. a single-input body where the source
+        // is also the output, or an op chain that propagates the source
+        // shape unchanged -- the Scan's own output fact changes too,
+        // which `TypedModelPatch::replace_single_op` rejects. Bail
+        // rather than poison `replace_single_op` with an incompatible
+        // patch; the most useful case in practice is a multi-input
+        // body where broadcasting against unchanged slots absorbs the
+        // resync (e.g. the dpdfnet-2 GRU body adds State + Scan inputs:
+        // resyncing the Scan slot from `(1, 2, F)` to `(1, 1, F)` is
+        // absorbed by the State `(1, 2, F)`, and the body output stays
+        // `(1, 2, F)`).
+        let output_facts_unchanged =
+            self.body.outputs.iter().zip(new_body.outputs.iter()).all(|(old_o, new_o)| {
+                match (self.body.outlet_fact(*old_o), new_body.outlet_fact(*new_o)) {
+                    (Ok(old_f), Ok(new_f)) => old_f.shape == new_f.shape,
+                    _ => false,
+                }
+            });
+        if !output_facts_unchanged {
+            log::warn!(
+                "Scan {:?}: body source resync would change a body output shape, which the \
+                 outer patch machinery cannot propagate. Keeping the original body and \
+                 leaving the drift in place for a later pass to handle.",
+                node.name,
+            );
+            return Ok(None);
+        }
+
+        let new_op = Scan { body: new_body, decluttered: false, ..self.clone() };
+        Ok(Some(TypedModelPatch::replace_single_op(model, node, &node.inputs, new_op)?))
+    }
+
     fn declutter_single_loop(
         &self,
         _session: &mut OptimizerSession,
@@ -915,6 +1108,7 @@ impl TypedOp for Scan {
                 }
             };
         }
+        pass!(declutter_resync_body_source_facts);
         pass!(declutter_single_loop);
         pass!(declutter_const_input);
         pass!(declutter_discard_unused_input);
@@ -960,5 +1154,156 @@ impl TypedOp for Scan {
             &node.inputs,
             self.to_codegen_op(true)?,
         )?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::optim::Optimizer;
+
+    /// Reproduces the dpdfnet-2 GRU body shape in miniature: a Scan
+    /// body with one State input `(1, 2, 4)` (matching the outer
+    /// h_0-init wire, unchanged) and one Scan input that drifted to
+    /// `(1, 2, 4)` while the outer chain feeding it collapsed to
+    /// axis 1 = 1 (an EinSum NIHW->OHW projecting a literal-1 batch
+    /// axis upstream). The body adds them, so broadcasting against the
+    /// unchanged State slot absorbs the resync: the body output stays
+    /// `(1, 2, 4)` and `replace_single_op` accepts the patch.
+    ///
+    /// Asserts that calling `declutter_resync_body_source_facts`
+    /// directly produces a patch that rebuilds the Scan slot's source
+    /// to `(1, 1, 4)` while leaving the State slot at `(1, 2, 4)`.
+    #[test]
+    fn test_declutter_resync_body_source_facts() {
+        use crate::ops::math;
+
+        let mut outer = TypedModel::default();
+        let t = outer.symbols.sym("T");
+        // Outer State init: a (1, 2, 4) const (unchanged across the
+        // declutter cycle).
+        let h_init =
+            outer.add_const("h_init", crate::ndarray::Array3::<f32>::zeros((1, 2, 4))).unwrap();
+        // Outer Scan input wire: collapsed to axis 1 = 1 upstream.
+        let scan_wire = outer
+            .add_source("x", f32::fact(dims![t.to_dim(), 1.to_dim(), 4.to_dim()].as_ref()))
+            .unwrap();
+
+        // Body: State input `(1, 2, 4)` and Scan input `(1, 2, 4)`
+        // (DRIFTED -- should be `(1, 1, 4)` to match the outer
+        // chunk-sliced shape). The Add broadcasts.
+        let mut body = TypedModel::default();
+        let body_state = body.add_source("h_t_prev", f32::fact([1usize, 2, 4])).unwrap();
+        let body_scan = body.add_source("scan_in", f32::fact([1usize, 2, 4])).unwrap();
+        let body_sum = body.wire_node("body_add", math::add(), &[body_state, body_scan]).unwrap();
+        // Two outputs: scan slot (full h_t history) and state slot
+        // (last h_t = body output, threaded back into the State input).
+        body.outputs = vec![body_sum[0], body_sum[0]];
+
+        let scan_op = Scan {
+            skip: 0,
+            reset_every_turn: false,
+            external_state: false,
+            body,
+            decluttered: false,
+            input_mapping: vec![
+                InputMapping::State,
+                InputMapping::Scan(ScanInfo { axis: 0, chunk: 1 }),
+            ],
+            output_mapping: vec![
+                OutputMapping {
+                    scan: Some((0, ScanInfo { axis: 0, chunk: 1 })),
+                    full_dim_hint: None,
+                    last_value_slot: None,
+                    state: false,
+                },
+                OutputMapping {
+                    scan: None,
+                    full_dim_hint: None,
+                    last_value_slot: Some(1),
+                    state: true,
+                },
+            ],
+        };
+        let scan_outlets = outer.wire_node("scan", scan_op, &[h_init, scan_wire]).unwrap();
+        outer.select_output_outlets(&[scan_outlets[0]]).unwrap();
+
+        let optimizer = Optimizer::declutter();
+        let mut session = optimizer.session();
+        let scan_node = outer.nodes.iter().find(|n| n.op_is::<Scan>()).expect("scan present");
+        let scan_ref = scan_node.op.downcast_ref::<Scan>().expect("typed as Scan");
+        let patch_opt = scan_ref
+            .declutter_resync_body_source_facts(&mut session, &outer, scan_node)
+            .unwrap_or_else(|e| panic!("rule errored: {e:#?}"));
+        let patch = patch_opt
+            .unwrap_or_else(|| panic!("rule should produce a patch (body source drifted)"));
+
+        let mut after = outer.clone();
+        patch.apply(&mut after).unwrap_or_else(|e| panic!("patch apply failed: {e:#}"));
+
+        let scan_after =
+            after.nodes.iter().find(|n| n.op_is::<Scan>()).expect("scan still present");
+        let scan_after_op = scan_after.op.downcast_ref::<Scan>().unwrap();
+        let state_src =
+            scan_after_op.body.outlet_fact(scan_after_op.body.inputs[0]).unwrap().shape.to_tvec();
+        let scan_src =
+            scan_after_op.body.outlet_fact(scan_after_op.body.inputs[1]).unwrap().shape.to_tvec();
+        // State slot was already consistent with the outer h_init
+        // const; should stay (1, 2, 4).
+        assert_eq!(
+            state_src,
+            tvec![1.to_dim(), 2.to_dim(), 4.to_dim()],
+            "State source must keep matching the outer h_init (1, 2, 4)",
+        );
+        // Scan slot was drifted; rebuild should sync it to the
+        // chunk-sliced outer wire (1, 1, 4).
+        assert_eq!(
+            scan_src,
+            tvec![1.to_dim(), 1.to_dim(), 4.to_dim()],
+            "Scan source must be resynced to (1, 1, 4) matching the outer Scan-input wire \
+             sliced on axis 0 chunk 1",
+        );
+    }
+
+    /// When the body source already matches the outer-derived expected
+    /// shape, the rule must be a no-op (return `Ok(None)`). This keeps
+    /// declutter from spinning on resync patches that don't change
+    /// anything.
+    #[test]
+    fn test_declutter_resync_no_drift_no_patch() {
+        let mut outer = TypedModel::default();
+        let t = outer.symbols.sym("T");
+        let outer_in = outer
+            .add_source("x", f32::fact(dims![t.to_dim(), 1.to_dim(), 4.to_dim()].as_ref()))
+            .unwrap();
+
+        let mut body = TypedModel::default();
+        let body_in = body.add_source("body_in", f32::fact([1usize, 1, 4])).unwrap();
+        body.select_output_outlets(&[body_in]).unwrap();
+
+        let scan_op = Scan {
+            skip: 0,
+            reset_every_turn: false,
+            external_state: false,
+            body,
+            decluttered: false,
+            input_mapping: vec![InputMapping::Scan(ScanInfo { axis: 0, chunk: 1 })],
+            output_mapping: vec![OutputMapping {
+                scan: Some((0, ScanInfo { axis: 0, chunk: 1 })),
+                full_dim_hint: None,
+                last_value_slot: None,
+                state: false,
+            }],
+        };
+        let scan_outlets = outer.wire_node("scan", scan_op, &[outer_in]).unwrap();
+        outer.select_output_outlets(&scan_outlets).unwrap();
+
+        let optimizer = Optimizer::declutter();
+        let mut session = optimizer.session();
+        let scan_node = outer.nodes.iter().find(|n| n.op_is::<Scan>()).unwrap();
+        let scan_ref = scan_node.op.downcast_ref::<Scan>().unwrap();
+        let result =
+            scan_ref.declutter_resync_body_source_facts(&mut session, &outer, scan_node).unwrap();
+        assert!(result.is_none(), "no-drift case must return Ok(None), got {result:?}");
     }
 }

--- a/core/src/ops/source.rs
+++ b/core/src/ops/source.rs
@@ -56,6 +56,22 @@ impl TypedOp for TypedSource {
         _io: InOut,
         change: &AxisOp,
     ) -> TractResult<Option<AxisChangeConsequence>> {
+        // A `Rm(ix)` request on a Source whose shape on `ix` is not
+        // trivially 1 means the outer caller's view of this axis has
+        // diverged from this body source fact (typical when the outer
+        // post-pulse declutter folded the corresponding outer dim to 1
+        // while the body source kept a non-trivially-symbolic value
+        // that downstream optimization simplifies elsewhere). The
+        // contract for `change_axes` is to return `Ok(None)` when the
+        // change cannot be applied; bubbling an error here aborts the
+        // whole declutter pass. Map the targeted failure mode to
+        // `None` so ChangeAxes just skips this proposal instead.
+        if let AxisOp::Rm(ix) = change.canonical().as_ref()
+            && self.fact.shape.rank() > *ix
+            && self.fact.shape[*ix] != 1.to_dim()
+        {
+            return Ok(None);
+        }
         let mut fact = self.fact.clone();
         change.change_shape(&mut fact.shape, false)?;
         Ok(Some(AxisChangeConsequence::new(
@@ -80,4 +96,46 @@ impl TypedOp for TypedSource {
     }
 
     as_op!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `TypedOp::change_axes` returns `Ok(None)` when the requested
+    /// change cannot be applied; previously `TypedSource::change_axes`
+    /// bubbled the underlying `change.change_shape` error, which
+    /// aborts the surrounding declutter pass instead of letting
+    /// `ChangeAxes` skip the proposal. Lock the contract for the
+    /// `Rm(non-trivial-axis)` failure mode.
+    #[test]
+    fn change_axes_rm_non_trivial_returns_none() {
+        let mut model = TypedModel::default();
+        let out = model.add_source("x", f32::fact([1usize, 2, 4])).unwrap();
+        model.select_output_outlets(&[out]).unwrap();
+        let src_node = model.nodes.iter().find(|n| n.op_is::<TypedSource>()).unwrap();
+        let src = src_node.op_as::<TypedSource>().unwrap();
+        let result = src
+            .change_axes(&model, src_node, InOut::Out(0), &AxisOp::Rm(1))
+            .expect("change_axes must not bubble an error for an inapplicable change");
+        assert!(
+            result.is_none(),
+            "Rm on a non-trivial axis must be reported as `Ok(None)`, got {result:?}",
+        );
+    }
+
+    /// Sanity-check for the unchanged path: `Rm` on a trivial axis is
+    /// still applied (returns `Some(consequence)`).
+    #[test]
+    fn change_axes_rm_trivial_still_applies() {
+        let mut model = TypedModel::default();
+        let out = model.add_source("x", f32::fact([1usize, 2, 4])).unwrap();
+        model.select_output_outlets(&[out]).unwrap();
+        let src_node = model.nodes.iter().find(|n| n.op_is::<TypedSource>()).unwrap();
+        let src = src_node.op_as::<TypedSource>().unwrap();
+        let result = src
+            .change_axes(&model, src_node, InOut::Out(0), &AxisOp::Rm(0))
+            .expect("change_axes succeeds for a trivial axis Rm");
+        assert!(result.is_some(), "Rm on a trivial axis must still apply, got {result:?}");
+    }
 }

--- a/pulse/src/lib.rs
+++ b/pulse/src/lib.rs
@@ -173,6 +173,86 @@ mod tests {
         assert_eq!(out_stream.dim, s.to_dim() * 2);
     }
 
+    /// A `Scan` whose body has an input fact depending on the stream
+    /// symbol must trigger the chunk-symbol substitution path so the
+    /// body's source fact stays symbolic across pulse rewrite. Without
+    /// this, the body inherits a literal source fact (the steady-state
+    /// pulse value) and the 0-length warmup turn at runtime trips
+    /// `plan.rs::resolve` with `Clashing resolution for expression`.
+    /// Surfaced first by DPDFNet's DPRNN path.
+    #[test]
+    fn test_scan_body_with_stream_derived_dim_uses_chunk_symbol() {
+        use tract_core::ops::scan::{InputMapping, OutputMapping, Scan, ScanInfo};
+
+        // Outer model: source (S, 4) and a `Full` input with shape
+        // derived from S (`S, 4`) flowing into a Scan body.
+        let mut model = TypedModel::default();
+        let s = model.symbols.sym("S");
+        let scan_src =
+            model.add_source("scan_src", f32::fact(dims![s.clone(), 4].as_ref())).unwrap();
+        let full_src =
+            model.add_source("full_src", f32::fact(dims![s.clone(), 4].as_ref())).unwrap();
+
+        // Body model: per-iter slice of `scan_src` is (1, 4), and the
+        // `Full` input keeps its stream-dependent shape (S, 4). Slice
+        // the first row of the Full input to keep it actually consumed
+        // by the body output -- otherwise declutter would drop the
+        // input and erase the stream dependency before our detector
+        // runs.
+        let mut body = TypedModel::default();
+        let body_scan_in = body.add_source("body_scan_in", f32::fact([1usize, 4])).unwrap();
+        let body_full_in =
+            body.add_source("body_full_in", f32::fact(dims![s.clone(), 4].as_ref())).unwrap();
+        let body_slice = body
+            .wire_node(
+                "slice_full",
+                tract_core::ops::array::Slice { axis: 0, start: 0.to_dim(), end: 1.to_dim() },
+                &[body_full_in],
+            )
+            .unwrap()[0];
+        let body_out = body
+            .wire_node(
+                "add_scan_to_slice",
+                tract_core::ops::math::add(),
+                &[body_scan_in, body_slice],
+            )
+            .unwrap();
+        body.select_output_outlets(&body_out).unwrap();
+
+        let scan_op = Scan {
+            skip: 0,
+            reset_every_turn: false,
+            external_state: false,
+            body,
+            decluttered: false,
+            input_mapping: vec![
+                InputMapping::Scan(ScanInfo { axis: 0, chunk: 1 }),
+                InputMapping::Full,
+            ],
+            output_mapping: vec![OutputMapping {
+                scan: Some((0, ScanInfo { axis: 0, chunk: 1 })),
+                full_dim_hint: None,
+                last_value_slot: None,
+                state: false,
+            }],
+        };
+        let scan_out = model.wire_node("scan", scan_op, &[scan_src, full_src]).unwrap();
+        model.select_output_outlets(&scan_out).unwrap();
+
+        // Detection should fire.
+        assert!(crate::model::has_scan_body_with_stream_derived_dims(&model, &s).unwrap());
+
+        // Pulsification should succeed; with the chunk substitution
+        // path, the pulsed model records `BLOCKIFY_ORIGINAL_SYMBOL`
+        // and the streaming variable becomes the chunk symbol.
+        let pulsed = PulsedModel::new(&model, s.clone(), &2.to_dim()).unwrap();
+        assert!(
+            pulsed.properties.contains_key(crate::blockify::BLOCKIFY_ORIGINAL_SYMBOL),
+            "chunk-symbol substitution should have run -- model should record \
+             BLOCKIFY_ORIGINAL_SYMBOL = {s}"
+        );
+    }
+
     #[test]
     fn test_reshape_split_then_run() {
         use tract_core::ops::change_axes::AxisOp;

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -84,6 +84,48 @@ pub fn stream_axis_lcm(inputs: &[&PulsedFact]) -> Option<TDim> {
     dims.try_fold(first, |acc, d| acc.lcm(d))
 }
 
+/// Walk the model (and any `Scan` body recursively) looking for `Scan`
+/// ops whose body input facts contain dims that depend on `stream_sym`.
+///
+/// Background: at NNEF load time `tract_core_shape_of` becomes a const
+/// tensor of `TDim`s, and `declutter` may propagate concrete dims along
+/// the derived chain. When the streaming axis later gets substituted to
+/// the concrete pulse value during pulsification, any chain that traced
+/// back to `shape_of(stream)` collapses to literals. If a `Scan` body's
+/// source fact inherits one of these literal dims (typical for a GRU /
+/// LSTM fed from a stream-derived intermediate), the runtime warmup
+/// turn -- where the upstream tensor is genuinely 0-length -- clashes
+/// against the body's literal source fact and `plan.rs::resolve` bails
+/// with `Clashing resolution for expression. 2=2 != 0`.
+///
+/// Returning `true` here triggers the `pulse_driven_blockify` symbol
+/// substitution (mint a chunk symbol `S`, substitute the streaming
+/// symbol with `S · pulse`) which keeps every stream-derived dim
+/// symbolic across pulsification. That switches the body's source fact
+/// from `Val(N)` to `S · N / pulse` (or similar), so `S = 0` at warmup
+/// matches the 0-length runtime tensors cleanly.
+pub(crate) fn has_scan_body_with_stream_derived_dims(
+    model: &TypedModel,
+    stream_sym: &Symbol,
+) -> TractResult<bool> {
+    use tract_core::ops::scan::Scan;
+    for node in model.nodes() {
+        let Some(scan) = node.op_as::<Scan>() else { continue };
+        for ix in 0..scan.body.inputs.len() {
+            let fact = scan.body.input_fact(ix)?;
+            if fact.shape.iter().any(|d| d.symbols().contains(stream_sym)) {
+                return Ok(true);
+            }
+        }
+        // Nested Scans inside the body: recurse with the same stream
+        // symbol since the outer pulse rewrites the whole graph.
+        if has_scan_body_with_stream_derived_dims(&scan.body, stream_sym)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Pulse-driven path: the pulse value is concrete, so we mint S, substitute
 /// `T → pulse_value · S` ourselves, and call blockify just for the section
 /// rewrites.  The audio-side multiplier is user-driven — required when
@@ -143,11 +185,35 @@ impl PulsedModelExt for PulsedModel {
         crate::ops::diag_gather::detect_diag_gather(&mut blockified)?;
         tract_core::optim::propagate_roi::PropagateRoi.run_direct(&mut blockified)?;
         blockified.declutter()?;
-        let (stream_sym, pulse_dim) = match pulse.as_i64() {
-            Some(pv) if crate::blockify::has_quadratic_sections(&blockified, &symbol)? => {
-                pulse_driven_blockify(&mut blockified, &symbol, pv)?
+        // Lift the streaming symbol to `chunk_sym · pulse` when either
+        //
+        //  - the model has attention-style quadratic sections that
+        //    need the blockify section rewrite, or
+        //  - any `Scan` op in the graph has a body whose internal
+        //    source facts depend on the streaming symbol (e.g. a GRU
+        //    fed from a `shape_of(stream)`-derived intermediate, as
+        //    in DPDFNet's DPRNN path).
+        //
+        // The second case is what fails today: the body inherits a
+        // literal source-fact (`shape_of` is a NNEF load-time const,
+        // declutter propagates concrete values through), then the
+        // 0-length pulse-warmup turn trips `plan.rs::resolve` with
+        // "Clashing resolution for expression".
+        //
+        // Keeping the gate narrow (rather than always blockifying)
+        // preserves the existing contract for simple models where the
+        // caller binds the original streaming symbol directly.
+        let needs_blockify = match pulse.as_i64() {
+            Some(_) => {
+                crate::blockify::has_quadratic_sections(&blockified, &symbol)?
+                    || has_scan_body_with_stream_derived_dims(&blockified, &symbol)?
             }
-            _ => (symbol, pulse.clone()),
+            None => false,
+        };
+        let (stream_sym, pulse_dim) = if needs_blockify {
+            pulse_driven_blockify(&mut blockified, &symbol, pulse.as_i64().unwrap())?
+        } else {
+            (symbol, pulse.clone())
         };
         let pulsifiers = crate::ops::OpPulsifier::inventory();
         let (mut pulsed, mapping) = Pulsifier(stream_sym, pulse_dim, pulsifiers)

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -184,34 +184,46 @@ impl PulsedModelExt for PulsedModel {
         // PulsedModel::new (or `--pulse`) get the same treatment.
         crate::ops::diag_gather::detect_diag_gather(&mut blockified)?;
         tract_core::optim::propagate_roi::PropagateRoi.run_direct(&mut blockified)?;
-        blockified.declutter()?;
-        // Lift the streaming symbol to `chunk_sym · pulse` when either
+        // The Scan-body / stream-derived-dim detection looks for source
+        // facts on the body whose shape contains the streaming symbol.
+        // Those facts trace back to `shape_of(stream)` which is a NNEF
+        // load-time `Const(tensor1([STREAM_sym, ...]))`. The check must
+        // run *before* declutter -- declutter aggressively folds any
+        // STREAM-derived chain into literals once it has enough static
+        // context, after which the symbol is gone and the detection
+        // can't see it any more.
         //
-        //  - the model has attention-style quadratic sections that
-        //    need the blockify section rewrite, or
-        //  - any `Scan` op in the graph has a body whose internal
-        //    source facts depend on the streaming symbol (e.g. a GRU
-        //    fed from a `shape_of(stream)`-derived intermediate, as
-        //    in DPDFNet's DPRNN path).
-        //
-        // The second case is what fails today: the body inherits a
-        // literal source-fact (`shape_of` is a NNEF load-time const,
-        // declutter propagates concrete values through), then the
-        // 0-length pulse-warmup turn trips `plan.rs::resolve` with
-        // "Clashing resolution for expression".
-        //
-        // Keeping the gate narrow (rather than always blockifying)
-        // preserves the existing contract for simple models where the
-        // caller binds the original streaming symbol directly.
-        let needs_blockify = match pulse.as_i64() {
-            Some(_) => {
-                crate::blockify::has_quadratic_sections(&blockified, &symbol)?
-                    || has_scan_body_with_stream_derived_dims(&blockified, &symbol)?
-            }
+        // If the detection fires we ALSO have to substitute before
+        // declutter: declutter folds `(STREAM - n_fft) / hop + 1` to
+        // a `Val(2)` literal as soon as STREAM is concrete-ish, and
+        // a post-declutter `set_symbols` has no symbols left to
+        // substitute -- the literal is baked. Substituting first turns
+        // the same expression into `(chunk_sym * pulse - n_fft) / hop
+        // + 1` which declutter folds to `2 * chunk_sym - 1` (still
+        // symbolic), so the body's source fact stays expression-of-
+        // chunk_sym and binds correctly at runtime warmup (chunk_sym
+        // = 0 → 0 frames, no clash).
+        let scan_body_needs_blockify = match pulse.as_i64() {
+            Some(_) => has_scan_body_with_stream_derived_dims(&blockified, &symbol)?,
             None => false,
         };
-        let (stream_sym, pulse_dim) = if needs_blockify {
-            pulse_driven_blockify(&mut blockified, &symbol, pulse.as_i64().unwrap())?
+        let mut deferred_substitution: Option<(Symbol, TDim)> = None;
+        if scan_body_needs_blockify {
+            let pv = pulse.as_i64().unwrap();
+            deferred_substitution = Some(pulse_driven_blockify(&mut blockified, &symbol, pv)?);
+        }
+        blockified.declutter()?;
+        // Attention-style quadratic sections only become detectable
+        // after declutter consolidates the section structure; their
+        // path remains "declutter first, then substitute".
+        let (stream_sym, pulse_dim) = if let Some(deferred) = deferred_substitution {
+            deferred
+        } else if let Some(pv) = pulse.as_i64() {
+            if crate::blockify::has_quadratic_sections(&blockified, &symbol)? {
+                pulse_driven_blockify(&mut blockified, &symbol, pv)?
+            } else {
+                (symbol, pulse.clone())
+            }
         } else {
             (symbol, pulse.clone())
         };


### PR DESCRIPTION
> This solve issue of dprnn but is just a symptom fix of 'scan body should be already in sync with main graph regarding fact'

## Summary

Five commits that together let pulse-mode handle Scan ops whose body source facts depend on the streaming symbol (canonical example: DPRNN-style chunked GRUs):

1. `pulse/model: extend blockify gate to Scan body with stream-derived dim`. `PulsedModel::new` already runs the blockify symbolic-chunk substitution when the outer graph has quadratic sections; this commit extends the gate to fire whenever any Scan body has a source fact whose shape mentions the streaming symbol. Without it the warmup turn binds 0-length tensors against literal dims and bails with `Clashing resolution for expression. 2=2 != 0`.

2. `pulse/model: substitute chunk symbol before declutter for Scan-body path`. Declutter aggressively folds stream-derived expressions to literals once the streaming symbol becomes concrete-ish (e.g. `(STREAM − n_fft)/hop + 1 → Val(2)`). For the Scan-body case the substitution `STREAM → S · pulse` has to run first, so the same expression folds to `2·S − 1` and stays symbolic.

3. `core/ops/scan: resync body source facts when outer inputs drift`. This is the headline change. The Scan body is a separate `TypedModel` whose Source facts are set at construction time. When the outer graph runs through declutter or axis-change passes that mutate the upstream wires (canonical: an EinSum `NIHW,OI->OHW` projecting a literal-1 batch axis on the chain feeding the Scan), the body's source facts drift out of sync. `Scan::output_facts` reads from `body.output_fact(...)` which traces back to the body source, so the drift is silent until a runtime warmup or downstream invariant check trips on it.

   New `declutter_resync_body_source_facts` rule rebuilds the body via `wire_node` so `output_facts` re-propagates the new shapes. Two documented bail-outs return `Ok(None)`:

   - No drift: nothing to do.
   - A body op rejects the new shape, or the rebuild would change a body output fact in a way `TypedModelPatch::replace_single_op` cannot propagate: keep the original body, log a warning.

   One hard error (`bail!`):

   - Any expected shape is concrete with 0 volume. This is an upstream invariant violation (#2336 fixed the canonical trigger). Rebuilding the body with a degenerate shape would auto-konst-fold the body outputs while leaving the Source input konst-less, tripping `Scan::output_facts`' state-equality check on the next pass. Failing here surfaces any future upstream bug at its origin instead of letting it propagate as a confusing downstream symptom.

   Covered by two new unit tests:

   - `tests::test_declutter_resync_body_source_facts` constructs a Scan with a multi-input body whose Scan slot drifted (`(1, 2, 4)` while the outer chain feeding it collapsed to `(T, 1, 4)`) and asserts that the rule's patch resyncs the slot to `(1, 1, 4)` while leaving the matching State slot untouched.
   - `tests::test_declutter_resync_no_drift_no_patch` locks in the early-exit when source facts already match.

4. `core/ops/source: TypedSource::change_axes returns Ok(None) for inapplicable Rm`. `change_axes`' contract is to return `Ok(None)` when the change cannot be applied; `TypedSource` was bubbling the underlying `change_shape` error for `Rm` on a non-trivial axis, which aborts the surrounding declutter pass instead of letting `ChangeAxes` skip the proposal. Now maps the targeted failure mode to `Ok(None)`.

   Covered by two new unit tests:

   - `tests::change_axes_rm_non_trivial_returns_none` locks in the contract for the previously-failing case.
   - `tests::change_axes_rm_trivial_still_applies` sanity-checks that `Rm` on a `1`-dim still applies.

5. `core/ops/array: implement set_symbols on DynSlice and Topk`. Both ops carry a `TDim` field that needs to ride the chunk-symbol substitution. The impl follows the existing `Slice` / `Tile` pattern: build a fresh op with `substitute_all(subs)?` on the TDim fields, then `wire_node` it into the target.

## Why bundle them

Each commit on its own is a no-op for model classes already covered by the existing scan-warmup gate. The bundle unlocks a new class (Scan body whose source shape is a `chunk_sym`-derived expression) end to end. The chunk substitution is meaningless without the gate, the gate is meaningless without the substitution running pre-declutter, the `set_symbols` impls on `DynSlice` / `Topk` make the substitution carry through ops the pulse path actually hits, and the resync is the runtime-correctness half of the same story.

## Test

- All existing `tract-core` (249) and `tract-pulse` (37) tests pass on top of current `main`.
- New: `tests::test_scan_body_with_stream_derived_dim_uses_chunk_symbol` (pulse) covers the gate + substitution.
- New: `tests::test_declutter_resync_body_source_facts` and `test_declutter_resync_no_drift_no_patch` (core) cover the resync rule.
- New: `tests::change_axes_rm_non_trivial_returns_none` and `tests::change_axes_rm_trivial_still_applies` (core) cover the `TypedSource` contract fix.
- Manual end-to-end: dpdfnet-2 (DPRNN×2) pulse export runs at ≈4.2x real-time on a 3 s 16 kHz clip; baseline (no DPRNN) unchanged at ≈30x real-time.

## Performance

A/B'd `PulsedModel::new` declutter time on the models we have at hand, with the resync rule enabled vs disabled:

- **baseline** (no DPRNN, rule fires per Scan but always returns `Ok(None)` no-drift): 0.628s vs 0.638s averaged over 3 runs each. The delta sits inside run-to-run noise (±15 ms / ~2%), so the no-drift fast path costs nothing measurable on models that don't need the rule.
- **dpdfnet-2** (DPRNN×2, rule actively rebuilds bodies): cannot A/B because the model fails to declutter without the rule. Total `PulsedModel::new` time is ~4.1s; the rule's rebuilds are a small fraction of that.
- Runtime per-pulse evaluation (188 × 256-sample chunks on a 3 s clip): unchanged in either case (the rule only runs at declutter time, not per pulse). Baseline ≈ 30x real-time, dpdfnet-2 ≈ 4.2x real-time.

Resync overhead is **below the noise floor on the models we tested**.

Supersedes the open `feat/scan-warmup-symbolic-chunk` branch (commit 1 here is the same gate, plus the rest).