### PR TITLE
Add /ci examples and /ci bench slash-command targets

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -1,9 +1,10 @@
 name: Bench comment
 
-# Trampoline for the Bench report. The Bench workflow runs on `pull_request`, which gets
-# a read-only token on fork PRs and so cannot comment. It instead uploads the rendered
-# comparison as the `bench-comment` artifact; this workflow runs on `workflow_run` (base
-# context, write token) and posts it — working for fork and same-repo PRs alike.
+# Trampoline for the Bench report. The Bench workflow's automatic `pull_request` trigger
+# gets a read-only token on fork PRs and so cannot comment (a `/ci bench` workflow_dispatch
+# run, by contrast, always has a write token and comments directly, fork or not). It instead
+# uploads the rendered comparison as the `bench-comment` artifact; this workflow runs on
+# `workflow_run` (base context, write token) and posts it.
 #
 # Security: the target PR is resolved from the triggering run's head SHA, never from
 # artifact contents, so a fork cannot redirect the comment at another issue. The artifact

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,6 +10,11 @@ on:
   schedule:
     - cron: '0 4 * * *'   # after large-models (3am) so they don't fight for the self-hosted boxes
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional PR number to bench (from fork ok). Leave empty to run on selected branch."
+        required: false
+        type: number
   pull_request:
     paths-ignore:
       - '**/*.md'
@@ -20,8 +25,8 @@ permissions:
 
 concurrency:
   # cancel superseded PR pushes (escape hatch); nightly keys on run_id so it never cancels
-  group: bench-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: bench-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event.inputs.pr_number != '' }}
 
 jobs:
   prepare:
@@ -30,19 +35,55 @@ jobs:
       enabled: ${{ steps.gate.outputs.enabled }}
       ref: ${{ steps.gate.outputs.ref }}
       day: ${{ steps.gate.outputs.day }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      is_pr: ${{ steps.gate.outputs.is_pr }}
+      same_repo: ${{ steps.gate.outputs.same_repo }}
     steps:
+      # Resolves this run's target ref and whether it should behave like a PR run
+      # (compare + comment) or a reference run (append to bench-data): a manual
+      # `/ci bench` dispatch on a PR must be treated as a PR run even though its
+      # event_name is workflow_dispatch, or its numbers would get pushed to
+      # bench-data as if it were a nightly/main reference point.
       - id: gate
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BENCH_ENABLED: ${{ vars.BENCH_ENABLED }}
-        run: |
-          if [ "$BENCH_ENABLED" = "false" ]; then
-            echo "::notice::bench disabled via BENCH_ENABLED repo variable"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          fi
-          echo "ref=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
-          echo "day=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+        with:
+          script: |
+            if (process.env.BENCH_ENABLED === 'false') {
+              core.notice('bench disabled via BENCH_ENABLED repo variable');
+              core.setOutput('enabled', 'false');
+            } else {
+              core.setOutput('enabled', 'true');
+            }
+            core.setOutput('day', new Date().toISOString().slice(0, 10));
+
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+            if (context.eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+              core.setOutput('is_pr', 'true');
+              core.setOutput('pr_number', String(pr.number));
+              core.setOutput('same_repo', String(pr.head.repo.full_name === baseRepo));
+              core.setOutput('ref', pr.head.sha);
+              return;
+            }
+            const prInput = context.payload.inputs?.pr_number;
+            if (!prInput) {
+              core.setOutput('is_pr', 'false');
+              core.setOutput('pr_number', '');
+              core.setOutput('same_repo', 'true');
+              core.setOutput('ref', process.env.GITHUB_SHA);
+              return;
+            }
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(prInput),
+            });
+            core.setOutput('is_pr', 'true');
+            core.setOutput('pr_number', String(prInput));
+            core.setOutput('same_repo', String(pr.data.head.repo.full_name === baseRepo));
+            core.setOutput('ref', pr.data.head.sha);
 
   build:
     needs: prepare
@@ -143,12 +184,12 @@ jobs:
             --bench-data bench-ref \
             --thresholds .travis/bench-thresholds.toml \
             --triple "$TRIPLE" --device "$DEVICE" \
-            ${{ github.event_name != 'pull_request' && '--samples 5' || '' }} \
+            ${{ needs.prepare.outputs.is_pr != 'true' && '--samples 5' || '' }} \
             ${{ matrix.bench_args }}        # produces ./metrics
 
       # --- nightly / dispatch: append the row to bench-data ---
       - name: Checkout bench-data
-        if: github.event_name != 'pull_request'
+        if: needs.prepare.outputs.is_pr != 'true'
         # zizmor: ignore[artipacked] credentials are needed to push the row back to
         # bench-data; this checkout is never uploaded as an artifact.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -157,7 +198,7 @@ jobs:
           path: bench-data
           fetch-depth: 1
       - name: Append and push
-        if: github.event_name != 'pull_request'
+        if: needs.prepare.outputs.is_pr != 'true'
         env:
           DEVICE: ${{ matrix.target }}
           TRIPLE: ${{ matrix.triple }}
@@ -180,7 +221,7 @@ jobs:
 
       # --- PR: emit this device's result for the fan-in report job ---
       - name: Stage PR result
-        if: github.event_name == 'pull_request'
+        if: needs.prepare.outputs.is_pr == 'true'
         env:
           DEVICE: ${{ matrix.target }}
           TRIPLE: ${{ matrix.triple }}
@@ -189,7 +230,7 @@ jobs:
           cp metrics result/metrics
           printf '{"device":"%s","triple":"%s"}\n' "$DEVICE" "$TRIPLE" > result/meta.json
       - name: Upload PR result
-        if: github.event_name == 'pull_request'
+        if: needs.prepare.outputs.is_pr == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-result-${{ matrix.target }}
@@ -277,7 +318,7 @@ jobs:
           DINGHY_TARGET: ${{ matrix.dinghy_target }}
           DEVICE: ${{ matrix.device }}
           TRIPLE: ${{ matrix.triple }}
-          SAMPLES: ${{ github.event_name != 'pull_request' && '--samples 5' || '' }}
+          SAMPLES: ${{ needs.prepare.outputs.is_pr != 'true' && '--samples 5' || '' }}
         run: |
           chmod +x tract-cli/tract
           mkdir -p result
@@ -314,7 +355,7 @@ jobs:
     # always() (like the report job) so a cancelled/failed device leg (e.g. one board that
     # timed out) still lets the boards that did finish append; each leg no-ops when its own
     # result artifact is absent.
-    if: ${{ always() && github.event_name != 'pull_request' && needs.prepare.outputs.enabled == 'true' && vars.BENCH_DINGHY_ENABLED == 'true' }}
+    if: ${{ always() && needs.prepare.outputs.is_pr != 'true' && needs.prepare.outputs.enabled == 'true' && vars.BENCH_DINGHY_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -377,7 +418,7 @@ jobs:
     needs: [ prepare, build, bench, bench-dinghy ]
     # always() (not !cancelled()) so a cancelled/failed device leg still reports from the rest;
     # bench-report writes no file with nothing to compare, so a fully-cancelled run posts nothing.
-    if: ${{ always() && github.event_name == 'pull_request' && needs.prepare.outputs.enabled == 'true' }}
+    if: ${{ always() && needs.prepare.outputs.is_pr == 'true' && needs.prepare.outputs.enabled == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -409,14 +450,16 @@ jobs:
           chmod +x tract-cli/tract
           tract-cli/tract bench-report --results results --bench-data bench-data \
             --thresholds .travis/bench-thresholds.toml --pr-sha "$PR_SHA" --out pr-comment.md
-      # Same-repo PRs have a write token: post directly here. A fresh comment per run (like the
-      # fork trampoline) so the PR thread keeps the full history in chronological order instead
-      # of overwriting the previous result.
-      - name: Comment on PR (same-repo)
-        if: ${{ hashFiles('pr-comment.md') != '' && github.event.pull_request.head.repo.full_name == github.repository }}
+      # Only an automatic `pull_request` event on a fork gets a read-only token; every other
+      # trigger (same-repo pull_request, or any workflow_dispatch — including /ci bench,
+      # which always runs with a write token regardless of the target PR's fork status) can
+      # post directly. A fresh comment per run (like the fork trampoline) so the PR thread
+      # keeps the full history in chronological order instead of overwriting the previous result.
+      - name: Comment on PR (direct)
+        if: ${{ hashFiles('pr-comment.md') != '' && (github.event_name != 'pull_request' || needs.prepare.outputs.same_repo == 'true') }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
         with:
           script: |
             const fs = require('fs');
@@ -425,12 +468,13 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo, issue_number, body,
             });
-      # Fork PRs get a read-only token and can't comment, so hand the rendered comment + target PR
-      # to the bench-comment trampoline (workflow_run, base context, write token) to post instead.
+      # Fork PRs on the automatic pull_request event get a read-only token and can't comment,
+      # so hand the rendered comment + target PR to the bench-comment trampoline (workflow_run,
+      # base context, write token) to post instead.
       - name: Stage comment for the trampoline (fork PRs)
-        if: ${{ hashFiles('pr-comment.md') != '' && github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ hashFiles('pr-comment.md') != '' && github.event_name == 'pull_request' && needs.prepare.outputs.same_repo != 'true' }}
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
         run: |
           mkdir -p bench-comment
           mv pr-comment.md bench-comment/

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,6 +8,10 @@ name: CI slash command
 #   /ci wheels         -> Python wheels            (wheels.yml)
 #   /ci python         -> alias of wheels
 #   /ci py             -> alias of wheels
+#   /ci examples       -> Examples                 (examples.yml)
+#   /ci ex             -> alias of examples
+#   /ci bench          -> Bench                    (bench.yml)
+#   /ci benches        -> alias of bench
 # Only commenters with write access can trigger (enforced by slash-command-dispatch).
 
 on:
@@ -54,13 +58,17 @@ jobs:
               'wheels': 'wheels.yml',
               'python': 'wheels.yml',
               'py': 'wheels.yml',
+              'examples': 'examples.yml',
+              'ex': 'examples.yml',
+              'bench': 'bench.yml',
+              'benches': 'bench.yml',
             };
             const workflow = map[target];
             if (!workflow) {
               const usage = [
                 `Unknown \`/ci\` target: \`${target || '(none)'}\`.`,
                 '',
-                'Usage: `/ci full`, `/ci large-models` (aliases: `large`, `llm`), or `/ci wheels` (aliases: `python`, `py`).',
+                'Usage: `/ci full`, `/ci large-models` (aliases: `large`, `llm`), `/ci wheels` (aliases: `python`, `py`), `/ci examples` (alias: `ex`), or `/ci bench` (alias: `benches`).',
               ].join('\n');
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron:  '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Optional PR number to test (from fork ok). Leave empty to run on selected branch."
+        required: false
+        type: number
 
 env:
   CARGO_INCREMENTAL: false
@@ -16,14 +21,55 @@ permissions:
   contents: read
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    outputs:
+      test_ref: ${{ steps.set.outputs.test_ref }}
+      pr_number: ${{ steps.set.outputs.pr_number }}
+    steps:
+      - id: set
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          STATUS_CONTEXT: "CI / examples"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const prInput = context.payload.inputs?.pr_number;
+            core.setOutput('pr_number', prInput ? String(prInput) : '');
+            if (!prInput) {
+              core.setOutput('test_ref', process.env.GITHUB_SHA);
+              return;
+            }
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(prInput),
+            });
+            const sha = pr.data.head.sha;
+            core.setOutput('test_ref', sha);
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: 'pending',
+              context: process.env.STATUS_CONTEXT,
+              target_url: process.env.RUN_URL,
+              description: 'Running',
+            });
+
   examples:
     runs-on: ubuntu-latest
+    needs: prepare
     outputs:
       examples: ${{steps.set-matrix.outputs.examples}}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.test_ref }}
           persist-credentials: false
       - id: set-matrix
         run: |
@@ -32,7 +78,7 @@ jobs:
   example:
     name: ${{ matrix.ex }}
     runs-on: ubuntu-latest
-    needs: examples
+    needs: [ prepare, examples ]
     permissions:
       id-token: write
       contents: read
@@ -44,6 +90,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
         persist-credentials: false
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -69,9 +116,11 @@ jobs:
 
   build-tract-cli:
     runs-on: ubuntu-latest
+    needs: prepare
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.test_ref }}
           persist-credentials: false
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -84,9 +133,11 @@ jobs:
 
   build-tract-cli-macos:
     runs-on: macOS
+    needs: prepare
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.test_ref }}
           persist-credentials: false
       - run: cargo build -p tract-cli --profile opt-no-lto
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -96,12 +147,14 @@ jobs:
 
   gpu-examples:
     runs-on: ubuntu-latest
+    needs: prepare
     outputs:
       examples: ${{steps.set-matrix.outputs.examples}}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.test_ref }}
           persist-credentials: false
       - id: set-matrix
         run: |
@@ -110,7 +163,7 @@ jobs:
   gpu-example:
     name: ${{ matrix.ex }} (CUDA)
     runs-on: cuda-lovelace
-    needs: [gpu-examples, build-tract-cli]
+    needs: [prepare, gpu-examples, build-tract-cli]
     strategy:
       fail-fast: false
       matrix:
@@ -119,6 +172,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
         persist-credentials: false
 
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -139,7 +193,7 @@ jobs:
   gpu-example-metal:
     name: ${{ matrix.ex }} (Metal)
     runs-on: macOS
-    needs: [gpu-examples, build-tract-cli-macos]
+    needs: [prepare, gpu-examples, build-tract-cli-macos]
     strategy:
       fail-fast: false
       matrix:
@@ -148,6 +202,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
         persist-credentials: false
 
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -164,3 +219,55 @@ jobs:
         ./ci-gpu.sh
       env:
         MATRIX_EX: ${{matrix.ex}}
+
+  report:
+    name: Report result to PR
+    needs: [ prepare, examples, example, build-tract-cli, build-tract-cli-macos, gpu-examples, gpu-example, gpu-example-metal ]
+    if: ${{ always() && needs.prepare.outputs.pr_number != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+          PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.prepare.outputs.test_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS_CONTEXT: "CI / examples"
+        with:
+          script: |
+            const needs = JSON.parse(process.env.NEEDS);
+            const prNumber = Number(process.env.PR_NUMBER);
+            const sha = process.env.HEAD_SHA;
+            const runUrl = process.env.RUN_URL;
+            const statusContext = process.env.STATUS_CONTEXT;
+            const icon = r => r === 'success' ? '✅' : r === 'skipped' ? '⏭️' : '❌';
+            const jobs = Object.entries(needs).filter(([k]) => k !== 'prepare');
+            const failed = jobs.filter(([, v]) => v.result !== 'success' && v.result !== 'skipped');
+            const state = failed.length ? 'failure' : 'success';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner, repo: context.repo.repo, sha, state,
+              context: statusContext, target_url: runUrl,
+              description: failed.length ? `${failed.length} job(s) failed` : 'All jobs passed',
+            });
+            const marker = `<!-- ${statusContext} -->`;
+            const body = [
+              marker,
+              `### ${icon(state)} ${statusContext}: ${state}`,
+              '',
+              ...jobs.map(([k, v]) => `- ${icon(v.result)} \`${k}\`: ${v.result}`),
+              '',
+              `[View workflow run](${runUrl})`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, per_page: 100,
+            });
+            const prev = comments.find(c => c.body?.includes(marker));
+            if (prev) {
+              await github.rest.issues.updateComment({ owner: context.repo.owner, repo: context.repo.repo, comment_id: prev.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber, body });
+            }


### PR DESCRIPTION
Extended the /ci PR-comment dispatcher (ci-command.yml) to cover the examples and bench workflows, alongside the existing full/large-models/ wheels targets. examples.yml gained the same pr_number input, prepare job (resolves the PR's fork head SHA) and report job (posts a pass/fail PR comment) as full.yml. bench.yml needed more care: it already auto-runs on every pull_request and gates its bench-data-append step on event_name != 'pull_request', so wiring workflow_dispatch naively would have let a manual /ci bench run on a PR fall through to the nightly path and push its numbers into the shared bench-data reference branch. Replaced those event_name checks with a prepare-job is_pr output that treats a PR-targeted workflow_dispatch the same as an automatic pull_request event, and fixed the same-repo/fork comment routing to key off trigger type instead of just fork status, since a workflow_dispatch run always carries a write token regardless of the target PR's origin.