### PR TITLE
metal: add missing bool instantiations for BitAnd/BitOr/BitXor

### DIFF
--- a/metal/src/kernels/bin_ops.metal
+++ b/metal/src/kernels/bin_ops.metal
@@ -309,6 +309,9 @@ INSTANTIATE_INTEGER(bitor, BitOr)
 INSTANTIATE_INTEGER(bitxor, BitXor)
 INSTANTIATE_BIN_OP(and, And, bool, bool, bool)
 INSTANTIATE_BIN_OP(or, Or, bool, bool, bool)
+INSTANTIATE_BIN_OP(bitand, BitAnd, bool, bool, bool)
+INSTANTIATE_BIN_OP(bitor, BitOr, bool, bool, bool)
+INSTANTIATE_BIN_OP(bitxor, BitXor, bool, bool, bool)
 
 INSTANTIATE_1ROW_BIN_OP()
 

--- a/metal/src/tests.rs
+++ b/metal/src/tests.rs
@@ -523,4 +523,33 @@ mod tests {
         println!("  attention-portion GAIN explode/fused = {:.2}x", et / ft);
         Ok(())
     }
+
+    #[test]
+    fn bool_bitor_matches_cpu_on_metal() -> TractResult<()> {
+        use tract_core::ops::logic::bitor;
+        let fact = bool::fact(tvec![TDim::from(4i64), TDim::from(8i64)]);
+        let mut model = TypedModel::default();
+        let a = model.add_source("a", fact.clone())?;
+        let b = model.add_source("b", fact)?;
+        let out = model.wire_node("bitor", bitor(), &[a, b])?;
+        model.select_output_outlets(&out)?;
+
+        let mk = |seed: i64| -> TractResult<TValue> {
+            let data: Vec<bool> = (0..32).map(|i| (i + seed) % 2 == 0).collect();
+            Ok(Tensor::from_shape(&[4, 8], &data)?.into_tvalue())
+        };
+        let (at, bt) = (mk(0)?, mk(1)?);
+
+        let cpu = model.clone().into_runnable()?;
+        let cpu_out = cpu.run(tvec![at.clone(), bt.clone()])?;
+
+        let metal = MetalTransform::default().transform_into(model)?;
+        let metal_out = metal.into_runnable()?.run(tvec![at, bt])?;
+
+        cpu_out[0]
+            .clone()
+            .into_tensor()
+            .close_enough(&metal_out[0].clone().into_tensor(), Approximation::Exact)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
The Metal shader only instantiated \`BitAnd\`/\`BitOr\`/\`BitXor\` for integer types, while \`is_supported()\` claims bool support for them too — so any bool bitwise op (e.g. combining causal masks) fails at dispatch with a missing-function error. This adds the bool variants, matching the existing \`And\`/\`Or\` pattern already in the file.

🍍