### PR TITLE
Revert "linalg/arm64simd: keep proven kernel speedups" (#2393)

### DIFF
--- a/linalg/src/arm64/arm64simd/gelu.rs
+++ b/linalg/src/arm64/arm64simd/gelu.rs
@@ -13,9 +13,28 @@ ew_impl_wrap!(
     (),
     #[inline(never)]
     fn run(buf: &mut [f32], _: ()) {
-        // Keep the composed symbol but route to the single-pass fused kernel:
-        // same approximation, less memory traffic (no scratch copy).
-        super::arm64simd_gelu_f32_4n_fused::run(buf, ());
+        const SQRT_2_OVER_PI: f32 = 0.7978845608028654;
+        const COEF: f32 = 0.044715;
+        const CHUNK: usize = 256;
+        let mut scratch = [0f32; CHUNK];
+        let mut start = 0;
+        while start < buf.len() {
+            let end = (start + CHUNK).min(buf.len());
+            let chunk = &mut buf[start..end];
+            let n = chunk.len();
+            // Save original x and pre-compute the tanh argument in place.
+            for i in 0..n {
+                let x = chunk[i];
+                scratch[i] = x;
+                chunk[i] = SQRT_2_OVER_PI * (x + COEF * x * x * x);
+            }
+            super::arm64simd_tanh_f32_4n::run(chunk, ());
+            // chunk now holds tanh(arg). Combine with saved x.
+            for i in 0..n {
+                chunk[i] = 0.5 * scratch[i] * (1.0 + chunk[i]);
+            }
+            start = end;
+        }
     }
 );
 

--- a/linalg/src/arm64/arm64simd/max.rs
+++ b/linalg/src/arm64/arm64simd/max.rs
@@ -16,9 +16,9 @@ reduce_impl_wrap!(
             let ptr = buf.as_ptr();
             let mut out: float32x4_t = vdupq_n_f32(f32::MIN);
             std::arch::asm!("
-            mov v1.16b, v0.16b
-            mov v2.16b, v0.16b
-            mov v3.16b, v0.16b
+            and v1.16b, v0.16b, v0.16b
+            and v2.16b, v0.16b, v0.16b
+            and v3.16b, v0.16b, v0.16b
             2:
                 ld1 {{v4.4s, v5.4s, v6.4s, v7.4s}}, [{ptr}], 64
                 fmax v0.4s, v0.4s, v4.4s

--- a/linalg/src/arm64/arm64simd/silu.rs
+++ b/linalg/src/arm64/arm64simd/silu.rs
@@ -6,9 +6,24 @@ ew_impl_wrap!(
     (),
     #[inline(never)]
     fn run(buf: &mut [f32], _: ()) {
-        // Keep the composed symbol but route to the single-pass fused kernel:
-        // same formula, less memory traffic (no scratch copy).
-        super::arm64simd_silu_f32_4n_fused::run(buf, ());
+        // SiLU(x) = x * sigmoid(x). Compose by saving the input chunk to a
+        // stack scratch buffer, running tract's NEON sigmoid kernel in place,
+        // then multiplying back by the saved original. Multiply loop
+        // auto-vectorises on aarch64.
+        const CHUNK: usize = 256;
+        let mut scratch = [0f32; CHUNK];
+        let mut start = 0;
+        while start < buf.len() {
+            let end = (start + CHUNK).min(buf.len());
+            let chunk = &mut buf[start..end];
+            let n = chunk.len();
+            scratch[..n].copy_from_slice(chunk);
+            super::arm64simd_sigmoid_f32_4n::run(chunk, ());
+            for i in 0..n {
+                chunk[i] *= scratch[i];
+            }
+            start = end;
+        }
     }
 );
 

--- a/linalg/src/arm64/arm64simd/softmax.rs
+++ b/linalg/src/arm64/arm64simd/softmax.rs
@@ -49,6 +49,11 @@ map_reduce_impl_wrap!(
                 fadd v10.4s, v10.4s, v6.4s
                 fadd v11.4s, v11.4s, v6.4s
 
+                fmax v8.4s, v8.4s, v7.4s
+                fmax v9.4s, v9.4s, v7.4s
+                fmax v10.4s, v10.4s, v7.4s
+                fmax v11.4s, v11.4s, v7.4s
+
                 fcvtnu v8.4s, v8.4s
                 fcvtnu v9.4s, v9.4s
                 fcvtnu v10.4s, v10.4s


### PR DESCRIPTION
The arm64 kernel micro-opts shifted f16 logits enough to regress the LLM RBO nightly: meta-llama--Llama-3.2-3B-Instruct-q40ef16.p0s100.arm64.cpu dropped 0.94 -> 0.87, with smaller arm64 drops on other models. The change is arm64-only; x86_64 cpu and the gpu paths of the same models are unaffected. #2393 was validated for speed only (kernel-microbench ns), and the arm64 softmax/activation kernel tests run at Approximation::SuperApproximate, too loose to catch a logit ranking shift. The end-to-end speed it bought is negligible against matmuls, so restore the proven-correct composed silu/gelu kernels and the pre-fcvtnu softmax clamp. Re-land individual variants gated by an RBO run if the speed is wanted.

This reverts commit fbbacc468f8aafe88aa60a4b57754d82375f8a02.