### PR TITLE
onnx: load NeMo FastConformer cache-aware streaming graphs (clamp-a-dim + Cast-of-TDim)

### DIFF
--- a/onnx/src/ops/cast.rs
+++ b/onnx/src/ops/cast.rs
@@ -66,7 +66,7 @@ impl ElementWiseMiniOp for Cast {
         node: &TypedNode,
     ) -> TractResult<Option<TypedModelPatch>> {
         let from = model.outlet_fact(node.inputs[0])?.datum_type;
-        if from == self.to || (from == TDim::datum_type() && self.to == i32::datum_type()) {
+        if from == self.to {
             Ok(Some(TypedModelPatch::replace_single_op(model, node, &node.inputs, Identity)?))
         } else if from == String::datum_type() && self.to == f32::datum_type() {
             Ok(None)

--- a/onnx/src/ops/math/clip.rs
+++ b/onnx/src/ops/math/clip.rs
@@ -54,12 +54,8 @@ impl Expansion for Clip11 {
             1 + self.input_min.is_some() as usize + self.input_max.is_some() as usize,
         )?;
         check_output_arity(outputs, 1)?;
-        if let Some(input) = self.input_min {
-            s.equals(&inputs[0].datum_type, &inputs[input].datum_type)?;
-        }
-        if let Some(input) = self.input_max {
-            s.equals(&inputs[0].datum_type, &inputs[input].datum_type)?;
-        }
+        // A bound may be an I64 constant while the clamped value is a symbolic TDim
+        // (streaming cache-len clamps); wire() casts each bound to the input dtype.
         s.equals(&inputs[0].datum_type, &outputs[0].datum_type)?;
         s.equals(&inputs[0].shape, &outputs[0].shape)?;
         Ok(())
@@ -71,21 +67,38 @@ impl Expansion for Clip11 {
         model: &mut TypedModel,
         inputs: &[OutletId],
     ) -> TractResult<TVec<OutletId>> {
+        let dt = model.outlet_fact(inputs[0])?.datum_type;
         let mut wire = inputs[0];
         if let Some(min) = self.input_min {
+            let mut b = inputs[min];
+            if model.outlet_fact(b)?.datum_type != dt {
+                b = model.wire_node(
+                    format!("{name}.min.cast"),
+                    tract_core::ops::cast::cast(dt),
+                    &[b],
+                )?[0];
+            }
             wire = wire_with_rank_broadcast(
                 format!("{name}.min"),
                 model,
                 tract_hir::ops::math::max(),
-                &[wire, inputs[min]],
+                &[wire, b],
             )?[0];
         }
         if let Some(max) = self.input_max {
+            let mut b = inputs[max];
+            if model.outlet_fact(b)?.datum_type != dt {
+                b = model.wire_node(
+                    format!("{name}.max.cast"),
+                    tract_core::ops::cast::cast(dt),
+                    &[b],
+                )?[0];
+            }
             wire = wire_with_rank_broadcast(
                 format!("{name}.max"),
                 model,
                 tract_hir::ops::math::min(),
-                &[wire, inputs[max]],
+                &[wire, b],
             )?[0];
         }
         Ok(tvec!(wire))


### PR DESCRIPTION
# PR: Load NeMo FastConformer cache-aware streaming graphs (clamp-a-dim + Cast-of-TDim)

## Summary
Two small inference-layer fixes let tract load & run ONNX exports of NVIDIA NeMo
**FastConformer cache-aware streaming** encoders (RNNT/CTC). These graphs are valid
(they run in onnxruntime and produce correct output) but tract rejects them during
analyse/declutter in two spots. Both fixes are localized to the ONNX front-end.

Verified end-to-end: a 114M FastConformer-CTC streaming model decodes **bit-identical
to onnxruntime** across chunks, fp32 and f16, after these patches (Persian ASR, 17 layers,
d_model 512, att_context [70,13], subsampling 8).

## Fix 1 — `onnx/src/ops/math/clip.rs`: allow clamping a `TDim` by an int constant
Streaming graphs clamp a **symbolic dimension** (the running cache length) with a
constant, e.g. `Clip(cache_len_expr, /*max=*/ 256)`. The clamped value is a `TDim`;
the bound is an `i64`/`i32` const. The analyser rule forced
`inputs[0].datum_type == min/max.datum_type`, which cannot unify `TDim` with `I64`:
```
Failed analyse ... Clip: inputs[0].datum_type == inputs[1].datum_type:
Impossible to unify TDim with I64.
```
Fix: drop the datum_type-equality constraint on the bounds in `rules()`, and in `wire()`
cast each bound to the clamped value's datum_type before the `min`/`max`.

## Fix 2 — `onnx/src/ops/cast.rs`: don't shunt a consumed `TDim -> i32` Cast to Identity
`onnx.Cast`'s declutter treats `TDim -> i32` as identity:
```rust
if from == self.to || (from == TDim::datum_type() && self.to == i32::datum_type()) {
    // replace with Identity
}
```
When the cast output is consumed as **data** (declared `i32`, e.g. feeding index math),
replacing with Identity leaves a `TDim` where `i32` is declared, and the patch validator
rejects it:
```
Trying to substitute a 1,I32 by 1,TDim as output #0 of "/Cast_1" onnx.Cast.
```
Fix: keep the identity shortcut only for `from == self.to`; let a genuine `TDim -> i32`
lower to a real cast (the existing `else` branch). This is always correct; it forgoes a
micro-optimization on shape-only casts. (Maintainers: happy to make this conditional on
the successor being a shape consumer instead, if preferred.)

## Repro
```
# any NeMo cache-aware streaming export with fixed input shapes, e.g.
tract model.onnx dump            # fails at Clip, then onnx.Cast, without these patches
```
Minimal loader:
```rust
tract_onnx::onnx().model_for_path(p)?.into_optimized()?.into_runnable()?; // Ok after patch
```

## Notes
- No new deps, no API changes. Diff: `clip.rs` +12/-7, `cast.rs` +1/-1.
- Enables pure-Rust on-device streaming ASR for the FastConformer family (Android/iOS/WASM/edge).



🍍
