### PR TITLE
ci: repin dtolnay/rust-toolchain in pydoc.yml to a live stable commit

### DIFF
--- a/.github/workflows/pydoc.yml
+++ b/.github/workflows/pydoc.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
The previous SHA had fallen off the stable branch's history (dtolnay/ rust-toolchain rewrites it on every Rust release), so it read as an impostor-commit and a version-comment mismatch to zizmor.