### PR TITLE
core/ops/array: implement set_symbols on DynSlice and Topk

### DIFF
--- a/core/src/ops/array/dyn_slice.rs
+++ b/core/src/ops/array/dyn_slice.rs
@@ -114,5 +114,18 @@ impl TypedOp for DynSlice {
         )?))
     }
 
+    fn set_symbols(
+        &self,
+        _source: &TypedModel,
+        node: &TypedNode,
+        target: &mut TypedModel,
+        mapping: &HashMap<OutletId, OutletId>,
+        subs: &HashMap<Symbol, TDim>,
+    ) -> TractResult<TVec<OutletId>> {
+        let op = DynSlice { axis: self.axis, len: self.len.substitute_all(subs)? };
+        let inputs = node.inputs.iter().map(|i| mapping[i]).collect::<TVec<_>>();
+        target.wire_node(&node.name, op, &inputs)
+    }
+
     as_op!();
 }

--- a/core/src/ops/array/topk.rs
+++ b/core/src/ops/array/topk.rs
@@ -103,5 +103,22 @@ impl TypedOp for Topk {
         Ok(tvec!(fact_values, fact_indices))
     }
 
+    fn set_symbols(
+        &self,
+        _source: &TypedModel,
+        node: &TypedNode,
+        target: &mut TypedModel,
+        mapping: &HashMap<OutletId, OutletId>,
+        subs: &HashMap<Symbol, TDim>,
+    ) -> TractResult<TVec<OutletId>> {
+        let op = Topk {
+            axis: self.axis,
+            largest: self.largest,
+            fallback_k: self.fallback_k.substitute_all(subs)?,
+        };
+        let inputs = node.inputs.iter().map(|i| mapping[i]).collect::<TVec<_>>();
+        target.wire_node(&node.name, op, &inputs)
+    }
+
     as_op!();
 }


### PR DESCRIPTION
## Summary

`DynSlice` and `Topk` each carry a `TDim` field (`len` and `fallback_k` respectively) that needs to ride the chunk-symbol substitution that pulse mode performs (`STREAM → S · pulse`). Without a `set_symbols` impl on these ops, the default trait method clones the op verbatim and the `TDim` field stays referring to the old symbol, leaving the post-substitution model inconsistent.

This commit hand-rolls `set_symbols` on both ops, following the existing `Slice` / `Tile` pattern: build a fresh op with `substitute_all(subs)?` applied to the TDim fields, then `wire_node` it into the target.

## Scope

Standalone, no behavior change for models that don't go through pulse-mode substitution. Extracted from the broader Scan body fact management work (#2337) so it can land independently.

## Test

All existing `tract-core` (245) tests pass.