### PR TITLE
Faster pooling: concrete geometry at codegen + opt-in separable average pool

### DIFF
--- a/core/src/ops/cnn/maxpool.rs
+++ b/core/src/ops/cnn/maxpool.rs
@@ -70,6 +70,23 @@ impl TypedOp for MaxPool {
         Ok(None)
     }
 
+    /// Lower to `OptMaxPool` with the geometry pre-resolved to `Concrete` when the
+    /// input shape is fixed, so the `Patch` is built once here rather than per eval.
+    /// Symbolic shapes are left as `MaxPool`.
+    fn codegen(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TypedModelPatch>> {
+        let fact = model.outlet_fact(node.inputs[0])?;
+        if fact.shape.as_concrete().is_none() {
+            return Ok(None);
+        }
+        let mut op = self.to_optimized(&fact.shape.to_tvec())?;
+        op.geometry = op.geometry.optimize_if(fact.shape.as_concrete())?;
+        Ok(Some(TypedModelPatch::replace_single_op(model, node, &node.inputs, op)?))
+    }
+
     as_op!();
 }
 
@@ -184,5 +201,55 @@ impl OptMaxPool {
         } else {
             Ok(tvec!(values.into_tvalue()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::cnn::PaddingSpec;
+    use crate::ops::nn::DataFormat;
+
+    fn test_case() -> (TypedModel, TVec<TValue>) {
+        let mut model = TypedModel::default();
+        let source = model.add_source("data", f32::fact([1, 3, 8, 8])).unwrap();
+        let pool_spec = PoolSpec::new(
+            DataFormat::NCHW,
+            tvec![2, 2],
+            PaddingSpec::Valid,
+            None,
+            Some(tvec![2, 2]),
+            3,
+            3,
+        );
+        let op = MaxPool { pool_spec, with_index_outputs: None };
+        let out = model.wire_node("pool", op, &[source]).unwrap();
+        model.select_output_outlets(&out).unwrap();
+        let input = ndarray::Array4::from_shape_fn((1, 3, 8, 8), |(_, c, y, x)| {
+            (c * 64 + y * 8 + x) as f32
+        })
+        .into_tensor()
+        .into_tvalue();
+        (model, tvec!(input))
+    }
+
+    #[test]
+    fn optimized_maxpool_has_concrete_geometry() {
+        let (model, input) = test_case();
+        let plain = model.clone().into_runnable().unwrap().run(input.clone()).unwrap();
+
+        let optimized = model.into_optimized().unwrap();
+        let pool = optimized
+            .nodes
+            .iter()
+            .find_map(|n| n.op_as::<OptMaxPool>())
+            .expect("optimized model should contain an OptMaxPool");
+        assert!(
+            pool.geometry.is_concrete(),
+            "OptMaxPool geometry should be concrete after optimization"
+        );
+
+        let opt = optimized.into_runnable().unwrap().run(input).unwrap();
+        assert_eq!(*opt[0], *plain[0]);
     }
 }

--- a/core/src/ops/cnn/sumpool.rs
+++ b/core/src/ops/cnn/sumpool.rs
@@ -4,6 +4,14 @@ use std::iter::Sum;
 
 use crate::ops::cnn::pools::{ConcretePoolGeometry, PoolGeometry, PoolSpec};
 
+crate::declare_knob!(
+    TRACT_AVGPOOL_SEPARABLE,
+    bool,
+    false,
+    "Use the separable average-pool kernel for stride-1 NCHW pools. Not bit-identical: \
+     it reassociates the sum, permitted by SumPool's Validation::Rounding contract."
+);
+
 #[derive(Debug, Clone, new, Hash, PartialEq, Eq)]
 pub struct SumPool {
     pub pool_spec: PoolSpec,
@@ -58,6 +66,23 @@ impl TypedOp for SumPool {
             )?));
         }
         Ok(None)
+    }
+
+    /// Lower to `OptSumPool` with the geometry pre-resolved to `Concrete` when the
+    /// input shape is fixed, so the `Patch` is built once here rather than per eval.
+    /// Symbolic shapes are left as `SumPool`.
+    fn codegen(
+        &self,
+        model: &TypedModel,
+        node: &TypedNode,
+    ) -> TractResult<Option<TypedModelPatch>> {
+        let fact = model.outlet_fact(node.inputs[0])?;
+        if fact.shape.as_concrete().is_none() {
+            return Ok(None);
+        }
+        let mut op = self.to_optimized(&fact.shape.to_tvec())?;
+        op.geometry = op.geometry.optimize_if(fact.shape.as_concrete())?;
+        Ok(Some(TypedModelPatch::replace_single_op(model, node, &node.inputs, op)?))
     }
 
     as_op!();
@@ -163,6 +188,9 @@ impl OptSumPool {
     where
         usize: AsPrimitive<T>,
     {
+        if self.try_fast_2d::<T>(input, values_ptr, geo)? {
+            return Ok(());
+        }
         let input_ptr = input.as_ptr::<T>()?;
 
         let n = *geo.input_shape.n().unwrap_or(&1);
@@ -202,5 +230,237 @@ impl OptSumPool {
             });
         }
         Ok(())
+    }
+
+    /// Opt-in separable average-pool fast path, gated by `TRACT_AVGPOOL_SEPARABLE`.
+    /// Returns `true` when it handled the eval, `false` to fall back to the generic
+    /// kernel. Restricted to rank-2, stride-1, dilation-1, normalize, NCHW.
+    fn try_fast_2d<T: Copy + Datum + num_traits::Float>(
+        &self,
+        input: &Tensor,
+        values_ptr: *mut T,
+        geo: &ConcretePoolGeometry,
+    ) -> TractResult<bool>
+    where
+        usize: AsPrimitive<T>,
+    {
+        let patch = &geo.patch;
+        if !TRACT_AVGPOOL_SEPARABLE.get()
+            || !self.normalize
+            || patch.rank() != 2
+            || &*patch.spec.strides != [1, 1]
+            || &*patch.spec.dilations != [1, 1]
+            || *geo.input_shape.w_stride() != 1
+        {
+            return Ok(false);
+        }
+        let input_ptr = input.as_ptr::<T>()?;
+        unsafe {
+            self.fast_2d_separable::<T>(input_ptr, values_ptr, geo);
+        }
+        Ok(true)
+    }
+
+    /// Separable running-sum average pool. Out-of-bounds taps contribute 0, so the
+    /// box sum over the padded window equals the sum of in-bounds values; the divisor
+    /// is the per-cell valid count, itself separable into `kx_valid * ky_valid`.
+    /// Reassociates the sum, so it is not bit-identical to the generic kernel.
+    unsafe fn fast_2d_separable<T: Copy + Datum + num_traits::Float>(
+        &self,
+        input_ptr: *const T,
+        values_ptr: *mut T,
+        geo: &ConcretePoolGeometry,
+    ) where
+        usize: AsPrimitive<T>,
+    {
+        let ish = &geo.input_shape;
+        let osh = &geo.output_shape;
+        let (h, w) = (ish.hw_dims()[0] as isize, ish.hw_dims()[1] as isize);
+        let (ho, wo) = (geo.patch.output_shape[0], geo.patch.output_shape[1]);
+        let (kh, kw) =
+            (geo.patch.spec.kernel_shape[0] as isize, geo.patch.spec.kernel_shape[1] as isize);
+        let (pt, pl) = (geo.patch.pad_before[0] as isize, geo.patch.pad_before[1] as isize);
+        let ih_stride = *ish.h_stride() as isize;
+        let oh_stride = *osh.h_stride() as isize;
+        let ow_stride = *osh.w_stride() as isize;
+        let n = *ish.n().unwrap_or(&1);
+        let in_stride = *ish.n_stride().unwrap_or(&0) as isize;
+        let on_stride = *osh.n_stride().unwrap_or(&0) as isize;
+        let c = *ish.c();
+        let ic_stride = *ish.c_stride() as isize;
+        let oc_stride = *osh.c_stride() as isize;
+
+        let axis_valid = |out: usize, k: isize, pad: isize, lim: isize| -> Vec<usize> {
+            (0..out)
+                .map(|o| {
+                    let lo = o as isize - pad;
+                    let start = (-lo).max(0);
+                    let end = (lim - lo).min(k);
+                    (end - start).max(0) as usize
+                })
+                .collect()
+        };
+        let kx_valid = axis_valid(wo, kw, pl, w);
+        let ky_valid = axis_valid(ho, kh, pt, h);
+        let full_recip: T = ((kh * kw) as usize).as_().recip();
+
+        let mut htmp = vec![T::zero(); h as usize * wo];
+        unsafe {
+            for nn in 0..n as isize {
+                for cc in 0..c as isize {
+                    let in_base = nn * in_stride + cc * ic_stride;
+                    let out_base = nn * on_stride + cc * oc_stride;
+                    for y in 0..h {
+                        let row = in_base + y * ih_stride;
+                        let dst = y as usize * wo;
+                        let mut acc = T::zero();
+                        for kx in 0..kw {
+                            let ix = -pl + kx;
+                            if ix >= 0 && ix < w {
+                                acc = acc + *input_ptr.offset(row + ix);
+                            }
+                        }
+                        *htmp.get_unchecked_mut(dst) = acc;
+                        for ox in 1..wo as isize {
+                            let entering = ox - pl + kw - 1;
+                            let leaving = ox - pl - 1;
+                            if entering >= 0 && entering < w {
+                                acc = acc + *input_ptr.offset(row + entering);
+                            }
+                            if leaving >= 0 && leaving < w {
+                                acc = acc - *input_ptr.offset(row + leaving);
+                            }
+                            *htmp.get_unchecked_mut(dst + ox as usize) = acc;
+                        }
+                    }
+                    for ox in 0..wo {
+                        let mut acc = T::zero();
+                        for ky in 0..kh {
+                            let iy = -pt + ky;
+                            if iy >= 0 && iy < h {
+                                acc = acc + *htmp.get_unchecked(iy as usize * wo + ox);
+                            }
+                        }
+                        let store = |oy: usize, acc: T| {
+                            let div = if self.count_include_pad {
+                                full_recip
+                            } else {
+                                (kx_valid[ox] * ky_valid[oy]).as_().recip()
+                            };
+                            *values_ptr.offset(
+                                out_base + oy as isize * oh_stride + ox as isize * ow_stride,
+                            ) = acc * div;
+                        };
+                        store(0, acc);
+                        for oy in 1..ho as isize {
+                            let entering = oy - pt + kh - 1;
+                            let leaving = oy - pt - 1;
+                            if entering >= 0 && entering < h {
+                                acc = acc + *htmp.get_unchecked(entering as usize * wo + ox);
+                            }
+                            if leaving >= 0 && leaving < h {
+                                acc = acc - *htmp.get_unchecked(leaving as usize * wo + ox);
+                            }
+                            store(oy as usize, acc);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::cnn::PaddingSpec;
+    use crate::ops::nn::DataFormat;
+
+    fn test_case() -> (TypedModel, TVec<TValue>) {
+        let mut model = TypedModel::default();
+        let source = model.add_source("data", f32::fact([1, 3, 8, 8])).unwrap();
+        let pool_spec = PoolSpec::new(
+            DataFormat::NCHW,
+            tvec![2, 2],
+            PaddingSpec::Valid,
+            None,
+            Some(tvec![2, 2]),
+            3,
+            3,
+        );
+        let op = SumPool { pool_spec, count_include_pad: false, normalize: true };
+        let out = model.wire_node("pool", op, &[source]).unwrap();
+        model.select_output_outlets(&out).unwrap();
+        let input = ndarray::Array4::from_shape_fn((1, 3, 8, 8), |(_, c, y, x)| {
+            (c * 64 + y * 8 + x) as f32
+        })
+        .into_tensor()
+        .into_tvalue();
+        (model, tvec!(input))
+    }
+
+    #[test]
+    fn optimized_sumpool_has_concrete_geometry() {
+        let (model, input) = test_case();
+        let plain = model.clone().into_runnable().unwrap().run(input.clone()).unwrap();
+
+        let optimized = model.into_optimized().unwrap();
+        let pool = optimized
+            .nodes
+            .iter()
+            .find_map(|n| n.op_as::<OptSumPool>())
+            .expect("optimized model should contain an OptSumPool");
+        assert!(
+            pool.geometry.is_concrete(),
+            "OptSumPool geometry should be concrete after optimization"
+        );
+
+        let opt = optimized.into_runnable().unwrap().run(input).unwrap();
+        assert_eq!(*opt[0], *plain[0]);
+    }
+
+    #[test]
+    fn separable_matches_generic_kernel() {
+        let (c, h, w) = (5usize, 7usize, 9usize);
+        let pool_spec = PoolSpec::new(
+            DataFormat::NCHW,
+            tvec![3, 3],
+            PaddingSpec::SameUpper,
+            None,
+            Some(tvec![1, 1]),
+            c,
+            c,
+        );
+        let op = OptSumPool {
+            pool_spec: pool_spec.clone(),
+            count_include_pad: false,
+            normalize: true,
+            geometry: pool_spec
+                .compute_geo(&[1.to_dim(), c.to_dim(), h.to_dim(), w.to_dim()])
+                .unwrap(),
+        };
+        let input: Tensor = ndarray::Array4::from_shape_fn((1, c, h, w), |(_, cc, y, x)| {
+            ((cc * 17 + y * 3 + x) % 13) as f32 - 6.0
+        })
+        .into_tensor();
+
+        // generic zoned kernel (knob off by default)
+        let generic = op.eval(tvec![input.clone().into_tvalue()]).unwrap();
+        let generic = generic[0].try_as_plain().unwrap().as_slice::<f32>().unwrap().to_vec();
+
+        // separable kernel, called directly
+        let geo = op.geometry.to_concrete(input.shape()).unwrap();
+        let mut out = Tensor::zero::<f32>(&geo.output_shape.shape).unwrap();
+        unsafe {
+            op.fast_2d_separable::<f32>(
+                input.as_ptr::<f32>().unwrap(),
+                out.as_ptr_mut::<f32>().unwrap(),
+                geo.as_ref(),
+            );
+        }
+        let sep = out.try_as_plain().unwrap().as_slice::<f32>().unwrap();
+
+        let max_abs = generic.iter().zip(sep).map(|(a, b)| (a - b).abs()).fold(0f32, f32::max);
+        assert!(max_abs < 1e-4, "separable vs generic max abs diff {max_abs}");
     }
 }

--- a/doc/cli-recipe.md
+++ b/doc/cli-recipe.md
@@ -190,6 +190,7 @@ highlights a few worth knowing; `list-knobs` is the complete set.
 | `TRACT_LOG` | `env_logger` filter (e.g. `tract=debug`, `cli=info,tract=warn`). The CLI also derives a default level from `-v` / `-vv`. |
 | `TRACT_LAZY_IM2COL_MIN_KERNEL` | Minimum convolution kernel volume before lazy im2col is preferred over eager. Default: 6. Lower it to experiment on memory-constrained targets. |
 | `TRACT_LAZY_IM2COL_MAX_EAGER_BYTES` | Scratch-buffer ceiling above which `Conv` switches from eager to lazy im2col. Per-family default (~1 MiB on WASM, ~4 MiB on native). Key knob for the canary-model regression gate. |
+| `TRACT_AVGPOOL_SEPARABLE` | Use the separable running-sum average-pool kernel (stride-1 NCHW), O(1) per output vs O(k²). Default: off. **Not bit-identical** — it reassociates the float sums (allowed by `SumPool`'s `Validation::Rounding`). ~2× on the avg-pool nodes; pool-heavy nets (Inception) see it E2E. |
 | `TRACT_CPU_AARCH64_KIND` | Force aarch64 CPU family detection (`a53`, `a55`, `a72`, `applem`, `generic`, …). Useful for QEMU runs that misreport. |
 | `TRACT_CPU_AARCH64_OVERRIDE_CPU_PART` | Force the raw CPU part hex (`0xd03`, …) before the kind-lookup table runs. Lower-level escape hatch when `TRACT_CPU_AARCH64_KIND` doesn't cover the target. |
 | `TRACT_CPU_ARM32_NEON` | Force armv7 NEON detection on/off (`true`/`1` or `false`/`0`). |
@@ -197,7 +198,8 @@ highlights a few worth knowing; `list-knobs` is the complete set.
 
 Knobs are declared with `declare_knob!`: the arch-detection ones in
 `linalg/src/knobs.rs`, the conv crossovers in `core/src/ops/cnn/conv/conv.rs`
-next to their default constants. `TRACT_LOG` (an `env_logger` filter) and the
+and the avg-pool kernel toggle in `core/src/ops/cnn/sumpool.rs`, each next to
+the code it steers. `TRACT_LOG` (an `env_logger` filter) and the
 CI-only `TRACT_CPU_EXPECT_ARM32_NEON` are conventions, not registry knobs, so
 they do not appear in `list-knobs`. See [`kernel-notes.md`](kernel-notes.md)
 for context on the kernel selection that `LAZY_IM2COL_*` is steering.


### PR DESCRIPTION
Two pooling changes for fixed-shape models: a `codegen` lowering MaxPool/SumPool to OptMaxPool/OptSumPool with the Patch geometry pre-resolved to `Concrete` (byte-identical; symbolic shapes untouched), and an opt-in separable running-sum average-pool kernel behind `TRACT_AVGPOOL_SEPARABLE` that trades bit-exactness — it reassociates the sum, permitted by `SumPool`'s `Validation::Rounding` — for a ~2× speedup on the avg-pool nodes. Happy to split the two if you'd rather take the byte-identical geometry change on its own.

🍍
