### PR TITLE
ci: stop SHA-pinning dtolnay/rust-toolchain@stable in pydoc.yml

### DIFF
--- a/.github/workflows/pydoc.yml
+++ b/.github/workflows/pydoc.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses]
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
dtolnay/rust-toolchain rewrites the `stable` branch to a new commit on every Rust release, so any SHA pinned to it eventually falls out of the branch's history and reads to zizmor as an impostor commit / version mismatch. Track the branch directly instead and suppress the resulting unpinned-uses finding inline, so this stops needing a manual repin every ~6 weeks.