### PR TITLE
release.sh: push only the version tag, not all tags. Pushing every ta…

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -51,5 +51,5 @@ if [ "$CRATE_PATH" = "cli" ]
 then
     git commit -m "release $VERSION" .
     git tag -f v"$VERSION"
-    git push -f --tags
+    git push -f origin "v$VERSION"
 fi


### PR DESCRIPTION
…g at once stopped triggering the release/wheels/binaries workflows once more than three tags had accumulated.