### PR TITLE
ci: stop rust-cache thrashing against the 10 GB repo cap

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -67,6 +67,12 @@ jobs:
         persist-credentials: false
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # beta/nightly change too often to cache usefully and just evict the stable
+      # entries under the 10 GB/repo cap; and only main should save, so PR runs
+      # restore without adding transient caches that push main's out.
+      if: matrix.rust != 'beta' && matrix.rust != 'nightly'
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Cargo test
       run: cargo test -p ${{matrix.crate}}
@@ -138,6 +144,9 @@ jobs:
         persist-credentials: false
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      if: matrix.rust != 'beta' && matrix.rust != 'nightly'
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - run: rustup component add clippy && cargo clippy
     - name: clippy (bench-suite feature)

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -101,6 +101,8 @@ jobs:
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         key: ${{ matrix.platform }}
+        # only main saves; PR runs restore without evicting main's caches.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Setup wasmtime
       if: matrix.platform == 'wasm32-wasi'
@@ -148,6 +150,8 @@ jobs:
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
         key: ${{ matrix.platform }}
+        # only main saves; PR runs restore without evicting main's caches.
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Cross script
       env:


### PR DESCRIPTION
The Actions cache sits at ~9.4/10 GB, so entries evict each other between runs and jobs that should hit rebuild cold. On the two pull_request workflows (crates, cross-platform), only save the cache on main (save-if) so PR runs restore without adding transient entries that push main's out; and skip the beta/nightly toolchains in crates, which change too often to cache usefully and only add churn. Schedule-only workflows run on main and keep warming the cache.