### PR TITLE
metal/ggml: keep q4_0 decode on the mat-vec kernel up to 8 rows

### DIFF
--- a/metal/src/kernels/matmul/ggml_gemm/mod.rs
+++ b/metal/src/kernels/matmul/ggml_gemm/mod.rs
@@ -183,10 +183,14 @@ impl GemmKernel for GgmlGemm {
 
         ensure!(!transpose_a && transpose_b);
 
+        // The q4_0 matrix-vector kernel stays bandwidth-bound (one weight read)
+        // for several activation rows, so it beats the tiled GEMM until ~8 rows;
+        // the f16/f32 mat-vec kernels are tuned for 4.
+        let gemv_max_rows = if q40_b { 8 } else { 4 };
         if matches!(dts[0], F32 | F16)
             && (k % 32 == 0)
             && (k >= 64)
-            && ((m > 4) || (q40_b && a_batch > 1))
+            && ((m > gemv_max_rows) || (q40_b && a_batch > 1))
         {
             dispatch_metal_ggml_gemm(
                 stream, params, a_offset, a_buffer, b_offset, b_buffer, c_buffer, c_offset,


### PR DESCRIPTION
**Depends on #2366** (`perf/metal-ggml-f16-roundtrip`) and is stacked on it — please merge #2366 first. Until then this PR's diff includes #2366's commit; it collapses to the single threshold change once #2366 lands.

The q4_0 matrix-vector kernel is bandwidth-bound on the weight read and stays cheaper than the tiled GEMM up to ~8 activation rows, but the dispatcher switched to GEMM at `m > 4`, so 5–8-row q4 decode (batched, or speculative / lookahead) paid the full GEMM cost for no gain. This raises the q4 mat-vec row cap to 8; f16/f32 stay at 4.

## Perf

Forward-pass latency, Qwen3-1.7B q40ef16, Metal (Apple M-series), 256-token past, median ms/pass:

| tokens/pass | main | +#2366 | +#2366 +this |
|---|---|---|---|
| 1  | 30.5 | 26.5 | 26.6 |
| 4  | 44.0 | 43.2 | 41.7 |
| 6  | 72.2 | 75.5 | **55.6** |
| 8  | 72.1 | 76.3 | 71.3 |
| 12 | 72.8 | 77.0 | 76.0 |

The 5–8-row band now lands on the mat-vec path (m=6: **−26%** vs #2366). Single-token decode (m=1) and prefill (m≥12) are unchanged. Downstream this turns k=4 speculative decoding on Qwen3-1.7B from a slowdown (~0.81×) into a ~1.19× speedup, and benefits any small-batch q4 decode.

The crossover (8) is measured on Apple GPUs and would ideally be device-tuned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
