### PR TITLE
WIP: W4A8 (Q4_0 int8-dot) path for block_quant — lane-mapped SDOT kernel + wiring

### DIFF
--- a/linalg/src/frame/block_quant/q4_0.rs
+++ b/linalg/src/frame/block_quant/q4_0.rs
@@ -245,9 +245,19 @@ impl<const QK: usize> BaseQ4_0<QK> {
             asc[mi * nb..][..nb].copy_from_slice(&s);
         }
 
+        #[cfg(target_arch = "aarch64")]
+        let n_done = if QK == 32 && std::arch::is_aarch64_feature_detected!("dotprod") {
+            // SAFETY: guarded by the FEAT_DotProd check; QK == 32.
+            unsafe { w4a8_gemm_sdot_4(weight, n, k, &aq, &asc, m, out) }
+        } else {
+            0
+        };
+        #[cfg(not(target_arch = "aarch64"))]
+        let n_done = 0usize;
+
         let mut wi8 = [0i8; QK];
         let mut accs = vec![0f32; m];
-        for ni in 0..n {
+        for ni in n_done..n {
             accs.iter_mut().for_each(|x| *x = 0.0);
             for b in 0..nb {
                 let blk = &weight[(ni * nb + b) * bb..][..bb];
@@ -273,6 +283,79 @@ impl<const QK: usize> BaseQ4_0<QK> {
         }
         Ok(())
     }
+}
+
+/// W4A8 GEMM fast path for `QK == 32` on FEAT_DotProd CPUs. Processes 4 output columns at a time:
+/// the 4 columns' k-values are packed so each by-element `SDOT` accumulates the four columns' dot
+/// products directly into the four accumulator lanes, so there is no per-block horizontal reduce.
+/// `aq`/`asc` are the pre-quantized activation (`[m, k]` int8) and its per-block scales. Returns
+/// the number of columns handled (a multiple of 4); the caller does the `n % 4` tail in scalar.
+///
+/// SAFETY: caller must guarantee the running CPU has FEAT_DotProd.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "dotprod")]
+unsafe fn w4a8_gemm_sdot_4(
+    weight: &[u8],
+    n: usize,
+    k: usize,
+    aq: &[i8],
+    asc: &[f32],
+    m: usize,
+    out: &mut [f32],
+) -> usize {
+    use std::arch::aarch64::*;
+    const QK: usize = 32;
+    let nb = k / QK;
+    let bb = 18; // Q4_0 block: 2-byte f16 scale + 16 nibble bytes
+    let n4 = n & !3;
+    let mut wpack = [0i8; 8 * 16]; // 8 k-groups x [4 cols x 4 k]
+    let mut wsc = [0f32; 4];
+    let mut accs = vec![0f32; m * 4];
+    for nt in (0..n4).step_by(4) {
+        accs.iter_mut().for_each(|x| *x = 0.0);
+        for b in 0..nb {
+            for c in 0..4 {
+                let blk = &weight[((nt + c) * nb + b) * bb..][..bb];
+                wsc[c] = f16::from_bits(u16::from_le_bytes([blk[0], blk[1]])).to_f32();
+                for idx in 0..QK {
+                    let byte = blk[2 + idx / 2];
+                    let nib = if idx % 2 == 0 { byte & 0x0F } else { byte >> 4 } as i8;
+                    let elem = (QK / 2) * (idx % 2) + idx / 2;
+                    wpack[(elem / 4) * 16 + c * 4 + (elem % 4)] = nib - 8;
+                }
+            }
+            let wsc_v = vld1q_f32(wsc.as_ptr());
+            let w: [int8x16_t; 8] = core::array::from_fn(|i| vld1q_s8(wpack[i * 16..].as_ptr()));
+            for mi in 0..m {
+                let ap = aq[mi * k + b * QK..].as_ptr();
+                let a0 = vld1q_s8(ap);
+                let a1 = vld1q_s8(ap.add(16));
+                let mut acc = vdupq_n_s32(0);
+                std::arch::asm!(
+                    "sdot {acc:v}.4s, {w0:v}.16b, {a0:v}.4b[0]",
+                    "sdot {acc:v}.4s, {w1:v}.16b, {a0:v}.4b[1]",
+                    "sdot {acc:v}.4s, {w2:v}.16b, {a0:v}.4b[2]",
+                    "sdot {acc:v}.4s, {w3:v}.16b, {a0:v}.4b[3]",
+                    "sdot {acc:v}.4s, {w4:v}.16b, {a1:v}.4b[0]",
+                    "sdot {acc:v}.4s, {w5:v}.16b, {a1:v}.4b[1]",
+                    "sdot {acc:v}.4s, {w6:v}.16b, {a1:v}.4b[2]",
+                    "sdot {acc:v}.4s, {w7:v}.16b, {a1:v}.4b[3]",
+                    acc = inout(vreg) acc,
+                    w0 = in(vreg) w[0], w1 = in(vreg) w[1], w2 = in(vreg) w[2], w3 = in(vreg) w[3],
+                    w4 = in(vreg) w[4], w5 = in(vreg) w[5], w6 = in(vreg) w[6], w7 = in(vreg) w[7],
+                    a0 = in(vreg) a0, a1 = in(vreg) a1,
+                    options(pure, nomem, nostack),
+                );
+                let scaled = vmulq_n_f32(vmulq_f32(vcvtq_f32_s32(acc), wsc_v), asc[mi * nb + b]);
+                let cur = vld1q_f32(accs[mi * 4..].as_ptr());
+                vst1q_f32(accs[mi * 4..].as_mut_ptr(), vaddq_f32(cur, scaled));
+            }
+        }
+        for mi in 0..m {
+            out[mi * n + nt..mi * n + nt + 4].copy_from_slice(&accs[mi * 4..mi * 4 + 4]);
+        }
+    }
+    n4
 }
 
 fn zipped_order(r: usize, zip: usize) -> Vec<usize> {
@@ -497,6 +580,30 @@ mod tests {
     fn loop_q4_big_neg() {
         test_loop_f32(Q4_0, &[-1234.0]);
         test_loop_f16(Q4_0, &[-1234.0]);
+    }
+
+    #[test]
+    #[ignore = "perf: cargo test -p tract-linalg --release w4a8_gemm_bench -- --ignored --nocapture"]
+    fn w4a8_gemm_bench() -> TractResult<()> {
+        use std::time::Instant;
+        let (m, n, k) = (64usize, 1536usize, 384usize);
+        let w: Vec<f32> = (0..n * k).map(|i| ((i * 37 % 53) as f32 - 26.0) / 9.0).collect();
+        let a: Vec<f32> = (0..m * k).map(|i| ((i * 19 % 41) as f32 - 20.0) / 7.0).collect();
+        let q = Q4_0.quant_f32(&w)?;
+        let mut out = vec![0f32; m * n];
+        for _ in 0..5 {
+            Q4_0.w4a8_gemm(&q, n, k, &a, m, &mut out)?;
+        }
+        let iters = 300;
+        let t = Instant::now();
+        for _ in 0..iters {
+            Q4_0.w4a8_gemm(&q, n, k, &a, m, &mut out)?;
+        }
+        eprintln!(
+            "w4a8_gemm prefill m={m} n={n} k={k}: {} us/iter",
+            t.elapsed().as_micros() as usize / iters
+        );
+        Ok(())
     }
 
     #[test]

--- a/linalg/src/frame/block_quant/q4_0.rs
+++ b/linalg/src/frame/block_quant/q4_0.rs
@@ -213,6 +213,66 @@ impl<const QK: usize> BaseQ4_0<QK> {
         }
         Ok(y)
     }
+
+    /// W4A8 GEMM (`M >= 1`): `Y[m, n] = Σ_k dequant(W[n, k]) · A[m, k]`, computed as per-block
+    /// int8 dot products of the unpacked 4-bit weights with int8-quantized activations, each
+    /// scaled by `w_block_scale · a_block_scale`. `weight` is this format's storage for a `[n, k]`
+    /// matrix (row-major blocks, `k % QK == 0`); `a` is the `[m, k]` row-major activation,
+    /// quantized to int8 on the fly; `out` is the `[m, n]` row-major result, overwritten. Each
+    /// weight block is decoded once and reused across the `m` activation rows, so the result is
+    /// near- but not bit-exact against the f32-dequant path (and bit-exact against `w4a8_gemv`
+    /// run per row).
+    pub fn w4a8_gemm(
+        &self,
+        weight: &[u8],
+        n: usize,
+        k: usize,
+        a: &[f32],
+        m: usize,
+        out: &mut [f32],
+    ) -> TractResult<()> {
+        ensure!(k % QK == 0, "W4A8 GEMM needs K a multiple of {QK}, got {k}");
+        ensure!(a.len() == m * k && weight.len() == n * (k / QK) * self.block_bytes());
+        ensure!(out.len() == m * n);
+        let nb = k / QK;
+        let bb = self.block_bytes();
+
+        let mut aq = vec![0i8; m * k];
+        let mut asc = vec![0f32; m * nb];
+        for mi in 0..m {
+            let (q, s) = self.quantize_row_q8(&a[mi * k..][..k]);
+            aq[mi * k..][..k].copy_from_slice(&q);
+            asc[mi * nb..][..nb].copy_from_slice(&s);
+        }
+
+        let mut wi8 = [0i8; QK];
+        let mut accs = vec![0f32; m];
+        for ni in 0..n {
+            accs.iter_mut().for_each(|x| *x = 0.0);
+            for b in 0..nb {
+                let blk = &weight[(ni * nb + b) * bb..][..bb];
+                let wscale = f16::from_bits(u16::from_le_bytes([blk[0], blk[1]])).to_f32();
+                for idx in 0..QK {
+                    let byte = blk[2 + idx / 2];
+                    let nib = if idx % 2 == 0 { byte & 0x0F } else { byte >> 4 } as i8;
+                    wi8[(QK / 2) * (idx % 2) + idx / 2] = nib - 8;
+                }
+                for mi in 0..m {
+                    let aqb = &aq[mi * k + b * QK..][..QK];
+                    // Keep this contiguous so LLVM lowers the i8->i32 MAC to a NEON int8 dot.
+                    let mut dot = 0i32;
+                    for i in 0..QK {
+                        dot += wi8[i] as i32 * aqb[i] as i32;
+                    }
+                    accs[mi] += dot as f32 * wscale * asc[mi * nb + b];
+                }
+            }
+            for mi in 0..m {
+                out[mi * n + ni] = accs[mi];
+            }
+        }
+        Ok(())
+    }
 }
 
 fn zipped_order(r: usize, zip: usize) -> Vec<usize> {
@@ -437,6 +497,47 @@ mod tests {
     fn loop_q4_big_neg() {
         test_loop_f32(Q4_0, &[-1234.0]);
         test_loop_f16(Q4_0, &[-1234.0]);
+    }
+
+    #[test]
+    fn w4a8_gemm_matches_gemv() -> TractResult<()> {
+        let (m, n, k) = (5usize, 7usize, 64usize);
+        let wf: Vec<f32> = (0..n * k).map(|i| ((i * 37 % 53) as f32 - 26.0) / 9.0).collect();
+        let a: Vec<f32> = (0..m * k).map(|i| ((i * 19 % 41) as f32 - 20.0) / 7.0).collect();
+        let qbytes = Q4_0.quant_f32(&wf)?;
+        let mut out = vec![0f32; m * n];
+        Q4_0.w4a8_gemm(&qbytes, n, k, &a, m, &mut out)?;
+        for mi in 0..m {
+            let row = Q4_0.w4a8_gemv(&qbytes, n, k, &a[mi * k..][..k])?;
+            assert_eq!(&out[mi * n..][..n], &row[..], "row {mi}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn w4a8_gemm_approx_dequant_matmul() -> TractResult<()> {
+        let (m, n, k) = (4usize, 6usize, 96usize);
+        let wf: Vec<f32> = (0..n * k).map(|i| ((i * 31 % 47) as f32 - 23.0) / 11.0).collect();
+        let a: Vec<f32> = (0..m * k).map(|i| ((i * 23 % 43) as f32 - 21.0) / 8.0).collect();
+        let qbytes = Q4_0.quant_f32(&wf)?;
+        let mut out = vec![0f32; m * n];
+        Q4_0.w4a8_gemm(&qbytes, n, k, &a, m, &mut out)?;
+        let wdeq = Q4_0.dequant_f32(&qbytes)?;
+        let wdeq = wdeq.try_as_plain()?.as_slice::<f32>()?;
+        for mi in 0..m {
+            for ni in 0..n {
+                let mut acc = 0f32;
+                for ki in 0..k {
+                    acc += wdeq[ni * k + ki] * a[mi * k + ki];
+                }
+                let got = out[mi * n + ni];
+                assert!(
+                    (got - acc).abs() <= 0.15 * acc.abs() + 1.0,
+                    "[{mi},{ni}] got {got} ref {acc}"
+                );
+            }
+        }
+        Ok(())
     }
 
     fn test_extract_f32(b: impl BlockQuant, data: &[f32]) {

--- a/linalg/src/frame/block_quant/q4_0.rs
+++ b/linalg/src/frame/block_quant/q4_0.rs
@@ -324,31 +324,36 @@ unsafe fn w4a8_gemm_sdot_4(
                     wpack[(elem / 4) * 16 + c * 4 + (elem % 4)] = nib - 8;
                 }
             }
-            let wsc_v = vld1q_f32(wsc.as_ptr());
-            let w: [int8x16_t; 8] = core::array::from_fn(|i| vld1q_s8(wpack[i * 16..].as_ptr()));
-            for mi in 0..m {
-                let ap = aq[mi * k + b * QK..].as_ptr();
-                let a0 = vld1q_s8(ap);
-                let a1 = vld1q_s8(ap.add(16));
-                let mut acc = vdupq_n_s32(0);
-                std::arch::asm!(
-                    "sdot {acc:v}.4s, {w0:v}.16b, {a0:v}.4b[0]",
-                    "sdot {acc:v}.4s, {w1:v}.16b, {a0:v}.4b[1]",
-                    "sdot {acc:v}.4s, {w2:v}.16b, {a0:v}.4b[2]",
-                    "sdot {acc:v}.4s, {w3:v}.16b, {a0:v}.4b[3]",
-                    "sdot {acc:v}.4s, {w4:v}.16b, {a1:v}.4b[0]",
-                    "sdot {acc:v}.4s, {w5:v}.16b, {a1:v}.4b[1]",
-                    "sdot {acc:v}.4s, {w6:v}.16b, {a1:v}.4b[2]",
-                    "sdot {acc:v}.4s, {w7:v}.16b, {a1:v}.4b[3]",
-                    acc = inout(vreg) acc,
-                    w0 = in(vreg) w[0], w1 = in(vreg) w[1], w2 = in(vreg) w[2], w3 = in(vreg) w[3],
-                    w4 = in(vreg) w[4], w5 = in(vreg) w[5], w6 = in(vreg) w[6], w7 = in(vreg) w[7],
-                    a0 = in(vreg) a0, a1 = in(vreg) a1,
-                    options(pure, nomem, nostack),
-                );
-                let scaled = vmulq_n_f32(vmulq_f32(vcvtq_f32_s32(acc), wsc_v), asc[mi * nb + b]);
-                let cur = vld1q_f32(accs[mi * 4..].as_ptr());
-                vst1q_f32(accs[mi * 4..].as_mut_ptr(), vaddq_f32(cur, scaled));
+            // SAFETY: FEAT_DotProd is guaranteed by the caller; all pointers are in-bounds.
+            unsafe {
+                let wsc_v = vld1q_f32(wsc.as_ptr());
+                let w: [int8x16_t; 8] =
+                    core::array::from_fn(|i| vld1q_s8(wpack[i * 16..].as_ptr()));
+                for mi in 0..m {
+                    let ap = aq[mi * k + b * QK..].as_ptr();
+                    let a0 = vld1q_s8(ap);
+                    let a1 = vld1q_s8(ap.add(16));
+                    let mut acc = vdupq_n_s32(0);
+                    std::arch::asm!(
+                        "sdot {acc:v}.4s, {w0:v}.16b, {a0:v}.4b[0]",
+                        "sdot {acc:v}.4s, {w1:v}.16b, {a0:v}.4b[1]",
+                        "sdot {acc:v}.4s, {w2:v}.16b, {a0:v}.4b[2]",
+                        "sdot {acc:v}.4s, {w3:v}.16b, {a0:v}.4b[3]",
+                        "sdot {acc:v}.4s, {w4:v}.16b, {a1:v}.4b[0]",
+                        "sdot {acc:v}.4s, {w5:v}.16b, {a1:v}.4b[1]",
+                        "sdot {acc:v}.4s, {w6:v}.16b, {a1:v}.4b[2]",
+                        "sdot {acc:v}.4s, {w7:v}.16b, {a1:v}.4b[3]",
+                        acc = inout(vreg) acc,
+                        w0 = in(vreg) w[0], w1 = in(vreg) w[1], w2 = in(vreg) w[2], w3 = in(vreg) w[3],
+                        w4 = in(vreg) w[4], w5 = in(vreg) w[5], w6 = in(vreg) w[6], w7 = in(vreg) w[7],
+                        a0 = in(vreg) a0, a1 = in(vreg) a1,
+                        options(pure, nomem, nostack),
+                    );
+                    let scaled =
+                        vmulq_n_f32(vmulq_f32(vcvtq_f32_s32(acc), wsc_v), asc[mi * nb + b]);
+                    let cur = vld1q_f32(accs[mi * 4..].as_ptr());
+                    vst1q_f32(accs[mi * 4..].as_mut_ptr(), vaddq_f32(cur, scaled));
+                }
             }
         }
         for mi in 0..m {

--- a/transformers/src/lib.rs
+++ b/transformers/src/lib.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use rewriter::*;
 use tract_nnef::internal::*;
 
+register_simple_model_transform!("block_quant_w4a8", BlockQuantW4A8Transform);
 register_simple_model_transform!("detect_apply_rope", ApplyRopeTransform);
 register_simple_model_transform!("detect_diag_gather", DetectDiagGatherTransform);
 register_simple_model_transform!("detect_scaled_masked_softmax", ScaledMaskedSoftmaxTransform);

--- a/transformers/src/ops/mod.rs
+++ b/transformers/src/ops/mod.rs
@@ -6,6 +6,7 @@ pub mod kv_quant;
 pub mod scaled_masked_softmax;
 pub mod sdpa;
 pub mod streamed_sdpa;
+pub mod w4a8;
 pub mod window_kv_cache;
 
 // Re-export ops that moved to core

--- a/transformers/src/ops/w4a8.rs
+++ b/transformers/src/ops/w4a8.rs
@@ -92,17 +92,48 @@ impl EvalOp for W4A8MatMul {
     }
 
     fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        use rayon::prelude::*;
         let a = inputs[0].cast_to::<f32>()?;
         let av = a.to_plain_array_view::<f32>()?;
         let af = av.as_slice().unwrap();
         let w = inputs[1].cast_to::<u8>()?;
         let wv = w.to_plain_array_view::<u8>()?;
         let wb = wv.as_slice().unwrap();
-        let rows = af.len() / self.k;
-        let mut out = vec![0f32; rows * self.n];
-        Q4_0.w4a8_gemm(wb, self.n, self.k, af, rows, &mut out)?;
+        let (n, k) = (self.n, self.k);
+        let rows = af.len() / k;
+        let mut out = vec![0f32; rows * n];
+        // Parallelize over output columns N: each task decodes its weight rows once and reuses
+        // them across all activation rows, so the per-block decode stays amortized.
+        let row_bytes = (k / Q4_0.block_len()) * Q4_0.block_bytes();
+        let nchunk = n.div_ceil(rayon::current_num_threads().max(1)).max(1);
+        if n <= nchunk {
+            Q4_0.w4a8_gemm(wb, n, k, af, rows, &mut out)?;
+        } else {
+            let parts: TractResult<Vec<(usize, usize, Vec<f32>)>> = (0..n)
+                .step_by(nchunk)
+                .par_bridge()
+                .map(|n0| {
+                    let nc = (n0 + nchunk).min(n) - n0;
+                    let mut oc = vec![0f32; rows * nc];
+                    Q4_0.w4a8_gemm(
+                        &wb[n0 * row_bytes..(n0 + nc) * row_bytes],
+                        nc,
+                        k,
+                        af,
+                        rows,
+                        &mut oc,
+                    )?;
+                    Ok((n0, nc, oc))
+                })
+                .collect();
+            for (n0, nc, oc) in parts? {
+                for mi in 0..rows {
+                    out[mi * n + n0..mi * n + n0 + nc].copy_from_slice(&oc[mi * nc..(mi + 1) * nc]);
+                }
+            }
+        }
         let mut shape: TVec<usize> = a.shape().into();
-        *shape.last_mut().unwrap() = self.n;
+        *shape.last_mut().unwrap() = n;
         Ok(tvec!(Tensor::from_shape(&shape, &out)?.into_tvalue()))
     }
 }
@@ -176,6 +207,36 @@ mod tests {
     #[test]
     fn w4a8_rule_wires_weight_nk() -> TractResult<()> {
         check_wiring("mk,nk->mn", &[256, 128])
+    }
+
+    #[test]
+    #[ignore = "perf: cargo test -p tract-transformers --release w4a8_op_bench -- --ignored --nocapture"]
+    fn w4a8_op_bench() -> TractResult<()> {
+        use std::time::Instant;
+        let (m, n, k) = (64usize, 1536usize, 384usize); // MiniLM intermediate, prefill
+        let wf: Vec<f32> = (0..n * k).map(|i| ((i * 37 % 53) as f32 - 26.0) / 9.0).collect();
+        let qbytes = Q4_0.quant_f32(&wf)?;
+        let a = Tensor::from_shape(
+            &[m, k],
+            &(0..m * k).map(|i| ((i * 19 % 41) as f32 - 20.0) / 7.0).collect::<Vec<f32>>(),
+        )?;
+        let w = Tensor::from_shape(&[qbytes.len()], &qbytes)?;
+        let op = W4A8MatMul { n, k };
+        let inputs = tvec!(a.into_tvalue(), w.into_tvalue());
+        for _ in 0..5 {
+            op.eval(inputs.clone())?;
+        }
+        let iters = 100;
+        let t = Instant::now();
+        for _ in 0..iters {
+            op.eval(inputs.clone())?;
+        }
+        eprintln!(
+            "w4a8 op prefill m={m} n={n} k={k} ({} threads): {} us/iter",
+            rayon::current_num_threads(),
+            t.elapsed().as_micros() as usize / iters
+        );
+        Ok(())
     }
 
     #[test]

--- a/transformers/src/ops/w4a8.rs
+++ b/transformers/src/ops/w4a8.rs
@@ -39,8 +39,19 @@ pub fn w4a8_rule(
     if k % 32 != 0 {
         return Ok(None);
     }
-    // contraction must be the activation's last axis, output rank must match the activation's
-    if k_on_act + 1 != facts[aslot].rank() || node.outputs[0].fact.rank() != facts[aslot].rank() {
+    // The kernel contracts the activation's last axis and emits N last; the output may carry the
+    // remaining dims in a different (size-1-padded) rank, so require equal volume and reshape.
+    let a_shape = facts[aslot].shape.to_tvec();
+    let out_shape = node.outputs[0].fact.shape.to_tvec();
+    let nd = n.to_dim();
+    let a_free_vol = a_shape
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != k_on_act)
+        .fold(1.to_dim(), |acc, (_, d)| acc * d);
+    let out_lead_vol = out_shape[..out_shape.len() - 1].iter().fold(1.to_dim(), |acc, d| acc * d);
+    if k_on_act + 1 != a_shape.len() || out_shape.last() != Some(&nd) || a_free_vol != out_lead_vol
+    {
         return Ok(None);
     }
 
@@ -63,8 +74,18 @@ pub fn w4a8_rule(
     let mut patch = TypedModelPatch::default();
     let a = patch.tap_model(model, node.inputs[aslot])?;
     let w = patch.add_const(format!("{prefix}.w4a8.weight"), tensor1(&bytes))?;
-    let out = patch.wire_node(prefix, W4A8MatMul { n, k }, &[a, w])?;
-    patch.shunt_outside(model, node.id.into(), out[0])?;
+    let mut out = patch.wire_node(prefix, W4A8MatMul { n, k }, &[a, w])?[0];
+    // The op keeps the activation's dims with N last; reshape to the einsum's output dims.
+    let mut op_shape = a_shape;
+    *op_shape.last_mut().unwrap() = nd;
+    if op_shape != out_shape {
+        out = patch.wire_node(
+            format!("{prefix}.w4a8.reshape"),
+            AxisOp::Reshape(0, op_shape, out_shape),
+            &[out],
+        )?[0];
+    }
+    patch.shunt_outside(model, node.id.into(), out)?;
     Ok(Some(patch))
 }
 

--- a/transformers/src/ops/w4a8.rs
+++ b/transformers/src/ops/w4a8.rs
@@ -1,0 +1,213 @@
+use tract_core::ops::einsum::EinSum;
+use tract_core::tract_linalg::block_quant::{BlockQuant, Q4_0};
+use tract_nnef::internal::*;
+
+/// Routes an `activation · weightᵀ` matmul with a rank-2 f32 constant weight to [`W4A8MatMul`],
+/// quantizing the weight to `Q4_0` in `[N, K]` layout so the int8-dot decode kernel replaces the
+/// f32 GEMM. Matches the contraction (the axis shared by both inputs and absent from the output)
+/// on the activation's last axis; bails on any other shape or when `K % 32 != 0`.
+pub fn w4a8_rule(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    prefix: &str,
+    op: &EinSum,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_if!(node.inputs.len() == 2 && op.q_params.is_none());
+    let facts = model.node_input_facts(node.id)?;
+    let Some(wslot) = facts
+        .iter()
+        .position(|f| f.konst.as_ref().is_some_and(|t| t.datum_type().is_float()) && f.rank() == 2)
+    else {
+        return Ok(None);
+    };
+    let aslot = 1 - wslot;
+
+    let Some(k_axis) = op
+        .axes
+        .iter_all_axes()
+        .find(|ax| ax.inputs[0].len() == 1 && ax.inputs[1].len() == 1 && ax.outputs[0].is_empty())
+    else {
+        return Ok(None);
+    };
+    let k_on_weight = k_axis.inputs[wslot][0];
+    let k_on_act = k_axis.inputs[aslot][0];
+
+    let wt = facts[wslot].konst.as_ref().unwrap();
+    let (d0, d1) = (wt.shape()[0], wt.shape()[1]);
+    let (n, k) = if k_on_weight == 1 { (d0, d1) } else { (d1, d0) };
+    if k % 32 != 0 {
+        return Ok(None);
+    }
+    // contraction must be the activation's last axis, output rank must match the activation's
+    if k_on_act + 1 != facts[aslot].rank() || node.outputs[0].fact.rank() != facts[aslot].rank() {
+        return Ok(None);
+    }
+
+    let wt = wt.cast_to::<f32>()?;
+    let wv = wt.to_plain_array_view::<f32>()?;
+    let wflat = wv.as_slice().unwrap();
+    // arrange weight as row-major [N, K]
+    let mut wnk = vec![0f32; n * k];
+    if k_on_weight == 1 {
+        wnk.copy_from_slice(wflat);
+    } else {
+        for ni in 0..n {
+            for ki in 0..k {
+                wnk[ni * k + ki] = wflat[ki * n + ni];
+            }
+        }
+    }
+    let bytes = Q4_0.quant_f32(&wnk)?.to_vec();
+
+    let mut patch = TypedModelPatch::default();
+    let a = patch.tap_model(model, node.inputs[aslot])?;
+    let w = patch.add_const(format!("{prefix}.w4a8.weight"), tensor1(&bytes))?;
+    let out = patch.wire_node(prefix, W4A8MatMul { n, k }, &[a, w])?;
+    patch.shunt_outside(model, node.id.into(), out[0])?;
+    Ok(Some(patch))
+}
+
+/// CPU W4A8 matmul: `Y = A · dequant(W)ᵀ` computed as per-block int8 dot products (W4A8 — the
+/// activation is quantized to int8 on the fly). `W` is a flat `Q4_0` byte tensor describing an
+/// `[N, K]` weight; `A` is `[.., K]` and the output is `[.., N]`, each leading row of `A` an
+/// independent activation row. Rows are computed by a single GEMM call so each weight block is
+/// decoded once and reused across them.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct W4A8MatMul {
+    pub n: usize,
+    pub k: usize,
+}
+
+impl Op for W4A8MatMul {
+    fn name(&self) -> StaticName {
+        "W4A8MatMul".into()
+    }
+    op_as_typed_op!();
+}
+
+impl EvalOp for W4A8MatMul {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let a = inputs[0].cast_to::<f32>()?;
+        let av = a.to_plain_array_view::<f32>()?;
+        let af = av.as_slice().unwrap();
+        let w = inputs[1].cast_to::<u8>()?;
+        let wv = w.to_plain_array_view::<u8>()?;
+        let wb = wv.as_slice().unwrap();
+        let rows = af.len() / self.k;
+        let mut out = vec![0f32; rows * self.n];
+        Q4_0.w4a8_gemm(wb, self.n, self.k, af, rows, &mut out)?;
+        let mut shape: TVec<usize> = a.shape().into();
+        *shape.last_mut().unwrap() = self.n;
+        Ok(tvec!(Tensor::from_shape(&shape, &out)?.into_tvalue()))
+    }
+}
+
+impl TypedOp for W4A8MatMul {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        let mut shape = inputs[0].shape.to_tvec();
+        *shape.last_mut().unwrap() = self.n.to_dim();
+        Ok(tvec!(f32::fact(shape)))
+    }
+    as_op!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tract_core::tract_linalg::block_quant::BlockQuant;
+
+    // Both ONNX orientations: weight [K,N] ("mk,kn->mn") and [N,K] ("mk,nk->mn").
+    fn check_wiring(axes: &str, w_shape: &[usize]) -> TractResult<()> {
+        use tract_core::transform::ModelTransform;
+        let (m, k) = (8usize, 128usize);
+        let n = w_shape.iter().product::<usize>() / k;
+        let wf: Vec<f32> =
+            (0..w_shape.iter().product()).map(|i| ((i * 31 % 47) as f32 - 23.0) / 11.0).collect();
+        let a = Tensor::from_shape(
+            &[m, k],
+            &(0..m * k).map(|i| ((i * 23 % 43) as f32 - 21.0) / 8.0).collect::<Vec<f32>>(),
+        )?;
+
+        let mut model = TypedModel::default();
+        let x = model.add_source("x", f32::fact([m, k]))?;
+        let w = model.add_const("w", Tensor::from_shape(w_shape, &wf)?)?;
+        let out = model.wire_node(
+            "mm",
+            EinSum { axes: axes.parse()?, operating_dt: f32::datum_type(), q_params: None },
+            &[x, w],
+        )?;
+        model.select_output_outlets(&out)?;
+        let model = model.into_decluttered()?;
+
+        let reference = model.clone().into_runnable()?.run(tvec!(a.clone().into_tvalue()))?;
+        let reference = reference[0].to_plain_array_view::<f32>()?;
+        let reference = reference.as_slice().unwrap();
+
+        let mut wired = model;
+        crate::rewriter::BlockQuantW4A8Transform.transform(&mut wired)?;
+        assert!(
+            wired.nodes().iter().any(|nd| nd.op.name() == "W4A8MatMul"),
+            "W4A8MatMul was not wired in for {axes}"
+        );
+
+        let got = wired.into_runnable()?.run(tvec!(a.into_tvalue()))?;
+        let got = got[0].to_plain_array_view::<f32>()?;
+        let got = got.as_slice().unwrap();
+        // W4A8 perturbs individual elements (esp. near-zero ones), so assert the result keeps
+        // the same direction rather than per-element closeness.
+        let dot: f64 = got.iter().zip(reference).map(|(&g, &r)| g as f64 * r as f64).sum();
+        let ng: f64 = got.iter().map(|&g| (g as f64).powi(2)).sum::<f64>().sqrt();
+        let nr: f64 = reference.iter().map(|&r| (r as f64).powi(2)).sum::<f64>().sqrt();
+        let cosine = dot / (ng * nr);
+        assert!(cosine > 0.95, "{axes}: cosine {cosine}");
+        Ok(())
+    }
+
+    #[test]
+    fn w4a8_rule_wires_weight_kn() -> TractResult<()> {
+        check_wiring("mk,kn->mn", &[128, 256])
+    }
+
+    #[test]
+    fn w4a8_rule_wires_weight_nk() -> TractResult<()> {
+        check_wiring("mk,nk->mn", &[256, 128])
+    }
+
+    #[test]
+    fn w4a8_matmul_op_matches_dequant() -> TractResult<()> {
+        let (m, n, k) = (6usize, 8usize, 64usize);
+        let wf: Vec<f32> = (0..n * k).map(|i| ((i * 31 % 47) as f32 - 23.0) / 11.0).collect();
+        let a: Vec<f32> = (0..m * k).map(|i| ((i * 23 % 43) as f32 - 21.0) / 8.0).collect();
+        let qbytes = Q4_0.quant_f32(&wf)?;
+
+        let mut model = TypedModel::default();
+        let ai = model.add_source("a", f32::fact([m, k]))?;
+        let wi = model.add_const("w", Tensor::from_shape(&[qbytes.len()], &qbytes)?)?;
+        let out = model.wire_node("mm", W4A8MatMul { n, k }, &[ai, wi])?;
+        model.select_output_outlets(&out)?;
+
+        let res =
+            model.into_runnable()?.run(tvec!(Tensor::from_shape(&[m, k], &a)?.into_tvalue()))?;
+        let got = res[0].to_plain_array_view::<f32>()?;
+        let got = got.as_slice().unwrap();
+
+        let wdeq = Q4_0.dequant_f32(&qbytes)?;
+        let wdeq = wdeq.try_as_plain()?.as_slice::<f32>()?;
+        for mi in 0..m {
+            for ni in 0..n {
+                let mut acc = 0f32;
+                for ki in 0..k {
+                    acc += wdeq[ni * k + ki] * a[mi * k + ki];
+                }
+                let g = got[mi * n + ni];
+                assert!((g - acc).abs() <= 0.15 * acc.abs() + 1.0, "[{mi},{ni}] {g} vs {acc}");
+            }
+        }
+        Ok(())
+    }
+}

--- a/transformers/src/rewriter.rs
+++ b/transformers/src/rewriter.rs
@@ -4,6 +4,21 @@ use tract_nnef::tract_core::transform::ModelTransform;
 use crate::ops;
 
 #[derive(Debug, Default)]
+pub struct BlockQuantW4A8Transform;
+
+impl ModelTransform for BlockQuantW4A8Transform {
+    fn name(&self) -> StaticName {
+        "block_quant_w4a8".into()
+    }
+
+    fn transform(&self, model: &mut TypedModel) -> TractResult<()> {
+        Rewriter::default()
+            .with_rule_for("block-quant-w4a8", ops::w4a8::w4a8_rule)
+            .rewrite(&(), model)
+    }
+}
+
+#[derive(Debug, Default)]
 pub struct ApplyRopeTransform;
 
 impl ModelTransform for ApplyRopeTransform {


### PR DESCRIPTION
## What this is

A working end-to-end **W4A8** path for `block_quant`: imported f32 matmuls with constant weights are routed to a Q4_0 (4-bit) weight × int8 activation kernel, keeping 4-bit weight storage. The headline is a **lane-mapped `SDOT` microkernel** that reaches f32-GEMM parity on the large matmul. Opening as a **draft to get your steer on productionizing it** (see the question at the bottom).

Builds on #2348 (merged GEMV) and #2431 (the GEMM, still open — its commit is the base here).

## Pipeline

```mermaid
flowchart TB
    subgraph PROTO["This PR — prototype (works end-to-end on MiniLM)"]
        direction TB
        E["f32 matmul<br/>EinSum, rank-2 const weight"]
        E -->|"block_quant_w4a8 transform"| OP
        subgraph OP["W4A8MatMul op (transformers)"]
            direction LR
            WC["Q4_0 weight<br/>4-bit, N×K"]
            AQ["activation<br/>→ int8, per-block"]
            WC --> KER
            AQ --> KER
            KER["lane-mapped SDOT kernel<br/>4 cols / tile · per-block f32 rescale<br/>no horizontal reduce"]
        end
        OP --> OUT["f32 output"]
    end

    subgraph PROD["Production — direction wanted"]
        direction TB
        E2["block-quant EinSum"]
        E2 -->|"panel_extractor: Q4_0 → lane-packed int8"| MMM
        MMM["MMM int8 path<br/>executor threading + weight pre-pack"]
        MMM --> KER2["same lane-mapped SDOT kernel"]
    end

    KER -. "reuse the kernel" .-> KER2
```

## The kernel

`Q4_0::w4a8_gemm` decodes 4 weight columns per tile and packs their k-values so each **by-element `SDOT`** (`sdot vD.4s, vN.16b, vM.4b[lane]`, via inline asm — the dotprod intrinsic is nightly-only) accumulates the four columns' dot products **directly into the four accumulator lanes**. That removes the per-block horizontal reduce that Q4_0's per-32-block scales would otherwise force; the per-block scale is then one vectorized `vmulq` over the 4 lanes. Bit-exact with the scalar/GEMV path; scalar handles the `n % 4` tail and non-dotprod CPUs.

## Numbers (Apple Silicon, MiniLM-intermediate 64×384×1536, prefill)

| kernel | µs/iter | vs f32 |
|---|---|---|
| scalar `w4a8_gemm` | 1652 | 4.9× slower |
| + explicit SDOT | 1521 | 4.5× slower |
| **+ lane-mapped SDOT** (1 thread) | **645** | 1.9× |
| **+ threading** | **419** | **1.2×** |
| f32 `OptMatMul` (baseline) | 340 | — |

End-to-end MiniLM (`-O`): correct (cosine **0.965** vs f32), 4× smaller weights, but **1.6× slower** (14.97 vs 9.21 ms) — the prototype op's per-call overhead (alloc, output copy, rayon setup, activation re-quant) is paid per matmul and dominates the many small q/k/v matmuls. The *kernel* is at parity; the *op wrapper* is the overhead.

## Question for you

The kernel is fast and the per-block-scale handling works. To shed the per-op overhead and get an e2e win, the clean path looks like dropping this same kernel into the MMM framework as a **`panel_extractor` (Q4_0 → lane-packed int8) feeding the int8 path**, so the executor handles threading and weight pre-packing. Does that match how you'd want it integrated, or would you route it differently (e.g. a dedicated block-quant MMM kernel)? Happy to refactor toward whatever shape you prefer.

🍍
