### PR TITLE
block_quant: role-aware weight quantization policy

### DIFF
--- a/core/src/ops/matmul/de_block_quant.rs
+++ b/core/src/ops/matmul/de_block_quant.rs
@@ -62,7 +62,8 @@ fn block_quant_einsum_weights(
         } else {
             format.quant_f32(a.cast_to::<f32>()?.try_as_plain()?.as_slice::<f32>()?)?
         };
-        let name = &model.node(node.inputs[0].node).name;
+        let act_slot = 1 - slot;
+        let name = &model.node(node.inputs[slot].node).name;
         let m = a.shape()[0];
         let k = a.shape()[1];
         let bqs = BlockQuantStorage::new(Box::new(format), m, k, Arc::new(weights))?;
@@ -76,13 +77,85 @@ fn block_quant_einsum_weights(
             )?,
             &[],
         )?;
-        let tap = patch.tap_model(model, node.inputs[1])?;
-        // Block-quant tensor is rank 3 [G=1, M, K]; add a group dim to the axes
+        let tap = patch.tap_model(model, node.inputs[act_slot])?;
+        // Block-quant tensor is rank 3 [G=1, M, K]; add a group dim to the weight's axes
         let mut new_op = op.op.clone();
         new_op.axes = new_op.axes.with_extra_axis('G', InOut::In(slot), 0)?;
-        let wire = patch.wire_node(prefix, new_op, &[weights[0], tap])?;
+        let inputs = if slot == 0 { [weights[0], tap] } else { [tap, weights[0]] };
+        let wire = patch.wire_node(prefix, new_op, &inputs)?;
         patch.shunt_outside(model, node.id.into(), wire[0])?;
         return Ok(Some(patch));
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ops::einsum::EinSum;
+
+    // Deterministic varied fill so quantization is actually exercised.
+    fn fill(shape: &[usize], seed: usize) -> Tensor {
+        let n: usize = shape.iter().product();
+        let data: Vec<f32> =
+            (0..n).map(|i| (((i * 13 + seed * 7) % 29) as f32 - 14.0) / 14.0).collect();
+        Tensor::from_shape(shape, &data).unwrap()
+    }
+
+    fn build(axes: &str, x_shape: &[usize], w: &Tensor) -> TractResult<TypedModel> {
+        let mut model = TypedModel::default();
+        let x = model.add_source("x", f32::fact(x_shape))?;
+        let w = model.wire_node("w", Const::new(w.clone().into_arc_tensor())?, &[])?[0];
+        let out = model.wire_node(
+            "mm",
+            EinSum { axes: axes.parse()?, operating_dt: f32::datum_type(), q_params: None },
+            &[x, w],
+        )?;
+        model.select_output_outlets(&out)?;
+        model.into_decluttered()
+    }
+
+    fn eval(model: TypedModel, x: &Tensor) -> TractResult<Tensor> {
+        let out = model.into_runnable()?.run(tvec!(x.clone().into_tvalue()))?;
+        Ok(out[0].clone().into_tensor())
+    }
+
+    // `X @ W` with W a rank-2 const (`w_k_axis` = contraction axis within W).
+    // Asserts BlockQuantTransform both applies AND computes `X @ Q4_0(W)` correctly:
+    // reference uses the same Q4_0-dequantized W, isolating operand wiring from quant error.
+    fn check(axes: &str, x_shape: &[usize], w_shape: &[usize], w_k_axis: usize) -> TractResult<()> {
+        let x = fill(x_shape, 1);
+        let w = fill(w_shape, 2);
+
+        // Q4_0 blocks along the last axis, so dequantize with k moved last, then back.
+        let last = w.rank() - 1;
+        let w_deq = Q4_0
+            .simulate_precision_loss(w.clone().move_axis(w_k_axis, last)?, last)?
+            .move_axis(last, w_k_axis)?;
+        let reference = eval(build(axes, x_shape, &w_deq)?, &x)?;
+
+        let mut quant = build(axes, x_shape, &w)?;
+        BlockQuantTransform.transform(&mut quant)?;
+        let got = eval(quant, &x)?;
+
+        got.close_enough(&reference, Approximation::Approximate)
+    }
+
+    #[test]
+    fn block_quant_xw_rank2() -> TractResult<()> {
+        // plain 2D, ONNX X@W orientation: X[m,k] @ W[k,n], k is W axis 0
+        check("mk,kn->mn", &[7, 256], &[256, 256], 0)
+    }
+
+    #[test]
+    fn block_quant_xw_batched() -> TractResult<()> {
+        // BERT-style: X[b,m,k] @ W[k,n] -> [b,m,n]
+        check("bmk,kn->bmn", &[2, 7, 256], &[256, 256], 0)
+    }
+
+    #[test]
+    fn block_quant_weights_already_nk() -> TractResult<()> {
+        // canonical orientation (k inner on W): X[m,k] @ W[n,k], k is W axis 1
+        check("mk,nk->mn", &[7, 256], &[256, 256], 1)
+    }
 }

--- a/core/src/ops/matmul/de_block_quant.rs
+++ b/core/src/ops/matmul/de_block_quant.rs
@@ -23,6 +23,19 @@ impl ModelTransform for BlockQuantTransform {
     }
 }
 
+/// Role-aware policy deciding whether a constant weight feeding an `EinSumMatMul`
+/// is block-quantized. Protects quant-sensitive tensors by name (embeddings,
+/// normalizations, output heads) and skips matmuls too small to benefit. `k` is
+/// the contraction dimension, `n` the weight's free dimension.
+fn should_block_quant(weight_name: &str, k: usize, n: usize) -> bool {
+    const PROTECTED: &[&str] =
+        &["embed", "Embed", "norm", "Norm", "pooler", "classifier", "lm_head", "logits"];
+    if PROTECTED.iter().any(|p| weight_name.contains(p)) {
+        return false;
+    }
+    k * n >= 1 << 14
+}
+
 fn block_quant_einsum_weights(
     _ctx: &(),
     model: &TypedModel,
@@ -36,7 +49,12 @@ fn block_quant_einsum_weights(
         if a.rank() != 2 {
             continue;
         };
-        if op.k_axis().inputs[slot][0] == 0 {
+        let weight_name = model.node(node.inputs[slot].node).name.clone();
+        let kpos = op.k_axis().inputs[slot][0];
+        if !should_block_quant(&weight_name, a.shape()[kpos], a.shape()[1 - kpos]) {
+            continue;
+        }
+        if kpos == 0 {
             let mut patch = TypedModelPatch::default();
             let mut taps = patch.taps(model, &node.inputs)?;
             taps[slot] = patch.wire_node(
@@ -63,7 +81,7 @@ fn block_quant_einsum_weights(
             format.quant_f32(a.cast_to::<f32>()?.try_as_plain()?.as_slice::<f32>()?)?
         };
         let act_slot = 1 - slot;
-        let name = &model.node(node.inputs[slot].node).name;
+        let name = &weight_name;
         let m = a.shape()[0];
         let k = a.shape()[1];
         let bqs = BlockQuantStorage::new(Box::new(format), m, k, Arc::new(weights))?;
@@ -157,5 +175,35 @@ mod test {
     fn block_quant_weights_already_nk() -> TractResult<()> {
         // canonical orientation (k inner on W): X[m,k] @ W[n,k], k is W axis 1
         check("mk,nk->mn", &[7, 256], &[256, 256], 1)
+    }
+
+    // The policy must skip protected/tiny weights and quantize the rest.
+    fn count_bq(weight_node: &str, w_shape: &[usize]) -> TractResult<usize> {
+        let mut model = TypedModel::default();
+        let x = model.add_source("x", f32::fact(&[7, w_shape[0]]))?;
+        let w =
+            model.wire_node(weight_node, Const::new(fill(w_shape, 3).into_arc_tensor())?, &[])?[0];
+        let out = model.wire_node(
+            "mm",
+            EinSum { axes: "mk,kn->mn".parse()?, operating_dt: f32::datum_type(), q_params: None },
+            &[x, w],
+        )?;
+        model.select_output_outlets(&out)?;
+        let mut model = model.into_decluttered()?;
+        BlockQuantTransform.transform(&mut model)?;
+        Ok(model.nodes().iter().filter(|n| n.name.ends_with(".bq")).count())
+    }
+
+    #[test]
+    fn policy_skips_protected_and_tiny() -> TractResult<()> {
+        // bulk weight, ordinary name -> quantized
+        assert_eq!(count_bq("encoder.layer.0.intermediate.dense.weight", &[256, 256])?, 1);
+        // protected by name (LayerNorm-ish / embeddings / head) -> skipped
+        assert_eq!(count_bq("embeddings.word_embeddings.weight", &[256, 256])?, 0);
+        assert_eq!(count_bq("encoder.LayerNorm.weight", &[256, 256])?, 0);
+        assert_eq!(count_bq("lm_head.dense.weight", &[256, 256])?, 0);
+        // too small to benefit -> skipped
+        assert_eq!(count_bq("encoder.layer.0.tiny.weight", &[64, 64])?, 0);
+        Ok(())
     }
 }


### PR DESCRIPTION
## What this does

Gates the `block_quant` transform on a **role-aware policy** instead of quantizing every constant matmul weight uniformly: quant-sensitive tensors (embeddings, normalizations, output heads) and matmuls too small to benefit are left in f32, and the rest are quantized to Q4_0.

```rust
fn should_block_quant(weight_name: &str, k: usize, n: usize) -> bool {
    const PROTECTED: &[&str] =
        &["embed", "Embed", "norm", "Norm", "pooler", "classifier", "lm_head", "logits"];
    !PROTECTED.iter().any(|p| weight_name.contains(p)) && k * n >= 1 << 14
}
```

## Why

Quantizing every weight uniformly degrades quality on the few sensitive tensors (embeddings/norms/heads are small *and* numerically sensitive — quantizing them costs accuracy and saves almost nothing) while small matmuls aren't worth the overhead. Protecting them by name + a size floor is the convention `llama.cpp` / GPTQ / bitsandbytes all converge on. The weight names survive ONNX import, so the policy can key on them.

Tests: protected/tiny weights are skipped, the rest are quantized (L1), and the quantized result matches `X @ Q4_0(W)` across both ONNX orientations (L2).

## Notes

- **Stacked on #2428** — the first commit is that block_quant slot-orientation fix (its dependency); the policy is the second commit.
- This is the "which-tensors" axis only. The asymmetric *bit-width* half of the recipe (bump `attn_v`/`ffn_down` to 8-bit) is a natural follow-up once a Q8_1-weight matmul path exists.

## Question for you

This bakes a name-based protected-list into core. Is that the shape you'd want, or would you rather it be **configurable** (transform params / a caller-supplied predicate or regex list), or kept out of core entirely? Happy to refactor toward whatever you prefer — opening as a draft to get your call before polishing.

🍍
