### PR TITLE
core: don't fuse AddUnicast into a native block-quant matmul

### DIFF
--- a/core/src/ops/matmul/optimized.rs
+++ b/core/src/ops/matmul/optimized.rs
@@ -568,6 +568,13 @@ impl TypedOp for OptMatMul {
                 let other_fact = patch.outlet_fact(other_input)?;
 
                 if other_fact.shape == self.c_fact.shape {
+                    // A native block-quant AddMatMul chained with a fused AddUnicast in the
+                    // same kernel call miscomputes on some kernels (that pairing has no direct
+                    // test coverage). Leave the add as its own node; it is always correct
+                    // unfused, and this pairing only arises for a sliced quant GEMV.
+                    if self.consumes_native_block_quant() {
+                        return Ok(None);
+                    }
                     let other_storage = unsafe { self.mmm[0].c_view(self.c_m_axis, self.c_n_axis) };
                     let mapping =
                         MapOutputAxisToInput((0..other_fact.rank()).map(|x| (x, x)).collect());
@@ -596,6 +603,21 @@ impl TypedOp for OptMatMul {
 }
 
 impl OptMatMul {
+    /// Whether any of the matmul kernels consumes a block-quant weight natively
+    /// (i.e. straight from its packed form, with no panel extractor to a plain type).
+    fn consumes_native_block_quant(&self) -> bool {
+        self.micro_ops.iter().any(|op| {
+            let ProtoFusedSpec::AddMatMul { packings, .. } = op else { return false };
+            packings.iter().zip(self.mmm.iter()).any(|((packing, extractor), mmm)| {
+                extractor.is_none()
+                    && matches!(
+                        mmm.packings()[*packing].0.precursor(),
+                        tract_linalg::WeightType::BlockQuant(_)
+                    )
+            })
+        })
+    }
+
     pub fn new(
         mmm: Vec<Box<dyn MatMatMul>>,
         mode_picker: ModePicker,


### PR DESCRIPTION
`OptMatMul::fuse` folds a following same-shape `Add` into the matmul as a fused `AddUnicast`. When the matmul consumes a block-quant weight natively (no panel extractor), that chain — `AddMatMul → AddUnicast → Store` in one kernel call — miscomputes and saturates the output to `inf`, even with finite, contiguous inputs. This gates the AddUnicast fast-path off for native block-quant matmuls, leaving the residual add as its own (correct) node.

Found on `Qwen2.5-7B-Instruct-q40ef16`: `PushSliceUp` produces a sliced `n=1` GEMV over the last token at the tail, the residual add fuses into it (`arm64simd_mmm_f32_32x1_gen`, q40 packing), and the last block's logits go NaN. With the fusion disabled the whole model decodes correctly (token-identical to Metal); llama3.2-1b / Qwen3-1.7b / openelm are unaffected.

The kernels are individually covered — `AddMatMul` alone (`packed_packed`) and `AddUnicast` after `Clear` (`add_unicast_non_contiguous`) — but not the two chained, which is the real gap. The proper follow-up is to add the `AddMatMul(native block-quant) → AddUnicast` chain to the linalg fuse proptests and fix the kernel; this change is the safe correctness guard in the meantime.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)