### PR TITLE
bench: add Pocket TTS, DeepFilterNet3 and DTLN to the CI bench suite

### DIFF
--- a/.travis/benches.toml
+++ b/.travis/benches.toml
@@ -343,3 +343,46 @@ model = "pocket-tts-en/mimi_decoder.onnx"
 archive = "pocket-tts-en.tar.gz"
 args = """--onnx-ignore-output-shapes --onnx-ignore-output-types --onnx-ignore-value-info
   -i 1,12,32,f32 -i 1,bool -i 1,512,6,f32 -i 1,bool -i 1,64,2,f32 -i 1,256,6,f32 -i 1,bool -i 1,256,2,f32 -i 1,bool -i 1,128,0,f32 -i 1,128,5,f32 -i 1,bool -i 1,128,2,f32 -i 1,bool -i 1,64,0,f32 -i 1,64,4,f32 -i 1,bool -i 1,64,2,f32 -i 1,bool -i 1,32,0,f32 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 1,bool -i 1,512,16,f32 -i 1,bool -i 1,1,6,f32 -i 1,bool -i 1,64,2,f32 -i 1,bool -i 1,32,0,f32 -i 1,bool -i 1,512,2,f32 -i 1,bool -i 1,64,4,f32 -i 1,bool -i 1,128,2,f32 -i 1,bool -i 1,64,0,f32 -i 1,bool -i 1,128,5,f32 -i 1,bool -i 1,256,2,f32 -i 1,bool -i 1,128,0,f32 -i 1,bool -i 1,256,6,f32 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 1,512,16,f32"""
+
+# --- DeepFilterNet3 (Rikorose/DeepFilterNet, MIT/Apache-2.0) — speech enhancement.
+# The three streaming submodels, symbolic time pinned at export to 100 frames
+# (1 s of audio at the 10 ms hop): encoder, ERB-mask decoder, deep-filter decoder.
+
+[[bench]]
+kind = "net"
+name = "dfn3-enc"
+variant = "1s"
+model = "dfn3/enc.onnx"
+archive = "dfn3.tar.gz"
+
+[[bench]]
+kind = "net"
+name = "dfn3-erb-dec"
+variant = "1s"
+model = "dfn3/erb_dec.onnx"
+archive = "dfn3.tar.gz"
+
+[[bench]]
+kind = "net"
+name = "dfn3-df-dec"
+variant = "1s"
+model = "dfn3/df_dec.onnx"
+archive = "dfn3.tar.gz"
+
+# --- DTLN (breizhn/DTLN, MIT) — dual-stage LSTM speech denoiser, one 8 ms frame
+# per call with LSTM state threaded through graph I/O (external-state pattern).
+# model_2's free batch dim on outputs is pinned to 1 (tf2onnx export artifact).
+
+[[bench]]
+kind = "net"
+name = "dtln-stage1"
+variant = "frame"
+model = "dtln/model_1.onnx"
+archive = "dtln.tar.gz"
+
+[[bench]]
+kind = "net"
+name = "dtln-stage2"
+variant = "frame"
+model = "dtln/model_2_fixed.onnx"
+archive = "dtln.tar.gz"

--- a/.travis/benches.toml
+++ b/.travis/benches.toml
@@ -299,3 +299,47 @@ kind = "llm"
 name = "qwen3-1_7B-q40ef16-541"
 model = "Qwen3-1.7B-q40ef16.541.nnef.tgz"
 runtimes = ["metal", "cuda"]
+
+# --- Pocket TTS (Kyutai, CC-BY-4.0; 100M-param CPU TTS, 24 kHz / 12.5 Hz frames).
+# ONNX export with explicit KV-cache states rewritten shape-static so the streaming
+# step position is a runtime input. decode = one 80 ms frame of the flow LM;
+# prefill25 = one 25-token text chunk; flow = one Euler step of the latent flow net;
+# mimi decoder = a 12-frame (960 ms) chunk. Random i64 inputs cast to 0: a valid
+# stream position, and the graphs are full-window so compute is position-independent.
+
+[[bench]]
+kind = "net"
+name = "pocket-tts-flow-lm"
+variant = "decode"
+model = "pocket-tts-en/flow_lm_main_static.onnx"
+archive = "pocket-tts-en.tar.gz"
+args = """--onnx-ignore-output-shapes --onnx-ignore-output-types --onnx-ignore-value-info
+  -i 1,1,32,f32 -i 1,0,1024,f32
+  -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64"""
+
+[[bench]]
+kind = "net"
+name = "pocket-tts-flow-lm"
+variant = "prefill25"
+model = "pocket-tts-en/flow_lm_main_static.onnx"
+archive = "pocket-tts-en.tar.gz"
+args = """--onnx-ignore-output-shapes --onnx-ignore-output-types --onnx-ignore-value-info
+  -i 1,0,32,f32 -i 1,25,1024,f32
+  -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64 -i 2,1,1000,16,64,f32 -i 0,f32 -i 1,i64"""
+
+[[bench]]
+kind = "net"
+name = "pocket-tts-flow-net"
+variant = "euler1"
+model = "pocket-tts-en/flow_lm_flow.onnx"
+archive = "pocket-tts-en.tar.gz"
+args = "--onnx-ignore-output-shapes -i 1,1024,f32 -i 1,1,f32 -i 1,1,f32 -i 1,32,f32"
+
+[[bench]]
+kind = "net"
+name = "pocket-tts-mimi-decoder"
+variant = "chunk12"
+model = "pocket-tts-en/mimi_decoder.onnx"
+archive = "pocket-tts-en.tar.gz"
+args = """--onnx-ignore-output-shapes --onnx-ignore-output-types --onnx-ignore-value-info
+  -i 1,12,32,f32 -i 1,bool -i 1,512,6,f32 -i 1,bool -i 1,64,2,f32 -i 1,256,6,f32 -i 1,bool -i 1,256,2,f32 -i 1,bool -i 1,128,0,f32 -i 1,128,5,f32 -i 1,bool -i 1,128,2,f32 -i 1,bool -i 1,64,0,f32 -i 1,64,4,f32 -i 1,bool -i 1,64,2,f32 -i 1,bool -i 1,32,0,f32 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 1,bool -i 1,512,16,f32 -i 1,bool -i 1,1,6,f32 -i 1,bool -i 1,64,2,f32 -i 1,bool -i 1,32,0,f32 -i 1,bool -i 1,512,2,f32 -i 1,bool -i 1,64,4,f32 -i 1,bool -i 1,128,2,f32 -i 1,bool -i 1,64,0,f32 -i 1,bool -i 1,128,5,f32 -i 1,bool -i 1,256,2,f32 -i 1,bool -i 1,128,0,f32 -i 1,bool -i 1,256,6,f32 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 2,1,8,1000,64,f32 -i 1,i64 -i 1,i64 -i 1,512,16,f32"""


### PR DESCRIPTION
Adds three CPU speech workloads to the bench suite.

**Pocket TTS** (Kyutai, 100M-param CPU TTS): the flow-LM streaming decode step (one 80 ms frame) and 25-token prefill, one Euler step of the latent flow net, and a 12-frame Mimi decoder chunk. This is an ONNX KV-cache streaming decode workload — ScatterND cache writes, full-window masked attention, per-frame GEMV — a shape the suite doesn't cover today, and precisely the path exercised by #2446/#2448. `flow_lm_flow.onnx` and `mimi_decoder.onnx` are unmodified from the community ONNX export ([KevinAHM/pocket-tts-onnx](https://huggingface.co/KevinAHM/pocket-tts-onnx), weights CC-BY-4.0 from [kyutai/pocket-tts](https://huggingface.co/kyutai/pocket-tts)); `flow_lm_main_static.onnx` is that export's flow LM with its runtime-`step` cache slicing rewritten shape-static (arange-table slices → `Range(0,s)+step`; window reads → full-window, the causal mask is a key-pos≤query-pos compare so out-of-window keys self-mask). The rewrite is validated against onnxruntime on the original graph to ≤2e-6 across (step, seq, text) combinations, and a full tract generation pipeline built on these graphs produces audio matching onnxruntime (corr 0.99999). Random-input note: `--allow-random-input` casts the random f32 `[0,1)` to 0 for the i64 `step`/offset states — a valid stream position — and the graphs are full-window, so compute is position-independent. M-series reference: decode 22.5 ms, prefill25 84.5 ms, flow 1.0 ms, mimi chunk12 136 ms.

**DeepFilterNet3** ([Rikorose/DeepFilterNet](https://github.com/Rikorose/DeepFilterNet), MIT/Apache-2.0): the three streaming submodels (encoder, ERB-mask decoder, deep-filter decoder), symbolic time pinned at export to 100 frames = 1 s of audio at the 10 ms hop. Depthwise-conv + GRU heavy. M-series reference: 7.6 / 7.3 / 6.7 ms.

**DTLN** ([breizhn/DTLN](https://github.com/breizhn/DTLN), MIT): both LSTM stages of the dual-signal denoiser, one 8 ms frame per call with LSTM state threaded through graph I/O — the external-state pattern of issue #2157. model_2's free batch dim on outputs is pinned to 1 (tf2onnx export artifact; tract rejects the unpinned graph). M-series reference: 38 / 67 µs per frame.

**Needs from a maintainer: mirror the model bundles to the S3 bucket.** Archives ready to hand over — I can stage them as release assets on my fork or anywhere convenient:

```
sha256  64daef9d8dfe780d2840d671ee2f9fb930ca13ef455bc5438df51ee488b41a0a  pocket-tts-en.tar.gz  (173 MB)
sha256  47052090e4884e39c531785868080e4e3c3d7d9aefba29dbf88a69a287bf4d13  dfn3.tar.gz           (7.6 MB)
sha256  b89911856e36cd93430be59a594d9bb5b231c7737d4d52b0516e0e7de7f28388  dtln.tar.gz           (3.5 MB)
-> s3://tract-ci-builds/model/
```

Until they're mirrored, the Bench run on this PR will 404 on the fetch — happy to keep this as draft until then. (#2446, which the shape-static flow-LM graph needs to load, and #2448, which the Pocket TTS ScatterND cache writes exercise, are both merged.)

All nine entries validated end-to-end through `tract bench-suite --manifest .travis/benches.toml` against a pre-populated cache (66 metrics emitted).

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)
