### PR TITLE
Add a nightly bench workflow for the two big machines: build tract-cl…

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,10 @@
 name: Nightly bench
 
-# Builds tract on GitHub-hosted runners (release/LTO), then runs the bench suite on
-# the self-hosted big machines and appends one row per run to the `bench-data` branch.
-# Building off the contended self-hosted boxes keeps the LTO build off the bench machine.
+# Build tract on GitHub-hosted runners, run the bench suite on the self-hosted bench
+# machines, and append one row per run to the bench-data branch. Building off the
+# contended self-hosted boxes keeps the LTO build off the bench machine. The Jetson
+# (aarch64 + CUDA 12) can't be built on a hosted runner natively, so it reuses cross.sh's
+# debian-stretch cross-build (no AWS creds here, so cross.sh's S3-push tail stays off).
 
 on:
   schedule:
@@ -21,8 +23,10 @@ jobs:
       day: ${{ steps.gate.outputs.day }}
     steps:
       - id: gate
+        env:
+          BENCH_ENABLED: ${{ vars.BENCH_ENABLED }}
         run: |
-          if [ "${{ vars.BENCH_ENABLED }}" = "false" ]; then
+          if [ "$BENCH_ENABLED" = "false" ]; then
             echo "::notice::bench disabled via BENCH_ENABLED repo variable"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           else
@@ -34,44 +38,57 @@ jobs:
   build:
     needs: prepare
     if: needs.prepare.outputs.enabled == 'true'
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.host }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest ]
+        include:
+          - target: apple-m1-max
+            host: macos-latest
+            build: ROOT=. ./.travis/ci-system-setup.sh && cargo build -p tract-cli --release
+            bin: target/release/tract
+          - target: i9-11900kb_rtx-4060
+            host: ubuntu-latest
+            build: ROOT=. ./.travis/ci-system-setup.sh && cargo build -p tract-cli --release
+            bin: target/release/tract
+          - target: jetson-orin-nx
+            host: ubuntu-latest
+            build: PLATFORM=aarch64-unknown-linux-gnu-stretch ./.travis/cross.sh
+            bin: target/aarch64-unknown-linux-gnu/release/tract
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
-      - run: |
-          ROOT=. ./.travis/ci-system-setup.sh
-          cargo build -p tract-cli --release
-      - run: echo uname=$(uname) >> "$GITHUB_ENV"
+      - run: ${{ matrix.build }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: tract-cli-${{ env.uname }}
-          path: ./target/release/tract
+          name: tract-cli-${{ matrix.target }}
+          path: ${{ matrix.bin }}
 
   bench:
     needs: [ prepare, build ]
     if: needs.prepare.outputs.enabled == 'true'
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       id-token: write     # AWS OIDC for S3 model fetch
       contents: write     # push to bench-data
     concurrency:
-      group: bench-${{ matrix.os }}   # serialize against itself; never fight a running bench
+      group: bench-${{ matrix.runner }}   # serialize against itself; never fight a running bench
       cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: macOS
-            device: apple-m1-max
+          - target: apple-m1-max
+            runner: macOS
             triple: aarch64-apple-darwin
-          - os: cuda-lovelace
-            device: i9-11900kb_rtx-4060
+          - target: i9-11900kb_rtx-4060
+            runner: cuda-lovelace
             triple: x86_64-unknown-linux-gnu
+          - target: jetson-orin-nx
+            runner: orin-nx-16g
+            triple: aarch64-unknown-linux-gnu-stretch
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -82,19 +99,18 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::567805100031:role/github-runner-tract-ci
           aws-region: us-east-2
-      - run: echo uname=$(uname) >> "$GITHUB_ENV"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: tract-cli-${{ env.uname }}
-          path: tract-cli-${{ env.uname }}
+          name: tract-cli-${{ matrix.target }}
+          path: tract-cli
       - name: Run bench suite
-        env:
-          UNAME: ${{ env.uname }}
         run: |
-          chmod +x "tract-cli-${UNAME}/tract"
-          export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli-${UNAME}/tract"
+          chmod +x tract-cli/tract
+          export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli/tract"
           ./.travis/bundle-entrypoint.sh        # produces ./metrics
       - name: Checkout bench-data
+        # zizmor: ignore[artipacked] credentials are needed to push the row back to
+        # bench-data; this checkout is never uploaded as an artifact.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: bench-data
@@ -102,18 +118,18 @@ jobs:
           fetch-depth: 1
       - name: Append and push
         env:
-          DEVICE: ${{ matrix.device }}
+          DEVICE: ${{ matrix.target }}
           TRIPLE: ${{ matrix.triple }}
           REF: ${{ needs.prepare.outputs.ref }}
           DAY: ${{ needs.prepare.outputs.day }}
         run: |
           python3 .travis/bench-append.py --metrics metrics --out bench-data \
-            --triple "$TRIPLE" --device "$DEVICE" --commit "$REF" --day "$DAY"
+            --triple "$TRIPLE" --device "$DEVICE" --day "$DAY"
           cd bench-data
           git config user.name "tract-ci"
           git config user.email "kali@zoy.org"
           git add -A
-          git commit -m "bench: $DEVICE $DAY"
+          git commit -m "bench: $DEVICE $DAY ${REF:0:9}"
           for i in 1 2 3 4 5; do
             git push origin HEAD:bench-data && exit 0
             git fetch origin bench-data

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,122 @@
+name: Nightly bench
+
+# Builds tract on GitHub-hosted runners (release/LTO), then runs the bench suite on
+# the self-hosted big machines and appends one row per run to the `bench-data` branch.
+# Building off the contended self-hosted boxes keeps the LTO build off the bench machine.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'   # after large-models (3am) so they don't fight for the self-hosted boxes
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.gate.outputs.enabled }}
+      ref: ${{ steps.gate.outputs.ref }}
+      day: ${{ steps.gate.outputs.day }}
+    steps:
+      - id: gate
+        run: |
+          if [ "${{ vars.BENCH_ENABLED }}" = "false" ]; then
+            echo "::notice::bench disabled via BENCH_ENABLED repo variable"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          echo "day=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: prepare
+    if: needs.prepare.outputs.enabled == 'true'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+          persist-credentials: false
+      - run: |
+          ROOT=. ./.travis/ci-system-setup.sh
+          cargo build -p tract-cli --release
+      - run: echo uname=$(uname) >> "$GITHUB_ENV"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tract-cli-${{ env.uname }}
+          path: ./target/release/tract
+
+  bench:
+    needs: [ prepare, build ]
+    if: needs.prepare.outputs.enabled == 'true'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write     # AWS OIDC for S3 model fetch
+      contents: write     # push to bench-data
+    concurrency:
+      group: bench-${{ matrix.os }}   # serialize against itself; never fight a running bench
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macOS
+            device: apple-m1-max
+            triple: aarch64-apple-darwin
+          - os: cuda-lovelace
+            device: i9-11900kb_rtx-4060
+            triple: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
+          persist-credentials: false
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: arn:aws:iam::567805100031:role/github-runner-tract-ci
+          aws-region: us-east-2
+      - run: echo uname=$(uname) >> "$GITHUB_ENV"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tract-cli-${{ env.uname }}
+          path: tract-cli-${{ env.uname }}
+      - name: Run bench suite
+        env:
+          UNAME: ${{ env.uname }}
+        run: |
+          chmod +x "tract-cli-${UNAME}/tract"
+          export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli-${UNAME}/tract"
+          ./.travis/bundle-entrypoint.sh        # produces ./metrics
+      - name: Checkout bench-data
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: bench-data
+          path: bench-data
+          fetch-depth: 1
+      - name: Append and push
+        env:
+          DEVICE: ${{ matrix.device }}
+          TRIPLE: ${{ matrix.triple }}
+          REF: ${{ needs.prepare.outputs.ref }}
+          DAY: ${{ needs.prepare.outputs.day }}
+        run: |
+          python3 .travis/bench-append.py --metrics metrics --out bench-data \
+            --triple "$TRIPLE" --device "$DEVICE" --commit "$REF" --day "$DAY"
+          cd bench-data
+          git config user.name "tract-ci"
+          git config user.email "kali@zoy.org"
+          git add -A
+          git commit -m "bench: $DEVICE $DAY"
+          for i in 1 2 3 4 5; do
+            git push origin HEAD:bench-data && exit 0
+            git fetch origin bench-data
+            git rebase origin/bench-data || git rebase --abort
+          done
+          echo "push failed after retries" >&2; exit 1

--- a/.travis/bench-append.py
+++ b/.travis/bench-append.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Append one nightly bench run to the bench-data branch (columnar, one value per line).
+
+Columnar keeps files compact and per-metric (report-friendly). Writing one value per
+line (json indent) makes a daily append an INSERTION into each metric array, so git
+diffs/commits stay small even though the whole file is rewritten.
+
+File: <out>/<build-triple>/<device>.json
+  {"start_day":"YYYY-MM-DD","metrics":{"<metric>":[v0, v1, ...]}}
+Column i of every array is start_day + i days; null = no run that day.
+"""
+import argparse, datetime, json, math, os, sys
+
+
+def sig(x, n=4):
+    if x == 0:
+        return 0
+    r = round(x, -int(math.floor(math.log10(abs(x)))) + (n - 1))
+    return int(r) if r == int(r) else r
+
+
+def read_metrics(path):
+    out = {}
+    for line in open(path):
+        parts = line.split()
+        if len(parts) == 2:
+            try:
+                out[parts[0]] = sig(float(parts[1]))
+            except ValueError:
+                pass
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--metrics", required=True)
+    ap.add_argument("--out", required=True, help="bench-data checkout root")
+    ap.add_argument("--triple", required=True)
+    ap.add_argument("--device", required=True)
+    ap.add_argument("--day", default=datetime.date.today().isoformat())
+    args = ap.parse_args()
+
+    today = read_metrics(args.metrics)
+    if not today:
+        print(f"no metrics in {args.metrics}", file=sys.stderr)
+        sys.exit(1)
+    day = datetime.date.fromisoformat(args.day)
+
+    path = os.path.join(args.out, args.triple, f"{args.device}.json")
+    if os.path.exists(path):
+        data = json.load(open(path))
+        start = datetime.date.fromisoformat(data["start_day"])
+        arrays = data["metrics"]
+    else:
+        start, arrays = day, {}
+
+    idx = (day - start).days
+    if idx < 0:
+        print(f"day {day} precedes start_day {start}", file=sys.stderr)
+        sys.exit(1)
+
+    n = idx + 1
+    for k in set(arrays) | set(today):
+        a = arrays.get(k, [])
+        if len(a) < n:                       # null-pad skipped days / new metric's prefix
+            a = a + [None] * (n - len(a))
+        a[idx] = today.get(k)                # value today, else null (metric not run today)
+        arrays[k] = a
+
+    obj = {"start_day": start.isoformat(),
+           "metrics": {k: arrays[k] for k in sorted(arrays)}}
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        json.dump(obj, fh, indent=0)         # one value per line -> insertion-friendly diffs
+        fh.write("\n")
+    print(f"appended {args.device} {args.day}: {len(today)} metrics, span now {n} days")
+
+
+if __name__ == "__main__":
+    main()

--- a/.travis/bundle-entrypoint.sh
+++ b/.travis/bundle-entrypoint.sh
@@ -18,22 +18,13 @@ else
 fi
 
 CACHEDIR=${CACHEDIR:-$HOME/.cache/tract-ci-minion-models}
-case $CACHEDIR in
-    "http"*)
-        wget $CACHEDIR/private/private-benches.sh
-        PRIVATE=`pwd`/private-benches.sh
-    ;;
-    *)
-        [ -d $CACHEDIR ] || mkdir $CACHEDIR
-        PATH=$PATH:/usr/local/bin # for aws command on darwin
-        aws s3 sync s3://tract-ci-builds/model $CACHEDIR || echo "Warning: aws s3 sync failed, continuing with cached models"
-        (cd $CACHEDIR
-            [ -d en_libri_real ] || tar zxf en_libri_real.tar.gz
-            [ -d en_tdnn_lstm_bn_q7 ] || tar zxf en_tdnn_lstm_bn_q7.tar.gz
-        )
-        PRIVATE=$CACHEDIR/private/private-benches.sh
-    ;;
-esac
+[ -d $CACHEDIR ] || mkdir $CACHEDIR
+PATH=$PATH:/usr/local/bin # for aws command on darwin
+aws s3 sync s3://tract-ci-builds/model $CACHEDIR || echo "Warning: aws s3 sync failed, continuing with cached models"
+(cd $CACHEDIR
+    [ -d en_libri_real ] || tar zxf en_libri_real.tar.gz
+    [ -d en_tdnn_lstm_bn_q7 ] || tar zxf en_tdnn_lstm_bn_q7.tar.gz
+)
 
 
 
@@ -147,8 +138,6 @@ net_bench voicecom_float 2sec $CACHEDIR/snips-voice-commands-cnn-float.pb -i 200
 
 net_bench trunet pulse1_f32 $CACHEDIR/trunet_dummy.nnef.tgz --nnef-tract-core --pulse 1
 net_bench trunet pulse1_f16 $CACHEDIR/trunet_dummy.nnef.tgz --nnef-tract-core -t f32_to_f16 --pulse 1
-
-[ -f "$PRIVATE" ] && . "$PRIVATE"
 
 if [ $(uname) = "Darwin" ]
 then


### PR DESCRIPTION
…i (release) on GitHub-hosted runners, run the full bench suite on the self-hosted macOS and cuda-lovelace boxes, and append one row per run to the bench-data branch. Strip the private-benches path from bundle-entrypoint.