### PR TITLE
bench: build the dinghy boards against glibc-stretch, not musl

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -207,10 +207,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - triple: aarch64-unknown-linux-musl
-            rustc_triple: aarch64-unknown-linux-musl
-          - triple: armv7-unknown-linux-musl
-            rustc_triple: armv7-unknown-linux-musleabihf
+          - triple: aarch64-unknown-linux-gnu-stretch
+            rustc_triple: aarch64-unknown-linux-gnu
+          - triple: armv7-unknown-linux-gnueabihf-stretch
+            rustc_triple: armv7-unknown-linux-gnueabihf
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -221,7 +221,9 @@ jobs:
           key: ${{ matrix.triple }}
           cache-directories: .cross-cache/target
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # Static musl CLI for the board: bench-suite on, cuda/tflite off; SKIP_QEMU_TEST builds only.
+      # glibc-stretch CLI for the board (matches the production devices), cross-built in the
+      # debian-stretch container: bench-suite on, cuda/tflite off; SKIP_QEMU_TEST builds only.
+      # TRACT_CLI_FEATURES suppresses the stretch leg's default cuda forcing (see cross.sh).
       - run: >-
           SKIP_QEMU_TEST=skip SUDO=sudo CARGO_TARGET_DIR=.cross-cache/target
           TRACT_CLI_FEATURES=onnx,tf,pulse,pulse-opl,transformers,extra,bench-suite
@@ -246,19 +248,19 @@ jobs:
       matrix:
         include:
           - device: cortex-a55
-            triple: aarch64-unknown-linux-musl
+            triple: aarch64-unknown-linux-gnu-stretch
             runner: dinghy-sidekick-a55
             dinghy_target: dinghy-a55
           - device: cortex-a53
-            triple: aarch64-unknown-linux-musl
+            triple: aarch64-unknown-linux-gnu-stretch
             runner: dinghy-sidekick-a53
             dinghy_target: dinghy-a53
           - device: cortex-a7
-            triple: armv7-unknown-linux-musl
+            triple: armv7-unknown-linux-gnueabihf-stretch
             runner: dinghy-sidekick-a7
             dinghy_target: dinghy-a7
           - device: cortex-a9
-            triple: armv7-unknown-linux-musl
+            triple: armv7-unknown-linux-gnueabihf-stretch
             runner: dinghy-sidekick-a9
             dinghy_target: dinghy-a9
     steps:
@@ -313,13 +315,13 @@ jobs:
       matrix:
         include:
           - device: cortex-a55
-            triple: aarch64-unknown-linux-musl
+            triple: aarch64-unknown-linux-gnu-stretch
           - device: cortex-a53
-            triple: aarch64-unknown-linux-musl
+            triple: aarch64-unknown-linux-gnu-stretch
           - device: cortex-a7
-            triple: armv7-unknown-linux-musl
+            triple: armv7-unknown-linux-gnueabihf-stretch
           - device: cortex-a9
-            triple: armv7-unknown-linux-musl
+            triple: armv7-unknown-linux-gnueabihf-stretch
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -281,7 +281,15 @@ jobs:
         run: |
           chmod +x tract-cli/tract
           mkdir -p result
-          if CARGO_PKG_NAME=tract cargo-dinghy -d "$DINGHY_TARGET" runner \
+          # dinghy otherwise copies the whole checkout to the board (source + every committed
+          # test model), which overflows the small armv7 boards and fails the rsync deploy.
+          # Scope the copy to just the bench manifest with a gitignore-style allowlist; the exe
+          # is copied separately. Written into the ephemeral work folder, never committed: a
+          # repo .dinghyignore would strip fixtures from everyone else's `cargo dinghy test`.
+          printf '%s\n' '/*' '!/.travis/' '/.travis/*' '!/.travis/benches.toml' > .dinghyignore
+          # --cleanup also tears the deploy down afterwards. It must precede -d: after -d
+          # consumes its value cargo-dinghy misparses a later -c and bails with -Zscript.
+          if CARGO_PKG_NAME=tract cargo-dinghy --cleanup -d "$DINGHY_TARGET" runner \
                ./tract-cli/tract -- bench-suite \
                --manifest .travis/benches.toml --skip-runtimes --no-cache --output - $SAMPLES \
                --base-url '${TRACT_BENCH_BASE_URL}' --cpu-governor '${TRACT_BENCH_CPU_GOVERNOR}' \

--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -89,8 +89,11 @@ case "$PLATFORM" in
         # aarch64 stretch bench targets Jetson-class boxes that ship with CUDA 12;
         # the default CUDA 13 cudarc binding wouldn't run there (cudart symbol
         # rename across the 12/13 boundary).  Force cuda-12000 for that build only.
+        # The Jetson leg wants cuda-12000; the dinghy boards reuse the same aarch64 stretch
+        # platform but pass an explicit TRACT_CLI_FEATURES (no cuda), so only force cuda when
+        # the caller has not chosen its own feature set.
         CUDA_FEATURE_ENV=""
-        if [ "$PLATFORM" = "aarch64-unknown-linux-gnu-stretch" ]
+        if [ "$PLATFORM" = "aarch64-unknown-linux-gnu-stretch" ] && [ -z "$TRACT_CLI_FEATURES" ]
         then
             CUDA_FEATURE_ENV="-e TRACT_CUDA_FEATURE=cuda-12000"
         fi
@@ -115,6 +118,7 @@ case "$PLATFORM" in
             -e CARGO_NET_RETRY \
             -e CARGO_HTTP_MULTIPLEXING \
             -e CARGO_REGISTRIES_CRATES_IO_PROTOCOL \
+            -e TRACT_CLI_FEATURES \
             ${CARGO_TARGET_DIR:+-e CARGO_TARGET_DIR=$CARGO_TARGET_DIR} \
             -e PLATFORM=$INNER_PLATFORM $CUDA_FEATURE_ENV "$STRETCH_TAG" \
             ./.travis/cross.sh


### PR DESCRIPTION
The dinghy board fleet was cross-built as static musl, which drifts from the glibc production devices the boards are meant to mirror. Point the build/bench/append matrices at the aarch64/armv7 -stretch platforms (cross-built in the debian-stretch container, as the Jetson leg already does), forward TRACT_CLI_FEATURES into that container so the board binary keeps bench-suite, and gate the stretch leg's cuda forcing on an unset TRACT_CLI_FEATURES so the GPU-less boards don't inherit the Jetson's cuda feature set.