### PR TITLE
nnef: checked_mul in read_block_quant_value (residual of #2371)

### DIFF
--- a/nnef/src/tensors.rs
+++ b/nnef/src/tensors.rs
@@ -284,9 +284,15 @@ fn read_block_quant_value(r: &mut impl Read, header: &Header) -> TractResult<Ten
     let shape: TVec<_> =
         header.dims.iter().take(header.rank as usize).map(|d| *d as usize).collect();
     let q_m = shape[0];
-    let q_k = shape.iter().skip(1).product::<usize>();
+    let Some(q_k) = shape.iter().skip(1).try_fold(1usize, |a, &d| a.checked_mul(d)) else {
+        bail!("Block-quant shape product overflows usize: {:?}", shape);
+    };
     ensure!(q_k % format.block_len() == 0);
-    let expected_len = (q_m * q_k) / format.block_len() * format.block_bytes();
+    let Some(expected_len) =
+        q_m.checked_mul(q_k).map(|n| n / format.block_len() * format.block_bytes())
+    else {
+        bail!("Block-quant length overflows usize: {:?}", shape);
+    };
     ensure!(expected_len == header.data_size_bytes as usize);
     let mut blob = unsafe { Blob::new_for_size_and_align(expected_len, 128) };
     r.read_exact(&mut blob)?;


### PR DESCRIPTION
Block-quant path still used unchecked products for q_k/expected_len; checked_mul + bail, matching 34c7df2c9b. Closes the residual from #2371.