### PR TITLE
fix: update test expectations for onnx metadata in model properties

### DIFF
--- a/api/py/tests/mobilenet_onnx_test.py
+++ b/api/py/tests/mobilenet_onnx_test.py
@@ -133,7 +133,7 @@ def test_pulse():
     assert str(typed.output_fact(0)) == "5,1000,f32"
     properties = typed.property_keys()
     properties.sort()
-    assert properties == ["pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]
+    assert properties == ["onnx.ir_version", "pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]
     assert typed.property("pulse.delay").to_numpy() == [0]
 
 def test_pulse_builder():
@@ -168,7 +168,7 @@ def test_runtime_properties():
     runnable = typed.into_runnable()
     properties = runnable.property_keys()
     properties.sort()
-    assert properties == ["pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]
+    assert properties == ["onnx.ir_version", "pulse.delay", "pulse.input_axes", "pulse.output_axes", "pulse.streaming_symbol"]
     assert runnable.property("pulse.delay").to_numpy() == [0]
 
 def test_f32_to_f16():

--- a/harness/pre-optimized-graphes/mdl-en-2019-Q3-librispeech/expected
+++ b/harness/pre-optimized-graphes/mdl-en-2019-Q3-librispeech/expected
@@ -123,7 +123,7 @@ fragment scan_body_1(
 fragment tract_core_properties(
 ) -> (properties: (string, tensor<scalar>)[])
 {
-  properties = [("pulse.delay", tract_core_cast([6], to = "i64")), ("pulse.input_axes", tract_core_cast([0], to = "i64")), ("pulse.output_axes", tract_core_cast([0], to = "i64")), ("pulse.streaming_symbol", ["S"]), ("tract_nnef_ser_version", "0.19.3-pre"), ("tract_nnef_format_version", "beta1")];
+  properties = [("onnx.ir_version", tract_core_cast(5, to = "i64")), ("onnx.producer_name", "snips"), ("pulse.delay", tract_core_cast([6], to = "i64")), ("pulse.input_axes", tract_core_cast([0], to = "i64")), ("pulse.output_axes", tract_core_cast([0], to = "i64")), ("pulse.streaming_symbol", ["S"]), ("tract_nnef_ser_version", "0.19.3-pre"), ("tract_nnef_format_version", "beta1")];
 }
 
 graph network(input) -> (output) {


### PR DESCRIPTION
#2408 propagates onnx.ir_version and onnx.producer_name into Graph.properties; update the pre-optimized-graph expected file and Python binding assertions to match.