### PR TITLE
bench: cache the stretch cross-build's aarch64 artifacts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -62,8 +62,8 @@ jobs:
             bin: target/release/tract
           - triple: aarch64-unknown-linux-gnu-stretch
             host: ubuntu-latest
-            build: PLATFORM=aarch64-unknown-linux-gnu-stretch ./.travis/cross.sh
-            bin: target/aarch64-unknown-linux-gnu/release/tract
+            build: CARGO_TARGET_DIR=.cross-cache/target PLATFORM=aarch64-unknown-linux-gnu-stretch ./.travis/cross.sh
+            bin: .cross-cache/target/aarch64-unknown-linux-gnu/release/tract
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -72,9 +72,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # per-PR build on the developer feedback path; PR runs restore but only main saves.
-          # The stretch leg builds in a docker container: target/ is host-mounted (cached),
-          # its in-container cargo registry is not, and the key tracks host rustc not the container.
+          # The stretch leg cross-builds in a debian-stretch container into .cross-cache/target
+          # (CARGO_TARGET_DIR); cache that verbatim so the container's aarch64 artifacts survive —
+          # rust-cache's own target/ cleanup is host-target-only and would drop them. The container
+          # also bind-mounts the host cargo registry (see cross.sh) so crate downloads persist.
           key: ${{ matrix.triple }}
+          cache-directories: .cross-cache/target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: ${{ matrix.build }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -95,15 +95,19 @@ case "$PLATFORM" in
             CUDA_FEATURE_ENV="-e TRACT_CUDA_FEATURE=cuda-12000"
         fi
         (cd .travis/docker-debian-stretch; docker build --tag debian-stretch .)
+        mkdir -p "$HOME/.cargo/registry" "$HOME/.cargo/git"
         docker run -v `pwd`:/tract -w /tract \
+            -v "$HOME/.cargo/registry":/root/.cargo/registry \
+            -v "$HOME/.cargo/git":/root/.cargo/git \
             -e CI=true \
             -e SKIP_QEMU_TEST=skip \
             -e CARGO_NET_RETRY \
             -e CARGO_HTTP_MULTIPLEXING \
             -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL \
+            ${CARGO_TARGET_DIR:+-e CARGO_TARGET_DIR=$CARGO_TARGET_DIR} \
             -e PLATFORM=$INNER_PLATFORM $CUDA_FEATURE_ENV debian-stretch \
             ./.travis/cross.sh
-        sudo chown -R `whoami` .
+        sudo chown -R `whoami` "$HOME/.cargo" .
         export RUSTC_TRIPLE=$INNER_PLATFORM
         ;;
 
@@ -238,7 +242,7 @@ case "$PLATFORM" in
         ;;
 esac
 
-if [ -e "target/$RUSTC_TRIPLE/release/tract" ]
+if [ -e "${CARGO_TARGET_DIR:-target}/$RUSTC_TRIPLE/release/tract" ]
 then
     export RUSTC_TRIPLE
     TASK_NAME=`.travis/make_bundle.sh`

--- a/.travis/make_bundle.sh
+++ b/.travis/make_bundle.sh
@@ -12,6 +12,7 @@ else
 fi
 BRANCH=$(echo $BRANCH | tr '/' '_')
 PLATFORM=${PLATFORM:-dummy-platform}
+TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 
 dates=`date -u +"%Y%m%dT%H%M%S %s"`
 date_iso=`echo $dates | cut -f 1 -d ' '`
@@ -36,10 +37,10 @@ fi
 touch sizes
 for bin in example-tensorflow-mobilenet-v2 tract
 do
-    if [ -e target/$RUSTC_TRIPLE/release/$bin ]
+    if [ -e $TARGET_DIR/$RUSTC_TRIPLE/release/$bin ]
     then
 
-        binary_size_cli=$($STAT -c "%s" target/$RUSTC_TRIPLE/release/$bin)
+        binary_size_cli=$($STAT -c "%s" $TARGET_DIR/$RUSTC_TRIPLE/release/$bin)
         token=$(echo $bin | tr '-' '_')
         if [ "$bin" = "tract" ]
         then
@@ -49,7 +50,7 @@ do
     fi
 done
 
-cp target/$RUSTC_TRIPLE/release/tract $TASK_NAME
+cp $TARGET_DIR/$RUSTC_TRIPLE/release/tract $TASK_NAME
 cp sizes $TASK_NAME
 cp .travis/bundle-entrypoint.sh $TASK_NAME/entrypoint.sh
 tar czf $TASK_NAME.tgz $TASK_NAME/


### PR DESCRIPTION
The debian-stretch bench build restored rust-cache with a full match yet recompiled all ~350 crates every run (0 fresh): rust-cache cleans and keys target/ for the host x86 toolchain, so the container's cross-compiled aarch64 artifacts never survived. Point the container at CARGO_TARGET_DIR=.cross-cache/ target and cache that dir verbatim via rust-cache cache-directories, and bind-mount the host cargo registry so crate downloads persist too. make_bundle and cross.sh honor CARGO_TARGET_DIR; other platforms keep target/ unchanged.