### PR TITLE
pulse/ops/scan: substitute stream symbol in Scan body during pulsification

### DIFF
--- a/harness/nnef-test-cases/scan-body-stream-drift/graph.nnef
+++ b/harness/nnef-test-cases/scan-body-stream-drift/graph.nnef
@@ -1,0 +1,35 @@
+version 1.0;
+
+extension tract_registry tract_core;
+extension tract_symbol S;
+
+# Path 1 construction (scan axis == streaming axis), with the streaming
+# symbol on a Full body source. The Scan iterates the streaming input on
+# axis 0 (chunk 1). A second Full body slot receives an internally
+# constructed zero-valued tensor whose shape mirrors the streaming
+# input ([S, 4]); the Pulsifier walks both wires and substitutes
+# `S -> pulse` in the outer scan op. The fix in pulse/ops/scan.rs
+# substitutes the same symbol inside the body so the Full slot's body
+# source goes from [S, 4] to [pulse, 4]; without the fix the body's
+# source fact stays symbolic in S.
+
+fragment scan_body_fn(
+    scan_x: tensor<scalar>,
+    full_y: tensor<scalar>
+) -> ( y_out: tensor<scalar> ) {
+    full_first = slice(full_y, axes = [0], begin = [0], end = [1]);
+    y_out      = add(scan_x, full_first);
+}
+
+graph scan_body_stream_drift(input) -> (output)
+{
+    input      = external<scalar>(shape = [S, 4]);
+    full_zeros = mul(input, 0.0);
+    output     = tract_core_scan(
+        body   = "scan_body_fn",
+        scan   = [("scan_x", input, 0, 1)],
+        full   = [("full_y", full_zeros)],
+        state  = [],
+        output = [("y_out", "full", 0, 1)]
+    );
+}

--- a/harness/nnef-test-cases/scan-body-stream-drift/runme.sh
+++ b/harness/nnef-test-cases/scan-body-stream-drift/runme.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# Batch run and streaming compare: smoke test that pulsified model
+# loads and produces the same output as the batched one.
+$TRACT_RUN --nnef-tract-core . \
+    -t 'set_symbols(values: {"S": 8})' \
+    run --allow-random-input -q
+
+$TRACT_RUN --nnef-tract-core . --pulse 4 compare \
+    --stream --allow-random-input -q
+
+# Body / outer fact consistency: the Pulsifier substitutes the stream
+# symbol S in the outer wire facts; it must do the same on the Scan
+# body source facts. Without the fix in pulse/src/ops/scan.rs the Full
+# slot's body source keeps `S,4,F32` while the outer wire is
+# `4,4,F32 [pulse axis:0 ...]`; assert here that the body source is
+# a concrete shape (no residual stream symbol).
+DUMP=$($TRACT_RUN --nnef-tract-core . --pulse 4 --pass pulse dump 2>&1 | sed 's/\x1b\[[0-9;]*m//g')
+if echo "$DUMP" | grep -A 1 '\[loop\].*Source.*full_y' | grep -qE '\bS\b'; then
+    echo "ERROR: Scan body source for 'full_y' still carries the stream symbol after pulse pass."
+    echo "       Pulsifier did not substitute it in the Scan body."
+    echo "$DUMP" | grep -A 1 '\[loop\].*Source.*full_y'
+    exit 1
+fi

--- a/pulse/src/ops/scan.rs
+++ b/pulse/src/ops/scan.rs
@@ -40,6 +40,13 @@ fn pulsify(
     let first_scan_axis =
         target.outlet_fact(pulse_inputs[first_scan_slot])?.stream.as_ref().unwrap().axis;
     let scan_axis = axes_mapping.axis((InOut::In(first_scan_slot), first_scan_axis))?;
+    // Bake the same `symbol -> pulse` substitution the outer pulsifier just
+    // applied to the wire facts into the Scan body and output_mapping. Without
+    // it, post-pulse declutter folds outer and body shape expressions in
+    // independent scopes and lands on different literals, producing a silent
+    // drift between outer-input facts and body source facts on every dim
+    // that mentioned the stream symbol.
+    let subs: HashMap<Symbol, TDim> = HashMap::from([(symbol.clone(), pulse.clone())]);
     if first_scan_axis == op.input_mapping[first_scan_slot].as_scan().unwrap().axis {
         let mut op = op.clone();
         op.skip = target.outlet_fact(pulse_inputs[first_scan_slot])?.stream.as_ref().unwrap().delay;
@@ -48,10 +55,19 @@ fn pulsify(
                 om.full_dim_hint = None;
             }
         }
+        op.body = op.body.set_symbols(&subs)?;
+        for om in op.output_mapping.iter_mut() {
+            *om = om.set_symbols(&subs)?;
+        }
         Ok(Some(target.wire_node(&*node.name, op, &pulse_inputs)?))
     } else if scan_axis.outputs.iter().all(|x| x.len() == 1) {
         let body = PulsedModel::new(&op.body, symbol.clone(), pulse)?.into_typed()?;
-        let mut new_op = Scan::new(body, op.input_mapping.clone(), op.output_mapping.clone(), 0)?;
+        let output_mapping = op
+            .output_mapping
+            .iter()
+            .map(|om| om.set_symbols(&subs))
+            .collect::<TractResult<Vec<_>>>()?;
+        let mut new_op = Scan::new(body, op.input_mapping.clone(), output_mapping, 0)?;
         new_op.reset_every_turn = true;
         target.wire_node(&node.name, new_op, &pulse_inputs).map(Some)
     } else {


### PR DESCRIPTION
Alternative approach to #2337, addressing kali's feedback that the body source / outer fact discrepancy should not happen in the first place rather than being patched after the fact.

## Where the drift comes from

Instrumenting `PulsedModel::new` and `OptimizerSession::run_all_passes` with a per-Scan checkpoint that compares `outer input fact` vs `Scan body source fact` shows on dpdfnet-2 (DPRNN x2):

- Every pre-pulse declutter checkpoint is `[OK]` (108 Scans across the model). Both outer and body still carry symbolic STREAM in their shape expressions, e.g. `1 + -1*min(2, -1 + (STREAM)/160) + (STREAM)/160`.
- After `Pulsifier::translate_model_with_mappings`, on the very first `before any pass` checkpoint of the post-pulse declutter loop, the Scan slots show:

```
Scan #136 enc__dprnn_erb___0__gru2_l0_gru_h_n  iters=4
  slot 0 State  outer=1,2,64  body_src=1,2,64  [OK]
  slot 1 Scan   outer=8,1,64  body_src=1,2,64  [DRIFT]
  slot 2 Scan   outer=8,1,64  body_src=1,2,64  [DRIFT]
  slot 3 Scan   outer=8,1,64  body_src=1,2,64  [DRIFT]
```

The drift is born inside `Pulsifier::translate_node` for the Scan path (`pulse/src/ops/scan.rs:43-51`). That path clones the original Scan op, adjusts `skip`, and wires it as-is. The body is untouched, so its source facts still carry STREAM through their shape expressions. Meanwhile the outer wires the pulsifier just rewrote are concretized (STREAM substituted with the pulse value). Post-pulse declutter then folds the same symbolic expression to different literals in the outer scope and the body scope, and the disagreement is visible from that point onward.

PR #2337's `declutter_resync_body_source_facts` rule ran later and rebuilt the body to match outer. Functionally correct, but per kali, treating the symptom rather than the cause.

## The fix

When the Scan pulsifier wraps the original op for the non-recursive path, apply the same `symbol -> pulse` substitution to the body and to the output_mapping that the outer pulsifier just applied to wire facts. After that, body and outer hold the same concrete expressions; post-pulse declutter folds both scopes to the same literal because there are no symbolic STREAM-dependent expressions left to fold differently.

The recursive-pulse path (`pulse/src/ops/scan.rs:52-56`) already bakes the substitution into the body via `PulsedModel::new(&op.body, ...)`. Only the cloned `output_mapping` needed the same substitution for symmetry.

## Verification on dpdfnet-2

Same checkpoint, with and without the fix:

```
BEFORE:  outer=8,1,64  body_src=1,2,64  [DRIFT]
AFTER:   outer=8,2,64  body_src=1,2,64  [OK]
```

The non-scan axis `2` is the correct evaluation at STREAM=320 of the symbolic expression that surrounds the chunking math. With the fix, outer and body agree on it; without the fix, outer was independently folded to `1`.

`grep -c DRIFT` on the full trace: `0` after fix, `108` before fix.

Pulse pipeline runs to completion. 151 chunks of 320 samples (3.00s audio) processed in 0.566s, 5.30x real-time, 3.751 ms/chunk.

## Test plan

- [x] `harness/core-proptest-pulse`: 72/72 pass (1 ignored), unchanged vs main.
- [x] Manual: dpdfnet-2 streaming pulse on a 3s 16kHz clip, output WAV correct length, no warnings.
- [x] New: `harness/nnef-test-cases/scan-body-stream-drift/`. Minimal NNEF graph that wires a streaming input into a Scan whose Full slot is an internally-constructed `[S, 4]` zero tensor. After pulsification with `--pass pulse`, the body source for the Full slot must be `4,4` (concrete) rather than `S,4` (symbolic). Verified: passes with fix (exit 0), fails without fix (exit 1, grep on `--pass pulse dump` catches the residual stream symbol in the body source).