### PR TITLE
The packed-packed test reference for the AMX f32-via-bf16 kernel comp…

### DIFF
--- a/linalg/src/frame/block_quant/mod.rs
+++ b/linalg/src/frame/block_quant/mod.rs
@@ -249,6 +249,11 @@ impl PackedBlockQuantFormat {
 }
 
 impl MMMInputFormat for PackedBlockQuantFormat {
+    fn simulate_precision_loss(&self, tensor: Tensor) -> TractResult<Tensor> {
+        let axis = tensor.rank() - 1;
+        self.bq.simulate_precision_loss(tensor, axis)
+    }
+
     fn prepare_tensor(&self, t: &Tensor, _k_axis: usize, _mn_axis: usize) -> TractResult<Tensor> {
         let bqs = t.try_storage_as::<BlockQuantStorage>()?;
         let num_groups: usize =

--- a/linalg/src/frame/mmm/input_store.rs
+++ b/linalg/src/frame/mmm/input_store.rs
@@ -21,6 +21,12 @@ pub trait MMMInputFormat:
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>>;
     fn precursor(&self) -> WeightType;
+    /// Round `tensor` through the numeric precision this format stores its data
+    /// in, so a reference matmul can reproduce the kernel's pack-time precision
+    /// loss. Default: identity, for formats that store inputs losslessly.
+    fn simulate_precision_loss(&self, tensor: Tensor) -> TractResult<Tensor> {
+        Ok(tensor)
+    }
     fn r(&self) -> usize;
     fn k_alignment(&self) -> usize;
     fn merge_with<'o, 'a: 'o, 'b: 'o>(

--- a/linalg/src/frame/mmm/tests/packed_packed.rs
+++ b/linalg/src/frame/mmm/tests/packed_packed.rs
@@ -1,5 +1,4 @@
 use crate::WeightType;
-use crate::block_quant::PackedBlockQuantFormat;
 use crate::mmm::tests::display_error;
 use crate::mmm::{AsInputValue, FusedKerSpec, FusedSpec, MatMatMul, MatMatMulKer, OutputStoreKer};
 use proptest::collection::vec;
@@ -283,11 +282,10 @@ impl<K: MatMatMulKer> PackedPackedProblem<K> {
     pub fn reference(&self) -> TractResult<Tensor> {
         let (m, k, n) = self.mkn();
         let (pack_a, pack_b) = &self.ker.packings()[self.packing];
-        let (mut a, b) = self.padded_inputs()?;
+        let (mut a, mut b) = self.padded_inputs()?;
         let k_aligned = k.next_multiple_of(pack_a.k_alignment().max(pack_b.k_alignment()));
-        if let Some(pbqf) = pack_a.downcast_ref::<PackedBlockQuantFormat>() {
-            a = pbqf.simulate_precision_loss(a, 1)?;
-        };
+        a = pack_a.simulate_precision_loss(a)?;
+        b = pack_b.simulate_precision_loss(b)?;
         let mut c = Tensor::zero::<K::Acc>(&[m, n])?;
 
         let a = a.cast_to::<K::Acc>()?;

--- a/linalg/src/x86_64_fma/amx_bf16.rs
+++ b/linalg/src/x86_64_fma/amx_bf16.rs
@@ -66,6 +66,19 @@ pub fn f32_to_bf16_rne(x: f32) -> u16 {
     }
 }
 
+/// Round every f32 element of `tensor` through bf16 (round-to-nearest-even),
+/// matching what the bf16 packers do at pack time. Non-f32 tensors pass through
+/// unchanged. Lets a reference f32 matmul reproduce the kernel's bf16 rounding.
+fn truncate_to_bf16(mut tensor: Tensor) -> TractResult<Tensor> {
+    if tensor.datum_type() == f32::datum_type() {
+        let mut plain = tensor.try_as_plain_mut()?;
+        for x in plain.as_slice_mut::<f32>()? {
+            *x = f32::from_bits((f32_to_bf16_rne(*x) as u32) << 16);
+        }
+    }
+    Ok(tensor)
+}
+
 /// AMX-friendly A packing for f32 matmul via bf16. Per `r`-row panel, the
 /// M-rows are laid out row-major in bf16 across `K_padded` contiguous bf16
 /// per row (K_padded = ceil(K/32)*32, so each row is a whole number of
@@ -170,6 +183,9 @@ impl MMMInputFormat for PackedAmxBf16A {
     }
     fn precursor(&self) -> WeightType {
         WeightType::Plain(f32::datum_type())
+    }
+    fn simulate_precision_loss(&self, tensor: Tensor) -> TractResult<Tensor> {
+        truncate_to_bf16(tensor)
     }
     fn merge_with<'o, 'a: 'o, 'b: 'o>(
         &'a self,
@@ -297,6 +313,9 @@ impl MMMInputFormat for PackedBf16K2 {
     }
     fn precursor(&self) -> WeightType {
         WeightType::Plain(f32::datum_type())
+    }
+    fn simulate_precision_loss(&self, tensor: Tensor) -> TractResult<Tensor> {
+        truncate_to_bf16(tensor)
     }
     fn merge_with<'o, 'a: 'o, 'b: 'o>(
         &'a self,


### PR DESCRIPTION
…uted its golden matmul in full f32 while the kernel truncates both operands to bf16 at pack time, so on AMX-BF16 hardware the f32 Approximate tolerance flagged the ~2^-8 bf16 rounding as a mismatch. Add a simulate_precision_loss hook on MMMInputFormat (default identity, implemented by the bf16 packers and folding in the existing block-quant path) and apply it to both operands in the reference.