### PR TITLE
bench-append.py: normalize metric keys '-' to '_' to match the recove…

### DIFF
--- a/.travis/bench-append.py
+++ b/.travis/bench-append.py
@@ -25,7 +25,9 @@ def read_metrics(path):
         parts = line.split()
         if len(parts) == 2:
             try:
-                out[parts[0]] = sig(float(parts[1]))
+                # '-' -> '_' matches the recovered history: the old minion ran the
+                # metric names through `tr '-' '_'` before pushing them to graphite.
+                out[parts[0].replace("-", "_")] = sig(float(parts[1]))
             except ValueError:
                 pass
     return out


### PR DESCRIPTION
…red history. The old minion ran the names through tr '-' '_' before graphite, so without this the live appends fork a parallel series (e.g. bundle.bench-runtime vs bundle.bench_runtime) instead of continuing the historical one.