### PR TITLE
linalg: probe the SVE f16 -march spelling instead of hardcoding +fp16

### DIFF
--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -141,6 +141,37 @@ fn compiler_supports_sve() -> bool {
         .is_ok()
 }
 
+// Probe which `-march` spelling this C compiler accepts for the SVE f16 kernels.
+// Native FP16 arithmetic is spelled `+fp16` by GCC's aarch64 backend but
+// `+fullfp16` by LLVM/clang — and therefore by `zig cc`, which cargo-zigbuild
+// drives to cross-compile the *-musl targets. Hardcoding `+fp16` makes the whole
+// crate fail to build under zig cc with "unknown CPU feature: 'fp16'". Trying the
+// spellings in turn keeps the f16 kernels building under either toolchain with
+// identical codegen; if neither is accepted we return None and the caller skips
+// the f16 kernels (and the `tract_sve_fp16` cfg), leaving the +sve-only f32/i32
+// kernels intact. The `-march` string is rejected during the compiler's target
+// parse, before codegen, so the base-SVE probe source is enough to discriminate
+// an accepted spelling from a rejected one.
+fn compiler_sve_fp16_flag() -> Option<String> {
+    let out_dir = path::PathBuf::from(var("OUT_DIR"));
+    let probe = out_dir.join("sve_fp16_probe.c");
+    fs::write(&probe, "#include <arm_sve.h>\nint p(void){ return (int)svcnth(); }\n").unwrap();
+    ["-march=armv8.2-a+sve+fp16", "-march=armv8.2-a+sve+fullfp16"]
+        .into_iter()
+        .enumerate()
+        .find(|(i, march)| {
+            cc::Build::new()
+                .file(&probe)
+                .flag(march)
+                .cargo_metadata(false)
+                .cargo_warnings(false)
+                .warnings(false)
+                .try_compile(&format!("tract_sve_fp16_probe_{i}"))
+                .is_ok()
+        })
+        .map(|(_, march)| march.to_string())
+}
+
 fn jump_table() -> Vec<String> {
     println!("cargo:rerun-if-changed=src/frame/mmm/fuse.rs");
     std::fs::read_to_string("src/frame/mmm/fuse.rs")
@@ -210,6 +241,9 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(tract_sme)");
     // Set below only when include_sve() and the SVE compiler probe both pass.
     println!("cargo:rustc-check-cfg=cfg(tract_sve)");
+    // Set below only when, in addition, the SVE f16 kernels find an accepted
+    // -march spelling for native FP16 (see compiler_sve_fp16_flag).
+    println!("cargo:rustc-check-cfg=cfg(tract_sve_fp16)");
     // Set below only when the aarch64 assembler probe for `sdot` passes.
     println!("cargo:rustc-check-cfg=cfg(tract_arm64_dotprod)");
     // Set below only when the x86_64 assembler probe for vpdpbusd ymm passes.
@@ -436,15 +470,24 @@ fn main() {
                     .file("arm64/sve/sve_rms_norm.c")
                     .flag("-march=armv8.2-a+sve")
                     .compile("tract_sve_kernels");
-                // f16 kernels need native FP16 arithmetic (+fp16); compiled
-                // separately so the +sve-only kernels above never gain fp16
-                // codegen. Runtime-gated on has_fp16() as well as SVE2.
-                cc::Build::new()
-                    .file("arm64/sve/sve_mmm_f16.c")
-                    .file("arm64/sve/sve_mmv_f16_64x1.c")
-                    .flag("-march=armv8.2-a+sve+fp16")
-                    .compile("tract_sve_f16_kernels");
                 println!("cargo:rustc-cfg=tract_sve");
+                // f16 kernels need native FP16 arithmetic; the -march spelling
+                // for it differs by toolchain (+fp16 on GCC, +fullfp16 on
+                // LLVM/zig cc), so probe for an accepted flag rather than
+                // hardcoding one — otherwise the crate fails to build under
+                // cargo-zigbuild for *-musl. Compiled separately so the
+                // +sve-only kernels above never gain fp16 codegen. When no
+                // spelling is accepted the f16 kernels (and tract_sve_fp16) are
+                // skipped and the f32/i32 SVE kernels still stand.
+                // Runtime-gated on has_fp16() as well as SVE2.
+                if let Some(fp16_march) = compiler_sve_fp16_flag() {
+                    cc::Build::new()
+                        .file("arm64/sve/sve_mmm_f16.c")
+                        .file("arm64/sve/sve_mmv_f16_64x1.c")
+                        .flag(&fp16_march)
+                        .compile("tract_sve_f16_kernels");
+                    println!("cargo:rustc-cfg=tract_sve_fp16");
+                }
             }
             if std::env::var("CARGO_FEATURE_NO_FP16").is_err() {
                 let config =

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -11,7 +11,7 @@ use crate::mmm::*;
 use crate::pack::PackedFormat;
 // Explicit import so `f16` is tract's half::f16 (LADatum), not rustc's builtin
 // primitive f16 — a glob import would not shadow the primitive.
-#[cfg(tract_sve)]
+#[cfg(tract_sve_fp16)]
 use tract_data::prelude::f16;
 
 // f32 SVE kernel can't do LeakyRelu or the i32 quantization ops (matches the
@@ -38,7 +38,7 @@ const CAN_FUSE_I32: fn(&FusedSpec) -> bool = |f| !matches!(f, FusedSpec::LeakyRe
 const SVE2: fn() -> bool = has_sve2;
 
 // The f16 kernels need FEAT_SVE2 AND FEAT_FP16 (native f16 arithmetic).
-#[cfg(tract_sve)]
+#[cfg(tract_sve_fp16)]
 const SVE2_FP16: fn() -> bool = || has_sve2() && crate::arm64::has_fp16();
 
 // The VLA SVE f32 GEMM kernel, implemented in C (arm64/sve/sve_mmm_f32.c) since
@@ -47,13 +47,16 @@ const SVE2_FP16: fn() -> bool = || has_sve2() && crate::arm64::has_fp16();
 #[cfg(tract_sve)]
 mod sve_sys {
     use crate::frame::mmm::FusedKerSpec;
+    #[cfg(tract_sve_fp16)]
     use tract_data::prelude::f16;
     unsafe extern "C" {
         pub fn sve_mmm_f32_kernel(ops: *const FusedKerSpec<f32>) -> isize;
         pub fn sve_mmv_f32_64x1_kernel(ops: *const FusedKerSpec<f32>) -> isize;
         pub fn sve_mmm_i32_kernel(ops: *const FusedKerSpec<i32>) -> isize;
         pub fn sve_mmm_i32_64x1_kernel(ops: *const FusedKerSpec<i32>) -> isize;
+        #[cfg(tract_sve_fp16)]
         pub fn sve_mmm_f16_kernel(ops: *const FusedKerSpec<f16>) -> isize;
+        #[cfg(tract_sve_fp16)]
         pub fn sve_mmv_f16_64x1_kernel(ops: *const FusedKerSpec<f16>) -> isize;
         // VLA SVE2 fused row-wise RmsNorm (arm64/sve/sve_rms_norm.c). Plugged
         // into Ops::rms_norm_f32 when FEAT_SVE2 is present, overriding the
@@ -121,7 +124,7 @@ MMMRustKernel!(sve_sys::sve_mmm_i32_64x1_kernel => sve_mmm_i32_64x1<i32>(64, 1)
 
 // The VLA SVE f16 GEMM kernel (arm64/sve/sve_mmm_f16.c), native f16 FMA, gated on
 // SVE2 + FP16. Wired to ops.mmm_f16 when has_fp16().
-#[cfg(tract_sve)]
+#[cfg(tract_sve_fp16)]
 MMMRustKernel!(sve_sys::sve_mmm_f16_kernel => sve_mmm_f16_8x8<f16>(8, 8)
     where(SVE2_FP16)
     can_fuse(CAN_FUSE)
@@ -130,7 +133,7 @@ MMMRustKernel!(sve_sys::sve_mmm_f16_kernel => sve_mmm_f16_8x8<f16>(8, 8)
 
 // The VLA SVE f16 GEMV kernel (arm64/sve/sve_mmv_f16_64x1.c), MR=64 NR=1,
 // dispatched when N == 1. Wired to ops.mmv_f16 when has_fp16().
-#[cfg(tract_sve)]
+#[cfg(tract_sve_fp16)]
 MMMRustKernel!(sve_sys::sve_mmv_f16_64x1_kernel => sve_mmv_f16_64x1<f16>(64, 1)
     where(SVE2_FP16)
     can_fuse(CAN_FUSE)
@@ -232,7 +235,10 @@ pub fn plug(ops: &mut Ops) {
                 sve_mmm_i32_8x8.mmm(),
                 sve_mmm_i32_64x1.mmm(),
             ]);
-            // f16 kernels additionally require FEAT_FP16.
+            // f16 kernels additionally require FEAT_FP16 — and are only compiled
+            // when build.rs found an accepted +fp16/+fullfp16 -march spelling
+            // (tract_sve_fp16), so gate the dispatch on that too.
+            #[cfg(tract_sve_fp16)]
             if crate::arm64::has_fp16() {
                 ops.mmm_f16 = Box::new(|_, _, _| sve_mmm_f16_8x8.mmm());
                 ops.mmv_f16 = Box::new(|_, _| sve_mmv_f16_64x1.mmm());


### PR DESCRIPTION
Fixes #2483.

## Problem

`linalg/build.rs` compiles the SVE f16 kernels with a hardcoded `-march=armv8.2-a+sve+fp16`. GCC's aarch64 backend spells native FP16 `+fp16`, but LLVM/clang — and therefore `zig cc`, which `cargo-zigbuild` uses to cross-compile the `*-musl` targets — only accepts `+fullfp16`. So `cargo zigbuild --target aarch64-unknown-linux-musl -p tract-linalg` fails with:

```
error: unknown CPU feature: 'fp16'
```

even though the base `+sve` f32/i32 kernels compile fine (the failure is specifically the f16 kernel `cc` invocation).

## Fix

Per your suggestion on #2483:

1. **Probe the spelling** — a new `compiler_sve_fp16_flag()` trial-compiles a tiny `arm_sve.h` TU against `-march=armv8.2-a+sve+fp16` then `-march=armv8.2-a+sve+fullfp16`, returning the first the compiler accepts (mirroring the existing `compiler_supports_sve` / assembler probes). The `-march` string is rejected during the compiler's target parse, before codegen, so a base-SVE probe source is enough to discriminate an accepted spelling.
2. **Split the cfg** — `tract_sve` still gates the f32/i32 SVE kernels; a new `tract_sve_fp16` gates the f16 kernels and is set only when an accepted spelling is found. The f16 externs, `MMMRustKernel!` defs, `SVE2_FP16`, the `f16` imports, and the `plug()` dispatch move to `tract_sve_fp16`. If no spelling works, the f16 kernels are skipped and the f32/i32 SVE kernels still build instead of the whole crate failing.

Native aarch64 (GCC) is unaffected: `+fp16` is tried first and accepted, so codegen and emitted cfgs are identical to before.

## Testing

On an x86_64 host with `zig` + `cargo-zigbuild`, target `aarch64-unknown-linux-musl`:

- **Before:** reproduced `error: unknown CPU feature: 'fp16'`.
- **After:** builds clean; build script emits both `cargo:rustc-cfg=tract_sve` and `cargo:rustc-cfg=tract_sve_fp16`, and both `libtract_sve_kernels.a` and `libtract_sve_f16_kernels.a` are compiled and linked (the fallback selects `+fullfp16`).
- **Degradation path:** with the fp16 probe forced to return `None`, the crate still builds — `tract_sve` set, `tract_sve_fp16` unset, f16 archive absent, no unresolved symbols.
- **Native/host:** `cargo build -p tract-linalg` (x86_64) unaffected; `cargo fmt --check` clean.

I don't have SVE hardware to run the runtime kernel tests — this is validated at the build/link level across the toolchains and cfg states.