### PR TITLE
Trigger full/large-models CI from PR comments

### DIFF
--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -1,0 +1,75 @@
+name: CI slash command
+
+# Lets maintainers trigger heavy CI on a PR by commenting:
+#   /ci full           -> Full test harness        (full.yml)
+#   /ci large-models   -> Large models             (large_models.yml)
+#   /ci large          -> alias of large-models
+#   /ci llm            -> alias of large-models
+# Only commenters with write access can trigger (enforced by slash-command-dispatch).
+
+on:
+  issue_comment:
+    types: [created]
+  repository_dispatch:
+    types: [ci-command]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch /ci comment
+    if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash command dispatch
+        uses: peter-evans/slash-command-dispatch@9bdcd7914ec1b75590b790b844aa3b8eee7c683a # v5.0.2
+        with:
+          token: ${{ secrets.CI_DISPATCH_TOKEN }}
+          commands: ci
+          permission: write
+          issue-type: pull-request
+
+  route:
+    name: Route /ci target
+    if: ${{ github.event_name == 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Route /ci target to its workflow
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ secrets.CI_DISPATCH_TOKEN }}
+          script: |
+            const cp = context.payload.client_payload;
+            const target = (cp.slash_command.args.unnamed.arg1 || '').toLowerCase();
+            const pr = cp.pull_request.number;
+            const map = {
+              'full': 'full.yml',
+              'large-models': 'large_models.yml',
+              'large': 'large_models.yml',
+              'llm': 'large_models.yml',
+            };
+            const workflow = map[target];
+            if (!workflow) {
+              const usage = [
+                `Unknown \`/ci\` target: \`${target || '(none)'}\`.`,
+                '',
+                'Usage: `/ci full` or `/ci large-models` (aliases: `large`, `llm`).',
+              ].join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body: usage,
+              });
+              core.setFailed(usage);
+              return;
+            }
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflow,
+              ref: context.payload.repository.default_branch,
+              inputs: { pr_number: String(pr) },
+            });
+            core.info(`Dispatched ${workflow} for PR #${pr}`);

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -20,15 +20,22 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       test_ref: ${{ steps.set.outputs.test_ref }}
+      pr_number: ${{ steps.set.outputs.pr_number }}
     steps:
       - id: set
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          STATUS_CONTEXT: "CI / full"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
             const prInput = context.payload.inputs?.pr_number;
-            core.info(`Fetching PR ${prInput}`);
+            core.setOutput('pr_number', prInput ? String(prInput) : '');
             if (!prInput) {
               // Use the ref the workflow was triggered on (branch/tag/SHA in base repo)
               core.setOutput('test_ref', process.env.GITHUB_SHA);
@@ -39,8 +46,17 @@ jobs:
               repo: context.repo.repo,
               pull_number: Number(prInput),
             });
-            core.info(pr.data.head.sha);
-            core.setOutput('test_ref', pr.data.head.sha);
+            const sha = pr.data.head.sha;
+            core.setOutput('test_ref', sha);
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'pending',
+              context: process.env.STATUS_CONTEXT,
+              target_url: process.env.RUN_URL,
+              description: 'Running',
+            });
 
   old-harness:
     runs-on: ubuntu-latest
@@ -214,3 +230,55 @@ jobs:
         source .venv/bin/activate
         uv pip install -e ".[dev]"
         pytest .
+
+  report:
+    name: Report result to PR
+    needs: [ prepare, old-harness, cli-tests, onnx-tests, tflite, some-tests-with-paranoid-asserts, without-default-features, complexes, check-all-targets, C, python ]
+    if: ${{ always() && needs.prepare.outputs.pr_number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.prepare.outputs.test_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: "CI / full"
+        with:
+          script: |
+            const needs = JSON.parse(process.env.NEEDS);
+            const prNumber = Number(process.env.PR_NUMBER);
+            const sha = process.env.HEAD_SHA;
+            const runUrl = process.env.RUN_URL;
+            const statusContext = process.env.STATUS_CONTEXT;
+            const icon = r => r === 'success' ? '✅' : r === 'skipped' ? '⏭️' : '❌';
+            const jobs = Object.entries(needs).filter(([k]) => k !== 'prepare');
+            const failed = jobs.filter(([, v]) => v.result !== 'success' && v.result !== 'skipped');
+            const state = failed.length ? 'failure' : 'success';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner, repo: context.repo.repo, sha, state,
+              context: statusContext, target_url: runUrl,
+              description: failed.length ? `${failed.length} job(s) failed` : 'All jobs passed',
+            });
+            const marker = `<!-- ${statusContext} -->`;
+            const body = [
+              marker,
+              `### ${icon(state)} ${statusContext}: ${state}`,
+              '',
+              ...jobs.map(([k, v]) => `- ${icon(v.result)} \`${k}\`: ${v.result}`),
+              '',
+              `[View workflow run](${runUrl})`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, per_page: 100,
+            });
+            const prev = comments.find(c => c.body?.includes(marker));
+            if (prev) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prev.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, body });
+            }

--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -1,7 +1,6 @@
 name: Large models
 
 on:
-  pull_request:
   schedule:
     - cron:  '0 3 * * *'
   workflow_dispatch:
@@ -20,27 +19,42 @@ permissions:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       test_ref: ${{ steps.set.outputs.test_ref }}
+      pr_number: ${{ steps.set.outputs.pr_number }}
     steps:
       - id: set
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          STATUS_CONTEXT: "CI / large-models"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
-            const prInput = context.payload.inputs?.pr_number ?? context.payload.pull_request?.number;
-            let ref;
-            if (prInput) {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: Number(prInput),
-              });
-              ref = pr.data.head.sha;
-            } else {
-              ref = process.env.GITHUB_SHA;
+            const prInput = context.payload.inputs?.pr_number;
+            core.setOutput('pr_number', prInput ? String(prInput) : '');
+            if (!prInput) {
+              core.setOutput('test_ref', process.env.GITHUB_SHA);
+              return;
             }
-            core.info(`test_ref: ${ref}`);
-            core.setOutput('test_ref', ref);
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(prInput),
+            });
+            const sha = pr.data.head.sha;
+            core.setOutput('test_ref', sha);
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'pending',
+              context: process.env.STATUS_CONTEXT,
+              target_url: process.env.RUN_URL,
+              description: 'Running',
+            });
 
   cli:
     name: Build tract on ${{ matrix.os }}
@@ -213,3 +227,55 @@ jobs:
         chmod +x "tract-cli-${UNAME}/tract"
         export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli-${UNAME}/tract"
         ./harness/nemotron-speech-streaming-en-0.6b/ci.sh
+
+  report:
+    name: Report result to PR
+    needs: [ prepare, cli, foundation-llms, foundation-llm, parakeet-tdt-600m-v3, nemotron-speech-streaming-en-06b ]
+    if: ${{ always() && needs.prepare.outputs.pr_number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.prepare.outputs.test_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: "CI / large-models"
+        with:
+          script: |
+            const needs = JSON.parse(process.env.NEEDS);
+            const prNumber = Number(process.env.PR_NUMBER);
+            const sha = process.env.HEAD_SHA;
+            const runUrl = process.env.RUN_URL;
+            const statusContext = process.env.STATUS_CONTEXT;
+            const icon = r => r === 'success' ? '✅' : r === 'skipped' ? '⏭️' : '❌';
+            const jobs = Object.entries(needs).filter(([k]) => k !== 'prepare');
+            const failed = jobs.filter(([, v]) => v.result !== 'success' && v.result !== 'skipped');
+            const state = failed.length ? 'failure' : 'success';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner, repo: context.repo.repo, sha, state,
+              context: statusContext, target_url: runUrl,
+              description: failed.length ? `${failed.length} job(s) failed` : 'All jobs passed',
+            });
+            const marker = `<!-- ${statusContext} -->`;
+            const body = [
+              marker,
+              `### ${icon(state)} ${statusContext}: ${state}`,
+              '',
+              ...jobs.map(([k, v]) => `- ${icon(v.result)} \`${k}\`: ${v.result}`),
+              '',
+              `[View workflow run](${runUrl})`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, per_page: 100,
+            });
+            const prev = comments.find(c => c.body?.includes(marker));
+            if (prev) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prev.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, body });
+            }


### PR DESCRIPTION
Maintainers run `/ci full` or `/ci large-models` (aliases large, llm) in a PR comment. slash-command-dispatch checks the commenter has write access and emits a repository_dispatch that a router maps to the target workflow's workflow_dispatch, passing the PR number so prepare checks out the PR head. Dispatch-triggered runs aren't attached to the PR, so each workflow reports a commit status and a sticky comment back via its own GITHUB_TOKEN. large-models no longer runs automatically on every PR.