### PR TITLE
Avoid building a discarded error in the TDim::simplify hot path

### DIFF
--- a/api/rs/src/lib.rs
+++ b/api/rs/src/lib.rs
@@ -606,7 +606,7 @@ impl DimInterface for Dim {
     }
 
     fn to_int64(&self) -> Result<i64> {
-        self.0.to_i64()
+        Ok(self.0.to_i64()?)
     }
 }
 

--- a/cli/src/compare.rs
+++ b/cli/src/compare.rs
@@ -340,7 +340,7 @@ pub fn handle_stream(
     let plan = Arc::new(model.as_ref().clone().into_runnable()?);
     let mut state = SimpleState::new(&plan)?;
     let input_shape: TVec<usize> =
-        model_input_fact.shape.iter().map(|d| d.to_usize()).collect::<TractResult<TVec<_>>>()?;
+        model_input_fact.shape.iter().map(|d| d.to_usize()).collect::<Result<TVec<_>, _>>()?;
 
     let mut node_slices: HashMap<String, Vec<Tensor>> = HashMap::new();
     let mut node_axes: HashMap<String, usize> = HashMap::new();

--- a/core/src/axes/mapping.rs
+++ b/core/src/axes/mapping.rs
@@ -191,8 +191,8 @@ impl AxesMapping {
     pub fn renaming(mut self, axis: impl AxisPattern, name: char) -> TractResult<AxesMapping> {
         let position = self.search(axis)?;
         let old_label = self.axes[position].repr;
-        if let Ok(conflict) = self.axis_mut(name) {
-            conflict.repr = old_label
+        if let Some(conflict) = name.search(&self) {
+            self.axes[conflict].repr = old_label
         }
         self.axes[position].repr = name;
         self.sort();

--- a/core/src/model/fact.rs
+++ b/core/src/model/fact.rs
@@ -152,8 +152,7 @@ impl ShapeFact {
 
     pub fn consistent(&self) -> TractResult<()> {
         ensure!(
-            self.concrete
-                == self.dims.iter().map(|d| d.to_usize()).collect::<TractResult<TVec<_>>>().ok()
+            self.concrete == self.dims.iter().map(|d| d.as_usize()).collect::<Option<TVec<_>>>()
         );
         Ok(())
     }

--- a/core/src/model/fact.rs
+++ b/core/src/model/fact.rs
@@ -18,9 +18,9 @@ impl ShapeFact {
     }
 
     fn compute_concrete(&mut self) {
-        assert!(self.dims.iter().all(|d| d.to_isize().map(|d| d >= 0).unwrap_or(true)));
+        assert!(self.dims.iter().all(|d| d.as_i64().map(|d| d >= 0).unwrap_or(true)));
         self.concrete =
-            self.dims.iter().map(|d| d.to_usize()).collect::<TractResult<TVec<_>>>().ok()
+            self.dims.iter().map(|d| d.as_i64().map(|d| d as usize)).collect::<Option<TVec<_>>>()
     }
 
     /// Shape of the tensor, unless it has symbolic dimensions.
@@ -396,8 +396,10 @@ impl Fact for TypedFact {
             return Ok(false);
         }
         for i in 0..t.rank() {
-            if let Ok(dim) =
-                self.shape[i].eval(symbols.unwrap_or(&SymbolValues::default())).to_usize()
+            if let Some(dim) = self.shape[i]
+                .eval(symbols.unwrap_or(&SymbolValues::default()))
+                .as_i64()
+                .map(|d| d as usize)
                 && dim != t.shape()[i]
             {
                 return Ok(false);

--- a/core/src/ops/array/slice.rs
+++ b/core/src/ops/array/slice.rs
@@ -88,8 +88,8 @@ fn eval_slice(input: &Tensor, axis: usize, start: usize, end: usize) -> TractRes
 impl TypedOp for Slice {
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
         anyhow::ensure!(inputs.len() == 1, "Slice has one single input");
-        if let (Ok(start), Ok(end), Ok(len)) =
-            (self.start.to_usize(), self.end.to_usize(), inputs[0].shape[self.axis].to_usize())
+        if let (Some(start), Some(end), Some(len)) =
+            (self.start.as_usize(), self.end.as_usize(), inputs[0].shape[self.axis].as_usize())
         {
             ensure!(start <= end);
             ensure!(end <= len);

--- a/core/src/ops/array/strided_slice.rs
+++ b/core/src/ops/array/strided_slice.rs
@@ -21,7 +21,7 @@ pub struct Dim {
 
 impl Dim {
     pub fn soft_len(&self) -> TractResult<TDim> {
-        if let Ok(len) = (self.end.clone() - &self.begin).to_isize() {
+        if let Some(len) = (self.end.clone() - &self.begin).as_i64() {
             Ok((((self.stride.abs() - 1) + len.abs() as i32) / self.stride.abs()).to_dim())
         } else if self.stride == 1 {
             Ok(self.end.clone() - &self.begin)
@@ -119,14 +119,14 @@ impl StridedSlice {
 
         let mut begin =
             begin.unwrap_or_else(|| if stride > 0 { 0.to_dim() } else { dim.clone() - 1 });
-        if begin.to_isize().map(|b| b < 0).unwrap_or(false) {
+        if begin.as_i64().map(|b| b < 0).unwrap_or(false) {
             if stride < 0 {
                 return Ok(Dim { begin: 0.to_dim(), end: 0.to_dim(), stride, shrink: false });
             } else {
                 begin = 0.to_dim();
             }
         }
-        if let (Ok(b), Ok(d)) = (begin.to_isize(), dim.to_isize())
+        if let (Some(b), Some(d)) = (begin.as_i64(), dim.as_i64())
             && b > d - 1
         {
             if stride > 0 {
@@ -137,14 +137,14 @@ impl StridedSlice {
         }
 
         let mut end = end.unwrap_or_else(|| if stride > 0 { dim.clone() } else { (-1).to_dim() });
-        if end.to_isize().map(|e| e < 0).unwrap_or(false) {
+        if end.as_i64().map(|e| e < 0).unwrap_or(false) {
             if stride > 0 {
                 return Ok(Dim { begin: 0.to_dim(), end: 0.to_dim(), stride, shrink: false });
             } else {
                 end = (-1).to_dim();
             }
         }
-        if let (Ok(e), Ok(d)) = (end.to_isize(), dim.to_isize())
+        if let (Some(e), Some(d)) = (end.as_i64(), dim.as_i64())
             && e > d - 1
         {
             if stride > 0 {
@@ -277,11 +277,10 @@ impl EvalOp for StridedSlice {
     fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut model = TypedModel::default();
         let scope = inputs.iter().find_map(|i| {
-            i.try_as_plain().ok().and_then(|d| {
-                d.as_slice::<TDim>()
-                    .ok()
-                    .and_then(|slice| slice.iter().find_map(|dim| dim.find_scope()))
-            })
+            if i.datum_type() != TDim::datum_type() {
+                return None;
+            }
+            i.try_as_plain().ok()?.as_slice::<TDim>().ok()?.iter().find_map(|dim| dim.find_scope())
         });
         model.symbols = scope.unwrap_or_default();
         let mut source = tvec!();

--- a/core/src/ops/array/tile.rs
+++ b/core/src/ops/array/tile.rs
@@ -35,7 +35,7 @@ impl EvalOp for Tile {
             .multipliers
             .iter()
             .map(|m| m.eval(&session.resolved_symbols).to_usize())
-            .collect::<TractResult<_>>()?;
+            .collect::<Result<_, _>>()?;
         let result =
             dispatch_datum_by_size!(eval_t(inputs[0].datum_type())(&inputs[0], &multipliers))?;
         Ok(tvec!(result))

--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -614,7 +614,7 @@ fn find_most_efficient_config(
 }
 
 pub fn gt_tdim(x: TDim, min_val: i64) -> bool {
-    TDim::Val(min_val).mini(x).to_i64().is_ok_and(|v| v == min_val)
+    TDim::Val(min_val).mini(x).as_i64().is_some_and(|v| v == min_val)
 }
 
 #[derive(Clone)]

--- a/core/src/ops/cnn/conv/block_quant.rs
+++ b/core/src/ops/cnn/conv/block_quant.rs
@@ -105,7 +105,7 @@ impl TypedOp for SplitGroupBlockQuant {
         let o: usize = input.shape[0].to_usize()?;
         ensure!(o % self.group == 0);
         let mut new_shape: TVec<usize> =
-            input.shape.iter().map(|d| d.to_usize()).collect::<TractResult<_>>()?;
+            input.shape.iter().map(|d| d.to_usize()).collect::<Result<_, _>>()?;
         new_shape[0] = o / self.group;
         new_shape.insert(0, self.group);
         let exotic_fact = BlockQuantFact::new(bqf.format.clone(), new_shape.clone());

--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -570,7 +570,7 @@ impl Conv {
                 .context("Not matmu found")
         } else {
             let mmm = tract_linalg::ops()
-                .mmm(acc, Some(m), Some(k), n.to_usize().ok())
+                .mmm(acc, Some(m), Some(k), n.as_usize())
                 .context("No matmul found")?;
             let packing = mmm
                 .packings()

--- a/core/src/ops/cnn/padding.rs
+++ b/core/src/ops/cnn/padding.rs
@@ -153,7 +153,7 @@ impl PaddingSpec {
         stride: usize,
     ) -> ComputedPaddedDim<D> {
         let kernel_field = (kernel - 1) * dilation + 1;
-        let output = if let Ok(int) = input.to_usize() {
+        let output = if let Some(int) = input.as_usize() {
             D::from((int + 1).saturating_sub(kernel_field).divceil(stride))
         } else {
             (input.clone() + 1 - kernel_field).divceil(stride)
@@ -181,7 +181,7 @@ impl PaddingSpec {
         bef: usize,
         aft: usize,
     ) -> ComputedPaddedDim<D> {
-        if let Ok(i) = input.to_dim().to_usize() {
+        if let Some(i) = input.as_usize() {
             let ints = Self::explicit_usize(i, kernel, dilation, stride, bef, aft);
             ComputedPaddedDim::new(
                 input.clone(),
@@ -220,7 +220,7 @@ impl PaddingSpec {
         aft: usize,
         ceil_mode: bool,
     ) -> ComputedPaddedDim<D> {
-        if let Ok(i) = input.to_dim().to_usize() {
+        if let Some(i) = input.as_usize() {
             let ints =
                 Self::explicit_onnx_pool_usize(i, kernel, dilation, stride, bef, aft, ceil_mode);
             ComputedPaddedDim::new(
@@ -286,7 +286,7 @@ impl PaddingSpec {
     ) -> ComputedPaddedDim<D> {
         let output = input.divceil(stride);
         let kernel_field = (kernel - 1) * dilation + 1;
-        let pad = if let Ok(input) = input.to_usize() {
+        let pad = if let Some(input) = input.as_usize() {
             let pad = (((output.clone() - 1) * stride + kernel_field).to_usize().unwrap())
                 .saturating_sub(input);
             pad.into()

--- a/core/src/ops/scan/optimized.rs
+++ b/core/src/ops/scan/optimized.rs
@@ -220,7 +220,7 @@ impl OpState for State {
                 let scanning_dim = output
                     .full_dim_hint
                     .as_ref()
-                    .and_then(|d| d.to_usize().ok())
+                    .and_then(|d| d.as_usize())
                     .unwrap_or(shape[info.axis] * iters);
                 shape[info.axis] = scanning_dim;
                 let t = unsafe { Tensor::uninitialized_dt(fact.datum_type, &shape)? };

--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -47,7 +47,7 @@ impl super::TypedPass for PropConst {
                 let input_mem: u64 = model
                     .node_input_facts(node.id)?
                     .iter()
-                    .map(|f| f.mem_size().to_i64().unwrap_or(i64::MAX) as u64)
+                    .map(|f| f.mem_size().as_i64().unwrap_or(i64::MAX) as u64)
                     .sum();
                 match node.op.eval_with_session(node.id, &TurnState::default(), inputs) {
                     Ok(mut res) => {

--- a/core/src/optim/propagate_roi.rs
+++ b/core/src/optim/propagate_roi.rs
@@ -117,7 +117,7 @@ pub fn recognise_chunked_band_project(roi: &TDim, p_sym: &Symbol, k_sym: &Symbol
     if r_val != &TDim::Val(0) {
         return None;
     }
-    let big_l = l_val.to_i64().ok()?;
+    let big_l = l_val.as_i64()?;
     if big_l < 0 {
         return None;
     }

--- a/core/src/optim/slice.rs
+++ b/core/src/optim/slice.rs
@@ -180,7 +180,7 @@ fn should_slice_output(
         }
     }
     rule_if_let!(Ok(mut boundaries) =
-        boundaries.iter().map(|x| x.to_usize()).collect::<TractResult<TVec<usize>>>());
+        boundaries.iter().map(|x| x.to_usize()).collect::<Result<TVec<usize>, _>>());
     rule_if_let!(Ok(end) = node.outputs[0].fact.shape[axis].to_usize());
     // op_slices_to_slice_op requires boundaries to cover the full
     // [0..full_len] range. When every slicing successor starts at

--- a/data/src/dim/assertion.rs
+++ b/data/src/dim/assertion.rs
@@ -40,21 +40,11 @@ impl Assertion {
     pub fn check(&self, values: &SymbolValues) -> Option<bool> {
         use Assertion::*;
         match self {
-            Eq(left, right) => {
-                (left.eval(values) - right.eval(values)).to_i64().ok().map(|d| d == 0)
-            }
-            GTE(left, right) => {
-                (left.eval(values) - right.eval(values)).to_i64().ok().map(|d| d >= 0)
-            }
-            GT(left, right) => {
-                (left.eval(values) - right.eval(values)).to_i64().ok().map(|d| d > 0)
-            }
-            LTE(left, right) => {
-                (left.eval(values) - right.eval(values)).to_i64().ok().map(|d| d <= 0)
-            }
-            LT(left, right) => {
-                (left.eval(values) - right.eval(values)).to_i64().ok().map(|d| d < 0)
-            }
+            Eq(left, right) => (left.eval(values) - right.eval(values)).as_i64().map(|d| d == 0),
+            GTE(left, right) => (left.eval(values) - right.eval(values)).as_i64().map(|d| d >= 0),
+            GT(left, right) => (left.eval(values) - right.eval(values)).as_i64().map(|d| d > 0),
+            LTE(left, right) => (left.eval(values) - right.eval(values)).as_i64().map(|d| d <= 0),
+            LT(left, right) => (left.eval(values) - right.eval(values)).as_i64().map(|d| d < 0),
         }
     }
 }

--- a/data/src/dim/mod.rs
+++ b/data/src/dim/mod.rs
@@ -60,17 +60,17 @@ pub trait DimLike:
         (self.clone() + other - 1) / other
     }
 
-    /// Convert to regular integer.
-    fn to_i64(&self) -> TractResult<i64>;
+    /// Convert to regular integer, or a lightweight `TooEarly` for a symbolic
+    /// dim. The error carries no anyhow conversion or backtrace, so discarding
+    /// it to probe concreteness is cheap; `?` in a `TractResult` context still
+    /// promotes it to a full error.
+    fn to_i64(&self) -> Result<i64, TooEarly>;
 
     /// Non-erroring counterpart of `to_i64`: `Some` iff the dim is a plain
-    /// constant, `None` for a symbolic or undetermined dim. Unlike `to_i64`
-    /// it builds no error, so no message string and (under `RUST_BACKTRACE`)
-    /// no backtrace are produced on failure. Use it on hot paths that only
-    /// probe for a concrete value and discard the reason for failure.
+    /// constant, `None` for a symbolic or undetermined dim.
     fn as_i64(&self) -> Option<i64>;
 
-    fn to_usize(&self) -> TractResult<usize> {
+    fn to_usize(&self) -> Result<usize, TooEarly> {
         self.to_i64().map(|d| d as usize)
     }
 
@@ -78,7 +78,7 @@ pub trait DimLike:
         self.as_i64().map(|d| d as usize)
     }
 
-    fn to_isize(&self) -> TractResult<isize> {
+    fn to_isize(&self) -> Result<isize, TooEarly> {
         self.to_i64().map(|d| d as isize)
     }
 
@@ -86,7 +86,7 @@ pub trait DimLike:
         self.as_i64().map(|d| d as isize)
     }
 
-    fn to_i32(&self) -> TractResult<i32> {
+    fn to_i32(&self) -> Result<i32, TooEarly> {
         self.to_i64().map(|d| d as i32)
     }
 
@@ -173,7 +173,7 @@ impl DimLike for TDim {
         Ok(((TDim::Mul(num) * num_int).reduce(), denum_int as u64))
     }
 
-    fn to_i64(&self) -> TractResult<i64> {
+    fn to_i64(&self) -> Result<i64, TooEarly> {
         TDim::to_i64(self)
     }
 
@@ -234,7 +234,7 @@ impl DimLike for usize {
         Ok((self / gcd, (other / gcd) as u64))
     }
 
-    fn to_i64(&self) -> TractResult<i64> {
+    fn to_i64(&self) -> Result<i64, TooEarly> {
         Ok(*self as i64)
     }
 
@@ -284,7 +284,7 @@ impl DimLike for usize {
 impl<'a> std::convert::TryFrom<&'a TDim> for usize {
     type Error = TractError;
     fn try_from(d: &'a TDim) -> TractResult<usize> {
-        d.to_usize()
+        Ok(d.to_usize()?)
     }
 }
 

--- a/data/src/dim/mod.rs
+++ b/data/src/dim/mod.rs
@@ -63,12 +63,27 @@ pub trait DimLike:
     /// Convert to regular integer.
     fn to_i64(&self) -> TractResult<i64>;
 
+    /// Non-erroring counterpart of `to_i64`: `Some` iff the dim is a plain
+    /// constant, `None` for a symbolic or undetermined dim. Unlike `to_i64`
+    /// it builds no error, so no message string and (under `RUST_BACKTRACE`)
+    /// no backtrace are produced on failure. Use it on hot paths that only
+    /// probe for a concrete value and discard the reason for failure.
+    fn as_i64(&self) -> Option<i64>;
+
     fn to_usize(&self) -> TractResult<usize> {
         self.to_i64().map(|d| d as usize)
     }
 
+    fn as_usize(&self) -> Option<usize> {
+        self.as_i64().map(|d| d as usize)
+    }
+
     fn to_isize(&self) -> TractResult<isize> {
         self.to_i64().map(|d| d as isize)
+    }
+
+    fn as_isize(&self) -> Option<isize> {
+        self.as_i64().map(|d| d as isize)
     }
 
     fn to_i32(&self) -> TractResult<i32> {
@@ -162,6 +177,10 @@ impl DimLike for TDim {
         TDim::to_i64(self)
     }
 
+    fn as_i64(&self) -> Option<i64> {
+        TDim::as_i64(self)
+    }
+
     fn eval(&self, values: &SymbolValues) -> Self {
         self.eval(values)
     }
@@ -217,6 +236,10 @@ impl DimLike for usize {
 
     fn to_i64(&self) -> TractResult<i64> {
         Ok(*self as i64)
+    }
+
+    fn as_i64(&self) -> Option<i64> {
+        Some(*self as i64)
     }
 
     fn eval(&self, _values: &SymbolValues) -> Self {

--- a/data/src/dim/sym.rs
+++ b/data/src/dim/sym.rs
@@ -349,7 +349,7 @@ impl SymbolScopeData {
         let mut visited = vec![];
         let mut todo = vec![t.clone()];
         while let Some(t) = todo.pop() {
-            if t.to_i64().is_ok_and(|i| i >= 0) {
+            if t.as_i64().is_some_and(|i| i >= 0) {
                 return true;
             }
             if t.inclusive_bound(self, false).is_some_and(|l| l >= 0) {

--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -253,6 +253,40 @@ impl TDim {
         if let Val(v) = self { Some(*v) } else { None }
     }
 
+    /// Non-erroring counterpart of `eval_to_i64`: returns `None` instead of
+    /// building an error when a symbol is undetermined or arithmetic overflows.
+    /// Use this on hot paths that only want the constant value and discard the
+    /// reason for failure, so no message string is formatted and (crucially,
+    /// when `RUST_BACKTRACE` is set) no backtrace is captured.
+    pub fn maybe_eval_to_i64(&self, values: &SymbolValues) -> Option<i64> {
+        match self {
+            Sym(sym) => values.get(sym),
+            Val(v) => Some(*v),
+            Add(terms) => terms
+                .iter()
+                .try_fold(0i64, |acc, it| acc.checked_add(it.maybe_eval_to_i64(values)?)),
+            Mul(terms) => terms
+                .iter()
+                .try_fold(1i64, |acc, it| acc.checked_mul(it.maybe_eval_to_i64(values)?)),
+            Min(terms) => terms
+                .iter()
+                .try_fold(i64::MAX, |acc, it| Some(acc.min(it.maybe_eval_to_i64(values)?))),
+            Max(terms) => terms
+                .iter()
+                .try_fold(i64::MIN, |acc, it| Some(acc.max(it.maybe_eval_to_i64(values)?))),
+            Broadcast(terms) => terms.iter().try_fold(1i64, |acc, it| {
+                (acc as usize)
+                    .broadcast(it.maybe_eval_to_i64(values)? as usize)
+                    .ok()
+                    .map(|x| x as i64)
+            }),
+            Div(a, q) => Some(a.maybe_eval_to_i64(values)? / *q as i64),
+            MulInt(p, a) => a.maybe_eval_to_i64(values)?.checked_mul(*p),
+            Ge(a, b) => Some((a.maybe_eval_to_i64(values)? >= b.maybe_eval_to_i64(values)?) as i64),
+            Eq(a, b) => Some((a.maybe_eval_to_i64(values)? == b.maybe_eval_to_i64(values)?) as i64),
+        }
+    }
+
     pub fn eval_to_i64(&self, values: &SymbolValues) -> TractResult<i64> {
         match self {
             Sym(sym) => {
@@ -549,7 +583,7 @@ impl TDim {
 
     pub fn simplify(self) -> TDim {
         use self::TDim::*;
-        if let Ok(v) = self.eval_to_i64(&SymbolValues::default()) {
+        if let Some(v) = self.maybe_eval_to_i64(&SymbolValues::default()) {
             return Val(v);
         }
         let Some(scope) = self.find_scope() else {
@@ -576,7 +610,7 @@ impl TDim {
         if extra.is_empty() {
             return self.simplify();
         }
-        if let Ok(v) = self.eval_to_i64(&SymbolValues::default()) {
+        if let Some(v) = self.maybe_eval_to_i64(&SymbolValues::default()) {
             return Val(v);
         }
         let Some(scope) = self.find_scope() else {
@@ -1363,7 +1397,7 @@ impl TDim {
     }
 
     pub fn compatible_with(&self, other: &TDim) -> bool {
-        if let Ok(x) = (self.clone() - other).to_i64() {
+        if let Some(x) = (self.clone() - other).as_i64() {
             return x == 0;
         }
         true // maybe ? :)

--- a/data/src/dim/tree.rs
+++ b/data/src/dim/tree.rs
@@ -240,12 +240,13 @@ impl TDim {
     }
 
     #[inline]
-    pub fn to_i64(&self) -> TractResult<i64> {
-        if let Val(v) = self {
-            Ok(*v)
-        } else {
-            Err(TooEarly::UndeterminedSymbol(self.to_string()))?
-        }
+    /// Concrete value of the dim, or a lightweight `TooEarly` for a symbolic
+    /// one. The error is a plain enum — no anyhow conversion, no message
+    /// formatting, and (crucially) no backtrace — so probing concreteness by
+    /// discarding the error (`.ok()`, `if let Ok`) is cheap. Use `?` in a
+    /// `TractResult` context to promote a genuine failure to a full error.
+    pub fn to_i64(&self) -> Result<i64, TooEarly> {
+        if let Val(v) = self { Ok(*v) } else { Err(TooEarly::UndeterminedSymbol(self.to_string())) }
     }
 
     #[inline]

--- a/examples/wasm-model-bench/src/lib.rs
+++ b/examples/wasm-model-bench/src/lib.rs
@@ -14,7 +14,7 @@ pub fn build_zero_inputs(model: &Runnable) -> Result<TVec<TValue>> {
     for &outlet in typed.input_outlets()?.iter() {
         let fact = typed.outlet_fact(outlet)?;
         let shape: Vec<usize> =
-            fact.shape.iter().map(|d| d.to_usize()).collect::<TractResult<Vec<_>>>()?;
+            fact.shape.iter().map(|d| d.to_usize()).collect::<Result<Vec<_>, _>>()?;
         let dt = fact.datum_type;
         let tensor = Tensor::zero_dt(dt, &shape)?;
         inputs.push(tensor.into_tvalue());

--- a/libcli/src/annotations.rs
+++ b/libcli/src/annotations.rs
@@ -165,7 +165,7 @@ impl Annotations {
         let peak_tmp_mem_usage = tmp_mem_usage
             .iter()
             .map(|(n, mem)| mem.to_usize().map(|m| (*n, m)))
-            .collect::<TractResult<TVec<_>>>()
+            .collect::<Result<TVec<_>, _>>()
             .ok()
             .and_then(|mems| {
                 mems.into_iter().map(|(n, mem)| (NodeQId(tvec![], n), mem)).max_by_key(|it| it.1)

--- a/nnef/src/deser.rs
+++ b/nnef/src/deser.rs
@@ -791,7 +791,7 @@ impl CoerceFrom<Value> for u64 {
 impl CoerceFrom<Value> for i64 {
     fn coerce(builder: &mut ModelBuilder, from: &Value) -> TractResult<Self> {
         match from {
-            Value::Dim(d) => d.to_i64(),
+            Value::Dim(d) => Ok(d.to_i64()?),
             Value::Tensor(t) => Ok(*t.try_as_plain()?.to_scalar::<i64>()?),
             Value::Wire(_) => Ok(from.to::<Arc<Tensor>>(builder)?.cast_to_scalar::<i64>()?),
             _ => bail!("Can not build a i64 from {:?}", from),

--- a/nnef/src/ops/nnef/ser.rs
+++ b/nnef/src/ops/nnef/ser.rs
@@ -209,11 +209,8 @@ pub fn make_conv_named_args<'a>(
         ("padding", padding),
     ];
     if deconv && adjustments.unwrap().iter().any(|a| *a != 0) {
-        let output_shape = output_shape
-            .hw_dims()
-            .iter()
-            .map(|d| d.to_usize())
-            .collect::<TractResult<TVec<_>>>()?;
+        let output_shape =
+            output_shape.hw_dims().iter().map(|d| d.to_usize()).collect::<Result<TVec<_>, _>>()?;
         named_args.push(("output_shape", ints(&output_shape)));
     };
     Ok(named_args)

--- a/onnx/src/ops/nn/conv_transpose.rs
+++ b/onnx/src/ops/nn/conv_transpose.rs
@@ -66,8 +66,8 @@ impl Expansion for ConvTranspose {
 
         s.given_2(&inputs[0].shape, &inputs[1].shape, move |s, x_shape, w_shape| {
             if let (Ok(x_shape), Ok(w_shape)) = (
-                x_shape.iter().map(|d| d.to_usize()).collect::<TractResult<TVec<usize>>>(),
-                w_shape.iter().map(|d| d.to_usize()).collect::<TractResult<TVec<usize>>>(),
+                x_shape.iter().map(|d| d.to_usize()).collect::<Result<TVec<usize>, _>>(),
+                w_shape.iter().map(|d| d.to_usize()).collect::<Result<TVec<usize>, _>>(),
             ) {
                 let y_shape = if let Some(output_shape) = &self.output_shape {
                     let mut y_shape = x_shape;

--- a/pulse/src/blockify.rs
+++ b/pulse/src/blockify.rs
@@ -975,7 +975,7 @@ fn wire_initiator_diag_gather(
     // T-XL convention `centre = (R-1)/2` for models where the op was built
     // with a row-count-based symbolic offset (e.g. `T - 1`) that hasn't
     // simplified post-substitution.
-    let centre = op.offset.to_i64().ok().unwrap_or((r - 1) / 2);
+    let centre = op.offset.as_i64().unwrap_or((r - 1) / 2);
     let l = mask.upper - mask.lower;
     let w = (l + 1) * k;
     let window_start = window_start_for(mask, contracted_axis);
@@ -1983,7 +1983,7 @@ fn wire_merge_reshape(
 fn affine_chunk_offset(dim: &TDim, chunk_sym: &Symbol, k: i64) -> Option<i64> {
     let target = chunk_sym.to_dim() * k;
     let diff = dim.clone() - target;
-    let c = diff.to_i64().ok()?;
+    let c = diff.as_i64()?;
     (c >= 0).then_some(c)
 }
 

--- a/pulse/src/ops/array/concat.rs
+++ b/pulse/src/ops/array/concat.rs
@@ -70,13 +70,13 @@ fn pulsify_along_concat_axis(
     let before_len: usize = source_facts[..stream_input_ix]
         .iter()
         .map(|f| f.shape[axis].to_usize())
-        .collect::<TractResult<Vec<_>>>()?
+        .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .sum();
     let after_len: usize = source_facts[stream_input_ix + 1..]
         .iter()
         .map(|f| f.shape[axis].to_usize())
-        .collect::<TractResult<Vec<_>>>()?
+        .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .sum();
 

--- a/tensorflow/src/ops/nn/dw_conv2d.rs
+++ b/tensorflow/src/ops/nn/dw_conv2d.rs
@@ -45,7 +45,7 @@ impl Expansion for DepthwiseConv2d {
             let img = self.data_format.shape(img)?;
             s.equals(&inputs[1].shape[2], &inputs[0].shape[img.c_axis()])?;
             s.equals(&outputs[0].shape[img.n_axis().unwrap()], img.n_dim().unwrap())?;
-            if let Ok(ker) = ker.iter().map(|d| d.to_usize()).collect::<TractResult<TVec<_>>>() {
+            if let Ok(ker) = ker.iter().map(|d| d.to_usize()).collect::<Result<TVec<_>, _>>() {
                 let output_shape = self.padding.compute(
                     img.hw_dims(),
                     &ker[0..2],

--- a/tensorflow/src/ops/random/random_uniform.rs
+++ b/tensorflow/src/ops/random/random_uniform.rs
@@ -134,7 +134,7 @@ impl EvalOp for TypedRandomUniform {
     }
 
     fn eval(&self, _inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        let shape = self.shape.iter().map(|d| d.to_usize()).collect::<TractResult<TVec<_>>>()?;
+        let shape = self.shape.iter().map(|d| d.to_usize()).collect::<Result<TVec<_>, _>>()?;
         match self.t {
             DatumType::F32 => Ok(tvec!(make_f32(&shape, self.seed1, self.seed2)?)),
             dt => bail!("RandomUniform not implemented for {:?}", dt),

--- a/tflite/src/ops/array.rs
+++ b/tflite/src/ops/array.rs
@@ -244,7 +244,7 @@ fn ser_axisop(
                 .shape
                 .iter()
                 .map(|x| x.to_i32())
-                .collect::<TractResult<Vec<i32>>>()?;
+                .collect::<Result<Vec<i32>, _>>()?;
             let new_shape = builder.fb().create_vector(&new_shape);
             let options = ReshapeOptions::create(
                 builder.fb(),
@@ -269,7 +269,7 @@ fn ser_broadcast_to(
     let mut inputs = tvec!(builder.outlets_to_tensors[&node.inputs[0]]);
     let output = builder.outlets_to_tensors[&node.id.into()];
     let shape =
-        node.outputs[0].fact.shape.iter().map(|x| x.to_i32()).collect::<TractResult<Vec<i32>>>()?;
+        node.outputs[0].fact.shape.iter().map(|x| x.to_i32()).collect::<Result<Vec<i32>, _>>()?;
     let shape = builder
         .write_fact(format!("{}.shape", node.name), TypedFact::try_from(tensor1(&shape))?)?;
     inputs.push(shape);


### PR DESCRIPTION
TDim::simplify used eval_to_i64 purely as a constant-fold check, discarding the error, but on any symbolic dim that error formatted the whole subtree into a String and, when RUST_BACKTRACE is set, made anyhow capture a full backtrace, making simplify several times slower. Add a non-erroring maybe_eval_to_i64 returning Option and use it there, and switch the sibling to_i64().ok() assertion/compatibility checks to as_i64().