### PR TITLE
refactor(silu): delegate f16 silu to the linalg kernel

### DIFF
--- a/core/src/ops/nn/silu.rs
+++ b/core/src/ops/nn/silu.rs
@@ -6,13 +6,7 @@ use crate::ops::nn::Sigmoid;
 use tract_data::half::f16;
 
 element_wise!(silu, Silu,
-    [f16] => |_, xs| {
-        xs.iter_mut().for_each(|x| {
-            let xf = x.to_f32();
-            *x = f16::from_f32(xf / (1.0 + (-xf).exp()));
-        });
-        Ok(())
-    },
+    [f16] => |_, xs| { (tract_linalg::ops().silu_f16)().run(xs) },
     [f32] => |_, xs| { (tract_linalg::ops().silu_f32)().run(xs) };
     cost: |dt| {tvec!((Cost::FMA(dt), 12), (Cost::Div(dt), 1))};
     declutter: detect_silu


### PR DESCRIPTION
The f16 silu op computed x * sigmoid(x) with its own scalar loop, duplicating the math already implemented and tested in linalg's HSiLU8 kernel. Route the f16 path through tract_linalg::ops().silu_f16 so it matches the f32 path, drops the duplication, and picks up the vectorized f16 kernel (e.g. AVX-512) where available.