### PR TITLE
doc: add a profile-guided optimization build recipe

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -11,6 +11,7 @@ that is harder to derive from reading the source.
 * [`graph.md`](graph.md) — Graph, Node, Outlet, Fact, model pipeline
 * [`op.md`](op.md) — anatomy of an Op (`Op` / `EvalOp` / `TypedOp` / `InferenceOp`)
 * [`cli-recipe.md`](cli-recipe.md) — `tract` command-line cookbook
+* [`pgo.md`](pgo.md) — profile-guided optimization build recipe
 * [`kernel-notes.md`](kernel-notes.md) — tract-linalg kernels and debugging
 * [`nnef/`](nnef/) — reference schemas for the `tract_*` NNEF extensions
 

--- a/doc/pgo.md
+++ b/doc/pgo.md
@@ -1,0 +1,80 @@
+# Profile-guided optimization (PGO)
+
+`tract`'s release profile already enables LTO. On top of that, a
+profile-guided build can give the engine glue — the plan executor, op
+dispatch, and tensor bookkeeping that every model runs through — a layout the
+compiler tuned to your actual workload. The hand-written `tract-linalg`
+matmul kernels are not affected: PGO does not instrument assembly, so the win
+concentrates in dispatch-heavy graphs (many small ops) and all but vanishes
+for graphs dominated by a steady-state matmul.
+
+PGO is therefore most useful for a *fixed* deployment: a known, stable set of
+models you serve in production. Profile that set once and ship one optimized
+binary.
+
+## Requirements
+
+The merge step needs `llvm-profdata`, shipped by the rustup component:
+
+```sh
+rustup component add llvm-tools-preview
+```
+
+It installs under the active toolchain, e.g.
+`$(rustc --print sysroot)/lib/rustlib/<host>/bin/llvm-profdata`.
+
+## Recipe
+
+The flow is: build an instrumented binary, run it on representative models to
+collect raw profiles, merge them, then rebuild using the merged profile. Keep
+the three builds in separate target directories so they do not clobber each
+other.
+
+**1. Instrumented build** — writes a `.profraw` per run into `$PROFDIR`:
+
+```sh
+PROFDIR=$(pwd)/pgo-profraw
+CARGO_TARGET_DIR=target-pgo-inst \
+  RUSTFLAGS="-Cprofile-generate=$PROFDIR" \
+  cargo build --release -p tract-cli
+```
+
+**2. Collect** — run the instrumented `tract` on each deployment model. Use
+the same command shape you serve with; `bench` exercises the eval loop
+repeatedly, which is what you want to profile. Profile a *representative
+basket* of your models, not just one — the shared engine glue dominates the
+result, so a diverse basket transfers well and per-model specialization buys
+little.
+
+```sh
+BIN=target-pgo-inst/release/tract
+for m in mobilenetv2-7 my_other_model; do
+  LLVM_PROFILE_FILE="$PROFDIR/$m-%p.profraw" \
+    "$BIN" "$m.onnx" -O bench --allow-random-input
+done
+```
+
+**3. Merge** the raw profiles into one `.profdata`:
+
+```sh
+llvm-profdata merge -o pgo.profdata "$PROFDIR"/*.profraw
+```
+
+**4. Optimized build** — rebuild with the merged profile:
+
+```sh
+CARGO_TARGET_DIR=target-pgo-opt \
+  RUSTFLAGS="-Cprofile-use=$(pwd)/pgo.profdata" \
+  cargo build --release -p tract-cli
+```
+
+`target-pgo-opt/release/tract` is the production binary. The instrumented
+binary and the `pgo-profraw`/`.profdata` artifacts can be discarded.
+
+## Notes
+
+- The profile must come from the same source tree as the optimized build. After
+  changing tract, recollect.
+- WebAssembly targets see little benefit: the host engine's JIT decides the
+  final code layout, so the machine-code-layout part of PGO does not carry
+  through. Prefer `simd128` and `wasm-opt` there.


### PR DESCRIPTION
Adds `doc/pgo.md`: a short recipe for building `tract-cli` with PGO on top of the existing LTO release profile, plus guidance on where it does and does not help.

The win concentrates in tract's engine glue (plan executor, op dispatch, tensor bookkeeping) — the hand-written linalg asm kernels are not instrumented by PGO, so kernel-bound graphs barely move. Measured on arm64 (M-series), release `lto=true, opt-level=2` baseline, basket-profiled build, median of paired interleaved runs:

| model | speedup |
|---|---|
| mobilenetv2 | +5.5–7.0% |
| matmul 16×576×1024 (skinny M=16) | +6.0% |
| DFN3 enc | +1.5–2.6% |
| inception_v3 | +1.3–2.1% |
| yolov8n | +0.5% |
| matmul 256×256 (square, control) | 0.0% |

The square-matmul control at 0.0% confirms the deltas are real PGO layout effects, not measurement noise. A profile from a single model (mobilenet-only) beat the diverse basket by only ~0.4pp on that model, so the doc recommends profiling a representative basket and shipping one binary — the shared glue dominates, per-model specialization buys almost nothing.