### PR TITLE
ci: pin action version comments to the exact resolved tag

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -35,14 +35,14 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true   # no artifact => nothing comparable => nothing to post
         with:
           name: bench-comment
           path: bench-comment
           run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           DISPATCH_RUN_ID: ${{ inputs.run_id }}
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -70,7 +70,7 @@ jobs:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
       - run: ${{ matrix.build }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tract-cli-${{ matrix.triple }}
           path: ${{ matrix.bin }}
@@ -105,7 +105,7 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tract-cli-${{ matrix.triple }}
           path: tract-cli
@@ -177,7 +177,7 @@ jobs:
           printf '{"device":"%s","triple":"%s"}\n' "$DEVICE" "$TRIPLE" > result/meta.json
       - name: Upload PR result
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-result-${{ matrix.target }}
           path: result
@@ -196,11 +196,11 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: bench-result-*
           path: results
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tract-cli-x86_64-unknown-linux-gnu
           path: tract-cli
@@ -222,7 +222,7 @@ jobs:
       # run, including manual re-runs (a re-run does not re-fire the workflow_run trampoline).
       - name: Comment on PR (same-repo)
         if: ${{ hashFiles('pr-comment.md') != '' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
@@ -250,7 +250,7 @@ jobs:
           mkdir -p bench-comment
           mv pr-comment.md bench-comment/
           printf '%s\n' "$PR_NUMBER" > bench-comment/pr-number
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ hashFiles('bench-comment/pr-comment.md') != '' }}
         with:
           name: bench-comment

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Route /ci target to its workflow
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.CI_DISPATCH_TOKEN }}
           script: |

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -29,7 +29,7 @@ jobs:
       tract_bench_branch_name: ${{ steps.set.outputs.tract_bench_branch_name }}
     steps:
       - id: set
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.info(`event: ${context.eventName}`);
@@ -106,7 +106,7 @@ jobs:
 
     - name: Setup wasmtime
       if: matrix.platform == 'wasm32-wasi'
-      uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1
+      uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
 
     - name: Cross script
       env:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -73,7 +73,7 @@ jobs:
           persist-credentials: false
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build -p tract-cli --profile opt-no-lto
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tract-cli-x86_64
           path: ./target/opt-no-lto/tract
@@ -85,7 +85,7 @@ jobs:
         with:
           persist-credentials: false
       - run: cargo build -p tract-cli --profile opt-no-lto
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tract-cli-aarch64-apple
           path: ./target/opt-no-lto/tract
@@ -117,7 +117,7 @@ jobs:
       with:
         persist-credentials: false
 
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: tract-cli-x86_64
         path: target/opt-no-lto
@@ -146,7 +146,7 @@ jobs:
       with:
         persist-credentials: false
 
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: tract-cli-aarch64-apple
         path: target/opt-no-lto

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -31,7 +31,7 @@ jobs:
       pr_number: ${{ steps.set.outputs.pr_number }}
     steps:
       - id: set
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           STATUS_CONTEXT: "CI / full"
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -238,7 +238,7 @@ jobs:
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
     - name: Setup Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.13"
 
@@ -264,7 +264,7 @@ jobs:
       statuses: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           NEEDS: ${{ toJSON(needs) }}
           PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}

--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -30,7 +30,7 @@ jobs:
       pr_number: ${{ steps.set.outputs.pr_number }}
     steps:
       - id: set
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           STATUS_CONTEXT: "CI / large-models"
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -77,7 +77,7 @@ jobs:
           ROOT=. ./.travis/ci-system-setup.sh
           cargo build -p tract-cli --profile opt-no-lto --no-default-features --features transformers,pulse,cuda-13000
       - run: echo uname=$(uname) >> $GITHUB_ENV
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tract-cli-${{env.uname}}
           path: ./target/opt-no-lto/tract
@@ -147,7 +147,7 @@ jobs:
         role-to-assume: arn:aws:iam::567805100031:role/github-runner-tract-ci
         aws-region: us-east-2
     - run: echo uname=$(uname) >> $GITHUB_ENV
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: tract-cli-${{env.uname}}
         path: tract-cli-${{env.uname}}
@@ -188,7 +188,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - run: echo uname=$(uname) >> $GITHUB_ENV
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: tract-cli-${{env.uname}}
         path: tract-cli-${{env.uname}}
@@ -219,7 +219,7 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - run: echo uname=$(uname) >> $GITHUB_ENV
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: tract-cli-${{env.uname}}
         path: tract-cli-${{env.uname}}
@@ -242,7 +242,7 @@ jobs:
       statuses: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           NEEDS: ${{ toJSON(needs) }}
           PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}

--- a/.github/workflows/pydoc.yml
+++ b/.github/workflows/pydoc.yml
@@ -28,7 +28,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: rustup toolchain install # channel + components from rust-toolchain.toml
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 
@@ -58,7 +58,7 @@ jobs:
         run: rustup target install x86_64-apple-darwin aarch64-apple-darwin
 
       - name: Build wheels
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           max_attempts: 1
           timeout_seconds: 54000 # 15 hours :/
@@ -76,7 +76,7 @@ jobs:
             python .github/scripts/inject_wheel_sboms.py "$w"
           done
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-${{github.run_id}}-${{matrix.os}}
           path: ./wheelhouse/*.whl
@@ -97,7 +97,7 @@ jobs:
     - name: Build SDist
       run: cd api/py && uv build --sdist
 
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: wheels-${{github.run_id}}-src
         path: api/py/dist/*.tar.gz
@@ -110,7 +110,7 @@ jobs:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || inputs.publish
 
     steps:
-    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: wheels-${{github.run_id}}-*
         merge-multiple: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
-    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       name: Install Rustup using win.rustup.rs
       with:
         timeout_minutes: 10
@@ -42,7 +42,7 @@ jobs:
             $ProgressPreference = "SilentlyContinue"
             Invoke-WebRequest https://win.rustup.rs/ -OutFile rustup-init.exe
             .\rustup-init.exe -y --default-host=x86_64-pc-windows-msvc --profile=minimal
-    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       name: Install the target
       with:
         timeout_minutes: 10
@@ -55,7 +55,7 @@ jobs:
       with:
         key: ${{ matrix.toolchain }}
     - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2
+      uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
       with:
         version: "11.0"
     - name: debug


### PR DESCRIPTION
Several actions were SHA-pinned with major-only comments (# v6, # v8, ...). When an upstream moves its major tag off the pinned commit, zizmor's ref-version-mismatch fires (it already had for actions/setup-python, whose # v6 pin is release v6.2.0). Rewrite every major-only comment to the exact tag the pinned SHA resolves to so the annotations stay accurate as upstreams release; SHAs unchanged.