### PR TITLE
bench: --skip-cpu, and use it to drop jetson CPU runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -97,6 +97,9 @@ jobs:
           - target: jetson-orin-nx
             runner: orin-nx-16g
             triple: aarch64-unknown-linux-gnu-stretch
+            # GPU-only box: its arm64 CPU is redundant with apple-m1-max for the net
+            # suite, so skip CPU runs and bench only the Orin GPU (cuda).
+            bench_args: --skip-cpu
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -122,11 +125,13 @@ jobs:
           chmod +x tract-cli/tract
           # no --cache-dir: honor each runner's CACHEDIR env (its curated model cache),
           # falling back to ~/.cache/tract-ci-minion-models, like the old bundle did.
+          # ${{ matrix.bench_args }} is empty except on jetson (--skip-cpu).
           tract-cli/tract bench-suite \
             --manifest .travis/benches.toml \
             --bench-data bench-ref \
             --thresholds .travis/bench-thresholds.toml \
-            --triple "$TRIPLE" --device "$DEVICE"        # produces ./metrics
+            --triple "$TRIPLE" --device "$DEVICE" \
+            ${{ matrix.bench_args }}        # produces ./metrics
 
       # --- nightly / dispatch: append the row to bench-data ---
       - name: Checkout bench-data

--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -155,6 +155,7 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
 
     let output = matches.get_one::<String>("output").map(String::as_str).unwrap_or("metrics");
     let no_fetch = matches.get_flag("no-fetch");
+    let skip_cpu = matches.get_flag("skip-cpu");
     let filter = matches.get_one::<String>("filter").map(String::as_str);
 
     let expectations = expectations(matches)?;
@@ -174,16 +175,22 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
         }
 
         let runs: Vec<(Option<Backend>, String)> = if bench.backends.is_empty() {
-            let variant = bench
-                .variant
-                .clone()
-                .with_context(|| format!("{}: no variant and no backends", bench.name))?;
-            vec![(None, variant)]
+            // Backend-less benches are a plain CPU run; --skip-cpu drops them entirely.
+            if skip_cpu {
+                vec![]
+            } else {
+                let variant = bench
+                    .variant
+                    .clone()
+                    .with_context(|| format!("{}: no variant and no backends", bench.name))?;
+                vec![(None, variant)]
+            }
         } else {
             bench
                 .backends
                 .iter()
                 .filter(|b| b.available())
+                .filter(|b| !(skip_cpu && matches!(**b, Backend::Cpu)))
                 .map(|b| (Some(*b), b.label().to_string()))
                 .collect()
         };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -263,6 +263,7 @@ fn main() -> TractResult<()> {
                 .arg(arg!(--output [PATH] "Metrics output file (default: metrics)"))
                 .arg(arg!(--filter [SUBSTR] "Only run benches whose name contains SUBSTR"))
                 .arg(arg!(--"no-fetch" "Do not fetch models; use the cache as-is"))
+                .arg(arg!(--"skip-cpu" "Skip CPU runs: drop backend-less (net) benches and the cpu backend of the rest. For GPU-only devices whose CPU is redundant with another arm64/x86 box."))
                 .arg(arg!(--expectations [PATH] "Pre-computed expectations file; re-run benches that would show a PR red"))
                 .arg(arg!(--"retry-max" [N] "Max re-runs of an out-of-threshold bench (default: 2)"))
                 .arg(arg!(--"bench-data" [DIR] "Compute expectations inline from this bench-data checkout (alternative to --expectations)"))


### PR DESCRIPTION
The jetson-orin-nx box is GPU-only value: its arm64 CPU is redundant with apple-m1-max for the net suite, and it's the slowest runner. Add a --skip-cpu flag to bench-suite (drops backend-less net benches and the cpu backend of the rest) and pass it for jetson in bench.yml, so jetson benches only its Orin GPU. No models retired — every bench still runs on i9 + m1-max.