### PR TITLE
fix(data): reject raw tensor whose data length != declared shape (#2390)

### DIFF
--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -499,6 +499,15 @@ impl Tensor {
         align: usize,
     ) -> TractResult<Tensor> {
         let mut tensor = unsafe { Tensor::uninitialized_aligned_dt(dt, shape, align) }?;
+        let expected = tensor.as_bytes().len();
+        ensure!(
+            content.len() == expected,
+            "Raw tensor data length ({}) does not match shape {:?} of {:?} ({} bytes)",
+            content.len(),
+            shape,
+            dt,
+            expected
+        );
         tensor.as_bytes_mut().copy_from_slice(content);
         Ok(tensor)
     }
@@ -1848,6 +1857,20 @@ mod tests {
     use litteral::tensor0;
     use proptest::collection::vec;
     use proptest::prelude::*;
+
+    // Regression for sonos/tract#2390: from_raw must reject a content length that
+    // does not match the declared shape rather than panicking in copy_from_slice.
+    #[test]
+    fn from_raw_rejects_length_mismatch() {
+        // shape [2, 3] of f32 needs 24 bytes; supply 12.
+        let err = unsafe { Tensor::from_raw_dt(f32::datum_type(), &[2, 3], &[0u8; 12]) }
+            .expect_err("from_raw must reject a short content buffer, not panic");
+        assert!(err.to_string().contains("does not match shape"), "unexpected error: {err}");
+        // Too-long content is rejected as well.
+        assert!(unsafe { Tensor::from_raw_dt(f32::datum_type(), &[2, 3], &[0u8; 32]) }.is_err());
+        // Exact match still succeeds.
+        assert!(unsafe { Tensor::from_raw_dt(f32::datum_type(), &[2, 3], &[0u8; 24]) }.is_ok());
+    }
 
     #[derive(Debug)]
     struct PermuteAxisProblem {


### PR DESCRIPTION
## Summary

Fixes #2390. `Tensor::from_raw_dt_align` allocated `∏(shape) × sizeof(dt)` bytes and then `copy_from_slice`-d the caller-supplied content into it **with no length check**. When the two lengths differ — e.g. a crafted or malformed `.onnx` whose initializer `raw_data` byte count does not match its declared `dims` — `copy_from_slice` panics, aborting model load in **both debug and release** builds. Since tract loads externally-supplied ONNX, this is a reachable DoS.

This validates the content length against the freshly-allocated tensor and returns a `TractResult` error instead of panicking. The check sits at `from_raw_dt_align`, the single choke point for all `from_raw` callers (ONNX, NNEF, …), so every raw-load path is covered.

## Reproduction (before this PR)

The 94-byte PoC from #2390 (`raw_data` of 12 bytes against a shape needing 440):

```
thread '...' panicked at data/src/tensor.rs:502:31:
copy_from_slice: source slice length (12) does not match destination slice length (440)
```

After this PR the same file loads to a graceful `Err` (no panic), verified in release.

## Change

```rust
let mut tensor = unsafe { Tensor::uninitialized_aligned_dt(dt, shape, align) }?;
let expected = tensor.as_bytes().len();
ensure!(
    content.len() == expected,
    "Raw tensor data length ({}) does not match shape {:?} of {:?} ({} bytes)",
    content.len(), shape, dt, expected
);
tensor.as_bytes_mut().copy_from_slice(content);
```

## Tests

- New regression test `from_raw_rejects_length_mismatch` in `data` (short, long, and exact-match cases).
- `cargo test -p tract-data --lib` (140) and `cargo test -p tract-onnx --lib` (10) pass; the end-to-end PoC load now returns `Err` instead of panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)