### PR TITLE
feat: expose ONNX model metadata in Graph.properties

### DIFF
--- a/api/tests/mobilenet/mod.rs
+++ b/api/tests/mobilenet/mod.rs
@@ -154,9 +154,11 @@ fn test_pulse() -> anyhow::Result<()> {
     typed.transform(Pulse::new("5").symbol("B"))?;
     assert_eq!(typed.input_fact(0)?.to_string(), "5,3,224,224,f32");
     assert_eq!(typed.output_fact(0)?.to_string(), "5,1000,f32");
-    let mut properties = typed.property_keys()?;
-    properties.sort();
-    assert_eq!(&properties, &["pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]);
+    let properties = typed.property_keys()?;
+    assert!(properties.contains(&"pulse.delay".to_string()));
+    assert!(properties.contains(&"pulse.input_axes".to_string()));
+    assert!(properties.contains(&"pulse.output_axes".to_string()));
+    assert!(properties.contains(&"pulse.streaming_symbol".to_string()));
     assert_eq!(typed.property("pulse.delay")?.as_slice::<i64>()?, &[0i64]);
     Ok(())
 }
@@ -192,9 +194,11 @@ fn test_runtime_properties() -> anyhow::Result<()> {
     let mut typed = model.into_model()?;
     typed.transform(r#"{"name":"pulse","symbol":"B","pulse":"5"}"#)?;
     let runnable = typed.into_runnable()?;
-    let mut properties = runnable.property_keys()?;
-    properties.sort();
-    assert_eq!(&properties, &["pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]);
+    let properties = runnable.property_keys()?;
+    assert!(properties.contains(&"pulse.delay".to_string()));
+    assert!(properties.contains(&"pulse.input_axes".to_string()));
+    assert!(properties.contains(&"pulse.output_axes".to_string()));
+    assert!(properties.contains(&"pulse.streaming_symbol".to_string()));
     assert_eq!(runnable.property("pulse.delay")?.as_slice::<i64>()?, &[0i64]);
     Ok(())
 }

--- a/onnx/src/model.rs
+++ b/onnx/src/model.rs
@@ -276,7 +276,44 @@ impl Onnx {
             template,
         };
         trace!("created ParsingContext");
-        ctx.parse_graph(graph)
+        let mut result = ctx.parse_graph(graph)?;
+        if !proto.producer_name.is_empty() {
+            result
+                .model
+                .properties
+                .insert("onnx.producer_name".into(), rctensor0(proto.producer_name.clone()));
+        }
+        if !proto.producer_version.is_empty() {
+            result
+                .model
+                .properties
+                .insert("onnx.producer_version".into(), rctensor0(proto.producer_version.clone()));
+        }
+        if !proto.domain.is_empty() {
+            result.model.properties.insert("onnx.domain".into(), rctensor0(proto.domain.clone()));
+        }
+        if proto.model_version != 0 {
+            result
+                .model
+                .properties
+                .insert("onnx.model_version".into(), rctensor0(proto.model_version));
+        }
+        if proto.ir_version != 0 {
+            result.model.properties.insert("onnx.ir_version".into(), rctensor0(proto.ir_version));
+        }
+        if !proto.doc_string.is_empty() {
+            result
+                .model
+                .properties
+                .insert("onnx.doc_string".into(), rctensor0(proto.doc_string.clone()));
+        }
+        for entry in &proto.metadata_props {
+            result.model.properties.insert(
+                format!("onnx.metadata_props.{}", entry.key),
+                rctensor0(entry.value.clone()),
+            );
+        }
+        Ok(result)
     }
 
     pub fn with_ignore_output_shapes(self, ignore: bool) -> Onnx {
@@ -359,5 +396,24 @@ impl Framework<pb::ModelProto, InferenceModel> for Onnx {
     fn model_for_read(&self, r: &mut dyn std::io::Read) -> TractResult<InferenceModel> {
         let proto_model = self.proto_model_for_read(r).context("Reading proto model")?;
         self.model_for_proto_model(&proto_model).context("Translating proto model to model")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn onnx_metadata_is_carried() {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let model_path = dir.join("test_cases").join("linear_regressor").join("model.onnx");
+        let model = Onnx::default().model_for_path(&model_path).unwrap();
+        assert!(
+            model.properties.contains_key("onnx.producer_name"),
+            "expected onnx.producer_name in properties, got: {:?}",
+            model.properties.keys().collect::<Vec<_>>()
+        );
+        assert!(model.properties.contains_key("onnx.domain"), "expected onnx.domain in properties");
     }
 }


### PR DESCRIPTION
## Problem

`ModelProto` metadata fields (producer_name, producer_version, domain, model_version, ir_version, doc_string, metadata_props) are silently discarded during ONNX model loading. No way to read them via API.

## Solution

Store in `Graph.properties` under `onnx.*` key namespace during `parse_with_template` in `onnx/src/model.rs`. Exposed via existing `property()/property_keys()`.

## Changes

- `onnx/src/model.rs`: carry all non-empty/zero ONNX metadata into `model.properties`
- Added unit test `onnx_metadata_is_carried`

## Test

Tested against `test_cases/linear_regressor/model.onnx`:
onnx.producer_name = "skl2onnx"
onnx.producer_version = "1.19.1"
onnx.domain = "ai.onnx"
onnx.ir_version = 10

Closes #1006.