### PR TITLE
bench: post the PR comment via a workflow_run trampoline

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -1,0 +1,66 @@
+name: Bench comment
+
+# Trampoline for the Bench report. The Bench workflow runs on `pull_request`, which gets
+# a read-only token on fork PRs and so cannot comment. It instead uploads the rendered
+# comparison as the `bench-comment` artifact; this workflow runs on `workflow_run` (base
+# context, write token) and posts it — working for fork and same-repo PRs alike.
+#
+# Security: the target PR is resolved from the triggering run's head SHA, never from
+# artifact contents, so a fork cannot redirect the comment at another issue. The artifact
+# only carries the comment body (a bench table rendered by our own tooling).
+
+# Hardened: no fork code is checked out or run here; the target PR comes from the run's
+# head SHA (not the artifact), and the token only posts a comment. workflow_run is the only
+# way to get a write token for fork-PR comments.
+on:  # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ["Bench"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read           # download the artifact from the triggering run
+  pull-requests: write    # post the comment
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true   # no artifact => nothing comparable => nothing to post
+        with:
+          name: bench-comment
+          path: bench-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('bench-comment/pr-comment.md')) {
+              core.info('no comment artifact; nothing to post');
+              return;
+            }
+            const body = fs.readFileSync('bench-comment/pr-comment.md', 'utf8');
+            // Resolve the PR from the run's head SHA — never trust artifact-supplied targets.
+            const sha = context.payload.workflow_run.head_sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner, repo: context.repo.repo, commit_sha: sha,
+            });
+            const pr = prs.find(p => p.state === 'open');
+            if (!pr) {
+              core.info(`no open PR for ${sha}; nothing to post`);
+              return;
+            }
+            const issue_number = pr.number;
+            const marker = '<!-- bench-vs-main -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number, per_page: 100,
+            });
+            const prev = comments.find(c => c.body?.includes(marker));
+            if (prev) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prev.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number, body });
+            }

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -179,13 +179,12 @@ jobs:
 
   report:
     needs: [ prepare, build, bench ]
-    # !cancelled() (not always()) so a superseded/cancelled bench doesn't post a vacuous
-    # "no regressions" over a real result; the post step also skips when there's no comment.
+    # !cancelled() (not always()) so a superseded/cancelled bench doesn't produce a vacuous
+    # "no regressions" comment; bench-report writes no file when there's nothing to compare.
     if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.prepare.outputs.enabled == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -213,23 +212,11 @@ jobs:
           chmod +x tract-cli/tract
           tract-cli/tract bench-report --results results --bench-data bench-data \
             --thresholds .travis/bench-thresholds.toml --pr-sha "$PR_SHA" --out pr-comment.md
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      # Hand the rendered comment to the bench-comment workflow to post. Posting is split
+      # out via workflow_run because this pull_request run gets a read-only token on fork
+      # PRs and can't comment. No file => nothing comparable => no artifact => nothing posted.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ hashFiles('pr-comment.md') != '' }}
         with:
-          script: |
-            const fs = require('fs');
-            if (!fs.existsSync('pr-comment.md')) {   // no results (cancelled/empty) -> leave any prior comment alone
-              core.info('no comparison produced; not posting');
-              return;
-            }
-            const body = fs.readFileSync('pr-comment.md', 'utf8');
-            const marker = '<!-- bench-vs-main -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner, repo: context.repo.repo,
-              issue_number: context.issue.number, per_page: 100,
-            });
-            const prev = comments.find(c => c.body?.includes(marker));
-            if (prev) {
-              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prev.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body });
-            }
+          name: bench-comment
+          path: pr-comment.md


### PR DESCRIPTION
The Bench report job runs on pull_request, which gets a read-only token on fork PRs and so can't comment (the comparison only landed in the job summary). Split posting out: the report job uploads the rendered comment as an artifact, and a new Bench-comment workflow runs on workflow_run (base context, write token) and posts it -- working for fork and same-repo PRs alike. The target PR is resolved from the run's head SHA, never from artifact contents, so a fork can't redirect the comment at another issue.