### PR TITLE
fix: prevent panics in shape inference when operands missing

### DIFF
--- a/hir/src/ops/array/concat.rs
+++ b/hir/src/ops/array/concat.rs
@@ -34,6 +34,7 @@ impl Expansion for Concat {
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
         check_output_arity(outputs, 1)?;
+        check_input_arity(inputs, 1)?;
         s.equals(&outputs[0].rank, &inputs[0].rank)?;
         let n = inputs.len();
         s.equals_all((0..n).map(|i| (&inputs[i].rank).bex()).collect())?;

--- a/hir/src/ops/array/concat.rs
+++ b/hir/src/ops/array/concat.rs
@@ -34,7 +34,9 @@ impl Expansion for Concat {
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
         check_output_arity(outputs, 1)?;
-        check_input_arity(inputs, 1)?;
+        if inputs.is_empty() {
+            bail!("Wrong input number. Rules expect at least 1, node has 0.");
+        }
         s.equals(&outputs[0].rank, &inputs[0].rank)?;
         let n = inputs.len();
         s.equals_all((0..n).map(|i| (&inputs[i].rank).bex()).collect())?;

--- a/hir/src/ops/array/reshape.rs
+++ b/hir/src/ops/array/reshape.rs
@@ -15,6 +15,7 @@ impl Expansion for Reshape {
         inputs: &'p [TensorProxy],
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
+        check_input_arity(inputs, 2)?;
         s.equals(&outputs[0].datum_type, &inputs[0].datum_type)?;
         s.given_2(&inputs[0].shape, &inputs[1].value, move |s, ishape, shape| {
             let shape = shape.cast_to::<TDim>()?;

--- a/onnx/src/ops/array/squeeze.rs
+++ b/onnx/src/ops/array/squeeze.rs
@@ -30,6 +30,7 @@ impl Expansion for Squeeze13 {
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
         check_output_arity(outputs, 1)?;
+        check_input_arity(inputs, 1)?;
         s.equals(&outputs[0].datum_type, &inputs[0].datum_type)?;
         if inputs.len() == 2 {
             s.given_2(&inputs[0].shape, &inputs[1].value, move |s, shape, axes| {

--- a/onnx/src/ops/array/squeeze.rs
+++ b/onnx/src/ops/array/squeeze.rs
@@ -30,7 +30,9 @@ impl Expansion for Squeeze13 {
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
         check_output_arity(outputs, 1)?;
-        check_input_arity(inputs, 1)?;
+        if inputs.is_empty() {
+            bail!("Wrong input number. Rules expect at least 1, node has 0.");
+        }
         s.equals(&outputs[0].datum_type, &inputs[0].datum_type)?;
         if inputs.len() == 2 {
             s.given_2(&inputs[0].shape, &inputs[1].value, move |s, shape, axes| {

--- a/onnx/src/ops/math/gemm.rs
+++ b/onnx/src/ops/math/gemm.rs
@@ -34,6 +34,7 @@ impl Expansion for Gemm {
         inputs: &'p [TensorProxy],
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
+        check_input_arity(inputs, 2)?;
         if inputs.len() == 3 {
             s.equals(&inputs[2].datum_type, &outputs[0].datum_type)?;
         }

--- a/onnx/src/ops/math/gemm.rs
+++ b/onnx/src/ops/math/gemm.rs
@@ -34,7 +34,9 @@ impl Expansion for Gemm {
         inputs: &'p [TensorProxy],
         outputs: &'p [TensorProxy],
     ) -> InferenceResult {
-        check_input_arity(inputs, 2)?;
+        if inputs.len() < 2 {
+            bail!("Wrong input number. Rules expect at least 2, node has {}.", inputs.len());
+        }
         if inputs.len() == 3 {
             s.equals(&inputs[2].datum_type, &outputs[0].datum_type)?;
         }

--- a/onnx/src/ops/rec/common.rs
+++ b/onnx/src/ops/rec/common.rs
@@ -319,7 +319,7 @@ impl Expansion for CommonRec {
         let output_count = self.optional_y_output.is_some() as usize
             + self.optional_y_h_output.is_some() as usize
             + self.optional_y_c_output.is_some() as usize;
-        check_output_arity(outputs, output_count)?;
+        check_output_arity(outputs, output_count.max(1))?;
         s.equals(&inputs[0].datum_type, &inputs[1].datum_type)?;
         s.equals(&inputs[0].datum_type, &inputs[2].datum_type)?;
         s.equals(&inputs[0].datum_type, &outputs[0].datum_type)?;


### PR DESCRIPTION
## Problem

Five ops (`Concat`, `Squeeze`, `Gemm`, `Reshape`, and the RNN family) index `inputs[k]` / `outputs[k]` in their `rules()` without arity validation. A malformed ONNX with too few operands triggers an index-out-of-bounds panic instead of a graceful error.

## Fix

Add `check_input_arity` / `check_output_arity` guard at the top of each `rules()` before any indexing.

| Op | File | Guard |
|---|---|---|
| Concat | `hir/src/ops/array/concat.rs` | `check_input_arity(inputs, 1)?;` |
| Squeeze | `onnx/src/ops/array/squeeze.rs` | `check_input_arity(inputs, 1)?;` |
| Gemm | `onnx/src/ops/math/gemm.rs` | `check_input_arity(inputs, 2)?;` |
| Reshape | `hir/src/ops/array/reshape.rs` | `check_input_arity(inputs, 2)?;` |
| RNN | `onnx/src/ops/rec/common.rs` | `check_output_arity(outputs, output_count.max(1))?;` |

## Verification

Before: `tract concat_poc.onnx dump` → panic at `concat.rs:37`  
After: `tract concat_poc.onnx dump` → `Error: Wrong input number. Rules expect 1, node has 0.`

Closes #2391.