### PR TITLE
arm64: honor f16 unicast operand in mmm_f32 32x1/32x3 add_unicast

### DIFF
--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_32x1_core.S.j2
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_32x1_core.S.j2
@@ -298,6 +298,10 @@
 
 .add_unicast:
     ldp         x5, x6, [x0, #8]           // c base ptr, rsc
+    ldr         x8, [x0, #32]              // item_size
+    cmp         x8, #2
+    beq         .add_unicast_f16
+
     cmp         x6, #4
     beq         .do_per_row_add
 
@@ -316,6 +320,36 @@
 
     {% for r in range(0, 8) %}
         fadd v{{ r + 24 }}.4s, v{{ r + 24 }}.4s, v{{r}}.4s
+    {% endfor %}
+
+    b           .non_linear_loop
+
+.add_unicast_f16:
+    cmp         x6, #2
+    bne         .add_unicast_f16_strided
+
+    ld1         { v0.8h, v1.8h, v2.8h, v3.8h }, [ x5 ], #64
+    b           .add_unicast_f16_acc
+
+.add_unicast_f16_strided:
+    {% for h in range(0, 4) %}
+        {% for lane in range(0, 8) %}
+            ld1 { v{{h}}.h }[{{lane}}], [ x5 ], x6
+        {% endfor %}
+    {% endfor %}
+
+.add_unicast_f16_acc:
+    fcvtl       v4.4s, v0.4h
+    fcvtl2      v5.4s, v0.8h
+    fcvtl       v6.4s, v1.4h
+    fcvtl2      v7.4s, v1.8h
+    fcvtl       v8.4s, v2.4h
+    fcvtl2      v9.4s, v2.8h
+    fcvtl       v10.4s, v3.4h
+    fcvtl2      v11.4s, v3.8h
+
+    {% for r in range(0, 8) %}
+        fadd v{{ r + 24 }}.4s, v{{ r + 24 }}.4s, v{{ r + 4 }}.4s
     {% endfor %}
 
     b           .non_linear_loop

--- a/linalg/arm64/arm64simd/arm64simd_mmm_f32_32x3_core.S.j2
+++ b/linalg/arm64/arm64simd/arm64simd_mmm_f32_32x3_core.S.j2
@@ -177,6 +177,9 @@
     ldp         x5, x6, [x0, #8]
     ldp         x7, x8, [x0, #24]
 
+    cmp         x8, #2
+    beq         .add_unicast_f16
+
     {% for col in range(0, 3) %}
         mov x4, x5
         {% for reg in range(0, 8) %}
@@ -184,6 +187,43 @@
                 ld1 {v0.s}[{{lane}}], [ x4 ], x6
             {% endfor %}
             fadd v{{ col * 8 + 8 + reg }}.4s, v{{ col * 8 + 8 + reg }}.4s, v0.4s
+        {% endfor %}
+        add x5, x5, x7
+    {% endfor %}
+
+    b           .non_linear_loop
+
+.add_unicast_f16:
+    cmp         x6, #2
+    bne         .add_unicast_f16_strided
+
+    {% for col in range(0, 3) %}
+        mov x4, x5
+        ld1 { v0.8h, v1.8h, v2.8h, v3.8h }, [ x4 ], #64
+        {% for reg in range(0, 4) %}
+            fcvtl  v4.4s, v{{reg}}.4h
+            fcvtl2 v5.4s, v{{reg}}.8h
+            fadd v{{ (col * 4 + reg) * 2 + 8 }}.4s, v{{ (col * 4 + reg) * 2 + 8 }}.4s, v4.4s
+            fadd v{{ (col * 4 + reg) * 2 + 9 }}.4s, v{{ (col * 4 + reg) * 2 + 9 }}.4s, v5.4s
+        {% endfor %}
+        add x5, x5, x7
+    {% endfor %}
+
+    b           .non_linear_loop
+
+.add_unicast_f16_strided:
+    {% for col in range(0, 3) %}
+        mov x4, x5
+        {% for reg in range(0, 4) %}
+            {% for lane in range(0, 8) %}
+                ld1 { v{{reg}}.h }[{{lane}}], [ x4 ], x6
+            {% endfor %}
+        {% endfor %}
+        {% for reg in range(0, 4) %}
+            fcvtl  v4.4s, v{{reg}}.4h
+            fcvtl2 v5.4s, v{{reg}}.8h
+            fadd v{{ (col * 4 + reg) * 2 + 8 }}.4s, v{{ (col * 4 + reg) * 2 + 8 }}.4s, v4.4s
+            fadd v{{ (col * 4 + reg) * 2 + 9 }}.4s, v{{ (col * 4 + reg) * 2 + 9 }}.4s, v5.4s
         {% endfor %}
         add x5, x5, x7
     {% endfor %}

--- a/linalg/src/frame/mmm/tests/store.rs
+++ b/linalg/src/frame/mmm/tests/store.rs
@@ -3,7 +3,7 @@ use crate::frame::mmm::fuse::FusedKerSpec;
 use crate::frame::mmm::storage::*;
 use crate::frame::mmm::tests::display_error;
 use crate::frame::mmm::*;
-use num_traits::Bounded;
+use num_traits::{AsPrimitive, Bounded};
 use tract_data::internal::*;
 use tract_itertools::Itertools;
 use tract_ndarray::Axis;
@@ -35,6 +35,18 @@ macro_rules! mmm_store_test {
 
                 #[test] fn add_unicast_dt() {
                     $crate::frame::mmm::tests::fuse::return_c_plus_d::<_, _, $tc>($ker);
+                }
+
+                #[test] fn add_unicast_col_major() {
+                    $crate::frame::mmm::tests::store::add_unicast_pattern::<_,$tc,_>($ker, StoreLayout::ColMajor);
+                }
+
+                #[test] fn add_unicast_row_major() {
+                    $crate::frame::mmm::tests::store::add_unicast_pattern::<_,$tc,_>($ker, StoreLayout::RowMajor);
+                }
+
+                #[test] fn add_unicast_arbitrary() {
+                    $crate::frame::mmm::tests::store::add_unicast_pattern::<_,$tc,_>($ker, StoreLayout::Arbitrary);
                 }
             }
         }
@@ -135,5 +147,64 @@ where
     let expected = expected.try_as_plain().unwrap().as_slice::<TC>().unwrap();
     let result = result.try_as_plain().unwrap().as_slice::<TC>().unwrap();
     display_error(result, expected, ker.mr(), ker.nr());
+    assert_eq!(result, expected);
+}
+
+/// `Clear` + `AddUnicast(operand of dtype TC)` + `Store(Acc)` and check the
+/// operand reached the accumulator unchanged. The unicast operand carries the
+/// kernel's declared output dtype `TC` (e.g. f16 for a kernel that stores f16
+/// while accumulating in f32), across the three `StoreLayout`s so both the
+/// contiguous and strided load paths are exercised. `add_unicast_dt` only
+/// covers one layout per kernel; without a dtype-aware load an f16 operand
+/// read as f32 saturates, so this catches `add_unicast` ignoring `item_size`.
+pub fn add_unicast_pattern<K, TC, TI>(ker: &K, layout: StoreLayout)
+where
+    K: MatMatMulKer<Acc = TI>,
+    TC: LADatum + AsPrimitive<TI>,
+    TI: LADatum + Bounded + PartialEq,
+    usize: AsPrimitive<TC>,
+{
+    if !ker.is_supported_here() {
+        return;
+    }
+    let (mr, nr) = (ker.mr(), ker.nr());
+    let size_of_tc = std::mem::size_of::<TC>();
+    let (row_stride, col_stride, operand_size) = match layout {
+        StoreLayout::RowMajor => (nr, 1, mr * nr),
+        StoreLayout::ColMajor => (1, mr, mr * nr),
+        // like row major, but reading every other third column
+        StoreLayout::Arbitrary => (nr * 3, 3, mr * nr * 3),
+    };
+    // Distinct value per (r, c) cell in the operand's dtype, with sentinel
+    // garbage in the unread cells of the strided layouts. Values round-trip
+    // through TC (so small integer output dtypes like i8 don't overflow).
+    let cell: Vec<TC> = (0..mr * nr).map(|i| (1 + i).as_()).collect();
+    let mut operand = vec![TC::max_value(); operand_size];
+    for r in 0..mr {
+        for c in 0..nr {
+            operand[r * row_stride + c * col_stride] = cell[r * nr + c];
+        }
+    }
+    let mut result = vec![TI::min_value(); mr * nr];
+    let non_linear = tvec![
+        FusedKerSpec::Clear,
+        FusedKerSpec::AddUnicast(OutputStoreKer {
+            ptr: operand.as_ptr() as _,
+            row_byte_stride: (size_of_tc * row_stride) as isize,
+            col_byte_stride: (size_of_tc * col_stride) as isize,
+            item_size: size_of_tc,
+        }),
+        FusedKerSpec::Store(OutputStoreKer {
+            ptr: result.as_mut_ptr() as _,
+            row_byte_stride: (std::mem::size_of::<TI>() * nr) as isize,
+            col_byte_stride: std::mem::size_of::<TI>() as isize,
+            item_size: std::mem::size_of::<TI>(),
+        }),
+        FusedKerSpec::Done,
+    ];
+    let err = ker.kernel(&non_linear);
+    assert_eq!(err, 0);
+    let expected: Vec<TI> = cell.iter().map(|&v| v.as_()).collect();
+    display_error(&result, &expected, mr, nr);
     assert_eq!(result, expected);
 }

--- a/linalg/src/frame/mmm/tests/store.rs
+++ b/linalg/src/frame/mmm/tests/store.rs
@@ -32,6 +32,10 @@ macro_rules! mmm_store_test {
                 #[test] fn store_arbitrary() {
                     $crate::frame::mmm::tests::store::store_pattern::<_,$tc,_>($ker, StoreLayout::Arbitrary);
                 }
+
+                #[test] fn add_unicast_dt() {
+                    $crate::frame::mmm::tests::fuse::return_c_plus_d::<_, _, $tc>($ker);
+                }
             }
         }
     };

--- a/linalg/x86_64/fma/fma_mmm_f32_32x1.S.j2
+++ b/linalg/x86_64/fma/fma_mmm_f32_32x1.S.j2
@@ -312,6 +312,10 @@ Windows ABI:
 {{L}}add_unicast:
     mov     r10,    [rdi + 8]           // c ptr
     mov     rsi,    [rdi + 16]          // row stride
+    mov     r11,    [rdi + 32]          // item size
+
+    cmp     r11, 2
+    je      {{L}}add_unicast_f16
 
 	cmp rsi, 4
 	jne {{L}}add_unicast_generic
@@ -321,7 +325,25 @@ Windows ABI:
     {% endfor %}
     jmp    {{L}}non_linear_loop
 
+{{L}}add_unicast_f16:
+    cmp     rsi, 2
+    jne     {{L}}add_unicast_generic_f16
 
+    {% for row in range(0, 4) %}
+        vcvtph2ps   ymm12, [ r10 + {{ row * 16 }} ]
+        vaddps      ymm{{row}}, ymm{{row}}, ymm12
+    {% endfor %}
+    jmp    {{L}}non_linear_loop
+
+{{L}}add_unicast_generic_f16:
+    {% for vec in range(0, 4) %}
+    {% for lane in range(0, 8) %}
+        vpinsrw     xmm12, xmm12, word ptr [ r10 ], {{lane}}
+        add         r10, rsi
+    {% endfor %}
+        vcvtph2ps   ymm12, xmm12
+        vaddps      ymm{{vec}}, ymm{{vec}}, ymm12
+    {% endfor %}
     jmp    {{L}}non_linear_loop
 
 {{L}}add_unicast_generic:

--- a/linalg/x86_64/fma/fma_mmm_f32_32x3.S.j2
+++ b/linalg/x86_64/fma/fma_mmm_f32_32x3.S.j2
@@ -200,6 +200,10 @@ Windows ABI:
     mov     r8,    [rdi + 8]           // c ptr
     mov     rsi,    [rdi + 16]          // row stride
     mov     rbx,    [rdi + 24]          // col stride
+    mov     rax,    [rdi + 32]          // item size
+
+    cmp     rax, 2
+    je      {{L}}add_unicast_f16
 
     cmp     rsi, 4
     jne     {{L}}unicast_generic
@@ -213,6 +217,40 @@ Windows ABI:
         vmovups     ymm12, [ r{{ col + 8 }} ]
         add         r{{ col + 8 }}, 32
         vaddps      ymm{{ col * 4 + row }}, ymm{{ col * 4 + row }}, ymm12
+    {% endfor %}
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}add_unicast_f16:
+    cmp     rsi, 2
+    jne     {{L}}unicast_generic_f16
+
+    lea             r9,  [ r8 + rbx ]
+    lea             r10, [ r9 + rbx ]
+
+{% for col in range(0, 3) %}
+    {% for row in range(0, 4) %}
+        vcvtph2ps   ymm12, [ r{{ col + 8 }} ]
+        add         r{{ col + 8 }}, 16
+        vaddps      ymm{{ col * 4 + row }}, ymm{{ col * 4 + row }}, ymm12
+    {% endfor %}
+{% endfor %}
+
+    jmp    {{L}}non_linear_loop
+
+{{L}}unicast_generic_f16:
+    lea             r9,  [ r8 + rbx ]
+    lea             r10, [ r9 + rbx ]
+
+{% for col in range(0, 3) %}
+    {% for vec in range(0, 4) %}
+    {% for lane in range(0, 8) %}
+        vpinsrw     xmm12, xmm12, word ptr [ r{{ col + 8 }} ], {{lane}}
+        add         r{{ col + 8 }}, rsi
+    {% endfor %}
+        vcvtph2ps   ymm12, xmm12
+        vaddps      ymm{{ col * 4 + vec }}, ymm{{ col * 4 + vec }}, ymm12
     {% endfor %}
 {% endfor %}
 


### PR DESCRIPTION
The arm64simd mmm_f32_32x1 / mmm_f32_32x3 and x86_64 fma_mmm_f32_32x1 / fma_mmm_f32_32x3 kernels declare store(f16) but their .add_unicast path never handled an f16 operand: it ignored item_size and always loaded the unicast operand as f32, so a fused f16 AddUnicast (e.g. a residual Add folded into a native q40 GEMV) was read at the wrong width and could saturate to inf.

Each kernel gains the missing item_size == 2 branch that converts the operand before the add — fcvtl on arm64, vcvtph2ps on x86_64 — mirroring the existing store_f16 path (both the contiguous and strided variants).

Tests:

add_unicast_dt (store-dtype-gated): operand dtype = the kernel's declared store dtype, covering the f16-into-f32 case for every f16-storing kernel. Fails on all four kernels without the fix, passes with it.
add_unicast_pattern (new): reads the operand across the col-major, row-major and arbitrary StoreLayouts, so both the contiguous and strided add_unicast load paths are checked for every store dtype.
Full tract-linalg suite green. Qwen2.5-7B-Instruct-q40ef16 decodes correctly on arm64 CPU (previously NaN); on x86_64 CPU the same kernels carried the latent bug (the add_unicast_dt test fails there without the fix) and the model continues to decode correctly.

Root-caused from #2475; complements #2477 (which gates off the fusion) by making the kernels themselves safe.

🍍
