### PR TITLE
fix: SimplifiedLayerNormalization mapped to RMSNorm instead of LayerNorm

### DIFF
--- a/onnx/src/ops/nn/layer_norm.rs
+++ b/onnx/src/ops/nn/layer_norm.rs
@@ -33,6 +33,19 @@ pub struct LayerNorm {
     invstddev_output: Option<usize>,
 }
 
+impl LayerNorm {
+    pub fn new(axis: isize, epsilon: f32, datum_type: DatumType) -> Self {
+        LayerNorm {
+            axis,
+            epsilon,
+            datum_type,
+            have_bias: false,
+            mean_output: None,
+            invstddev_output: None,
+        }
+    }
+}
+
 impl Expansion for LayerNorm {
     fn name(&self) -> StaticName {
         "LayerNorm".into()

--- a/onnx/src/ops/nn/mod.rs
+++ b/onnx/src/ops/nn/mod.rs
@@ -101,7 +101,6 @@ pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("MultiHeadAttention", multi_head_attention::multi_head_attention);
     reg.insert("RMSNormalization", rms_norm::rms_normalization);
     reg.insert("RotaryEmbedding", rotary_embedding::rotary_embedding);
-    reg.insert("SimplifiedLayerNormalization", rms_norm::rms_normalization);
     reg.insert("SimplifiedLayerNormalization", simplified_layer_norm::simplified_layer_norm);
     reg.insert(
         "SkipSimplifiedLayerNormalization",

--- a/onnx/src/ops/nn/mod.rs
+++ b/onnx/src/ops/nn/mod.rs
@@ -27,6 +27,7 @@ mod reduce;
 mod rms_norm;
 mod rms_norm_contrib;
 mod rotary_embedding;
+mod simplified_layer_norm;
 mod skip_layer_norm;
 
 pub fn arg_max_min(
@@ -101,6 +102,7 @@ pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("RMSNormalization", rms_norm::rms_normalization);
     reg.insert("RotaryEmbedding", rotary_embedding::rotary_embedding);
     reg.insert("SimplifiedLayerNormalization", rms_norm::rms_normalization);
+    reg.insert("SimplifiedLayerNormalization", simplified_layer_norm::simplified_layer_norm);
     reg.insert(
         "SkipSimplifiedLayerNormalization",
         rms_norm_contrib::skip_simplified_layer_normalization,

--- a/onnx/src/ops/nn/simplified_layer_norm.rs
+++ b/onnx/src/ops/nn/simplified_layer_norm.rs
@@ -1,0 +1,14 @@
+use crate::model::ParsingContext;
+use crate::ops::nn::layer_norm::LayerNorm;
+use crate::pb::NodeProto;
+use tract_hir::internal::*;
+
+pub fn simplified_layer_norm(
+    _ctx: &ParsingContext,
+    node: &NodeProto,
+) -> TractResult<(Box<dyn InferenceOp>, Vec<String>)> {
+    let axis = node.get_attr_opt("axis")?.unwrap_or(-1);
+    let epsilon = node.get_attr_opt("epsilon")?.unwrap_or(1e-5);
+    let datum_type = node.get_attr_opt("stash_type")?.unwrap_or(DatumType::F32);
+    Ok((expand(LayerNorm::new(axis, epsilon, datum_type)), vec![]))
+}


### PR DESCRIPTION
## Problem

`SimplifiedLayerNormalization` (LayerNorm without bias) was registered to the `RMSNorm` handler (`rms_norm::rms_normalization`). RMSNorm computes `X / RMS(X) * Scale`, while SimplifiedLayerNorm computes `(X - μ) / σ * Scale` (mean-subtracting LayerNorm without the bias term). The math is incorrect.

## Solution

Re-register to a new handler that constructs `LayerNorm` with `have_bias: false` and no optional mean/invstddev outputs. The existing `LayerNorm` expansion in `layer_norm.rs` already supports this configuration.

## Changes

- `onnx/src/ops/nn/layer_norm.rs`: add `LayerNorm::new()` constructor
- `onnx/src/ops/nn/simplified_layer_norm.rs` (new): handler that creates `LayerNorm` with `have_bias: false`
- `onnx/src/ops/nn/mod.rs`: register new handler, remove incorrect mapping

## Notes

This is a pure ONNX-level decomposition fix. No core ops, GPU kernels, or NNEF serialization changes needed.

Closes #1775.