### PR TITLE
metal: honor PrefixMatMul operating_dt in the GEMM lowering

### DIFF
--- a/metal/src/tests.rs
+++ b/metal/src/tests.rs
@@ -361,6 +361,54 @@ mod tests {
         Ok(())
     }
 
+    // A f16 matmul asking for f32 accumulation: the products leave f16 range even
+    // though the inputs (and the f32 result) are ordinary. The metal GEMMs compute in
+    // their input dtype, so the f16 operands must be cast up or the dot saturates to
+    // inf -- which is how an Sdpa scores matmul turns a whole attention head to NaN.
+    #[test]
+    fn f16_matmul_honors_f32_operating_dt() -> TractResult<()> {
+        let (m, k, n) = (8usize, 128usize, 8usize);
+        let fact = |rows: usize| {
+            f16::fact(tvec![TDim::from(1i64), TDim::from(rows as i64), TDim::from(k as i64)])
+        };
+        let mut model = TypedModel::default();
+        let a = model.add_source("a", fact(m))?;
+        let b = model.add_source("b", fact(n))?;
+        let out = model.wire_node(
+            "matmul",
+            PrefixMatMul {
+                transpose_a: false,
+                transpose_b: true,
+                transpose_c: false,
+                quantize_output: None,
+                operating_dt: Some(DatumType::F32),
+            },
+            &[a, b],
+        )?;
+        model.select_output_outlets(&out)?;
+
+        // 60 * 400 * 128 = 3_072_000, well past f16's 65504 ceiling.
+        let mk = |rows: usize, v: f32| -> TractResult<TValue> {
+            let data: Vec<f16> = (0..rows * k).map(|_| f16::from_f32(v)).collect();
+            Ok(Tensor::from_shape(&[1, rows, k], &data)?.into_tvalue())
+        };
+        let (at, bt) = (mk(m, 60.0)?, mk(n, 400.0)?);
+
+        let cpu_out = model.clone().into_runnable()?.run(tvec![at.clone(), bt.clone()])?;
+        let metal = MetalTransform::default().transform_into(model)?;
+        let metal_out = metal.into_runnable()?.run(tvec![at, bt])?;
+
+        let metal_t = metal_out[0].clone().into_tensor();
+        let seen = metal_t.cast_to::<f32>()?;
+        let view = seen.view();
+        assert!(
+            view.as_slice::<f32>()?.iter().all(|x| x.is_finite()),
+            "metal f16 matmul saturated to inf: {seen:?}"
+        );
+        cpu_out[0].clone().into_tensor().close_enough(&metal_t, Approximation::Approximate)?;
+        Ok(())
+    }
+
     // Model-level A/B through the metal transform: a fused Sdpa (3 inputs ->
     // MetalMfaSdpa) vs the explode path (4-input Sdpa w/ neutral zero mask ->
     // gemm+softmax+gemm). The zero mask is neutral so both compute the same attn.

--- a/metal/src/transform.rs
+++ b/metal/src/transform.rs
@@ -360,7 +360,27 @@ fn convert_matmul_to_metal(
     op: &PrefixMatMul,
     gemm_impl: Option<MetalGemmImplKind>,
 ) -> TractResult<TVec<OutletId>> {
-    let mut input_facts = model.node_input_facts(node.id)?;
+    let mut owned_facts: TVec<TypedFact> =
+        model.node_input_facts(node.id)?.iter().map(|f| (*f).clone()).collect();
+
+    // The metal GEMMs accumulate in their input dtype, so a matmul asking for a wider
+    // `operating_dt` than its inputs must have them cast up: an SDPA scores matmul is
+    // wired f32 precisely because its f16 products can leave f16 range, and a f16 GEMM
+    // would saturate them to inf.
+    if let Some(acc) = op.operating_dt {
+        for i in 0..2 {
+            let dt = owned_facts[i].datum_type;
+            if dt.is_float() && acc.is_float() && dt.size_of() < acc.size_of() {
+                inputs[i] = target.wire_node(
+                    format!("{}.cast_acc_{i}", node.name),
+                    metal_cast_new(acc).with_context(|| format!("No metal cast to {acc:?}"))?,
+                    &[inputs[i]],
+                )?[0];
+                owned_facts[i].datum_type = acc;
+            }
+        }
+    }
+    let mut input_facts: TVec<&TypedFact> = owned_facts.iter().collect();
 
     let resolved_gemm_impl = resolve_gemm_impl(gemm_impl, input_facts.clone())?;
     if matches!(resolved_gemm_impl, MetalGemmImplKind::Mlx | MetalGemmImplKind::Mfa)


### PR DESCRIPTION
`convert_matmul_to_metal` built the metal GEMM from the input dtypes and ignored `operating_dt`, so an f16 matmul that asked for f32 accumulation ran in f16 — its products saturated to `inf` and the softmax turned a whole attention head to NaN. This casts the float operands up to `operating_dt` before the GEMM.

Found on `Qwen2.5-7B-Instruct-q40ef16`: its SDPA scores matmul is wired `acc_datum_type=f32` on purpose (true `max|Q·Kᵀ|` ≈ 91k, past f16's 65504 ceiling), but Metal ran it in f16 → all-NaN logits on the last block. Qwen3-1.7B is unaffected because its linears use f16 operating_dt.

Test `f16_matmul_honors_f32_operating_dt` reproduces the all-`inf` output without the fix and passes with it; the full `tract-metal` suite is otherwise unchanged.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)