### PR TITLE
pulse: dedup sync_inputs Delay node names per input slot

### DIFF
--- a/harness/nnef-test-cases/pulse-sync-inputs-multi-delay/graph.nnef
+++ b/harness/nnef-test-cases/pulse-sync-inputs-multi-delay/graph.nnef
@@ -1,0 +1,31 @@
+version 1.0;
+
+extension tract_registry tract_core;
+
+# Reproducer for the duplicate Delay-node name minted by `sync_inputs`.
+#
+# Three causal convs over the streaming axis give the same per-pulse length but
+# pulse delays 1, 2 and 3. `select` is elementwise with no dedicated pulse
+# pulsifier, so it goes through the generic PulseWrappingOp path, whose
+# `sync_inputs` inserts a Delay on every streaming input below the max delay.
+# Here two inputs (the value tensors, delays 1 and 2) sit below the condition's
+# delay 3, so two Delays are minted on the same node. Before the fix both were
+# named `<node>.Delay` and collided at graph compaction ("duplicate name for
+# node"). Constant kernels keep batch and streaming outputs equal element-wise
+# so `compare --stream` is a valid check.
+
+graph multi_delay_select(input) -> (output)
+{
+    input = external<scalar>(shape = [1, 1, S]);
+
+    ka = [[[0.5, 0.5]]];
+    kb = [[[0.3, 0.3, 0.3]]];
+    kc = [[[0.25, 0.25, 0.25, 0.25]]];
+
+    a    = conv(input, ka, padding = [(0, 1)], border = 'constant', stride = [1], dilation = [1]);
+    b    = conv(input, kb, padding = [(0, 2)], border = 'constant', stride = [1], dilation = [1]);
+    cdrv = conv(input, kc, padding = [(0, 3)], border = 'constant', stride = [1], dilation = [1]);
+
+    cond   = gt(cdrv, 0.0);
+    output = select(cond, a, b);
+}

--- a/harness/nnef-test-cases/pulse-sync-inputs-multi-delay/runme.sh
+++ b/harness/nnef-test-cases/pulse-sync-inputs-multi-delay/runme.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# Batch run with the streaming symbol concretized.
+$TRACT_RUN --nnef-tract-core . \
+    -t 'set_symbols(values: {"S": 8})' \
+    run --allow-random-input -q
+
+# Streaming compare. `select` has no dedicated pulse pulsifier, so it goes
+# through the generic PulseWrappingOp path; its two value inputs (delays 1 and
+# 2) sit below the condition's delay 3, so sync_inputs inserts a Delay on each.
+# Before the fix both Delays were named `output.Delay` and pulsification failed
+# at graph compaction with "duplicate name for node ... output.Delay". This
+# step pulsifies and compares against the batch run, so it fails without the
+# fix and passes with it.
+$TRACT_RUN --nnef-tract-core . --pulse 4 compare \
+    --stream --allow-random-input -q

--- a/pulse/src/ops/mod.rs
+++ b/pulse/src/ops/mod.rs
@@ -32,15 +32,20 @@ pub(crate) fn sync_inputs(
         }
     }
     let mut inputs = tvec!();
-    for input in &node.inputs {
+    for (input_ix, input) in node.inputs.iter().enumerate() {
         let mut input = mapping[input];
         let fact = target.outlet_fact(input)?.clone();
         if let Some(stream) = &fact.stream {
             if stream.delay < max_delay {
                 let add_delay = max_delay - stream.delay;
                 let delay_axis = stream.axis;
+                // Suffix with the input slot: a node with more than one
+                // under-delayed streaming input would otherwise mint several
+                // Delay nodes all named "{node}.Delay" and collide at graph
+                // compaction (e.g. a Concat fed by two differently-delayed
+                // pulse paths).
                 input = target.wire_node(
-                    format!("{}.Delay", &*node.name),
+                    format!("{}.Delay-{}", &*node.name, input_ix),
                     Delay::new_typed(&fact.into(), delay_axis, add_delay, 0),
                     &[input],
                 )?[0];


### PR DESCRIPTION
When a node has more than one streaming input below the max input delay, `sync_inputs` minted several `Delay` nodes all named `{node}.Delay`, which collided at graph compaction and aborted pulsification (hit on a DPRNN-based speech-enhancement model). This suffixes each inserted Delay with its input slot index, and adds an NNEF test case (a 3-input `select` fed by paths of delay 1/2/3) that fails before the fix and passes after.