### PR TITLE
metal: pack element-wise kernels into full-width threadgroups

### DIFF
--- a/metal/examples/threadgroup_bench.rs
+++ b/metal/examples/threadgroup_bench.rs
@@ -1,0 +1,56 @@
+//! Micro-benchmark for Metal element-wise kernel threadgroup occupancy.
+//!
+//! Times the converted flat (`thread_position_in_grid`) kernels — silu (the FFN
+//! activation, compute-bound via exp) and cast (memory-bound) — over large
+//! tensors. Compare before/after the `dispatch_threads_1d` change: the old code
+//! dispatched `n` threadgroups of a single thread, leaving 31/32 SIMD lanes idle.
+//!
+//! Run: cargo run --release --example threadgroup_bench -p tract-metal
+use std::time::Instant;
+
+use tract_core::internal::*;
+use tract_gpu::tensor::{DeviceTensor, IntoDevice};
+use tract_metal::kernels::array::Cast;
+use tract_metal::kernels::nn::Silu;
+use tract_metal::with_metal_stream;
+
+fn main() -> TractResult<()> {
+    with_metal_stream(|stream| {
+        let k = 200;
+        println!("{:>6} | {:>12} | {:>11} | {:>10}", "op", "n_elements", "us/call", "GB/s");
+        println!("{:-<6}-+-{:-<12}-+-{:-<11}-+-{:-<10}", "", "", "", "");
+        for &n in &[1usize << 14, 1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24] {
+            // ---- silu f32 (in == out dt) ----
+            let input = Tensor::from_shape(&[n], &vec![0.5f32; n])?.into_device()?;
+            let out = DeviceTensor::uninitialized_dt(DatumType::F32, &[n])?;
+            for _ in 0..5 {
+                Silu.dispatch_eval(stream, &input, &out)?;
+            }
+            stream.wait_until_completed()?;
+            let t = Instant::now();
+            for _ in 0..k {
+                Silu.dispatch_eval(stream, &input, &out)?;
+            }
+            stream.wait_until_completed()?;
+            let us = t.elapsed().as_secs_f64() * 1e6 / k as f64;
+            let gbps = (n as f64 * 4.0 * 2.0) / (us * 1e-6) / 1e9;
+            println!("{:>6} | {:>12} | {:>11.2} | {:>10.1}", "silu", n, us, gbps);
+
+            // ---- cast f32 -> f16 ----
+            let out16 = DeviceTensor::uninitialized_dt(DatumType::F16, &[n])?;
+            for _ in 0..5 {
+                Cast.dispatch_eval(stream, &input, &out16)?;
+            }
+            stream.wait_until_completed()?;
+            let t = Instant::now();
+            for _ in 0..k {
+                Cast.dispatch_eval(stream, &input, &out16)?;
+            }
+            stream.wait_until_completed()?;
+            let us = t.elapsed().as_secs_f64() * 1e6 / k as f64;
+            let gbps = (n as f64 * (4.0 + 2.0)) / (us * 1e-6) / 1e9;
+            println!("{:>6} | {:>12} | {:>11.2} | {:>10.1}", "cast", n, us, gbps);
+        }
+        Ok(())
+    })
+}

--- a/metal/src/kernels/array/cast.rs
+++ b/metal/src/kernels/array/cast.rs
@@ -2,7 +2,6 @@ use crate::encoder::EncoderExt;
 
 use crate::{LibraryName, MetalStream};
 use derive_new::new;
-use metal::{MTLSize, NSUInteger};
 use std::fmt;
 use tract_core::internal::*;
 use tract_gpu::tensor::DeviceTensor;
@@ -82,9 +81,7 @@ impl Cast {
             encoder.set_metal_tensor(0, input, metal::MTLResourceUsage::Read);
             encoder.set_metal_tensor(1, output, metal::MTLResourceUsage::Write);
 
-            let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
-            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-            encoder.dispatch_thread_groups(grid_size, group_size);
+            crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, output.len());
         });
         Ok(())
     }

--- a/metal/src/kernels/array/copy.rs
+++ b/metal/src/kernels/array/copy.rs
@@ -1,7 +1,6 @@
 use crate::encoder::EncoderExt;
 use crate::{LibraryName, MetalStream};
 use derive_new::new;
-use metal::{MTLSize, NSUInteger};
 use std::fmt;
 use tract_core::internal::*;
 use tract_gpu::tensor::DeviceTensor;
@@ -74,9 +73,7 @@ impl Memcpy {
             );
             encoder.set_metal_tensor(1, output, metal::MTLResourceUsage::Write);
 
-            let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
-            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-            encoder.dispatch_thread_groups(grid_size, group_size);
+            crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, output.len());
         });
         Ok(())
     }

--- a/metal/src/kernels/bin_ops.rs
+++ b/metal/src/kernels/bin_ops.rs
@@ -4,7 +4,6 @@ use crate::encoder::EncoderExt;
 use crate::kernels::utils::compute_broadcast_strides;
 use crate::{LibraryName, MetalStream};
 use anyhow::ensure;
-use metal::{MTLSize, NSUInteger};
 use std::ffi::c_void;
 use tract_core::internal::tract_smallvec::SmallVec;
 use tract_core::internal::*;
@@ -176,10 +175,7 @@ pub fn dispatch_eval(
                 &b.len() as *const usize as *const c_void,
             );
 
-            let grid_size =
-                MTLSize { width: (output.len() / 4) as NSUInteger, height: 1, depth: 1 };
-            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-            encoder.dispatch_thread_groups(grid_size, group_size);
+            crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, output.len() / 4);
         });
     } else {
         let (lhs_shape, rhs_shape, out_shape) = reshape_to_rank_4_with_broadcast(lhs, rhs, output)?;
@@ -279,9 +275,7 @@ pub fn metal_iff_dispatch(
             encoder.set_slice(7, &else_strides_usize);
             encoder.set_slice(8, &out_strides_usize);
 
-            let grid_size = MTLSize { width: total_elems as NSUInteger, height: 1, depth: 1 };
-            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-            encoder.dispatch_thread_groups(grid_size, group_size);
+            crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, total_elems);
         });
         Ok(())
     })

--- a/metal/src/kernels/element_wise.rs
+++ b/metal/src/kernels/element_wise.rs
@@ -1,7 +1,6 @@
 use crate::encoder::EncoderExt;
 use crate::{LibraryName, MetalStream};
 use anyhow::ensure;
-use metal::{MTLSize, NSUInteger};
 use tract_core::internal::*;
 use tract_core::ops::element_wise::ElementWiseMiniOp;
 use tract_gpu::tensor::DeviceTensor;
@@ -83,9 +82,7 @@ pub fn dispatch_eval(
         encoder.set_metal_tensor(0, input, metal::MTLResourceUsage::Read);
         encoder.set_metal_tensor(1, output, metal::MTLResourceUsage::Write);
 
-        let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
-        let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-        encoder.dispatch_thread_groups(grid_size, group_size);
+        crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, output.len());
     });
     Ok(())
 }

--- a/metal/src/kernels/nn/gelu_approximate.rs
+++ b/metal/src/kernels/nn/gelu_approximate.rs
@@ -1,6 +1,5 @@
 use crate::encoder::EncoderExt;
 use crate::{LibraryName, MetalStream};
-use metal::MTLSize;
 use tract_core::internal::*;
 use tract_gpu::tensor::DeviceTensor;
 
@@ -59,9 +58,7 @@ impl GeluApproximate {
             encoder.set_compute_pipeline_state(&pipeline);
             encoder.set_metal_tensor(0, input, metal::MTLResourceUsage::Read);
             encoder.set_metal_tensor(1, output, metal::MTLResourceUsage::Write);
-            let grid_size = MTLSize { width: output.len() as _, height: 1, depth: 1 };
-            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-            encoder.dispatch_thread_groups(grid_size, group_size);
+            crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, output.len());
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/leaky_relu.rs
+++ b/metal/src/kernels/nn/leaky_relu.rs
@@ -1,6 +1,5 @@
 use crate::encoder::EncoderExt;
 use crate::{LibraryName, MetalStream};
-use metal::{MTLSize, NSUInteger};
 use std::ffi::c_void;
 use tract_core::internal::*;
 use tract_gpu::tensor::DeviceTensor;
@@ -45,9 +44,7 @@ impl LeakyRelu {
                 &alpha as *const f32 as *const c_void,
             );
 
-            let grid_size = MTLSize { width: output.len() as NSUInteger, height: 1, depth: 1 };
-            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-            encoder.dispatch_thread_groups(grid_size, group_size);
+            crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, output.len());
         });
         Ok(())
     }

--- a/metal/src/kernels/nn/silu.rs
+++ b/metal/src/kernels/nn/silu.rs
@@ -1,6 +1,5 @@
 use crate::encoder::EncoderExt;
 use crate::{LibraryName, MetalStream};
-use metal::MTLSize;
 use tract_core::internal::*;
 use tract_gpu::tensor::DeviceTensor;
 
@@ -54,9 +53,7 @@ impl Silu {
             encoder.set_metal_tensor(0, input, metal::MTLResourceUsage::Read);
             encoder.set_metal_tensor(1, output, metal::MTLResourceUsage::Write);
 
-            let grid_size = MTLSize { width: n_threads as _, height: 1, depth: 1 };
-            let group_size = MTLSize { width: 1, height: 1, depth: 1 };
-            encoder.dispatch_thread_groups(grid_size, group_size);
+            crate::kernels::utils::dispatch_threads_1d(encoder, &pipeline, n_threads);
         });
         Ok(())
     }

--- a/metal/src/kernels/utils.rs
+++ b/metal/src/kernels/utils.rs
@@ -1,5 +1,27 @@
-use metal::{ComputePipelineState, MTLSize};
+use metal::{ComputeCommandEncoderRef, ComputePipelineState, MTLSize, NSUInteger};
 use tract_core::internal::TractResult;
+
+/// Dispatch a flat, one-thread-per-element kernel that indexes its work by
+/// `thread_position_in_grid`, packing the `n` threads into full-width
+/// threadgroups.
+///
+/// The element-wise / cast / copy kernels historically dispatched `n`
+/// threadgroups of a *single* thread (`dispatch_thread_groups(grid = n,
+/// group = 1)`), which leaves 31 of every 32 SIMD lanes idle on Apple GPUs
+/// (each threadgroup owns its own SIMD-group). `dispatch_threads` lets Metal
+/// pack the same `n` threads into threadgroups of up to the pipeline maximum
+/// (non-uniform threadgroups cover the tail), with no kernel change since the
+/// global `thread_position_in_grid` each thread sees is unchanged.
+pub fn dispatch_threads_1d(
+    encoder: &ComputeCommandEncoderRef,
+    pipeline: &ComputePipelineState,
+    n: usize,
+) {
+    let grid = MTLSize { width: n as NSUInteger, height: 1, depth: 1 };
+    let group_width = n.clamp(1, pipeline.max_total_threads_per_threadgroup() as usize);
+    let group = MTLSize { width: group_width as NSUInteger, height: 1, depth: 1 };
+    encoder.dispatch_threads(grid, group);
+}
 
 pub fn build_metal_size_for_shape(shape: &[usize]) -> MTLSize {
     match shape.len() {


### PR DESCRIPTION
## What

The flat, one-thread-per-element Metal kernels dispatched `n` threadgroups of a **single thread** (`dispatch_thread_groups(grid = n, group = 1)`). On Apple GPUs each threadgroup owns its own SIMD-group, so a 1-thread threadgroup leaves 31 of every 32 lanes idle.

This adds `utils::dispatch_threads_1d`, which uses `dispatch_threads` (non-uniform threadgroups — already used by `apply_rope`) to pack the same `n` threads into threadgroups of up to the pipeline maximum. The kernels index by `thread_position_in_grid`, which is unchanged, so this is a **dispatch-side-only change — no kernel edits**.

Converted (all index by `thread_position_in_grid`): `element_wise`, `cast`, `copy_unicast`, `silu`, `gelu_approx`, `leaky_relu`, the `bin_op` 1-row path, and the `iff`/select `iff_generic` kernel.

Left as-is: the `threadgroup_position_in_grid` kernels (`gather`, `diag_gather`, broadcast `bin_op`) — they structurally encode one threadgroup per element and need separate reworks; the broadcast `bin_op` already uses a real threadgroup via `build_metal_grid_and_groups_for_el_wise_op`.

## Honest scope

The "31/32 SIMD lanes idle" framing oversells it: these ops are **memory-bandwidth-bound**, and on large tensors the GPU already has enough 1-thread threadgroups in flight to saturate bandwidth, so the change is **neutral there**. The win shows up on **small/medium dispatches** — which is exactly the per-token LLM-decode regime (element-wise/activation/cast over `hidden_size × 1 token`).

## Benchmark

Added `metal/examples/threadgroup_bench.rs` (M-series GPU, µs/call, 200 iters; baseline = 1-thread threadgroups):

| n_elements | silu base→fix | speedup | cast (f32→f16) base→fix | speedup |
|---:|---:|:--:|---:|:--:|
| 16 384 | 6.08 → 3.32 | **1.8×** | 6.85 → 2.96 | **2.3×** |
| 65 536 | 24.91 → 5.00 | **5.0×** | 13.71 → 6.15 | **2.2×** |
| 262 144 | 31.64 → 13.12 | **2.4×** | 54.60 → 10.67 | **5.1×** |
| 1 048 576 | 143.1 → 68.7 | **2.1×** | 69.1 → 48.6 | **1.4×** |
| 4 194 304 | 385 → 391 | 1.0× | 279 → 280 | 1.0× |
| 16 777 216 | 1541 → 1556 | 1.0× | 1149 → 1160 | 1.0× |

**1.4–5× on small/medium element-wise dispatches; neutral on large memory-bound tensors. No regression.**

## Testing

All **63 `tract-metal` GPU tests pass** (run on Apple Silicon). The change is +31/−33 in the library (the helper replaces 8 duplicated grid/group blocks); the example adds the benchmark.

## Files
- `metal/src/kernels/utils.rs` — `dispatch_threads_1d` helper
- `metal/src/kernels/{element_wise,bin_ops}.rs`, `kernels/array/{cast,copy}.rs`, `kernels/nn/{silu,gelu_approximate,leaky_relu}.rs` — use it
- `metal/examples/threadgroup_bench.rs` — benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)