### PR TITLE
bench: fix fork-PR comment target resolution in the trampoline

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -38,22 +38,30 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            if (!fs.existsSync('bench-comment/pr-comment.md')) {
+            if (!fs.existsSync('bench-comment/pr-comment.md') || !fs.existsSync('bench-comment/pr-number')) {
               core.info('no comment artifact; nothing to post');
               return;
             }
             const body = fs.readFileSync('bench-comment/pr-comment.md', 'utf8');
-            // Resolve the PR from the run's head SHA — never trust artifact-supplied targets.
+            // The artifact names the target PR (the only thing that survives for fork PRs —
+            // a fork commit isn't in this repo, so listPullRequestsAssociatedWithCommit finds
+            // nothing). Trust it only after verifying that PR's head SHA matches the run's, so
+            // a fork can name its own PR but never redirect the comment at another issue.
             const sha = context.payload.workflow_run.head_sha;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner, repo: context.repo.repo, commit_sha: sha,
-            });
-            const pr = prs.find(p => p.state === 'open');
-            if (!pr) {
-              core.info(`no open PR for ${sha}; nothing to post`);
+            const issue_number = parseInt(fs.readFileSync('bench-comment/pr-number', 'utf8').trim(), 10);
+            if (!Number.isInteger(issue_number)) {
+              core.info('no valid PR number in artifact; nothing to post');
               return;
             }
-            const issue_number = pr.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number: issue_number,
+            });
+            if (pr.head.sha !== sha) {
+              // Either a stale run (the PR was re-pushed; a fresh run will post) or a forged
+              // target. Skip quietly either way — the security property is that we never post.
+              core.info(`PR #${issue_number} head ${pr.head.sha} != run head ${sha}; not posting`);
+              return;
+            }
             const marker = '<!-- bench-vs-main -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo, issue_number, per_page: 100,

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -212,11 +212,19 @@ jobs:
           chmod +x tract-cli/tract
           tract-cli/tract bench-report --results results --bench-data bench-data \
             --thresholds .travis/bench-thresholds.toml --pr-sha "$PR_SHA" --out pr-comment.md
-      # Hand the rendered comment to the bench-comment workflow to post. Posting is split
-      # out via workflow_run because this pull_request run gets a read-only token on fork
-      # PRs and can't comment. No file => nothing comparable => no artifact => nothing posted.
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      # Hand the rendered comment + target PR to the bench-comment workflow to post. Posting
+      # is split out via workflow_run because this pull_request run gets a read-only token on
+      # fork PRs and can't comment. No file => nothing comparable => no artifact => nothing posted.
+      - name: Stage comment for the trampoline
         if: ${{ hashFiles('pr-comment.md') != '' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          mkdir -p bench-comment
+          mv pr-comment.md bench-comment/
+          printf '%s\n' "$PR_NUMBER" > bench-comment/pr-number
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: ${{ hashFiles('bench-comment/pr-comment.md') != '' }}
         with:
           name: bench-comment
-          path: pr-comment.md
+          path: bench-comment


### PR DESCRIPTION
Resolving the PR from the run's head SHA returns nothing for a fork PR (the head commit lives in the fork, not this repo), so the trampoline posted no comment -- the exact case it exists for. Pass the PR number in the artifact instead, and validate it: fetch that PR and require its head SHA to equal the run's, so a fork can name only its own PR, never redirect at another issue. Mismatch (or a stale re-pushed run) skips quietly.