### PR TITLE
fix: profiler no longer inflates in-place op timings via input clone

### DIFF
--- a/libcli/src/profile.rs
+++ b/libcli/src/profile.rs
@@ -327,24 +327,25 @@ pub fn rec_profiler(
     let r = state.run_plan_with_eval(
         inputs.clone(),
         |session_state, mut node_state, node, input| {
+            // Keep a copy of the inputs only when a nested submodel will need them
+            // for recursive profiling. Otherwise move them straight into eval: an
+            // extra clone here holds a second Arc ref to each input and forces
+            // in-place ops (reshape, by-scalar/unicast bias add, ...) down their
+            // copy-on-shared path, inflating their measured time versus production.
+            let saved_input = (!folded && node_state.is_some()).then(|| input.clone());
             // Profile node
             let start = crate::time::now();
-            let res = tract_core::plan::eval(
-                session_state,
-                node_state.as_deref_mut(),
-                node,
-                input.clone(),
-            );
+            let res = tract_core::plan::eval(session_state, node_state.as_deref_mut(), node, input);
             let elapsed = start.elapsed().mul_f32(multiplier.unwrap_or(1) as _);
             let node_id = NodeQId(prefix.into(), node.id);
             *dg.node_mut(node_id).profile.get_or_insert(Duration::default()) += elapsed;
 
-            if !folded {
+            if let Some(saved_input) = saved_input {
                 let start = crate::time::now();
                 profile_submodel(
                     node,
                     node_state,
-                    input,
+                    saved_input,
                     dg,
                     profilers,
                     prefix,


### PR DESCRIPTION
## Problem

The per-node profiler in `libcli/src/profile.rs` (`rec_profiler`) clones each node's inputs *before* the timed `eval`:

```rust
let res = tract_core::plan::eval(session_state, node_state.as_deref_mut(), node, input.clone());
```

That clone holds a second `Arc` reference to every input for the duration of the call. In-place ops then take their copy-on-shared path: `into_tensor()` is `Arc::try_unwrap(self).unwrap_or_else(|t| (*t).clone())`, so the extra ref makes `try_unwrap` fail and forces a **full deep copy** of the tensor — for `IntoShape`/reshape, by-scalar/unicast bias adds, and any other op that mutates its input in place.

In production these ops run with a uniquely-owned input (the producer is flushed before the consumer's `eval`), so no copy happens. The profiler was therefore over-reporting in-place ops and the network total.

## Fix

Move the inputs into `eval` so the refcount matches production, and keep a copy only when a nested submodel (`Scan` / `TypedModel`) actually needs the inputs for recursive profiling (`!folded && node_state.is_some()`).

## Effect (DeepFilterNet3 `enc`, `-O dump --profile`)

| | before | after |
|---|---|---|
| `IntoShape` (22 nodes) | 6.3% (0.267 ms/i) | **1.3% (0.048 ms/i)** — per-node single-consumer reshapes now ~0.000 ms |
| reported "Entire network performance" | 4.22 ms/i | **3.73 ms/i** |
| real `bench` | 3.73 ms/i | 3.73 ms/i |

The reported total now matches `bench` on all three DFN3 models (df_dec / erb_dec / enc); previously the profiler ran ~14% high. Costs that are genuinely real (e.g. bias-add elementwise passes) are unchanged, so only the measurement artifact is removed. Scan/submodel profiling output is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)