### PR TITLE
docs: add CLAUDE.md with contributor rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,10 @@ Re-export shims in `transformers/src/ops/mod.rs` keep downstream crates
   - Comments describe the **current** code only. Don't narrate the diff ("the previous code did X", "this used to be Y", "was a copy-paste of the 32x1 kernel") -- that history belongs in the commit message and will be wrong after the next refactor.
   - Avoid section banners (// -- Step 2: Pad -> Reshape --), prefer split in functions. It's ok to have long function prototype in private function (within reason) #[allow(clippy::too_many_arguments)] authorized in such case.
 
+  Doc comments (`///` / `//!`):
+  - Unlike inline comments, these are encouraged. tract has historically under-documented its items -- do add a concise doc comment on public / non-trivial items (ops, declutter & codegen passes, public fns) stating what it is, its contract, valid inputs, and which rules it interacts with.
+  - Same anti-narration rule as inline: document the **current** contract, not benchmarks, perf numbers ("0.77 ms vs ORT's 1.13 ms"), issue numbers, or change history ("Measured on...", "Regression:...").
+
   Idioms:
   - Prefer `as_X()` over `to_X().ok()` for cheap reference-style conversions.
   - No new `unsafe` without explicit permission. `shunt_outside_unchecked` is a last resort for surgical patches whose safety is locally obvious; reach for safe alternatives first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,19 @@ reference: doc/. This file is the rules an agent must follow to contribute clean
 - No consequence chains ("X broke Y broke Z"), no "Result:/Symptom:" sections,
   no bullet lists of every place the bug surfaced.
 
-## Code comments
+## Inline comments
 - Default to NONE. Names carry the meaning. A comment signals a hidden
   constraint / invariant / workaround — not narration.
 - Never describe the diff or history ("used to be X", "previously…"). Comments
   describe current code only.
 - No section-banner comments; split into functions instead.
+
+## Doc comments (`///` / `//!`)
+- DO add a concise one on public / non-trivial items — ops, declutter & codegen
+  passes, public fns. State what it is, its contract, valid inputs, and which
+  rules it interacts with. This is the one place to be more generous than before.
+- Same anti-narration rule: document the *current contract*, not benchmarks,
+  perf numbers, issue numbers, or history ("Measured on…", "Regression:…").
 
 ## How to change a model
 - Use `TypedModelPatch` / `Rewriter` / `ModelTransform`. Do NOT hand-roll

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md — tract contributor rules (read fully; this is auto-loaded)
+
+tract is Sonos' Rust NN inference engine. Full guide: AGENTS.md. Architecture/
+reference: doc/. This file is the rules an agent must follow to contribute cleanly.
+
+## Before you commit
+- Format with the PINNED toolchain: `cargo +1.91.0 fmt --all`. Never bare
+  `cargo fmt` — a newer rustfmt makes diffs CI rejects. Metal files too, on Linux.
+- `cargo clippy --workspace` clean.
+
+## Commit messages
+- One short paragraph: what was wrong + the fix. Nothing else.
+- No consequence chains ("X broke Y broke Z"), no "Result:/Symptom:" sections,
+  no bullet lists of every place the bug surfaced.
+
+## Code comments
+- Default to NONE. Names carry the meaning. A comment signals a hidden
+  constraint / invariant / workaround — not narration.
+- Never describe the diff or history ("used to be X", "previously…"). Comments
+  describe current code only.
+- No section-banner comments; split into functions instead.
+
+## How to change a model
+- Use `TypedModelPatch` / `Rewriter` / `ModelTransform`. Do NOT hand-roll
+  model-walk loops or rebuild a fresh TypedModel.
+- Don't touch `pulse` / `pulse-opl` casually — subtle streaming invariants.
+
+## Public API
+- The public surface is `api/rs/src/lib.rs`. Check there, not internal `pub`
+  items. Apps/examples/bindings use `api/rs` only.
+
+## Tests
+- Add op tests to the `suite-*` crates; add synthetic NNEF cases under
+  `harness/nnef-test-cases/` (driven by `runme.sh` + `--assert-output-bundle`).
+  If the CLI can't express the assertion, extend the CLI.
+- No new Rust integration tests for the above; no mocking internals — prefer
+  real model round-trips.
+
+## Idioms / avoid
+- No new `unsafe` outside linalg kernels without explicit permission.
+  No abstraction beyond the task — three similar lines beat a premature helper.
+
+## Pull requests
+- Open with a 1–2 sentence summary of what and why.
+- Follow-up questions/review replies are handled by a HUMAN, not the bot. The
+  maintainer wants to talk to the author, not prompt an LLM.


### PR DESCRIPTION
Curated behavioral subset of AGENTS.md (fmt, commit/comment style, model-edit tooling, public API, test placement, PR etiquette) inlined so it lands in the auto-loaded context; AGENTS.md stays the full reference.