### PR TITLE
cuda: give each thread its own non-blocking stream

### DIFF
--- a/cuda/src/context.rs
+++ b/cuda/src/context.rs
@@ -64,6 +64,11 @@ impl TractCudaContext {
         let context =
             CudaContext::new(0).with_context(|| "Could not find system default CUDA device")?;
 
+        // Each thread runs its own stream over thread-local, per-run tensors; shared weights are
+        // read-only. cudarc's automatic cross-stream SyncOnDrop event tracking (a CudaEvent per
+        // buffer use) is therefore pure overhead — the caller owns synchronization.
+        unsafe { context.disable_event_tracking() };
+
         let prop = get_device_prop(0)?;
 
         // Log device identity so users diagnosing a bad deploy can tell what their code actually

--- a/cuda/src/context.rs
+++ b/cuda/src/context.rs
@@ -368,7 +368,8 @@ pub struct TractCudaStream {
 
 impl TractCudaStream {
     fn new() -> TractResult<TractCudaStream> {
-        let stream = cuda_context().default_stream();
+        let stream =
+            cuda_context().new_stream().context("Could not create a per-thread CUDA stream")?;
         let cublas = CudaBlas::new(stream.clone()).context(
             "CudaBlas::new failed: libcublas loaded but the handle could not be created",
         )?;

--- a/cuda/src/lib.rs
+++ b/cuda/src/lib.rs
@@ -9,6 +9,7 @@ pub mod utils;
 pub use context::with_cuda_stream;
 use tract_core::internal::*;
 use tract_core::transform::ModelTransform;
+use tract_gpu::device::DeviceContext;
 pub use transform::CudaTransform;
 
 use crate::utils::ensure_cuda_runtime_dependencies;
@@ -41,6 +42,11 @@ impl Runtime for CudaRuntime {
                     .context("While sizing memory arena. Missing hint ?")?;
             runnable = runnable.with_session_handler(session_handler);
         }
+
+        // Constants are uploaded to the device here on the preparing thread's stream via async
+        // copies. Event tracking is disabled, so nothing else orders those uploads before the
+        // per-thread streams that later read the constants; drain them now to establish that order.
+        context::cuda_context().synchronize()?;
 
         Ok(Box::new(Arc::new(runnable)))
     }


### PR DESCRIPTION
TractCudaStream::new took the context's shared default (null) stream, so concurrent runs from different threads serialized all GPU work onto one stream and inherited the null stream's implicit device-wide synchronization. Build a fresh non-blocking stream per thread instead; the thread-local storage already holds one per worker, so independent inference threads can overlap on the device.