### PR TITLE
perf(linalg): add NEON sigmoid_f16 fallback on non-fp16 arm64

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -104,6 +104,10 @@ name = "sigmoid"
 harness = false
 
 [[bench]]
+name = "sigmoid_f16_arm64"
+harness = false
+
+[[bench]]
 name = "softmax"
 harness = false
 

--- a/linalg/benches/sigmoid_f16_arm64.rs
+++ b/linalg/benches/sigmoid_f16_arm64.rs
@@ -35,7 +35,7 @@ fn sigmoid_f16(c: &mut Criterion) {
         let mut tf = aligned_input(n);
         let sf = unsafe { tf.as_slice_mut_unchecked::<f16>() };
         group.bench_with_input(BenchmarkId::new("neon-f32-roundtrip", n), &(), |b, _| {
-            b.iter(|| tract_linalg::arm64::arm64simd_sigmoid_f16_32n::run(sf, ()))
+            b.iter(|| tract_linalg::arm64::arm64simd_sigmoid_f16_4n::run(sf, ()))
         });
 
         if tract_linalg::arm64::has_fp16() {

--- a/linalg/benches/sigmoid_f16_arm64.rs
+++ b/linalg/benches/sigmoid_f16_arm64.rs
@@ -1,0 +1,53 @@
+// Microbenchmark: arm64 f16 sigmoid across the cache hierarchy.
+// The three sizes span working sets from cache-resident (compute-bound) to
+// larger-than-cache (bandwidth-bound), so the generic-vs-roundtrip comparison
+// holds in both regimes. Exact cache tiers are hardware-specific — these are
+// representative, not calibrated to a particular core.
+// Kernels are called by name to bypass dispatch, which always selects the
+// native fp16 kernel on an fp16-capable core. The f32-roundtrip fallback only
+// uses baseline FCVTL/FCVTN, so it is safe to call on any arm64.
+#![cfg(target_arch = "aarch64")]
+
+use criterion::*;
+use tract_data::prelude::*;
+use tract_linalg::element_wise::ElementWiseKer;
+
+fn aligned_input(n: usize) -> Tensor {
+    let mut t = unsafe { Tensor::uninitialized_aligned::<f16>(&[n], 16).unwrap() };
+    let s = unsafe { t.as_slice_mut_unchecked::<f16>() };
+    for (i, x) in s.iter_mut().enumerate() {
+        *x = f16::from_f32((i as f32 / 10.0).sin() * 5.0);
+    }
+    t
+}
+
+fn sigmoid_f16(c: &mut Criterion) {
+    for n in [1024usize, 32_768, 1_048_576] {
+        let mut group = c.benchmark_group("sigmoid_f16");
+        group.throughput(Throughput::Elements(n as u64));
+
+        let mut tg = aligned_input(n);
+        let sg = unsafe { tg.as_slice_mut_unchecked::<f16>() };
+        group.bench_with_input(BenchmarkId::new("generic", n), &(), |b, _| {
+            b.iter(|| tract_linalg::generic::sigmoid::HSigmoid8::run(sg, ()))
+        });
+
+        let mut tf = aligned_input(n);
+        let sf = unsafe { tf.as_slice_mut_unchecked::<f16>() };
+        group.bench_with_input(BenchmarkId::new("neon-f32-roundtrip", n), &(), |b, _| {
+            b.iter(|| tract_linalg::arm64::arm64simd_sigmoid_f16_8n::run(sf, ()))
+        });
+
+        if tract_linalg::arm64::has_fp16() {
+            let mut tn = aligned_input(n);
+            let sn = unsafe { tn.as_slice_mut_unchecked::<f16>() };
+            group.bench_with_input(BenchmarkId::new("native-fp16", n), &(), |b, _| {
+                b.iter(|| tract_linalg::arm64::arm64fp16_sigmoid_f16_8n::run(sn, ()))
+            });
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(g, sigmoid_f16);
+criterion_main!(g);

--- a/linalg/benches/sigmoid_f16_arm64.rs
+++ b/linalg/benches/sigmoid_f16_arm64.rs
@@ -35,7 +35,7 @@ fn sigmoid_f16(c: &mut Criterion) {
         let mut tf = aligned_input(n);
         let sf = unsafe { tf.as_slice_mut_unchecked::<f16>() };
         group.bench_with_input(BenchmarkId::new("neon-f32-roundtrip", n), &(), |b, _| {
-            b.iter(|| tract_linalg::arm64::arm64simd_sigmoid_f16_8n::run(sf, ()))
+            b.iter(|| tract_linalg::arm64::arm64simd_sigmoid_f16_32n::run(sf, ()))
         });
 
         if tract_linalg::arm64::has_fp16() {

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -509,7 +509,7 @@ pub fn plug(ops: &mut Ops) {
         ops.mul_by_scalar_f16 = Box::new(|| arm64fp16_mul_by_scalar_f16_32n::ew());
     } else {
         log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 activated");
-        ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_32n::ew());
+        ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_4n::ew());
     }
     #[cfg(any(target_os = "macos", all(target_os = "ios", feature = "apple-amx-ios")))]
     {

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -509,7 +509,7 @@ pub fn plug(ops: &mut Ops) {
         ops.mul_by_scalar_f16 = Box::new(|| arm64fp16_mul_by_scalar_f16_32n::ew());
     } else {
         log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 activated");
-        ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_8n::ew());
+        ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_32n::ew());
     }
     #[cfg(any(target_os = "macos", all(target_os = "ios", feature = "apple-amx-ios")))]
     {

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -508,7 +508,8 @@ pub fn plug(ops: &mut Ops) {
         ops.sum_f16 = Box::new(|| arm64fp16_sum_f16_32n::red());
         ops.mul_by_scalar_f16 = Box::new(|| arm64fp16_mul_by_scalar_f16_32n::ew());
     } else {
-        log::info!("No native fp16 support");
+        log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 activated");
+        ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_8n::ew());
     }
     #[cfg(any(target_os = "macos", all(target_os = "ios", feature = "apple-amx-ios")))]
     {

--- a/linalg/src/arm64/arm64simd.rs
+++ b/linalg/src/arm64/arm64simd.rs
@@ -14,7 +14,7 @@ mod softmax;
 mod sum;
 mod unicast;
 
-pub use act_f16::arm64simd_sigmoid_f16_32n;
+pub use act_f16::arm64simd_sigmoid_f16_4n;
 pub use by_scalar::*;
 pub use gelu::arm64simd_gelu_f32_4n;
 pub use gelu_fused::arm64simd_gelu_f32_4n_fused;

--- a/linalg/src/arm64/arm64simd.rs
+++ b/linalg/src/arm64/arm64simd.rs
@@ -14,7 +14,7 @@ mod softmax;
 mod sum;
 mod unicast;
 
-pub use act_f16::arm64simd_sigmoid_f16_8n;
+pub use act_f16::arm64simd_sigmoid_f16_32n;
 pub use by_scalar::*;
 pub use gelu::arm64simd_gelu_f32_4n;
 pub use gelu_fused::arm64simd_gelu_f32_4n_fused;

--- a/linalg/src/arm64/arm64simd.rs
+++ b/linalg/src/arm64/arm64simd.rs
@@ -1,3 +1,4 @@
+mod act_f16;
 mod by_scalar;
 mod gelu;
 mod gelu_fused;
@@ -13,6 +14,7 @@ mod softmax;
 mod sum;
 mod unicast;
 
+pub use act_f16::arm64simd_sigmoid_f16_8n;
 pub use by_scalar::*;
 pub use gelu::arm64simd_gelu_f32_4n;
 pub use gelu_fused::arm64simd_gelu_f32_4n_fused;

--- a/linalg/src/arm64/arm64simd/act_f16.rs
+++ b/linalg/src/arm64/arm64simd/act_f16.rs
@@ -10,82 +10,108 @@ use tract_data::internal::f16;
 
 const CHUNK: usize = 256;
 
+const _: () = assert!(
+    CHUNK % 32 == 0,
+    "CHUNK must be a multiple of the cvt block width (32) so the conversions stay fully SIMD"
+);
+
 #[repr(C, align(16))]
 struct AlignedScratch([f32; CHUNK]);
 
-/// Convert `src` (f16) into `dst` (f32) via FCVTL/FCVTL2, 8 lanes per iteration.
-/// The 1..8 leftover lanes fall back to scalar. NEON is baseline on aarch64, so
-/// no target-feature gate is needed.
+/// Convert `src` (f16) into `dst` (f32) via FCVTL/FCVTL2, 32 lanes per iteration.
+/// Callers route through the `_32n` kernel, so `n` is a multiple of 32 and the
+/// scalar tail never runs; it stays only to keep the helper total. NEON is
+/// baseline on aarch64, so no target-feature gate is needed.
 #[inline]
 unsafe fn cvt_f16_to_f32(src: &[f16], dst: &mut [f32]) {
     let n = src.len();
     debug_assert!(dst.len() >= n);
-    let chunks = n / 8;
-    if chunks > 0 {
+    let blocks = n / 32;
+    if blocks > 0 {
         unsafe {
             let s = src.as_ptr();
             let d = dst.as_mut_ptr();
-            let c = chunks;
+            let c = blocks;
             std::arch::asm!("
                 2:
-                    ld1    {{v0.8h}}, [{s}], #16
-                    fcvtl  v1.4s, v0.4h
-                    fcvtl2 v2.4s, v0.8h
-                    st1    {{v1.4s, v2.4s}}, [{d}], #32
+                    ld1    {{v0.8h, v1.8h, v2.8h, v3.8h}}, [{s}], #64
+                    fcvtl  v4.4s,  v0.4h
+                    fcvtl2 v5.4s,  v0.8h
+                    fcvtl  v6.4s,  v1.4h
+                    fcvtl2 v7.4s,  v1.8h
+                    fcvtl  v16.4s, v2.4h
+                    fcvtl2 v17.4s, v2.8h
+                    fcvtl  v18.4s, v3.4h
+                    fcvtl2 v19.4s, v3.8h
+                    st1    {{v4.4s, v5.4s, v6.4s, v7.4s}}, [{d}], #64
+                    st1    {{v16.4s, v17.4s, v18.4s, v19.4s}}, [{d}], #64
                     subs   {c}, {c}, #1
                     bne    2b
             ",
             s = inout(reg) s => _,
             d = inout(reg) d => _,
             c = inout(reg) c => _,
-            out("v0") _, out("v1") _, out("v2") _,
+            out("v0") _, out("v1") _, out("v2") _, out("v3") _,
+            out("v4") _, out("v5") _, out("v6") _, out("v7") _,
+            out("v16") _, out("v17") _, out("v18") _, out("v19") _,
             options(nostack),
             );
         }
     }
-    for k in (chunks * 8)..n {
+    for k in (blocks * 32)..n {
         unsafe { *dst.get_unchecked_mut(k) = src.get_unchecked(k).to_f32() };
     }
 }
 
-/// Convert `src` (f32) into `dst` (f16) via FCVTN/FCVTN2, 8 lanes per iteration.
-/// FCVTN rounds to nearest-even under the default FPCR, matching `f16::from_f32`.
+/// Convert `src` (f32) into `dst` (f16) via FCVTN/FCVTN2, 32 lanes per iteration.
+/// Callers route through the `_32n` kernel, so `n` is a multiple of 32 and the
+/// scalar tail never runs; it stays only to keep the helper total. FCVTN rounds
+/// to nearest-even under the default FPCR, matching `f16::from_f32`.
 #[inline]
 unsafe fn cvt_f32_to_f16(src: &[f32], dst: &mut [f16]) {
     let n = src.len();
     debug_assert!(dst.len() >= n);
-    let chunks = n / 8;
-    if chunks > 0 {
+    let blocks = n / 32;
+    if blocks > 0 {
         unsafe {
             let s = src.as_ptr();
             let d = dst.as_mut_ptr();
-            let c = chunks;
+            let c = blocks;
             std::arch::asm!("
                 2:
-                    ld1    {{v1.4s, v2.4s}}, [{s}], #32
-                    fcvtn  v0.4h, v1.4s
-                    fcvtn2 v0.8h, v2.4s
-                    st1    {{v0.8h}}, [{d}], #16
+                    ld1    {{v4.4s, v5.4s, v6.4s, v7.4s}}, [{s}], #64
+                    ld1    {{v16.4s, v17.4s, v18.4s, v19.4s}}, [{s}], #64
+                    fcvtn  v0.4h, v4.4s
+                    fcvtn2 v0.8h, v5.4s
+                    fcvtn  v1.4h, v6.4s
+                    fcvtn2 v1.8h, v7.4s
+                    fcvtn  v2.4h, v16.4s
+                    fcvtn2 v2.8h, v17.4s
+                    fcvtn  v3.4h, v18.4s
+                    fcvtn2 v3.8h, v19.4s
+                    st1    {{v0.8h, v1.8h, v2.8h, v3.8h}}, [{d}], #64
                     subs   {c}, {c}, #1
                     bne    2b
             ",
             s = inout(reg) s => _,
             d = inout(reg) d => _,
             c = inout(reg) c => _,
-            out("v0") _, out("v1") _, out("v2") _,
+            out("v0") _, out("v1") _, out("v2") _, out("v3") _,
+            out("v4") _, out("v5") _, out("v6") _, out("v7") _,
+            out("v16") _, out("v17") _, out("v18") _, out("v19") _,
             options(nostack),
             );
         }
     }
-    for k in (chunks * 8)..n {
+    for k in (blocks * 32)..n {
         unsafe { *dst.get_unchecked_mut(k) = f16::from_f32(*src.get_unchecked(k)) };
     }
 }
 
 ew_impl_wrap!(
     f16,
-    arm64simd_sigmoid_f16_8n,
-    8,
+    arm64simd_sigmoid_f16_32n,
+    32,
     8,
     (),
     #[inline(never)]
@@ -108,7 +134,7 @@ ew_impl_wrap!(
 );
 
 #[cfg(test)]
-pub mod test_arm64simd_sigmoid_f16_8n {
+pub mod test_arm64simd_sigmoid_f16_32n {
     use super::*;
-    sigmoid_frame_tests!(true, f16, arm64simd_sigmoid_f16_8n);
+    sigmoid_frame_tests!(true, f16, arm64simd_sigmoid_f16_32n);
 }

--- a/linalg/src/arm64/arm64simd/act_f16.rs
+++ b/linalg/src/arm64/arm64simd/act_f16.rs
@@ -6,113 +6,158 @@
 //! by converting into an f32 scratch, running the existing f32 kernel, and
 //! converting back — rather than dropping to the generic scalar path.
 
+use std::mem::MaybeUninit;
+
 use tract_data::internal::f16;
 
+/// f32 scratch length for the f16 round-trip, in elements. Kept small so the
+/// scratch stays cache-hot across the three passes over each chunk (convert in,
+/// run the f32 kernel in place, convert out) instead of being sized to fill a
+/// cache level. Must stay a multiple of 4: we call the f32 sigmoid kernel's
+/// `run` directly rather than through `ew()`/`run_with_params`, so nothing
+/// trims a tail — the kernel steps 4 lanes at a time down to a zero count, and
+/// a non-multiple length would run off the scratch. The conversions handle any
+/// length, so nothing else constrains it.
 const CHUNK: usize = 256;
 
 const _: () = assert!(
-    CHUNK % 32 == 0,
-    "CHUNK must be a multiple of the cvt block width (32) so the conversions stay fully SIMD"
+    CHUNK % 4 == 0,
+    "f32 sigmoid kernel steps 4 lanes with no tail; CHUNK must stay a multiple of 4"
 );
 
 #[repr(C, align(16))]
 struct AlignedScratch([f32; CHUNK]);
 
-/// Convert `src` (f16) into `dst` (f32) via FCVTL/FCVTL2, 32 lanes per iteration.
-/// Callers route through the `_32n` kernel, so `n` is a multiple of 32 and the
-/// scalar tail never runs; it stays only to keep the helper total. NEON is
-/// baseline on aarch64, so no target-feature gate is needed.
+/// Convert `src` (f16) into `dst` (f32) via FCVTL/FCVTL2 for any length: a
+/// 32-lane unrolled main loop, an 8-lane fallback loop, then a scalar-step
+/// FCVT loop for the final <8 elements — all in asm, no Rust tail. NEON and
+/// scalar FCVT are baseline on aarch64, so no target-feature gate is needed.
 #[inline]
 unsafe fn cvt_f16_to_f32(src: &[f16], dst: &mut [f32]) {
     let n = src.len();
     debug_assert!(dst.len() >= n);
-    let blocks = n / 32;
-    if blocks > 0 {
-        unsafe {
-            let s = src.as_ptr();
-            let d = dst.as_mut_ptr();
-            let c = blocks;
-            std::arch::asm!("
-                2:
-                    ld1    {{v0.8h, v1.8h, v2.8h, v3.8h}}, [{s}], #64
-                    fcvtl  v4.4s,  v0.4h
-                    fcvtl2 v5.4s,  v0.8h
-                    fcvtl  v6.4s,  v1.4h
-                    fcvtl2 v7.4s,  v1.8h
-                    fcvtl  v16.4s, v2.4h
-                    fcvtl2 v17.4s, v2.8h
-                    fcvtl  v18.4s, v3.4h
-                    fcvtl2 v19.4s, v3.8h
-                    st1    {{v4.4s, v5.4s, v6.4s, v7.4s}}, [{d}], #64
-                    st1    {{v16.4s, v17.4s, v18.4s, v19.4s}}, [{d}], #64
-                    subs   {c}, {c}, #1
-                    bne    2b
-            ",
-            s = inout(reg) s => _,
-            d = inout(reg) d => _,
-            c = inout(reg) c => _,
-            out("v0") _, out("v1") _, out("v2") _, out("v3") _,
-            out("v4") _, out("v5") _, out("v6") _, out("v7") _,
-            out("v16") _, out("v17") _, out("v18") _, out("v19") _,
-            options(nostack),
-            );
-        }
-    }
-    for k in (blocks * 32)..n {
-        unsafe { *dst.get_unchecked_mut(k) = src.get_unchecked(k).to_f32() };
+    unsafe {
+        let s = src.as_ptr();
+        let d = dst.as_mut_ptr();
+        let c32 = n / 32;
+        let c8 = (n % 32) / 8;
+        let c1 = n % 8;
+        std::arch::asm!("
+                cbz    {c32}, 3f
+            2:
+                ld1    {{v0.8h, v1.8h, v2.8h, v3.8h}}, [{s}], #64
+                fcvtl  v4.4s,  v0.4h
+                fcvtl2 v5.4s,  v0.8h
+                fcvtl  v6.4s,  v1.4h
+                fcvtl2 v7.4s,  v1.8h
+                fcvtl  v16.4s, v2.4h
+                fcvtl2 v17.4s, v2.8h
+                fcvtl  v18.4s, v3.4h
+                fcvtl2 v19.4s, v3.8h
+                st1    {{v4.4s, v5.4s, v6.4s, v7.4s}}, [{d}], #64
+                st1    {{v16.4s, v17.4s, v18.4s, v19.4s}}, [{d}], #64
+                subs   {c32}, {c32}, #1
+                bne    2b
+            3:
+                cbz    {c8}, 5f
+            4:
+                ld1    {{v0.8h}}, [{s}], #16
+                fcvtl  v4.4s,  v0.4h
+                fcvtl2 v5.4s,  v0.8h
+                st1    {{v4.4s, v5.4s}}, [{d}], #32
+                subs   {c8}, {c8}, #1
+                bne    4b
+            5:
+                cbz    {c1}, 7f
+            6:
+                ldr    h0, [{s}], #2
+                fcvt   s0, h0
+                str    s0, [{d}], #4
+                subs   {c1}, {c1}, #1
+                bne    6b
+            7:
+        ",
+        s = inout(reg) s => _,
+        d = inout(reg) d => _,
+        c32 = inout(reg) c32 => _,
+        c8 = inout(reg) c8 => _,
+        c1 = inout(reg) c1 => _,
+        out("v0") _, out("v1") _, out("v2") _, out("v3") _,
+        out("v4") _, out("v5") _, out("v6") _, out("v7") _,
+        out("v16") _, out("v17") _, out("v18") _, out("v19") _,
+        options(nostack),
+        );
     }
 }
 
-/// Convert `src` (f32) into `dst` (f16) via FCVTN/FCVTN2, 32 lanes per iteration.
-/// Callers route through the `_32n` kernel, so `n` is a multiple of 32 and the
-/// scalar tail never runs; it stays only to keep the helper total. FCVTN rounds
-/// to nearest-even under the default FPCR, matching `f16::from_f32`.
+/// Convert `src` (f32) into `dst` (f16) via FCVTN/FCVTN2 for any length: a
+/// 32-lane unrolled main loop, an 8-lane fallback loop, then a scalar-step
+/// FCVT loop for the final <8 elements — all in asm, no Rust tail. FCVTN and
+/// scalar FCVT round to nearest-even under the default FPCR, matching
+/// `f16::from_f32`.
 #[inline]
 unsafe fn cvt_f32_to_f16(src: &[f32], dst: &mut [f16]) {
     let n = src.len();
     debug_assert!(dst.len() >= n);
-    let blocks = n / 32;
-    if blocks > 0 {
-        unsafe {
-            let s = src.as_ptr();
-            let d = dst.as_mut_ptr();
-            let c = blocks;
-            std::arch::asm!("
-                2:
-                    ld1    {{v4.4s, v5.4s, v6.4s, v7.4s}}, [{s}], #64
-                    ld1    {{v16.4s, v17.4s, v18.4s, v19.4s}}, [{s}], #64
-                    fcvtn  v0.4h, v4.4s
-                    fcvtn2 v0.8h, v5.4s
-                    fcvtn  v1.4h, v6.4s
-                    fcvtn2 v1.8h, v7.4s
-                    fcvtn  v2.4h, v16.4s
-                    fcvtn2 v2.8h, v17.4s
-                    fcvtn  v3.4h, v18.4s
-                    fcvtn2 v3.8h, v19.4s
-                    st1    {{v0.8h, v1.8h, v2.8h, v3.8h}}, [{d}], #64
-                    subs   {c}, {c}, #1
-                    bne    2b
-            ",
-            s = inout(reg) s => _,
-            d = inout(reg) d => _,
-            c = inout(reg) c => _,
-            out("v0") _, out("v1") _, out("v2") _, out("v3") _,
-            out("v4") _, out("v5") _, out("v6") _, out("v7") _,
-            out("v16") _, out("v17") _, out("v18") _, out("v19") _,
-            options(nostack),
-            );
-        }
-    }
-    for k in (blocks * 32)..n {
-        unsafe { *dst.get_unchecked_mut(k) = f16::from_f32(*src.get_unchecked(k)) };
+    unsafe {
+        let s = src.as_ptr();
+        let d = dst.as_mut_ptr();
+        let c32 = n / 32;
+        let c8 = (n % 32) / 8;
+        let c1 = n % 8;
+        std::arch::asm!("
+                cbz    {c32}, 3f
+            2:
+                ld1    {{v4.4s, v5.4s, v6.4s, v7.4s}}, [{s}], #64
+                ld1    {{v16.4s, v17.4s, v18.4s, v19.4s}}, [{s}], #64
+                fcvtn  v0.4h, v4.4s
+                fcvtn2 v0.8h, v5.4s
+                fcvtn  v1.4h, v6.4s
+                fcvtn2 v1.8h, v7.4s
+                fcvtn  v2.4h, v16.4s
+                fcvtn2 v2.8h, v17.4s
+                fcvtn  v3.4h, v18.4s
+                fcvtn2 v3.8h, v19.4s
+                st1    {{v0.8h, v1.8h, v2.8h, v3.8h}}, [{d}], #64
+                subs   {c32}, {c32}, #1
+                bne    2b
+            3:
+                cbz    {c8}, 5f
+            4:
+                ld1    {{v4.4s, v5.4s}}, [{s}], #32
+                fcvtn  v0.4h, v4.4s
+                fcvtn2 v0.8h, v5.4s
+                st1    {{v0.8h}}, [{d}], #16
+                subs   {c8}, {c8}, #1
+                bne    4b
+            5:
+                cbz    {c1}, 7f
+            6:
+                ldr    s0, [{s}], #4
+                fcvt   h0, s0
+                str    h0, [{d}], #2
+                subs   {c1}, {c1}, #1
+                bne    6b
+            7:
+        ",
+        s = inout(reg) s => _,
+        d = inout(reg) d => _,
+        c32 = inout(reg) c32 => _,
+        c8 = inout(reg) c8 => _,
+        c1 = inout(reg) c1 => _,
+        out("v0") _, out("v1") _, out("v2") _, out("v3") _,
+        out("v4") _, out("v5") _, out("v6") _, out("v7") _,
+        out("v16") _, out("v17") _, out("v18") _, out("v19") _,
+        options(nostack),
+        );
     }
 }
 
 ew_impl_wrap!(
     f16,
-    arm64simd_sigmoid_f16_32n,
-    32,
-    8,
+    arm64simd_sigmoid_f16_4n,
+    4,
+    4,
     (),
     #[inline(never)]
     fn run(buf: &mut [f16], _: ()) {
@@ -120,8 +165,11 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        let mut scratch = AlignedScratch([0f32; CHUNK]);
-        let s = &mut scratch.0;
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the kernel or `cvt_f32_to_f16` reads
+        // it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
         let mut i = 0;
         while i < buf.len() {
             let n = CHUNK.min(buf.len() - i);
@@ -134,7 +182,7 @@ ew_impl_wrap!(
 );
 
 #[cfg(test)]
-pub mod test_arm64simd_sigmoid_f16_32n {
+pub mod test_arm64simd_sigmoid_f16_4n {
     use super::*;
-    sigmoid_frame_tests!(true, f16, arm64simd_sigmoid_f16_32n);
+    sigmoid_frame_tests!(true, f16, arm64simd_sigmoid_f16_4n);
 }

--- a/linalg/src/arm64/arm64simd/act_f16.rs
+++ b/linalg/src/arm64/arm64simd/act_f16.rs
@@ -1,0 +1,114 @@
+//! ARMv8.0 f32-roundtrip f16 activations.
+//!
+//! FEAT_FP16 adds half-precision *arithmetic*; the f16<->f32 conversions
+//! (FCVTL / FCVTN) are baseline ASIMD and always available. A core without
+//! FEAT_FP16 can therefore still reach NEON-f32 throughput on f16 activations
+//! by converting into an f32 scratch, running the existing f32 kernel, and
+//! converting back — rather than dropping to the generic scalar path.
+
+use tract_data::internal::f16;
+
+const CHUNK: usize = 256;
+
+#[repr(C, align(16))]
+struct AlignedScratch([f32; CHUNK]);
+
+/// Convert `src` (f16) into `dst` (f32) via FCVTL/FCVTL2, 8 lanes per iteration.
+/// The 1..8 leftover lanes fall back to scalar. NEON is baseline on aarch64, so
+/// no target-feature gate is needed.
+#[inline]
+unsafe fn cvt_f16_to_f32(src: &[f16], dst: &mut [f32]) {
+    let n = src.len();
+    debug_assert!(dst.len() >= n);
+    let chunks = n / 8;
+    if chunks > 0 {
+        unsafe {
+            let s = src.as_ptr();
+            let d = dst.as_mut_ptr();
+            let c = chunks;
+            std::arch::asm!("
+                2:
+                    ld1    {{v0.8h}}, [{s}], #16
+                    fcvtl  v1.4s, v0.4h
+                    fcvtl2 v2.4s, v0.8h
+                    st1    {{v1.4s, v2.4s}}, [{d}], #32
+                    subs   {c}, {c}, #1
+                    bne    2b
+            ",
+            s = inout(reg) s => _,
+            d = inout(reg) d => _,
+            c = inout(reg) c => _,
+            out("v0") _, out("v1") _, out("v2") _,
+            options(nostack),
+            );
+        }
+    }
+    for k in (chunks * 8)..n {
+        unsafe { *dst.get_unchecked_mut(k) = src.get_unchecked(k).to_f32() };
+    }
+}
+
+/// Convert `src` (f32) into `dst` (f16) via FCVTN/FCVTN2, 8 lanes per iteration.
+/// FCVTN rounds to nearest-even under the default FPCR, matching `f16::from_f32`.
+#[inline]
+unsafe fn cvt_f32_to_f16(src: &[f32], dst: &mut [f16]) {
+    let n = src.len();
+    debug_assert!(dst.len() >= n);
+    let chunks = n / 8;
+    if chunks > 0 {
+        unsafe {
+            let s = src.as_ptr();
+            let d = dst.as_mut_ptr();
+            let c = chunks;
+            std::arch::asm!("
+                2:
+                    ld1    {{v1.4s, v2.4s}}, [{s}], #32
+                    fcvtn  v0.4h, v1.4s
+                    fcvtn2 v0.8h, v2.4s
+                    st1    {{v0.8h}}, [{d}], #16
+                    subs   {c}, {c}, #1
+                    bne    2b
+            ",
+            s = inout(reg) s => _,
+            d = inout(reg) d => _,
+            c = inout(reg) c => _,
+            out("v0") _, out("v1") _, out("v2") _,
+            options(nostack),
+            );
+        }
+    }
+    for k in (chunks * 8)..n {
+        unsafe { *dst.get_unchecked_mut(k) = f16::from_f32(*src.get_unchecked(k)) };
+    }
+}
+
+ew_impl_wrap!(
+    f16,
+    arm64simd_sigmoid_f16_8n,
+    8,
+    8,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f16], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        let mut scratch = AlignedScratch([0f32; CHUNK]);
+        let s = &mut scratch.0;
+        let mut i = 0;
+        while i < buf.len() {
+            let n = CHUNK.min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::arm64simd_sigmoid_f32_4n::run(&mut s[..n], ());
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_arm64simd_sigmoid_f16_8n {
+    use super::*;
+    sigmoid_frame_tests!(true, f16, arm64simd_sigmoid_f16_8n);
+}


### PR DESCRIPTION
On arm64 cores without FEAT_FP16, f16 sigmoid had no SIMD kernel registered and dropped to tract's generic scalar path. It now runs on the existing NEON f32 sigmoid, giving these cores NEON-f32 throughput on f16 models. The native arm64fp16 kernel still takes precedence wherever FEAT_FP16 is present.

> [!NOTE]
> I based this work on what is done in [`linalg/src/x86_64_fma/act_f16.rs`](https://github.com/cverrier/tract/blob/a3997659bf8bcb7e6315e67cc1fc476d8a7b7e09/linalg/src/x86_64_fma/act_f16.rs), so I inlined the Assembly code in a `.rs` file rather than creating a brand new `.S.j2` file for the kernel: consequently, the f16↔f32 conversion uses an intermediate scratch buffer that should always live in L1 cache. The reason I chose this approach is that it avoids code duplication from [`linalg/arm64/arm64simd/arm64simd_sigmoid_f32_4n.S.j2`](https://github.com/cverrier/tract/blob/a3997659bf8bcb7e6315e67cc1fc476d8a7b7e09/linalg/arm64/arm64simd/arm64simd_sigmoid_f32_4n.S.j2). The price to pay is that we need an intermediate buffer in memory (L1, so high-bandwidth) to handle the conversion, rather than handling it inside registers. I thought this would be a good tradeoff, though I might be wrong. @kali if you think the conversion might be exclusively handled inside registers, I can adapt.

Add a criterion bench comparing the scalar path, the f32-roundtrip NEON fallback, and the native fp16 kernel for f16 sigmoid, across L1, L2, and DRAM-sized buffers (this is hardware-dependent, but I tried to pick numbers that would make sense on a small chip). The kernels are invoked by name so the fallback can be measured on fp16-capable hardware, where dispatch would otherwise always pick the native kernel.

Regarding the ASM unrolling in the f16↔f32 conversion loops I introduced in commit eed405aa3318acb8cdc32ccd323aa391a0c550e7 (this hash will change because I'll likely rebase onto the `main` branch, so I'm talking about the commit whose title is "_perf(linalg): unroll arm64 f16 sigmoid conversions to 32 lanes_"): This `sigmoid_f16` path is the fallback we dispatch to on ARMv8.2 cores without FEAT_FP16: we widen f16→f32, put the result in a scratch register, run the existing f32 sigmoid kernel, and narrow back. The two conversion loops are just chains of FCVTL/FCVTN, which are latency-bound (each iteration's few instructions don't fill the pipeline on their own). My hypothesis was that unrolling from 8 to 32 lanes would keep several independent convert chains in flight, hiding that latency and amortizing the loop overhead. The expected beneficiary is an in-order core (e.g., a Cortex-A55 chip), where the CPU can't reorder around the convert latency itself.

I ran the following Criterion benchmarks on a Cortex-A55 chip (frequency-locked with `performance` governor so we have the CPU running at maximum frequency during the whole experiment) using `dinghy`, to see whether this unrolling is truly beneficial (again, the commit hash I use below is likely to change, see my explanation before to find the right commit):

```sh
# Keep the deploy small
printf '/*\n' > .dinghyignore

# 1. BEFORE — parent commit, save a named baseline
git checkout eed405aa3~1
cargo dinghy -d <CORTEX_A55_DEVICE> bench -p tract-linalg --bench sigmoid_f16_arm64 \
    -- --save-baseline before

# 2. AFTER — the commit itself, compare against that baseline
git checkout eed405aa3318acb8cdc32ccd323aa391a0c550e7
cargo dinghy -d <CORTEX_A55_DEVICE> bench -p tract-linalg --bench sigmoid_f16_arm64 \
    -- --baseline before

# Cleanup
rm -f .dinghyignore
git checkout perf/add-neon-sigmoid-f16-fallback-on-non-fp16-arm64
```

Results after the comparison for the new kernel (the generic code and the native f16 kernel didn't significantly change, which is expected):

```
sigmoid_f16/neon-f32-roundtrip/1024
                        time:   [7.3282 µs 7.3302 µs 7.3321 µs]
                        thrpt:  [139.66 Melem/s 139.70 Melem/s 139.73 Melem/s]
                 change:
                        time:   [−4.7514% −4.7130% −4.6740%] (p = 0.00 < 0.05)
                        thrpt:  [+4.9031% +4.9461% +4.9884%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
  
sigmoid_f16/neon-f32-roundtrip/32768
                        time:   [234.32 µs 234.36 µs 234.42 µs]
                        thrpt:  [139.79 Melem/s 139.82 Melem/s 139.85 Melem/s]
                 change:
                        time:   [−4.4795% −4.4324% −4.3948%] (p = 0.00 < 0.05)
                        thrpt:  [+4.5968% +4.6380% +4.6896%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

sigmoid_f16/neon-f32-roundtrip/1048576
                        time:   [7.5719 ms 7.5744 ms 7.5768 ms]
                        thrpt:  [138.39 Melem/s 138.44 Melem/s 138.48 Melem/s]
                 change:
                        time:   [−5.1631% −5.1122% −5.0641%] (p = 0.00 < 0.05)
                        thrpt:  [+5.3343% +5.3876% +5.4442%]
                        Performance has improved.
```

The medians from each `time:`/`change:` triple are reported below for clarity:

| Benchmark (`neon-f32-roundtrip`) | Time (median) | Throughput | Δ Time | Δ Throughput | Verdict |
|---|---|---|---|---|---|
| `sigmoid_f16/.../1024` | 7.3302 µs | 139.70 Melem/s | −4.71% | +4.95% | improved (p<0.05) |
| `sigmoid_f16/.../32768` | 234.36 µs | 139.82 Melem/s | −4.43% | +4.64% | improved (p<0.05) |
| `sigmoid_f16/.../1048576` | 7.5744 ms | 138.44 Melem/s | −5.11% | +5.39% | improved (p<0.05) |

This shows a significant improvement, about 5%.

I also ran that same commands (without `dinghy`) on a laptop equipped with an Apple M3 Pro chip, but I couldn't observe a significant improvement: I guess this might be due to general noise, and also due to the fact that it's an out-of-order chip, so the loop unrolling for the conversions isn't really necessary.