### PR TITLE
test: relax two 1-ULP-brittle numerical assertions

### DIFF
--- a/harness/nnef-test-cases/test_manage_gru_states/runme.sh
+++ b/harness/nnef-test-cases/test_manage_gru_states/runme.sh
@@ -7,4 +7,6 @@ set -ex
 
 # Check result is as expected
 # bug appear only if model optimized and input-fact-from-bundle
-$TRACT_RUN --nnef-tract-core ./model.nnef.tgz -O --input-facts-from-bundle ./io.npz run --input-from-bundle io.npz --assert-output-bundle io.npz
+# --approx approximate: the f32 output legitimately varies by ~1 ULP with matmul
+# kernel selection (reduction order); the default exact-ish Close check is too tight.
+$TRACT_RUN --nnef-tract-core ./model.nnef.tgz -O --input-facts-from-bundle ./io.npz run --input-from-bundle io.npz --assert-output-bundle io.npz --approx approximate

--- a/test-rt/suite-unit/src/conv_f16.rs
+++ b/test-rt/suite-unit/src/conv_f16.rs
@@ -68,9 +68,11 @@ impl Test for ConvProblemF16 {
         let input_f16 = self.0.data.mapv(f16::from_f32).into_tensor();
         let mut output = runtime.prepare(model)?.run(tvec![input_f16.into_tvalue()])?;
         let output = output.remove(0).into_tensor();
-        // Cast output back to f32 for comparison with f32 reference
-        let output_f32 = output.cast_to::<f32>()?.into_owned();
-        output_f32.close_enough(&reference, approx)
+        // Judge at f16 precision: the conv ran in f16, so compare against the reference
+        // rounded to f16 (this selects the F16 tolerance row). Casting the output up to
+        // f32 and comparing with f32 tolerances rejects legitimate ~1 f16-ULP differences.
+        let reference_f16 = reference.cast_to::<f16>()?.into_owned();
+        output.close_enough(&reference_f16, approx)
     }
 }
 


### PR DESCRIPTION
The 06-24 nightly went red on two checks that demand near-bit-exactness of inherently 1-ULP-variable float ops (kernel-selection/reduction-order shifts after the #2339 matmul changes), not on any correctness regression:

- test_manage_gru_states: f32 output off by ~1 ULP under the default Close check; use --approx approximate.
- conv_f16 proptest: f16 conv was judged at f32 tolerance (output cast up to f32); compare against the f16-rounded reference so the F16 tolerance applies.

Verified: GRU assert passes; conv_f16 proptest passes at 1024 cases.