### PR TITLE
bench: retire the binary-size metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target
 *.rustfmt
 *.back
 examples/data
+/*.tar.gz
 .idea
 .cached/**
 flamegraph.svg

--- a/.travis/bench-thresholds.toml
+++ b/.travis/bench-thresholds.toml
@@ -32,7 +32,6 @@ active_at     = 2
 time_to       = 5
 rsz           = 5   # matches rsz_at and rszmax; k*noise auto-widens it on noisy hosts
 bench_runtime = 10
-binary_size   = 1
 
 # Short labels for the star-metric matrix columns only; the per-device detail tables
 # keep the full name. Canonical device names are fixed (they key the bench-data

--- a/.travis/bundle-entrypoint.sh
+++ b/.travis/bundle-entrypoint.sh
@@ -38,7 +38,6 @@ aws s3 sync s3://tract-ci-builds/model "$CACHEDIR" --only-show-errors || echo "W
 endgroup
 
 touch metrics
-[ -e sizes ] && cat sizes >> metrics
 
 if [ "$(uname)" = "Linux" ] && [ -r /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ] && [ "$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)" = "userspace" ]; then
     F=$(printf '%s\n' $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_frequencies) | sort -n | tail -1)

--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -36,7 +36,7 @@ case "$PLATFORM" in
         export RUSTC_TRIPLE=arm-unknown-linux-gnueabihf
         rustup target add $RUSTC_TRIPLE
         echo "[platforms.$PLATFORM]\nrustc_triple='$RUSTC_TRIPLE'\ntoolchain='$TOOLCHAIN'" > .dinghy.toml
-        cargo dinghy --platform $PLATFORM build --release -p tract-cli -p example-tensorflow-mobilenet-v2 -p tract-ffi
+        cargo dinghy --platform $PLATFORM build --release -p tract-cli -p tract-ffi
         ;;
 
     "aarch64-linux-android"|"armv7-linux-androideabi"|"i686-linux-android"|"x86_64-linux-android")
@@ -217,9 +217,8 @@ case "$PLATFORM" in
                 --no-default-features \
                 --features "onnx,tf,pulse,pulse-opl,tflite,transformers,extra,bench-suite,$TRACT_CUDA_FEATURE" \
                 -p tract-cli
-            cargo dinghy --platform $PLATFORM build --release -p example-tensorflow-mobilenet-v2
         else
-            cargo dinghy --platform $PLATFORM build --release -p tract-cli -p example-tensorflow-mobilenet-v2
+            cargo dinghy --platform $PLATFORM build --release -p tract-cli
         fi
         ;;
 

--- a/.travis/make_bundle.sh
+++ b/.travis/make_bundle.sh
@@ -27,31 +27,7 @@ echo "export DATE_ISO=$date_iso" >> $TASK_NAME/vars
 echo "export TIMESTAMP=$timestamp" >> $TASK_NAME/vars
 echo "export PLATFORM=$PLATFORM" >> $TASK_NAME/vars
 
-if which gstat > /dev/null
-then
-    STAT=gstat
-else
-    STAT=stat
-fi
-
-touch sizes
-for bin in example-tensorflow-mobilenet-v2 tract
-do
-    if [ -e $TARGET_DIR/$RUSTC_TRIPLE/release/$bin ]
-    then
-
-        binary_size_cli=$($STAT -c "%s" $TARGET_DIR/$RUSTC_TRIPLE/release/$bin)
-        token=$(echo $bin | tr '-' '_')
-        if [ "$bin" = "tract" ]
-        then
-            token=cli
-        fi
-        echo binary_size.$token $binary_size_cli >> sizes
-    fi
-done
-
 cp $TARGET_DIR/$RUSTC_TRIPLE/release/tract $TASK_NAME
-cp sizes $TASK_NAME
 cp .travis/bundle-entrypoint.sh $TASK_NAME/entrypoint.sh
 tar czf $TASK_NAME.tgz $TASK_NAME/
 

--- a/cli/src/bench_report.rs
+++ b/cli/src/bench_report.rs
@@ -121,7 +121,6 @@ const TYPE_INFO: &[(&str, &str, &str)] = &[
     ("pp512", "prefill", "tok"),
     ("tg128", "decode", "tok"),
     ("bench_runtime", "bench wall", "s"),
-    ("binary_size", "binary size", "mem"),
 ];
 
 /// (model, label, variant, unit) for a metric key `kind.model.type.variant`.

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,5 @@
 *.onnx
 *.nnef.tgz
 *.tar.gz
+assets/
+reference/


### PR DESCRIPTION
binary_size only ever reached the old S3/graphite path via make_bundle's sizes file; the new bench flow runs tract bench-suite directly and never consumed it, so the metric was effectively dead. Dropping it removes the sole reason cross.sh built example-tensorflow-mobilenet-v2, whose default feature set differed from the cli build and forced a second full workspace recompile (~3.5 min on the stretch leg). Also drop the now-unused sizes handling, threshold floor, and report label.

While here, ignore the untracked model artifacts that make these builds heavy: /*.tar.gz at the root and assets/ + reference/ under examples, so a stray add can't sweep a multi-GB tarball into a commit again.