### PR TITLE
linalg/cache sorcery: LLC/SLC-aware budget for the L3 outer blocking tier

### DIFF
--- a/linalg/src/cache.rs
+++ b/linalg/src/cache.rs
@@ -52,6 +52,135 @@ pub fn cache_info() -> CacheInfo {
     *CACHE.get_or_init(detect)
 }
 
+/// Where the last-level cache used for the outer GEMM blocking tier comes from,
+/// which implies how aggressively a single thread may budget it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LlcKind {
+    /// Architectural cluster L3 (or an operator-provided size) — effectively
+    /// private to the CPU, so a single thread can assume most of it.
+    Dedicated,
+    /// System-Level Cache: an interconnect cache shared with the GPU/NPU/display
+    /// (e.g. Qualcomm LLCC, Apple SLC). Contended — budget it conservatively.
+    SystemLevel,
+}
+
+/// Size (bytes) and kind of the last-level cache to size the outer GEMM blocking
+/// tier against, or `None` when nothing usefully larger than L2 is known.
+///
+/// Resolution order (first hit wins):
+///  1. `TRACT_LLC_BYTES` env override (e.g. `"8M"`, `"33554432"`) — for embedders
+///     who know their SoC's LLC/SLC when the OS doesn't expose it. Marked
+///     [`LlcKind::SystemLevel`] iff `TRACT_LLC_CONTENDED` is set, else `Dedicated`.
+///  2. architecturally-detected L3 ([`CacheInfo::l3`]) when it exceeds L2 — `Dedicated`.
+///  3. a System-Level Cache discovered via the Linux devicetree (`cache-level == 3`
+///     with a `cache-size`, outside `/cpus`) — `SystemLevel`.
+///
+/// The per-CPU `cpu/cache/index*` topology the L3 probe reads does **not** list an
+/// SLC (it's a separate interconnect IP), which is why an SLC needs a distinct
+/// source. Prior art — runtime cache sizing: Eigen `queryCacheSizes` (CPUID/sysctl),
+/// glibc `sysconf(_SC_LEVELx_CACHE_SIZE)`, ACPI PPTT, hwloc. SLC exposure: Qualcomm
+/// LLCC (`drivers/soc/qcom/llcc-qcom.c`, devicetree `qcom,llcc`) and the generic
+/// devicetree cache bindings.
+pub fn last_level_cache() -> Option<(usize, LlcKind)> {
+    // Memoised for the process lifetime: this sits on the per-matmul block-sizing
+    // path, and the inputs (env overrides + the devicetree SLC probe) are static.
+    // Recomputing per call cost an env lock + a full recursive devicetree walk on
+    // every GEMM — catastrophic on Arm SoCs with a large devicetree (orders of
+    // magnitude slowdown), negligible elsewhere. Detect once, like `cache_info`.
+    static LLC: OnceLock<Option<(usize, LlcKind)>> = OnceLock::new();
+    *LLC.get_or_init(|| {
+        let ci = cache_info();
+        let override_bytes = env_llc_override();
+        // Lazy: the devicetree walk only runs when neither an env override nor an
+        // architectural L3 (> L2) would already win below, so a normal-L3 part
+        // never pays for the recursive filesystem probe.
+        let slc =
+            if override_bytes.is_some() || ci.l3 > ci.l2 { 0 } else { system_level_cache_bytes() };
+        resolve_llc(
+            override_bytes,
+            std::env::var_os("TRACT_LLC_CONTENDED").is_some(),
+            ci.l2,
+            ci.l3,
+            slc,
+        )
+    })
+}
+
+/// Pure resolution of [`last_level_cache`] (factored out so it is testable without
+/// touching process-global env / hardware).
+fn resolve_llc(
+    override_bytes: Option<usize>,
+    override_contended: bool,
+    l2: usize,
+    l3: usize,
+    slc: usize,
+) -> Option<(usize, LlcKind)> {
+    if let Some(b) = override_bytes.filter(|b| *b > 0) {
+        let kind = if override_contended { LlcKind::SystemLevel } else { LlcKind::Dedicated };
+        return Some((b, kind));
+    }
+    if l3 > l2 {
+        return Some((l3, LlcKind::Dedicated));
+    }
+    if slc > l2 && slc > 0 {
+        return Some((slc, LlcKind::SystemLevel));
+    }
+    None
+}
+
+fn env_llc_override() -> Option<usize> {
+    let b = parse_cache_size(&std::env::var("TRACT_LLC_BYTES").ok()?);
+    (b > 0).then_some(b)
+}
+
+/// Best-effort System-Level Cache size (bytes) from the Linux devicetree: the
+/// largest node carrying `cache-level == 3` *and* a `cache-size`, outside the
+/// `/cpus` subtree (so it is an interconnect cache, not a CPU cache the L3 probe
+/// already saw). Returns `0` when unavailable — e.g. SLCs whose size is fixed in
+/// the controller (Qualcomm LLCC) carry no `cache-size` here, so those still rely
+/// on the `TRACT_LLC_BYTES` override.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn system_level_cache_bytes() -> usize {
+    use std::path::Path;
+    fn be_u32(p: &Path) -> Option<u32> {
+        let b = std::fs::read(p).ok()?;
+        (b.len() >= 4).then(|| u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+    }
+    fn walk(dir: &Path, depth: usize, best: &mut usize) {
+        if depth == 0 {
+            return;
+        }
+        if be_u32(&dir.join("cache-level")) == Some(3) {
+            let sz = be_u32(&dir.join("cache-size")).unwrap_or(0) as usize;
+            *best = (*best).max(sz);
+        }
+        let Ok(rd) = std::fs::read_dir(dir) else { return };
+        for e in rd.flatten() {
+            let p = e.path();
+            // CPU caches are handled by the architectural L3 probe; skip them.
+            if p.is_dir() && p.file_name().and_then(|n| n.to_str()) != Some("cpus") {
+                walk(&p, depth - 1, best);
+            }
+        }
+    }
+    let mut best = 0;
+    for root in ["/proc/device-tree", "/sys/firmware/devicetree/base"] {
+        let p = Path::new(root);
+        if p.exists() {
+            walk(p, 4, &mut best);
+            if best > 0 {
+                break;
+            }
+        }
+    }
+    best
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn system_level_cache_bytes() -> usize {
+    0
+}
+
 /// Parse a Linux `/sys` cache `size` string (e.g. `"256K"`, `"8M"`, `"512"`).
 #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(dead_code))]
 fn parse_cache_size(s: &str) -> usize {
@@ -189,6 +318,44 @@ fn detect() -> CacheInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn llc_resolution_priority() {
+        // override wins over everything; contended flag selects the kind.
+        assert_eq!(
+            resolve_llc(Some(8 << 20), false, 1 << 20, 4 << 20, 0),
+            Some((8 << 20, LlcKind::Dedicated))
+        );
+        assert_eq!(
+            resolve_llc(Some(8 << 20), true, 1 << 20, 0, 0),
+            Some((8 << 20, LlcKind::SystemLevel))
+        );
+        // no override: architectural L3 (> L2) is Dedicated.
+        assert_eq!(
+            resolve_llc(None, false, 1 << 20, 4 << 20, 0),
+            Some((4 << 20, LlcKind::Dedicated))
+        );
+        // no L3, but an SLC > L2 is reported: SystemLevel (contended).
+        assert_eq!(
+            resolve_llc(None, false, 512 << 10, 0, 4 << 20),
+            Some((4 << 20, LlcKind::SystemLevel))
+        );
+        // nothing larger than L2 known ⇒ no outer tier (regression-safe).
+        assert_eq!(resolve_llc(None, false, 1 << 20, 0, 0), None);
+        assert_eq!(resolve_llc(None, false, 1 << 20, 1 << 20, 512 << 10), None);
+        // a zero/garbage override is ignored, falling through to detection.
+        assert_eq!(
+            resolve_llc(Some(0), false, 1 << 20, 4 << 20, 0),
+            Some((4 << 20, LlcKind::Dedicated))
+        );
+    }
+
+    #[test]
+    fn slc_probe_never_panics() {
+        // On the test host this is typically 0 (no devicetree SLC); just exercise it.
+        let _ = system_level_cache_bytes();
+        let _ = last_level_cache();
+    }
 
     #[test]
     fn parse_cache_size_units() {

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -309,11 +309,16 @@ fn l2_block_budget_bytes() -> usize {
 /// larger than L2 (otherwise an outer tier just duplicates the inner one).
 /// `None` ⇒ no outer tier; the walk stays single-level (identical to before).
 fn l3_block_budget_bytes() -> Option<usize> {
-    let ci = crate::cache::cache_info();
-    if ci.l3 == 0 || ci.l3 <= ci.l2 {
-        return None;
-    }
-    Some(tier_budget_bytes(ci.l3, 1, 2, 0))
+    use crate::cache::LlcKind;
+    let (bytes, kind) = crate::cache::last_level_cache()?;
+    // Dedicated cluster L3: ~half. A shared System-Level Cache is contended by the
+    // GPU/NPU/display, so we can't assume residency of lines they keep evicting —
+    // budget it to ~a quarter.
+    let (num, den) = match kind {
+        LlcKind::Dedicated => (1, 2),
+        LlcKind::SystemLevel => (1, 4),
+    };
+    Some(tier_budget_bytes(bytes, num, den, 0))
 }
 
 /// Cache-adaptive panel-block edge for a given byte budget: large enough to

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -279,41 +279,142 @@ unsafe fn run_with_scratch_space_vec<K: MatMatMulKer>(
     }
 }
 
-/// Upper bound on the single-thread panel-block edge (matches the multithread
-/// `chunk_grid` default).
+/// Upper bound on the inner (L2-resident) panel-block edge (matches the
+/// multithread `chunk_grid` default).
 const ST_BLK_MAX: usize = 16;
 
-/// Working-set budget (bytes) for the single-thread cache-block: ~a third of L2
-/// (leaving room for the C accumulator tile + packing metadata). Conservative
-/// 256 KiB fallback when L2 is unknown (WASM/Windows/BSD) ⇒ small blocks ≈ the
-/// naive loop, so it can never over-block a cache it can't see. L2 geometry
-/// comes from the shared [`crate::cache`] probe.
-fn block_budget_bytes() -> usize {
-    let l2 = crate::cache::cache_info().l2;
-    if l2 == 0 { 256 * 1024 } else { (l2 / 3).clamp(64 * 1024, 8 * 1024 * 1024) }
+/// Upper bound on the outer (L3-resident) super-block edge. 4× the inner cap so
+/// an L3 several times larger than L2 can hold a meaningfully bigger super-block.
+const ST_BLK_L3_MAX: usize = 64;
+
+/// Panel-block working-set budget (bytes) from a detected cache size: a fraction
+/// `num/den` of the cache (leaving room for the C accumulator tile + packing
+/// metadata), clamped to a sane range. `0` (cache unknown) ⇒ `fallback`, which
+/// is kept small so the block ≈ the naive loop and can never over-block a cache
+/// it can't see. Sizes come from the shared [`crate::cache`] probe.
+fn tier_budget_bytes(cache_bytes: usize, num: usize, den: usize, fallback: usize) -> usize {
+    if cache_bytes == 0 {
+        fallback
+    } else {
+        (cache_bytes * num / den).clamp(64 * 1024, 64 * 1024 * 1024)
+    }
 }
 
-/// Cache-adaptive panel-block edge: large enough to amortise streaming, small
-/// enough that the block's A+B sub-panels (`~blk·(mr+nr)·k·elem_bytes`) stay
-/// L2-resident at the given `k`. Capped at [`ST_BLK_MAX`]; the floor of 1
-/// degrades exactly to the naive loop, so an unknown/small cache can never
-/// over-block (regression-safe). The budget is **cache-size derived** (not a
+/// Inner tier: ~a third of L2 (private per perf-core), 256 KiB fallback.
+fn l2_block_budget_bytes() -> usize {
+    tier_budget_bytes(crate::cache::cache_info().l2, 1, 3, 256 * 1024)
+}
+
+/// Outer tier: ~half of L3, but only when an L3 is detected and is meaningfully
+/// larger than L2 (otherwise an outer tier just duplicates the inner one).
+/// `None` ⇒ no outer tier; the walk stays single-level (identical to before).
+fn l3_block_budget_bytes() -> Option<usize> {
+    let ci = crate::cache::cache_info();
+    if ci.l3 == 0 || ci.l3 <= ci.l2 {
+        return None;
+    }
+    Some(tier_budget_bytes(ci.l3, 1, 2, 0))
+}
+
+/// Cache-adaptive panel-block edge for a given byte budget: large enough to
+/// amortise streaming, small enough that the block's A+B sub-panels
+/// (`~blk·(mr+nr)·k·elem_bytes`) stay cache-resident at the given `k`. Capped at
+/// `cap`; the floor of 1 degrades exactly to the naive loop, so an unknown/small
+/// cache can never over-block (regression-safe).
+#[inline]
+fn block_edge_for(
+    budget: usize,
+    mr: usize,
+    nr: usize,
+    k: usize,
+    elem_bytes: usize,
+    cap: usize,
+) -> usize {
+    if k == 0 {
+        return cap;
+    }
+    let per_blk = ((mr + nr) * k * elem_bytes.max(1)).max(1);
+    (budget / per_blk).clamp(1, cap)
+}
+
+/// Inner (L2) panel-block edge. Budget is **cache-size derived** (not a
 /// hard-coded constant), so it is correct across hardware.
 #[inline]
 fn st_block_edge(mr: usize, nr: usize, k: usize, elem_bytes: usize) -> usize {
-    if k == 0 {
-        return ST_BLK_MAX;
+    block_edge_for(l2_block_budget_bytes(), mr, nr, k, elem_bytes, ST_BLK_MAX)
+}
+
+/// Outer (L3) super-block edge, or `usize::MAX` (one block over the whole grid,
+/// i.e. no outer tier) when no usable L3 is detected. Never smaller than the
+/// inner edge `inner`.
+#[inline]
+fn st_outer_block_edge(mr: usize, nr: usize, k: usize, elem_bytes: usize, inner: usize) -> usize {
+    match l3_block_budget_bytes() {
+        Some(budget) => block_edge_for(budget, mr, nr, k, elem_bytes, ST_BLK_L3_MAX).max(inner),
+        None => usize::MAX,
     }
-    let per_blk = ((mr + nr) * k * elem_bytes.max(1)).max(1);
-    (block_budget_bytes() / per_blk).clamp(1, ST_BLK_MAX)
+}
+
+/// Visit every `(ia, ib)` tile of the `m_panels × n_panels` grid exactly once,
+/// blocked two levels deep: an outer `blk_outer` super-block (L3-resident) holds
+/// inner `blk` blocks (L2-resident). `col_outer` selects the within-block inner
+/// order (B-reuse vs A-reuse). When `blk_outer >= max(m,n)` the outer loop runs
+/// once and this is exactly the single-level inner walk. Pure tile reordering ⇒
+/// no result changes; extracted so the nesting can be unit-tested independently
+/// of the kernel.
+#[inline]
+fn for_each_blocked_tile(
+    m_panels: usize,
+    n_panels: usize,
+    blk: usize,
+    blk_outer: usize,
+    col_outer: bool,
+    mut f: impl FnMut(usize, usize) -> TractResult<()>,
+) -> TractResult<()> {
+    let blk = blk.max(1);
+    let blk_outer = blk_outer.max(blk);
+    let mut jb3 = 0;
+    while jb3 < n_panels {
+        let jb3_end = jb3.saturating_add(blk_outer).min(n_panels);
+        let mut ja3 = 0;
+        while ja3 < m_panels {
+            let ja3_end = ja3.saturating_add(blk_outer).min(m_panels);
+            let mut jb = jb3;
+            while jb < jb3_end {
+                let jb_end = (jb + blk).min(jb3_end);
+                let mut ja = ja3;
+                while ja < ja3_end {
+                    let ja_end = (ja + blk).min(ja3_end);
+                    if col_outer {
+                        for ib in jb..jb_end {
+                            for ia in ja..ja_end {
+                                f(ia, ib)?;
+                            }
+                        }
+                    } else {
+                        for ia in ja..ja_end {
+                            for ib in jb..jb_end {
+                                f(ia, ib)?;
+                            }
+                        }
+                    }
+                    ja = ja_end;
+                }
+                jb = jb_end;
+            }
+            ja3 = ja3_end;
+        }
+        jb3 = jb3_end;
+    }
+    Ok(())
 }
 
 /// Single-thread tile walk over the `m_panels × n_panels` grid, blocked into
 /// cache-sized panel blocks for locality (the naive nested loop re-streams the
 /// whole inner operand per outer panel at large k; the multithread path already
-/// blocks this way via `chunk_grid`). `col_outer` selects the within-block inner
-/// order (B-reuse vs A-reuse). Reordering independent tiles changes no result —
-/// bit-exact with the naive loop.
+/// blocks this way via `chunk_grid`). Two tiers: an inner L2-resident block and,
+/// where an L3 is detected, an outer L3-resident super-block. Reordering
+/// independent tiles changes no result — bit-exact with the naive loop.
 #[inline]
 unsafe fn run_single_thread_blocked<K: MatMatMulKer>(
     ker: &K,
@@ -325,32 +426,13 @@ unsafe fn run_single_thread_blocked<K: MatMatMulKer>(
     non_linear: &[FusedSpec],
 ) -> TractResult<()> {
     unsafe {
-        let blk = st_block_edge(ker.mr(), ker.nr(), k, K::Acc::datum_type().size_of());
+        let elem = K::Acc::datum_type().size_of();
+        let blk = st_block_edge(ker.mr(), ker.nr(), k, elem);
+        let blk_outer = st_outer_block_edge(ker.mr(), ker.nr(), k, elem, blk);
         scratch.run_in_tls_scope(|scratch, tls| {
-            let mut jb = 0;
-            while jb < n_panels {
-                let jb_end = (jb + blk).min(n_panels);
-                let mut ja = 0;
-                while ja < m_panels {
-                    let ja_end = (ja + blk).min(m_panels);
-                    if col_outer {
-                        for ib in jb..jb_end {
-                            for ia in ja..ja_end {
-                                scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
-                            }
-                        }
-                    } else {
-                        for ia in ja..ja_end {
-                            for ib in jb..jb_end {
-                                scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
-                            }
-                        }
-                    }
-                    ja = ja_end;
-                }
-                jb = jb_end;
-            }
-            TractResult::Ok(())
+            for_each_blocked_tile(m_panels, n_panels, blk, blk_outer, col_outer, |ia, ib| {
+                scratch.run_one_tile(ker, non_linear, tls, ia, ib)
+            })
         })
     }
 }
@@ -547,4 +629,94 @@ where
         })
     };
     if use_global { body() } else { pool.unwrap().install(body) }
+}
+
+#[cfg(test)]
+mod blocked_walk_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn collect(
+        m: usize,
+        n: usize,
+        blk: usize,
+        blk_outer: usize,
+        col_outer: bool,
+    ) -> Vec<(usize, usize)> {
+        let mut v = Vec::new();
+        for_each_blocked_tile(m, n, blk, blk_outer, col_outer, |ia, ib| {
+            v.push((ia, ib));
+            Ok(())
+        })
+        .unwrap();
+        v
+    }
+
+    /// Every grid tile is visited exactly once, for both inner orders and a
+    /// range of (blk, blk_outer) — single-tier (outer = MAX), two-tier, and
+    /// degenerate edges. Coverage being a permutation is what makes the walk
+    /// bit-exact with the naive loop.
+    #[test]
+    fn covers_every_tile_once() {
+        for &(m, n) in &[(1, 1), (3, 5), (16, 16), (40, 7), (7, 40), (80, 80)] {
+            for &blk in &[1, 3, 16] {
+                for &blk_outer in &[blk, blk + 1, 64, usize::MAX] {
+                    for &col_outer in &[false, true] {
+                        let tiles = collect(m, n, blk, blk_outer, col_outer);
+                        assert_eq!(tiles.len(), m * n, "m={m} n={n} blk={blk} outer={blk_outer}");
+                        let set: HashSet<_> = tiles.iter().copied().collect();
+                        assert_eq!(
+                            set.len(),
+                            m * n,
+                            "duplicate tiles m={m} n={n} blk={blk} outer={blk_outer}"
+                        );
+                        for ia in 0..m {
+                            for ib in 0..n {
+                                assert!(set.contains(&(ia, ib)), "missing ({ia},{ib})");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// With no outer tier (blk_outer = MAX) the two-tier walk must emit the exact
+    /// same order as the original single-level blocked loop — guarantees the L3
+    /// path is a pure no-op on hardware without a detectable L3.
+    #[test]
+    fn outer_max_matches_single_level() {
+        for &(m, n) in &[(40, 7), (80, 80), (13, 29)] {
+            for &blk in &[1, 4, 16] {
+                for &col_outer in &[false, true] {
+                    let two_tier = collect(m, n, blk, usize::MAX, col_outer);
+                    let mut single = Vec::new();
+                    let mut jb = 0;
+                    while jb < n {
+                        let jb_end = (jb + blk).min(n);
+                        let mut ja = 0;
+                        while ja < m {
+                            let ja_end = (ja + blk).min(m);
+                            if col_outer {
+                                for ib in jb..jb_end {
+                                    for ia in ja..ja_end {
+                                        single.push((ia, ib));
+                                    }
+                                }
+                            } else {
+                                for ia in ja..ja_end {
+                                    for ib in jb..jb_end {
+                                        single.push((ia, ib));
+                                    }
+                                }
+                            }
+                            ja = ja_end;
+                        }
+                        jb = jb_end;
+                    }
+                    assert_eq!(two_tier, single, "m={m} n={n} blk={blk} col_outer={col_outer}");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Stacked on #2349 (cache module) + #2350 (L3 outer tier). **Review only the top commit** — GitHub shows the whole stack until the lower PRs merge (a fork branch can't be a PR base in upstream).

## Problem

#2350's outer tier fires only when the per-CPU cache topology exposes an architectural L3 (`cpu/cache` `level 3`). Many Arm SoCs (and Apple) have **no cluster L3** but a **System-Level Cache (SLC)** shared with the GPU/NPU/display (Qualcomm LLCC, Apple SLC), which is never listed under `cpu/cache/index*` — so those parts see `l3 == 0` and miss a real last-level cache the tier could use.

"LLC" = role (last cache before DRAM). "SLC" = a specific shared interconnect cache that is *one kind* of LLC. This generalises "detect L3" → "establish the LLC budget," and treats a contended SLC more conservatively than a dedicated L3.

## Change

New `cache::last_level_cache() -> Option<(usize, LlcKind)>` resolving, first hit wins:

1. `TRACT_LLC_BYTES` env override (`"8M"`, `"33554432"`); kind = `SystemLevel` iff `TRACT_LLC_CONTENDED` is set, else `Dedicated`.
2. architectural **L3** (`cache_info().l3 > l2`) → `Dedicated`.
3. best-effort **Linux devicetree** SLC probe (`cache-level == 3` + `cache-size`, outside `/cpus`) → `SystemLevel`.

`l3_block_budget_bytes()` now budgets a `Dedicated` L3 at ~½ and a contended `SystemLevel` cache at ~¼ (can't assume residency of lines the GPU/NPU keep evicting). Unknown ⇒ `None` ⇒ no outer tier (unchanged, regression-safe).

## Notes

- Purely additive; default behavior on parts with a normal L3 is identical (L3 path, ½ budget).
- SLCs whose size is fixed in the controller (e.g. Qualcomm LLCC carries no `cache-size` in DT) fall to the `TRACT_LLC_BYTES` override — documented.
- Pure resolver `resolve_llc()` is unit-tested for priority/regression-safety; the DT probe is panic-tested.

## Prior art

- **Runtime cache sizing:** Eigen `queryCacheSizes` (CPUID/sysctl) + `manage_caching_sizes`; glibc `sysconf(_SC_LEVELx_CACHE_SIZE)`; ACPI PPTT; hwloc.
- **SLC exposure:** Qualcomm LLCC (`drivers/soc/qcom/llcc-qcom.c`, devicetree `qcom,llcc`; LWN "SDM845 System Cache Driver"); generic devicetree cache bindings (`cache-level`/`cache-size`).
- **Gap this addresses:** mainstream GEMM libs (OpenBLAS/BLIS/Eigen/MKL) detect L1/L2/L3 but don't chase the SLC — they equate "L3" with "LLC" — so SLC-aware blocking on SoCs whose LLC is an SLC is under-addressed.

## Caveats (honest)

- The **¼ SLC fraction** and the **depth-4 DT walk** are heuristics; they want validation on a real SLC SoC (Snapdragon/Apple). None was available where this was authored (x86/Apple-Silicon hosts — the SLC path is inert on both: x86 takes the `Dedicated` L3 branch, Apple Silicon exposes no DT SLC, so locally only the regression-safe path is exercised).
- The robust core is the `TRACT_LLC_BYTES` override; the devicetree autodetect is best-effort and only kicks in when there is no architectural L3 and a DT node actually carries a numeric `cache-size`.

This falls in the Extreme Category
