### PR TITLE
Quality: u32 overflow in CUDA grid dimension calculation silently truncates large tensor indices

### DIFF
--- a/cuda/src/kernels/utils.rs
+++ b/cuda/src/kernels/utils.rs
@@ -19,8 +19,14 @@ pub fn cuda_launch_cfg_for_cpy(shape: &[usize]) -> LaunchConfig {
         2 => (shape[0] as _, 1, 1),
         3 => (shape[1] as _, shape[0] as _, 1),
         4 => (shape[2] as _, shape[1] as _, shape[0] as _),
-        5 => (shape[2] as u32 * shape[3] as u32, shape[1] as _, shape[0] as _),
-        6 => (shape[2] as u32 * shape[3] as u32 * shape[4] as u32, shape[1] as _, shape[0] as _),
+        5 => {
+            let x: u32 = (shape[2] * shape[3]).try_into().expect("Grid dimension x overflow u32");
+            (x, shape[1] as _, shape[0] as _)
+        }
+        6 => {
+            let x: u32 = (shape[2] * shape[3] * shape[4]).try_into().expect("Grid dimension x overflow u32");
+            (x, shape[1] as _, shape[0] as _)
+        }
         _ => panic!("Unsupported rank {rank} for cuda copy launch config"),
     };
     LaunchConfig {


### PR DESCRIPTION
## Problem

For rank 5 and 6, intermediate multiplications are performed in u32 arithmetic before the result is assigned to the grid dimension. If the product of shape dimensions exceeds u32::MAX (4,294,967,295), the result wraps around silently, producing a grid that is too small. CUDA threads beyond the wrapped grid will never launch, causing silent data corruption (uninitialized portions of the output tensor). For example, shape = [2, 3, 4096, 4096, 1] for rank 5 computes `4096u32 * 4096u32` = 16,777,216 which fits, but shape = [2, 3, 65536, 65536, 1] computes `65536u32 * 65536u32` which overflows u32.


**Severity**: `high`
**File**: `cuda/src/kernels/utils.rs`

## Solution

Perform intermediate multiplication in usize (or u64), then saturating-cast or validate before assigning to u32:


## Changes

- `cuda/src/kernels/utils.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
