### PR TITLE
cpu decode: route f16 SDPA through FlashSdpa, fuse GQA broadcast through cache-read cast/rope

### DIFF
--- a/transformers/src/ops/flash_sdpa.rs
+++ b/transformers/src/ops/flash_sdpa.rs
@@ -404,6 +404,36 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn flash_sdpa_eval_f16_matches_f32() -> TractResult<()> {
+        let (b, hq, hkv, sq, sk, d) = (1usize, 4, 2, 1, 33, 8);
+        let qv = rng(b * hq * sq * d, 4);
+        let kv = rng(b * hkv * sk * d, 5);
+        let vv = rng(b * hkv * sk * d, 6);
+        let q = Tensor::from_shape(&[b, hq, sq, d], &qv)?;
+        let k = Tensor::from_shape(&[b, hkv, sk, d], &kv)?;
+        let v = Tensor::from_shape(&[b, hkv, sk, d], &vv)?;
+        let op = FlashSdpaOp { causal: true, scale: None };
+        let f32_out = op
+            .eval(tvec!(q.clone().into_tvalue(), k.clone().into_tvalue(), v.clone().into_tvalue()))?
+            .remove(0);
+        let (q16, k16, v16) = (
+            q.cast_to::<f16>()?.into_owned(),
+            k.cast_to::<f16>()?.into_owned(),
+            v.cast_to::<f16>()?.into_owned(),
+        );
+        let f16_out =
+            op.eval(tvec!(q16.into_tvalue(), k16.into_tvalue(), v16.into_tvalue()))?.remove(0);
+        ensure!(f16_out.datum_type() == f16::datum_type());
+        let f16_as_f32 = f16_out.cast_to::<f32>()?;
+        let got = f32_out.to_plain_array_view::<f32>()?;
+        let via_f16 = f16_as_f32.to_plain_array_view::<f32>()?;
+        let max_abs =
+            got.iter().zip(via_f16.iter()).map(|(x, y)| (x - y).abs()).fold(0f32, f32::max);
+        ensure!(max_abs < 5e-3, "f16 flash eval diverges from f32: {max_abs}");
+        Ok(())
+    }
+
     // A/B the P·V step (tile GEMM vs strided per-column dot) across the microbench
     // shape AND the real Llama-3.2-1B PP512 prefill shape (causal, GQA 32q/8kv).
     //   cargo test -p tract-transformers --release bench_flash_sdpa_pv -- --ignored --nocapture

--- a/transformers/src/ops/sdpa.rs
+++ b/transformers/src/ops/sdpa.rs
@@ -380,7 +380,9 @@ impl TypedOp for Sdpa {
         model: &TypedModel,
         node: &TypedNode,
     ) -> TractResult<Option<TypedModelPatch>> {
-        if self.acc_datum_type.is::<f32>() {
+        // FlashSdpaOp accumulates in f32 whatever the input floats are, so an f16
+        // accumulator request is satisfied (with extra precision) as well.
+        if self.acc_datum_type.is::<f32>() || self.acc_datum_type.is::<f16>() {
             // FlashSdpaOp requires Q and V to share the same head dim (last axis).
             // When they differ (MLA / diff-head-sizes attention), fall back to the
             // generic SDPA expansion instead.
@@ -449,8 +451,12 @@ pub fn match_broadcast_kv_cache_pattern(
         n.op_is::<DynKeyValueCache>() && n.inputs.len() == 1 && n.outputs.len() == 1
     }
 
-    // Find concat or dyn kvcache node
-    rule_if_some!(node = model.previous_node(unsqueeze_node));
+    // Find concat or dyn kvcache node, looking through layout-preserving ops
+    // (dtype casts, rope applied at cache-read time) on the unrepeated branch.
+    let mut node = model.node(unsqueeze_node.inputs[0].node);
+    while node.op_is::<Cast>() || node.op_is::<crate::ops::apply_rope::ApplyRope>() {
+        node = model.node(node.inputs[0].node);
+    }
     rule_if!(is_concat(model, node) || is_dynkv(node));
 
     let kv_outlet = unsqueeze_node.inputs[0];
@@ -558,4 +564,102 @@ pub fn wire_attention_mask(
         &[mask],
     )?[0];
     Ok(reshaped_mask)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::apply_rope::ApplyRope;
+    use tract_core::ops::array::MultiBroadcastTo;
+    use tract_core::ops::nn::Reduce;
+
+    fn seq_tensor(shape: &[usize], seed: f32) -> Tensor {
+        let n: usize = shape.iter().product();
+        let v: Vec<f32> = (0..n).map(|i| ((i as f32 * 0.37 + seed).sin() * 0.5) as f32).collect();
+        Tensor::from_shape(shape, &v).unwrap()
+    }
+
+    /// The torch-exported GQA idiom: the repeat-interleave chain sits on top of
+    /// cache-read Cast/ApplyRope ops. The fusion must look through them and hand
+    /// the unrepeated K/V to the (GQA-aware) Sdpa.
+    #[test]
+    fn fuse_kv_broadcast_through_cast_and_rope() -> TractResult<()> {
+        let (b, hq, hkv, s, d) = (1usize, 4usize, 2usize, 6usize, 8usize);
+        let g = hq / hkv;
+        let mut model = TypedModel::default();
+        let dim = |x: usize| x.to_dim();
+        let q = model.add_source("q", f32::fact([b, hq, s, d]))?;
+        let knew = model.add_source("k", f32::fact([b, hkv, s, d]))?;
+        let vnew = model.add_source("v", f32::fact([b, hkv, s, d]))?;
+        let p_sym = model.sym("P");
+        let mkcache = |nm: &str| DynKeyValueCache {
+            name: nm.to_string(),
+            axis: 2,
+            past_sequence_fact: f32::fact([dim(b), dim(hkv), p_sym.clone().into(), dim(d)]),
+            input_sequence_fact: f32::fact([b, hkv, s, d]),
+        };
+        let kc = model.wire_node("kc", mkcache("kc"), &[knew])?[0];
+        let vc = model.wire_node("vc", mkcache("vc"), &[vnew])?[0];
+        let cos = model
+            .add_const("cos", seq_tensor(&[1, 1, s, d], 1.5).cast_to::<f16>()?.into_owned())?;
+        let sin = model
+            .add_const("sin", seq_tensor(&[1, 1, s, d], 2.5).cast_to::<f16>()?.into_owned())?;
+        let k16 = model.wire_node("k.cast16", Cast::new(f16::datum_type()), &[kc])?[0];
+        let kroped = model.wire_node("k.rope", ApplyRope, &[k16, cos, sin])?;
+        let k32 = model.wire_node("k.cast32", Cast::new(f32::datum_type()), &kroped)?[0];
+
+        let mut repeat = |name: &str, outlet: OutletId| -> TractResult<OutletId> {
+            let unsq =
+                model.wire_node(format!("{name}.unsq"), change_axes::AxisOp::Add(2), &[outlet])?[0];
+            let bc = model.wire_node(
+                format!("{name}.bc"),
+                MultiBroadcastTo::new(tvec![dim(b), dim(hkv), dim(g), dim(s), dim(d)].into()),
+                &[unsq],
+            )?[0];
+            Ok(model.wire_node(
+                format!("{name}.reshape"),
+                change_axes::AxisOp::Reshape(1, tvec![dim(hkv), dim(g)], tvec![dim(hkv * g)]),
+                &[bc],
+            )?[0])
+        };
+        let krep = repeat("k", k32)?;
+        let vrep = repeat("v", vc)?;
+
+        let sdpa = Sdpa {
+            scale: None,
+            datum_type: f32::datum_type(),
+            acc_datum_type: f32::datum_type(),
+            is_causal: false,
+        };
+        let out = model.wire_node("sdpa", sdpa, &[q, krep, vrep])?;
+        // keep a single output to compare
+        let red = model.wire_node(
+            "sum",
+            Reduce::new(tvec![0, 1, 2, 3], tract_core::ops::nn::Reducer::Sum),
+            &out,
+        )?;
+        model.select_output_outlets(&red)?;
+
+        let reference = model.clone().into_runnable()?;
+        let mut fused_model = model.clone();
+        Rewriter::default()
+            .with_rule_for("detect-sdpa-kv-cache-broadcast", fuse_kv_cache_broadcast_rule)
+            .rewrite(&(), &mut fused_model)?;
+        ensure!(
+            fused_model.nodes().iter().filter(|n| n.op_is::<MultiBroadcastTo>()).count() == 0,
+            "broadcasts should be fused away"
+        );
+        let fused = fused_model.into_runnable()?;
+
+        let qv = seq_tensor(&[b, hq, s, d], 0.1);
+        let kv = seq_tensor(&[b, hkv, s, d], 0.2);
+        let vv = seq_tensor(&[b, hkv, s, d], 0.3);
+        let r = reference
+            .spawn()?
+            .run(tvec![qv.clone().into(), kv.clone().into(), vv.clone().into()])?
+            .remove(0);
+        let f = fused.spawn()?.run(tvec![qv.into(), kv.into(), vv.into()])?.remove(0);
+        r.close_enough(&f, Approximation::Approximate)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Routes f16-accumulator SDPA through `FlashSdpaOp` on CPU and lets the GQA broadcast fusion look through cache-read `Cast`/`ApplyRope` ops, so torch-style f16 GQA exports stop paying a materialized head broadcast plus full-KV-cache repacking on every decode step.

Profiling an OpenELM-270M q40ef16 decode step at P=1000 showed the real GEMV work (~14 ms) buried under per-token recompute over unchanged data: 13.1 ms `OptMatMulPack` re-packing the KV cache, 8.2 ms `MultiBroadcastTo` materializing the repeat-interleave, 4.1 ms `ApplyRope` re-roping the whole window. Two routing gaps kept the existing flash path out of reach: the codegen gate only admitted f32 accumulators (the kernel itself takes any float and accumulates in f32), and the fusion matcher required the `DynKeyValueCache` directly under the repeat chain, which torch exports interpose with cache-read casts and rope.

Measured on Apple M-series, 1 thread, interleaved A/B against main via `llm_decode_bench` (medians):

| context | main ms/tok | this PR | speedup |
|---|---|---|---|
| 100 | 15.1 | 13.9 | 1.09× |
| 1000 | 43.0 | 30.5 | 1.41× |
| 2000 | 75.3 | 48.1 | 1.57× |

`llm-bench`: PP512 262 → 338 tok/s (+29%). One trade-off to be aware of: TG128 is −3% (75.1 → 72.7 tok/s) — at very shallow context the decomposed path still competes, and `TRACT_FLASH_SDPA_MIN_SEQ_LEN` can't gate it because kv_len is symbolic at codegen time. A runtime-side dispatch could recover it if you think it's worth the complexity.

Tests: f16-eval-vs-f32 parity on the op, and a model-level test replicating the torch GQA idiom (cache → cast → rope → repeat-interleave → SDPA) asserting the broadcasts fuse away and the fused model matches the unfused reference through real cache state. transformers/onnx-core/core/unit/linalg suites green.

Follow-ups I'd like to explore next, in order: folding the f16→f32 cast per-block into the flash streaming loop, folding rope-at-read into the kernel, and letting `InPlaceKvSdpa` match through the same cast/rope chain (which also removes the concat copy).

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)
