### PR TITLE
Iff: broadcast the selected branch when folding a constant condition

### DIFF
--- a/core/src/ops/logic.rs
+++ b/core/src/ops/logic.rs
@@ -241,7 +241,17 @@ impl TypedOp for Iff {
         rule_if_let!(Ok(cond_val) = uniform.cast_to_scalar::<bool>());
         let branch = if cond_val { node.inputs[1] } else { node.inputs[2] };
         let mut patch = TypedModelPatch::default();
-        let wire = patch.tap_model(model, branch)?;
+        let mut wire = patch.tap_model(model, branch)?;
+        // The output shape is the broadcast of all three inputs; the selected
+        // branch may be narrower and must be broadcast up, not shunted as is.
+        let out_shape = &model.outlet_fact(node.id.into())?.shape;
+        if &model.outlet_fact(branch)?.shape != out_shape {
+            wire = patch.wire_node(
+                format!("{}.broadcast", node.name),
+                crate::ops::array::MultiBroadcastTo::new(out_shape.clone()),
+                &[wire],
+            )?[0];
+        }
         patch.shunt_outside(model, node.id.into(), wire)?;
         Ok(Some(patch))
     }
@@ -546,6 +556,36 @@ mod tests {
         assert!(t_unsq_fact.uniform_tdim.is_some(), "t_unsq should have uniform_tdim");
         assert!(lt_fact.uniform_tdim.is_some(), "lt should have uniform_tdim");
 
+        Ok(())
+    }
+
+    /// Iff(const_cond, t, f) where the selected branch is narrower than the
+    /// output (which is the broadcast of cond and both branches).  The fold
+    /// must broadcast the branch up; shunting it as-is fails patch
+    /// validation ("Trying to substitute a 1,2,3 by 1,2,1").
+    #[test]
+    fn iff_fold_broadcasts_narrower_branch() -> TractResult<()> {
+        let mut model = TypedModel::default();
+        let cond = model.wire_node(
+            "cond",
+            crate::ops::konst::Const::new(
+                Tensor::from_shape(&[1, 2, 3], &[false; 6])?.into_arc_tensor(),
+            )?,
+            &[],
+        )?[0];
+        let then = model.add_source("then", f32::fact([1, 2, 3]))?;
+        let otherwise = model.add_source("else", f32::fact([1, 2, 1]))?;
+        let iff = model.wire_node("iff", Iff, &[cond, then, otherwise])?[0];
+        model.select_output_outlets(&[iff])?;
+
+        let model = model.into_decluttered()?;
+
+        let iff_count = model.nodes().iter().filter(|n| n.op_as::<Iff>().is_some()).count();
+        assert_eq!(iff_count, 0, "Expected Iff to be folded");
+        assert_eq!(
+            model.output_fact(0)?.shape.to_tvec(),
+            tvec![1.to_dim(), 2.to_dim(), 3.to_dim()]
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Iff's constant-condition fold shunted the selected branch as-is, but the op's output shape is the broadcast of the condition and both branches; a branch narrower than the condition (e.g. `select(cond[1,512,16], t, f[1,512,1])`) made the patch validator reject the substitution ("Trying to substitute a 1,512,16,F32 by 1,512,1,F32") and decluttering failed. Wire a MultiBroadcastTo up to the output shape when the shapes differ; regression test included (fails before the fix).

Hit on Kyutai's Pocket TTS `mimi_encoder.onnx` (valid graph, runs in onnxruntime).

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)
