### PR TITLE
RFC: fuse bias/activation epilogue through the einsum unmerge reshape (workload-dependent)

### DIFF
--- a/core/src/ops/matmul/optimized.rs
+++ b/core/src/ops/matmul/optimized.rs
@@ -535,23 +535,83 @@ impl TypedOp for OptMatMul {
                 wire = patch.wire_node(&succ.name, succ.op.clone(), &[wire])?[0];
                 patch.shunt_outside(model, next_node.id.into(), wire)?;
                 return Ok(Some(patch));
-            } else if let Some(op) = next_node.op_as::<ops::binary::TypedBinOp>() {
-                rule_if!(op.0.as_linalg_binop().is_some());
-                let flipped = succ.inputs[0].node == node.id;
-                let other_outlet = next_node.inputs[flipped as usize];
-                if let Some(uni) = &model.outlet_fact(other_outlet)?.uniform {
+            } else {
+                // matmul -> reshape -> elementwise(broadcast operand): reorder into
+                // matmul -> elementwise -> reshape so the bias/activation can fuse
+                // into the matmul epilogue on a later pass. Match the generic
+                // TypedBinOp as well as its already-codegen'd OptBin* forms.
+                let rewire_op = next_node
+                    .op_as::<ops::binary::TypedBinOp>()
+                    .and_then(|op| op.0.as_linalg_binop().map(|_| op.clone()))
+                    .or_else(|| {
+                        next_node.op_as::<ops::binary::OptBinByScalar>().and_then(|op| {
+                            op.binop
+                                .as_linalg_binop()
+                                .map(|_| ops::binary::TypedBinOp(op.binop.clone(), None))
+                        })
+                    })
+                    .or_else(|| {
+                        next_node.op_as::<ops::binary::OptBinUnicast>().and_then(|op| {
+                            op.binop
+                                .as_linalg_binop()
+                                .map(|_| ops::binary::TypedBinOp(op.binop.clone(), None))
+                        })
+                    });
+                if let Some(rewire_op) = rewire_op {
+                    // The op has two inputs: the reshaped matmul output (data) and a
+                    // broadcast operand. Move the operand in front of the reshape.
+                    let data_slot = (next_node.inputs[1].node == succ.id) as usize;
+                    let other_outlet = next_node.inputs[1 - data_slot];
+                    let other_fact = model.outlet_fact(other_outlet)?;
                     let mut patch = TypedModelPatch::default();
-                    let cst = patch.add_const(&model.node(other_outlet.node).name, uni.clone())?;
-                    let output = patch.tap_model(model, node.id.into())?;
-                    let wire = wire_with_rank_broadcast(
-                        &next_node.name,
-                        &mut patch,
-                        op.clone(),
-                        &if flipped { [output, cst] } else { [cst, output] },
-                    )?;
-                    let wire = patch.wire_node(&succ.name, succ.op.clone(), &wire)?[0];
-                    patch.shunt_outside(model, next_node.id.into(), wire)?;
-                    return Ok(Some(patch));
+                    let operand: Option<OutletId> = if let Some(uni) = &other_fact.uniform {
+                        // Uniform value: rank-broadcast a scalar const (fuses as BinScalar).
+                        Some(patch.add_const(&model.node(other_outlet.node).name, uni.clone())?)
+                    } else if let (Some(konst), Some(nd_shape), Some(into)) = (
+                        other_fact.konst.clone(),
+                        other_fact.shape.as_concrete(),
+                        succ.op_as::<IntoShape>(),
+                    ) {
+                        // Per-channel constant: track its single non-unary axis back
+                        // through the reshape to the matmul output axis, and only
+                        // reorder when that lands on m or n (where fuse_binary can
+                        // turn it into a BinPerRow / BinPerCol epilogue).
+                        use crate::ops::change_axes::InOut;
+                        let nonunary: TVec<usize> = nd_shape
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, d)| **d != 1)
+                            .map(|(i, _)| i)
+                            .collect();
+                        let mm_ax = if nonunary.len() == 1 {
+                            into.mapping.track_axis((InOut::Out(0), nonunary[0]), InOut::In(0))?
+                        } else {
+                            None
+                        };
+                        match mm_ax {
+                            Some(ax) if Some(ax) == self.c_m_axis || Some(ax) == self.c_n_axis => {
+                                let mut target = tvec![1usize; self.c_fact.rank()];
+                                target[ax] = nd_shape[nonunary[0]];
+                                let reshaped = konst.as_ref().clone().into_shape(&target)?;
+                                Some(patch.add_const(format!("{}.fused-operand", node.name), reshaped)?)
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    };
+                    if let Some(operand) = operand {
+                        let output = patch.tap_model(model, node.id.into())?;
+                        let wire = wire_with_rank_broadcast(
+                            &next_node.name,
+                            &mut patch,
+                            rewire_op,
+                            &if data_slot == 0 { [output, operand] } else { [operand, output] },
+                        )?;
+                        let wire = patch.wire_node(&succ.name, succ.op.clone(), &wire)?[0];
+                        patch.shunt_outside(model, next_node.id.into(), wire)?;
+                        return Ok(Some(patch));
+                    }
                 }
             }
         }


### PR DESCRIPTION
**This is an RFC / discussion draft — not proposed for merge as-is.** It implements a real fusion, but the measurements show it's a net win only for memory-bound models and a regression for compute-bound ones, so the question is whether you'd want it behind a cost heuristic (or at all).

## Observation

Pointwise conv and `Einsum` lower to:

```
OptMatMul → IntoShape(unmerge_out) → elementwise   (per-channel bias add, ReLU, …)
```

The matmul epilogue can already absorb these (`FusedSpec::{BinScalar, BinPerRow, BinPerCol}`), and the **direct** `matmul → bias` case does fuse in `OptMatMul::fuse`. But when the `unmerge` reshape sits between them, fusion is blocked: the reshape-reorder branch in `OptMatMul::fuse` only handled `TypedBinOp`/`Cast` with a **uniform** operand, not the codegen'd `OptBinByScalar`/`OptBinUnicast` per-channel forms.

## What this patch does

Extends that reorder to:
- match the `OptBinByScalar` / `OptBinUnicast` forms (rebuilding a `TypedBinOp` to rewire), and
- handle a **per-channel constant** operand: its single non-unary axis is tracked back through the reshape's `AxesMapping` (`track_axis`) to the matmul output axis, and the constant is reshaped onto that axis. A later `fuse` pass then turns it into a `BinPerRow`/`BinPerCol` epilogue.

It only fires when the tracked axis lands on `c_m_axis`/`c_n_axis` (where `fuse_binary` can express it) and bails otherwise.

## Correctness

Bit-identical output (`max_abs_diff = 0`) on every model I tested — DeepFilterNet3 (enc/erb_dec/df_dec), MobileNetV2 (98→44 epilogue ops fused), SqueezeNet (49→18). `cargo test -p tract-core` passes (252).

## Performance — the catch

Paired benchmarks (`tract … -O bench`, baseline vs this, interleaved to cancel thermal drift) on aarch64 macOS:

| Model | Regime | Result |
|-------|--------|--------|
| DeepFilterNet3 `enc` | memory-bound streaming | **~10% faster** (bias-only); ~5% with ReLU fusion too |
| DeepFilterNet3 `erb_dec` / `df_dec` | memory-bound | ~4–5% faster |
| **MobileNetV2** | **compute-bound CNN** | **~8–10% slower** |

The MobileNet regression holds for bias-only (ReLU excluded), so it's the bias fusion itself. Intuition: fusing the epilogue into a compute-bound matmul's hot loop costs more than the cheap standalone vectorized pass it replaces, whereas on memory-bound matmuls (where the bias is a large fraction of runtime) fusing avoids a full output read-modify-write and wins.

## Question

Is fusing bias/activation through the unmerge reshape something you'd want — gated by a cost heuristic (e.g. only when the matmul is memory-bound / low arithmetic intensity)? Or is it deliberately left undone for this reason? Happy to rework into a gated version (or drop it) based on your preference — I didn't want to guess a threshold from two data points.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)