### PR TITLE
ci: resolve zizmor findings on the release workflows

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -150,14 +150,16 @@ jobs:
           sbom-path: tract-${{ matrix.target }}-${{ steps.version.outputs.value }}.spdx.json
 
       - name: Upload asset
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          files: |
-            tract-${{matrix.target}}-${{ steps.version.outputs.value }}.tgz
-            tract-${{matrix.target}}-${{ steps.version.outputs.value }}.cdx.json
-            tract-${{matrix.target}}-${{ steps.version.outputs.value }}.spdx.json
-          name: ${{ steps.version.outputs.value }}
-          tag_name: v${{ steps.version.outputs.value }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.value }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          tag="v$VERSION"
+          gh release create "$tag" --target "$GITHUB_SHA" --title "$VERSION" --notes "" 2>/dev/null || true
+          gh release upload "$tag" \
+            "tract-${TARGET}-${VERSION}.tgz" \
+            "tract-${TARGET}-${VERSION}.cdx.json" \
+            "tract-${TARGET}-${VERSION}.spdx.json" \
+            --clobber
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,11 @@ jobs:
           persist-credentials: false
 
       - name: Create Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          name: tract ${{ steps.version.outputs.value }}
         env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN_RELEASE }}
+          GH_TOKEN: ${{ secrets.ACCESS_TOKEN_RELEASE }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          tag="v$VERSION"
+          gh release create "$tag" --title "tract $VERSION" --notes "" --verify-tag \
+            || gh release edit "$tag" --title "tract $VERSION"
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -105,6 +105,8 @@ jobs:
   upload_all:
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
 
     steps:
@@ -116,6 +118,4 @@ jobs:
 
     - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
-        user: __token__
-        password: ${{ secrets.PYPI }}
         verbose: true


### PR DESCRIPTION
Replace softprops/action-gh-release with gh release script steps in binaries.yml and release.yml (race-safe create-or-upload across the target matrix), and switch the PyPI wheel upload to Trusted Publishing (id-token: write, no static token).