### PR TITLE
Separable average pool: NHWC kernel (stacked on #2420)

### DIFF
--- a/core/src/ops/cnn/sumpool.rs
+++ b/core/src/ops/cnn/sumpool.rs
@@ -8,7 +8,7 @@ crate::declare_knob!(
     TRACT_AVGPOOL_SEPARABLE,
     bool,
     false,
-    "Use the separable average-pool kernel for stride-1 NCHW pools. Not bit-identical: \
+    "Use the separable average-pool kernel for stride-1 NCHW/NHWC pools. Not bit-identical: \
      it reassociates the sum, permitted by SumPool's Validation::Rounding contract."
 );
 
@@ -234,7 +234,8 @@ impl OptSumPool {
 
     /// Opt-in separable average-pool fast path, gated by `TRACT_AVGPOOL_SEPARABLE`.
     /// Returns `true` when it handled the eval, `false` to fall back to the generic
-    /// kernel. Restricted to rank-2, stride-1, dilation-1, normalize, NCHW.
+    /// kernel. Restricted to rank-2, stride-1, dilation-1, normalize pools; the NCHW
+    /// and NHWC layouts have dedicated kernels, any other layout falls back.
     fn try_fast_2d<T: Copy + Datum + num_traits::Float>(
         &self,
         input: &Tensor,
@@ -248,17 +249,26 @@ impl OptSumPool {
         if !TRACT_AVGPOOL_SEPARABLE.get()
             || !self.normalize
             || patch.rank() != 2
-            || &*patch.spec.strides != [1, 1]
-            || &*patch.spec.dilations != [1, 1]
-            || *geo.input_shape.w_stride() != 1
+            || *patch.spec.strides != [1, 1]
+            || *patch.spec.dilations != [1, 1]
         {
             return Ok(false);
         }
         let input_ptr = input.as_ptr::<T>()?;
-        unsafe {
-            self.fast_2d_separable::<T>(input_ptr, values_ptr, geo);
+        let ish = &geo.input_shape;
+        if *ish.w_stride() == 1 {
+            unsafe {
+                self.fast_2d_separable::<T>(input_ptr, values_ptr, geo);
+            }
+            Ok(true)
+        } else if *ish.c_stride() == 1 && *ish.w_stride() == *ish.c() {
+            unsafe {
+                self.fast_2d_separable_nhwc::<T>(input_ptr, values_ptr, geo);
+            }
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(true)
     }
 
     /// Separable running-sum average pool. Out-of-bounds taps contribute 0, so the
@@ -368,6 +378,132 @@ impl OptSumPool {
             }
         }
     }
+
+    /// NHWC counterpart of `fast_2d_separable`. Channels are the innermost
+    /// (contiguous) axis, so both separable passes accumulate `C`-wide running
+    /// sums, keeping the inner channel loops contiguous. Same reassociation
+    /// caveat as the NCHW path: not bit-identical to the generic kernel.
+    unsafe fn fast_2d_separable_nhwc<T: Copy + Datum + num_traits::Float>(
+        &self,
+        input_ptr: *const T,
+        values_ptr: *mut T,
+        geo: &ConcretePoolGeometry,
+    ) where
+        usize: AsPrimitive<T>,
+    {
+        let ish = &geo.input_shape;
+        let osh = &geo.output_shape;
+        let (h, w) = (ish.hw_dims()[0] as isize, ish.hw_dims()[1] as isize);
+        let (ho, wo) = (geo.patch.output_shape[0], geo.patch.output_shape[1]);
+        let (kh, kw) =
+            (geo.patch.spec.kernel_shape[0] as isize, geo.patch.spec.kernel_shape[1] as isize);
+        let (pt, pl) = (geo.patch.pad_before[0] as isize, geo.patch.pad_before[1] as isize);
+        let ih_stride = *ish.h_stride() as isize;
+        let iw_stride = *ish.w_stride() as isize;
+        let oh_stride = *osh.h_stride() as isize;
+        let ow_stride = *osh.w_stride() as isize;
+        let n = *ish.n().unwrap_or(&1);
+        let in_stride = *ish.n_stride().unwrap_or(&0) as isize;
+        let on_stride = *osh.n_stride().unwrap_or(&0) as isize;
+        let c = *ish.c();
+
+        let axis_valid = |out: usize, k: isize, pad: isize, lim: isize| -> Vec<usize> {
+            (0..out)
+                .map(|o| {
+                    let lo = o as isize - pad;
+                    let start = (-lo).max(0);
+                    let end = (lim - lo).min(k);
+                    (end - start).max(0) as usize
+                })
+                .collect()
+        };
+        let kx_valid = axis_valid(wo, kw, pl, w);
+        let ky_valid = axis_valid(ho, kh, pt, h);
+        let full_recip: T = ((kh * kw) as usize).as_().recip();
+
+        let mut htmp = vec![T::zero(); h as usize * wo * c];
+        let mut acc = vec![T::zero(); c];
+        unsafe {
+            for nn in 0..n as isize {
+                let in_base = nn * in_stride;
+                let out_base = nn * on_stride;
+                for y in 0..h {
+                    let row = in_base + y * ih_stride;
+                    let hrow = y as usize * wo * c;
+                    acc.iter_mut().for_each(|a| *a = T::zero());
+                    for kx in 0..kw {
+                        let ix = -pl + kx;
+                        if ix >= 0 && ix < w {
+                            let p = row + ix * iw_stride;
+                            for (ch, a) in acc.iter_mut().enumerate() {
+                                *a = *a + *input_ptr.offset(p + ch as isize);
+                            }
+                        }
+                    }
+                    htmp[hrow..hrow + c].copy_from_slice(&acc);
+                    for ox in 1..wo as isize {
+                        let entering = ox - pl + kw - 1;
+                        let leaving = ox - pl - 1;
+                        if entering >= 0 && entering < w {
+                            let p = row + entering * iw_stride;
+                            for (ch, a) in acc.iter_mut().enumerate() {
+                                *a = *a + *input_ptr.offset(p + ch as isize);
+                            }
+                        }
+                        if leaving >= 0 && leaving < w {
+                            let p = row + leaving * iw_stride;
+                            for (ch, a) in acc.iter_mut().enumerate() {
+                                *a = *a - *input_ptr.offset(p + ch as isize);
+                            }
+                        }
+                        let dst = hrow + ox as usize * c;
+                        htmp[dst..dst + c].copy_from_slice(&acc);
+                    }
+                }
+                for ox in 0..wo {
+                    acc.iter_mut().for_each(|a| *a = T::zero());
+                    for ky in 0..kh {
+                        let iy = -pt + ky;
+                        if iy >= 0 && iy < h {
+                            let src = iy as usize * wo * c + ox * c;
+                            for (ch, a) in acc.iter_mut().enumerate() {
+                                *a = *a + *htmp.get_unchecked(src + ch);
+                            }
+                        }
+                    }
+                    let store = |oy: usize, acc: &[T]| {
+                        let div = if self.count_include_pad {
+                            full_recip
+                        } else {
+                            (kx_valid[ox] * ky_valid[oy]).as_().recip()
+                        };
+                        let o = out_base + oy as isize * oh_stride + ox as isize * ow_stride;
+                        for (ch, &a) in acc.iter().enumerate() {
+                            *values_ptr.offset(o + ch as isize) = a * div;
+                        }
+                    };
+                    store(0, &acc);
+                    for oy in 1..ho as isize {
+                        let entering = oy - pt + kh - 1;
+                        let leaving = oy - pt - 1;
+                        if entering >= 0 && entering < h {
+                            let src = entering as usize * wo * c + ox * c;
+                            for (ch, a) in acc.iter_mut().enumerate() {
+                                *a = *a + *htmp.get_unchecked(src + ch);
+                            }
+                        }
+                        if leaving >= 0 && leaving < h {
+                            let src = leaving as usize * wo * c + ox * c;
+                            for (ch, a) in acc.iter_mut().enumerate() {
+                                *a = *a - *htmp.get_unchecked(src + ch);
+                            }
+                        }
+                        store(oy as usize, &acc);
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -462,5 +598,50 @@ mod tests {
 
         let max_abs = generic.iter().zip(sep).map(|(a, b)| (a - b).abs()).fold(0f32, f32::max);
         assert!(max_abs < 1e-4, "separable vs generic max abs diff {max_abs}");
+    }
+
+    #[test]
+    fn separable_nhwc_matches_generic_kernel() {
+        let (c, h, w) = (5usize, 7usize, 9usize);
+        let pool_spec = PoolSpec::new(
+            DataFormat::NHWC,
+            tvec![3, 3],
+            PaddingSpec::SameUpper,
+            None,
+            Some(tvec![1, 1]),
+            c,
+            c,
+        );
+        let op = OptSumPool {
+            pool_spec: pool_spec.clone(),
+            count_include_pad: false,
+            normalize: true,
+            geometry: pool_spec
+                .compute_geo(&[1.to_dim(), h.to_dim(), w.to_dim(), c.to_dim()])
+                .unwrap(),
+        };
+        let input: Tensor = ndarray::Array4::from_shape_fn((1, h, w, c), |(_, y, x, cc)| {
+            ((cc * 17 + y * 3 + x) % 13) as f32 - 6.0
+        })
+        .into_tensor();
+
+        // generic zoned kernel (knob off by default)
+        let generic = op.eval(tvec![input.clone().into_tvalue()]).unwrap();
+        let generic = generic[0].try_as_plain().unwrap().as_slice::<f32>().unwrap().to_vec();
+
+        // separable NHWC kernel, called directly
+        let geo = op.geometry.to_concrete(input.shape()).unwrap();
+        let mut out = Tensor::zero::<f32>(&geo.output_shape.shape).unwrap();
+        unsafe {
+            op.fast_2d_separable_nhwc::<f32>(
+                input.as_ptr::<f32>().unwrap(),
+                out.as_ptr_mut::<f32>().unwrap(),
+                geo.as_ref(),
+            );
+        }
+        let sep = out.try_as_plain().unwrap().as_slice::<f32>().unwrap();
+
+        let max_abs = generic.iter().zip(sep).map(|(a, b)| (a - b).abs()).fold(0f32, f32::max);
+        assert!(max_abs < 1e-4, "separable NHWC vs generic max abs diff {max_abs}");
     }
 }

--- a/doc/cli-recipe.md
+++ b/doc/cli-recipe.md
@@ -190,7 +190,7 @@ highlights a few worth knowing; `list-knobs` is the complete set.
 | `TRACT_LOG` | `env_logger` filter (e.g. `tract=debug`, `cli=info,tract=warn`). The CLI also derives a default level from `-v` / `-vv`. |
 | `TRACT_LAZY_IM2COL_MIN_KERNEL` | Minimum convolution kernel volume before lazy im2col is preferred over eager. Default: 6. Lower it to experiment on memory-constrained targets. |
 | `TRACT_LAZY_IM2COL_MAX_EAGER_BYTES` | Scratch-buffer ceiling above which `Conv` switches from eager to lazy im2col. Per-family default (~1 MiB on WASM, ~4 MiB on native). Key knob for the canary-model regression gate. |
-| `TRACT_AVGPOOL_SEPARABLE` | Use the separable running-sum average-pool kernel (stride-1 NCHW), O(1) per output vs O(k²). Default: off. **Not bit-identical** — it reassociates the float sums (allowed by `SumPool`'s `Validation::Rounding`). ~2× on the avg-pool nodes; pool-heavy nets (Inception) see it E2E. |
+| `TRACT_AVGPOOL_SEPARABLE` | Use the separable running-sum average-pool kernel (stride-1 NCHW or NHWC), O(1) per output vs O(k²). Default: off. **Not bit-identical** — it reassociates the float sums (allowed by `SumPool`'s `Validation::Rounding`). Multiplies the avg-pool node throughput; pool-heavy nets (Inception) see it E2E. |
 | `TRACT_CPU_AARCH64_KIND` | Force aarch64 CPU family detection (`a53`, `a55`, `a72`, `applem`, `generic`, …). Useful for QEMU runs that misreport. |
 | `TRACT_CPU_AARCH64_OVERRIDE_CPU_PART` | Force the raw CPU part hex (`0xd03`, …) before the kind-lookup table runs. Lower-level escape hatch when `TRACT_CPU_AARCH64_KIND` doesn't cover the target. |
 | `TRACT_CPU_ARM32_NEON` | Force armv7 NEON detection on/off (`true`/`1` or `false`/`0`). |


### PR DESCRIPTION
Extends the opt-in `TRACT_AVGPOOL_SEPARABLE` separable average-pool kernel to the NHWC layout, which the NCHW-only fast path previously skipped — so TF/TFLite pool-heavy models now benefit too. Channels are innermost in NHWC, so both running-sum passes accumulate contiguous C-wide vectors.

Stacked on #2420 (reuses its knob, dispatch, and `fast_2d_separable`); the diff here shows both commits until #2420 merges, after which I'll rebase. Draft for that reason.

Correctness: `separable_nhwc_matches_generic_kernel` checks the kernel against the generic zoned path (max abs diff < 1e-4), same contract as the existing NCHW test. Not bit-identical by design — reassociates the sum, allowed by `SumPool`'s `Validation::Rounding`.

Local NHWC Inception v3 (M-series), avg-pool nodes vs the generic kernel with MaxPool as an untouched control; end-to-end is min-of-6 interleaved:

| | generic | separable NHWC |
|---|---|---|
| SumPool nodes | ~10.9 ms/i | ~1.84 ms/i |
| MaxPool (control) | ~4.1 ms/i | ~4.2 ms/i |
| E2E | ~69.9 ms/i | ~64.7 ms/i |

🍍
