### PR TITLE
metal: accumulate the matmul test reference in f32 to match the kernels

### DIFF
--- a/metal/src/kernels/matmul/mfa/mod.rs
+++ b/metal/src/kernels/matmul/mfa/mod.rs
@@ -20,6 +20,12 @@ impl GemmKernel for MfaGemm {
         "mfa"
     }
 
+    /// MFA's GEMM accumulates in the operand precision (its hgemm has no
+    /// f32-accumulator variant), so f16 inputs accumulate in f16.
+    fn accumulator_dt(operand: DatumType) -> DatumType {
+        operand
+    }
+
     fn dispatch_eval(
         &self,
         stream: &MetalStream,

--- a/metal/src/kernels/matmul/mod.rs
+++ b/metal/src/kernels/matmul/mod.rs
@@ -877,7 +877,11 @@ mod tests {
                 transpose_b: self.transpose_rhs,
                 transpose_c: false,
                 quantize_output: None,
-                operating_dt: Some(F::datum_type()),
+                // The GGML/MLX/MFA kernels accumulate in f32 and only round the output to the
+                // activation dtype, so the golden must accumulate in f32 too: a f16 reference
+                // accumulator is noisier than the kernel it checks and flags spurious mismatches
+                // at large k.
+                operating_dt: Some(f32::datum_type()),
             };
 
             let lhs_tensor = if self.transpose_lhs {

--- a/metal/src/kernels/matmul/mod.rs
+++ b/metal/src/kernels/matmul/mod.rs
@@ -222,6 +222,14 @@ pub trait GemmKernel:
         Ok(a_dt)
     }
 
+    /// Datum type the kernel accumulates in for the given operand dtype. The
+    /// default (f32) keeps the proptest reference accurate; a kernel that
+    /// accumulates in operand precision must override, else the reference is
+    /// unfairly more accurate than the kernel and flags spurious mismatches.
+    fn accumulator_dt(_operand: DatumType) -> DatumType {
+        DatumType::F32
+    }
+
     fn dispatch_eval(
         &self,
         stream: &MetalStream,
@@ -877,11 +885,11 @@ mod tests {
                 transpose_b: self.transpose_rhs,
                 transpose_c: false,
                 quantize_output: None,
-                // The GGML/MLX/MFA kernels accumulate in f32 and only round the output to the
-                // activation dtype, so the golden must accumulate in f32 too: a f16 reference
-                // accumulator is noisier than the kernel it checks and flags spurious mismatches
-                // at large k.
-                operating_dt: Some(f32::datum_type()),
+                // Accumulate the golden in each kernel's own accumulation precision. GGML/MLX
+                // accumulate in f32, so a f16 reference accumulator would be noisier than the
+                // kernel it checks and flag spurious mismatches at large k; MFA's GEMM instead
+                // accumulates in the operand dtype.
+                operating_dt: Some(K::accumulator_dt(F::datum_type())),
             };
 
             let lhs_tensor = if self.transpose_lhs {


### PR DESCRIPTION
The GGML/MLX/MFA GEMM kernels accumulate in f32 and only round the output to the f16 activation dtype, but the proptest reference accumulated in f16 (operating_dt = the activation dtype). At large k the f16 reference accumulator drifted more than the kernel it checks, so mmm_ggml_prop_f16 intermittently failed the VeryApproximate tolerance on random large-k draws. Compute the golden in f32.