### PR TITLE
core: drop per-run String/TypedFact alloc in resolve_symbols_with_states

### DIFF
--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -116,6 +116,17 @@ pub trait OpState: fmt::Debug + dyn_clone::DynClone + OpStateFreeze + Downcast {
         None
     }
 
+    /// Allocation-free predicate mirroring whether [`OpState::init_tensor_fact`]
+    /// returns `Some`. The per-run symbol-resolution path queries this once for
+    /// every stateful op on every `run`, so it must not call `init_tensor_fact`
+    /// (which clones a `String` and a `TypedFact`) merely to test for presence.
+    /// Any impl that overrides `init_tensor_fact` to return `Some` must override
+    /// this to return `true` (and delegate it wherever `init_tensor_fact` is
+    /// delegated), or its `resolve_symbols` will not run.
+    fn has_init_tensor_fact(&self) -> bool {
+        false
+    }
+
     fn resolve_symbols(&mut self, _: &mut TurnState) -> TractResult<()> {
         Ok(())
     }

--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -284,7 +284,7 @@ where
             .op_states
             .iter_mut()
             .filter_map(Option::as_mut)
-            .filter(|s| s.init_tensor_fact().is_some())
+            .filter(|s| s.has_init_tensor_fact())
         {
             state.resolve_symbols(&mut self.turn_state)?;
         }

--- a/cuda/src/ops/fused_axis_op.rs
+++ b/cuda/src/ops/fused_axis_op.rs
@@ -74,6 +74,10 @@ impl OpState for CudaFusedAxisOpState {
         self.op_state.init_tensor_fact()
     }
 
+    fn has_init_tensor_fact(&self) -> bool {
+        self.op_state.has_init_tensor_fact()
+    }
+
     fn load_from(
         &mut self,
         session: &mut TurnState,

--- a/gpu/src/ops/dyn_kv_cache.rs
+++ b/gpu/src/ops/dyn_kv_cache.rs
@@ -43,6 +43,10 @@ impl OpState for GpuDynKVCacheState {
         Some((self.name.clone(), self.past_sequence_fact.clone()))
     }
 
+    fn has_init_tensor_fact(&self) -> bool {
+        true
+    }
+
     fn resolve_symbols(&mut self, state: &mut TurnState) -> TractResult<()> {
         let shape = self
             .kv_cache

--- a/metal/src/ops/fused_axis_op.rs
+++ b/metal/src/ops/fused_axis_op.rs
@@ -74,6 +74,10 @@ impl OpState for MetalFusedAxisOpState {
         self.op_state.init_tensor_fact()
     }
 
+    fn has_init_tensor_fact(&self) -> bool {
+        self.op_state.has_init_tensor_fact()
+    }
+
     fn load_from(
         &mut self,
         session: &mut TurnState,

--- a/transformers/examples/kv_resolve_probe.rs
+++ b/transformers/examples/kv_resolve_probe.rs
@@ -1,0 +1,123 @@
+//! Micro-probe for the per-run symbol-resolution overhead of stateful KV-cache
+//! ops (`resolve_symbols_with_states`).
+//!
+//! Builds a compute-light model with `N` real `DynKeyValueCache` ops (mimicking
+//! an N-layer transformer's K/V caches) and runs a short decode loop, reporting
+//! HEAP ALLOCATIONS PER DECODE STEP and wall-time per step via a counting global
+//! allocator. The KV-cache state persists across steps (one `SimpleState`), so
+//! every step goes through `run_plan_with_eval` -> `resolve_symbols_with_states`.
+//!
+//! Run:  cargo run --release --example kv_resolve_probe -p tract-transformers
+//!
+//! Compare the `allocs/step` column before vs. after the `has_init_tensor_fact`
+//! change: the old code called `init_tensor_fact()` (cloning a `String` name +
+//! `TypedFact`) once per stateful op purely for an `is_some()` test.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use tract_nnef::internal::*;
+use tract_transformers::ops::dyn_kv_cache::DynKeyValueCache;
+
+// ---- counting global allocator -------------------------------------------------
+struct Counting;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+static BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(l.size(), Ordering::Relaxed);
+        unsafe { System.alloc(l) }
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        unsafe { System.dealloc(p, l) }
+    }
+    unsafe fn realloc(&self, p: *mut u8, l: Layout, n: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        BYTES.fetch_add(n, Ordering::Relaxed);
+        unsafe { System.realloc(p, l, n) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+fn allocs() -> usize {
+    ALLOCS.load(Ordering::Relaxed)
+}
+
+/// One source feeding `n_caches` `DynKeyValueCache` ops, all on a `head_dim`-wide
+/// trailing axis, growing along axis 1 (sequence). Compute-light by design so the
+/// per-run fixed overhead (incl. symbol resolution) is a visible fraction.
+fn build(n_caches: usize, head_dim: usize) -> TractResult<Arc<TypedRunnableModel>> {
+    let mut model = TypedModel::default();
+    let s = model.sym("S");
+    let p = model.sym("P");
+    let input_shape: TVec<TDim> = tvec![1.to_dim(), s.into(), (head_dim as i64).to_dim()];
+    let past_shape: TVec<TDim> = tvec![1.to_dim(), p.into(), (head_dim as i64).to_dim()];
+
+    let input = model.add_source("input", f32::fact(&input_shape))?;
+    let mut outs: TVec<OutletId> = tvec![];
+    for i in 0..n_caches {
+        // Realistic, allocation-forcing name (mirrors HF/Qwen NNEF cache names).
+        let op = DynKeyValueCache {
+            name: format!("model.layers.{i}.self_attn.kv_cache"),
+            axis: 1,
+            past_sequence_fact: f32::fact(&past_shape),
+            input_sequence_fact: f32::fact(&input_shape),
+        };
+        let out = model.wire_node(format!("kv_{i}"), op, &[input])?;
+        outs.push(out[0]);
+    }
+    model.select_output_outlets(&outs)?;
+    model.into_runnable()
+}
+
+fn probe(n_caches: usize, head_dim: usize, steps: usize) -> TractResult<(f64, f64)> {
+    let runnable = build(n_caches, head_dim)?;
+    let mut state = runnable.spawn()?;
+
+    // One decode token: [batch=1, seq=1, head_dim].
+    let token: TValue = Tensor::zero::<f32>(&[1, 1, head_dim])?.into();
+
+    // Warm up (first run resolves symbols / grows caches off the cold path).
+    for _ in 0..3 {
+        state.run(tvec![token.clone()])?;
+    }
+
+    let a0 = allocs();
+    let t0 = Instant::now();
+    for _ in 0..steps {
+        let out = state.run(tvec![token.clone()])?;
+        std::hint::black_box(&out);
+    }
+    let elapsed = t0.elapsed();
+    let a1 = allocs();
+
+    let allocs_per_step = (a1 - a0) as f64 / steps as f64;
+    let ns_per_step = elapsed.as_nanos() as f64 / steps as f64;
+    Ok((allocs_per_step, ns_per_step))
+}
+
+fn main() -> TractResult<()> {
+    let head_dim = 8; // tiny -> concat is cheap -> fixed overhead is visible
+    let steps = 64;
+
+    println!("KV-cache resolve probe  (head_dim={head_dim}, steps/measurement={steps})");
+    println!("{:>10} | {:>14} | {:>14}", "n_caches", "allocs/step", "ns/step");
+    println!("{:-<10}-+-{:-<14}-+-{:-<14}", "", "", "");
+    for &n in &[16usize, 32, 64, 128] {
+        // a couple of repeats; report the best (least-noisy) timing, allocs are deterministic
+        let mut best = (f64::MAX, f64::MAX);
+        for _ in 0..5 {
+            let r = probe(n, head_dim, steps)?;
+            if r.1 < best.1 {
+                best = r;
+            }
+        }
+        println!("{:>10} | {:>14.1} | {:>14.0}", n, best.0, best.1);
+    }
+    Ok(())
+}

--- a/transformers/examples/llm_decode_bench.rs
+++ b/transformers/examples/llm_decode_bench.rs
@@ -1,0 +1,118 @@
+//! End-to-end decode-loop benchmark in FOLDED KV-cache mode.
+//!
+//! Loads an NNEF LLM, applies `transformers_detect_all` (which folds attention
+//! into stateful `DynKeyValueCache` ops) WITHOUT unfolding them, then drives a
+//! real prefill + token-by-token decode loop through a persistent `SimpleState`.
+//! Every decode step therefore goes through `resolve_symbols_with_states` over
+//! all of the model's KV-cache op states — the path the `has_init_tensor_fact`
+//! change optimizes.
+//!
+//! Reports allocations/token and ms/token (a counting global allocator measures
+//! the decode window only, after warmup).
+//!
+//! Usage:
+//!   cargo run --release --example llm_decode_bench -p tract-transformers -- <model.nnef.tgz> [prefill_len] [decode_tokens]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use tract_nnef::internal::*;
+use tract_nnef::tract_core::transform::get_transform;
+use tract_transformers::WithTractTransformers;
+
+struct Counting;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(l) }
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        unsafe { System.dealloc(p, l) }
+    }
+    unsafe fn realloc(&self, p: *mut u8, l: Layout, n: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(p, l, n) }
+    }
+}
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+fn allocs() -> usize {
+    ALLOCS.load(Ordering::Relaxed)
+}
+
+fn count_kv_caches(model: &TypedModel) -> usize {
+    model
+        .nodes()
+        .iter()
+        .filter(|n| n.op().name().contains("KeyValueCache") || n.op().name().contains("KvCache"))
+        .count()
+}
+
+fn main() -> TractResult<()> {
+    let mut args = std::env::args().skip(1);
+    let model_path =
+        args.next().expect("usage: llm_decode_bench <model.nnef.tgz> [prefill] [decode]");
+    let prefill_len: usize = args.next().map(|s| s.parse().unwrap()).unwrap_or(16);
+    let decode_tokens: usize = args.next().map(|s| s.parse().unwrap()).unwrap_or(64);
+
+    eprintln!("Loading {model_path} ...");
+    let t_load = Instant::now();
+    let nnef = tract_nnef::nnef().with_tract_transformers();
+    // Declutter BEFORE detection (matches the facade's load path), so the
+    // Source -> Concat -> output KV-cache pattern is in canonical form.
+    let mut model = nnef.model_for_path(&model_path)?.into_decluttered()?;
+
+    // FOLD attention into stateful DynKeyValueCache ops (do NOT unfold).
+    get_transform("transformers_detect_all")?
+        .expect("transformers_detect_all not registered")
+        .transform(&mut model)?;
+
+    let n_kv = count_kv_caches(&model);
+    let runnable = model.into_optimized()?.into_runnable()?;
+    eprintln!("Loaded + optimized in {:?} ({n_kv} KV-cache ops)", t_load.elapsed());
+
+    let mut state = runnable.spawn()?;
+
+    // Token id input [1, S], i64. Values are irrelevant to decode timing.
+    let prefill: TValue = Tensor::from_shape(&[1, prefill_len], &vec![1i64; prefill_len])?.into();
+    let one_tok: TValue = Tensor::from_shape(&[1, 1], &[1i64])?.into();
+
+    // Prefill once.
+    let _ = state.run(tvec![prefill])?;
+
+    // Warm up a few decode steps (prime allocator / caches / branch predictors).
+    for _ in 0..4 {
+        let o = state.run(tvec![one_tok.clone()])?;
+        std::hint::black_box(&o);
+    }
+
+    // Measured decode window.
+    let a0 = allocs();
+    let t0 = Instant::now();
+    let mut per_token_ns: Vec<u128> = Vec::with_capacity(decode_tokens);
+    for _ in 0..decode_tokens {
+        let ts = Instant::now();
+        let o = state.run(tvec![one_tok.clone()])?;
+        per_token_ns.push(ts.elapsed().as_nanos());
+        std::hint::black_box(&o);
+    }
+    let elapsed = t0.elapsed();
+    let a1 = allocs();
+
+    let allocs_per_tok = (a1 - a0) as f64 / decode_tokens as f64;
+    let ms_per_tok = elapsed.as_secs_f64() * 1e3 / decode_tokens as f64;
+    let toks_per_s = decode_tokens as f64 / elapsed.as_secs_f64();
+    per_token_ns.sort_unstable();
+    let median_ms = per_token_ns[per_token_ns.len() / 2] as f64 / 1e6;
+
+    println!(
+        "--- E2E folded decode ({n_kv} KV-cache ops, prefill={prefill_len}, decode={decode_tokens}) ---"
+    );
+    println!("allocs/token : {allocs_per_tok:.1}");
+    println!("ms/token     : {ms_per_tok:.3}  (median {median_ms:.3})");
+    println!("tokens/sec   : {toks_per_s:.2}");
+    Ok(())
+}

--- a/transformers/src/ops/dyn_kv_cache.rs
+++ b/transformers/src/ops/dyn_kv_cache.rs
@@ -146,6 +146,10 @@ impl OpState for DynKeyValueCacheState {
         Some((self.name.clone(), self.past_sequence_fact.clone()))
     }
 
+    fn has_init_tensor_fact(&self) -> bool {
+        true
+    }
+
     fn resolve_symbols(&mut self, state: &mut TurnState) -> TractResult<()> {
         let shape = self.kv_cache.as_ref().map(|kv_cache| kv_cache.shape());
         Self::resolve_symbols(state, self.past_sequence_fact.clone(), shape)
@@ -497,6 +501,28 @@ mod tests {
         run_test_case::<f32>(&[vec![2, 2]], 0)?;
         run_test_case::<f32>(&[vec![2, 2], vec![4, 2]], 0)?;
         run_test_case::<f32>(&[vec![2, 2], vec![2, 1], vec![2, 3]], 1)?;
+        Ok(())
+    }
+
+    // Guards against `has_init_tensor_fact` (the allocation-free predicate used
+    // on the per-run symbol-resolution hot path) drifting out of sync with
+    // `init_tensor_fact`. If they disagree, `resolve_symbols` would silently stop
+    // running for this op.
+    #[test]
+    fn has_init_tensor_fact_matches_init_tensor_fact() -> TractResult<()> {
+        let model = TypedModel::default();
+        let past: TVec<TDim> = tvec![1.to_dim(), model.sym("P").into(), 64.to_dim()];
+        let input: TVec<TDim> = tvec![1.to_dim(), model.sym("S").into(), 64.to_dim()];
+        let op = DynKeyValueCache {
+            name: "kv_cache_0".to_string(),
+            axis: 1,
+            past_sequence_fact: f32::fact(&past),
+            input_sequence_fact: f32::fact(&input),
+        };
+        let session = TurnState::default();
+        let state = op.state(&session, 0)?.unwrap();
+        assert!(state.has_init_tensor_fact());
+        assert_eq!(state.has_init_tensor_fact(), state.init_tensor_fact().is_some());
         Ok(())
     }
 


### PR DESCRIPTION
## What

`SimpleState::resolve_symbols_with_states` runs once per `run()` — i.e. **once per decode token** for an autoregressive model. It selects the stateful ops that need symbol resolution with:

```rust
.filter(|s| s.init_tensor_fact().is_some())
```

but `OpState::init_tensor_fact()` clones a `String` (the cache name) and a `TypedFact`, wraps them in an `Option`, and returns them — only for the result to be tested with `is_some()` and immediately dropped.

This PR adds an allocation-free predicate `OpState::has_init_tensor_fact() -> bool` that mirrors `init_tensor_fact()`, and uses it for the filter.

The set of ops that override `init_tensor_fact` to return `Some` (the transformers + GPU `DynKeyValueCache` states, with the metal/cuda fused ops delegating) is **exactly** the set that overrides `resolve_symbols`, so the filter selects the same states as before — only the per-state allocation is removed. A drift-guard test (`has_init_tensor_fact_matches_init_tensor_fact`) keeps the two in sync, since if they ever disagreed an op's `resolve_symbols` would silently stop running.

## Honesty up front: this is a micro-optimization

It removes **exactly one heap allocation per KV-cache op per decode step** (`2 * n_layers` per token), with no behavioural change. On a real, compute-bound model it is a tiny fraction of per-token work and **does not move wall-clock time**. The value is reduced allocator pressure on the per-token hot path — most visible when layer count is high relative to compute, and under allocator contention. I'm filing it because it's a strictly-better, zero-risk change with a clear measurement, not because it's a speedup you'll feel on a 1.7B model.

## Benchmarks

Two reproducible benchmark examples are included under `transformers/examples/`, both using a counting global allocator.

**`kv_resolve_probe`** — compute-light model with N real `DynKeyValueCache` ops, allocations per decode step:

| n_caches | before | after | Δ allocs | before ns/step | after ns/step |
|---:|---:|---:|---:|---:|---:|
| 16  | 52  | 36  | −16  | 8544  | 7723  |
| 32  | 101 | 69  | −32  | 14842 | 11923 |
| 64  | 198 | 134 | −64  | 24336 | 22628 |
| 128 | 391 | 263 | −128 | 37502 | 31523 |

Allocations drop by **exactly N** (one `String` clone per cache per step; the `TypedFact` clone was inline-smallvec and didn't hit the heap). Wall-time is consistently lower and scales with N when compute is light.

**`llm_decode_bench`** — end-to-end, Qwen3-1.7B q40, folded `DynKeyValueCache` decode (56 caches = 28 layers × 2), persistent `SimpleState`, 128 decode tokens × 3 runs:

| | before | after |
|---|---:|---:|
| allocs/token | 17444 | 17388 |
| tokens/sec | ~19.6 | ~19.6 |

**Exactly −56 allocations/token** (= `2 * n_layers`), deterministic across runs, **no wall-clock regression**.

(Note: the `causal_llm` example *unfolds* KV caches into explicit model I/O, which removes these stateful ops entirely, so it does not exercise this path — hence the dedicated folded-mode `llm_decode_bench`.)

## Testing

- `cargo test -p tract-core` (247) and `-p tract-transformers` (incl. the `dyn_kv_cache` NNEF round-trip + the new drift-guard test) pass.
- metal builds; the cuda override mirrors metal (delegation).
- The stateless path is unaffected by construction (no op states → the filter iterates nothing).

## Files

- `core/src/ops/mod.rs` — new `has_init_tensor_fact()` trait method (default `false`)
- `core/src/plan.rs` — use it in the per-run filter
- `transformers/src/ops/dyn_kv_cache.rs` — override `true` + drift-guard test
- `gpu/src/ops/dyn_kv_cache.rs` — override `true`
- `metal/src/ops/fused_axis_op.rs`, `cuda/src/ops/fused_axis_op.rs` — delegate
- `transformers/examples/{kv_resolve_probe,llm_decode_bench}.rs` — benchmarks

🤖 Generated with [Claude Code](https://claude.com/claude-code)