### PR TITLE
The f16 add_unicast fast path in the 32x1/32x3 fma kernels loaded the…

### DIFF
--- a/linalg/x86_64/fma/fma_mmm_f32_32x1.S.j2
+++ b/linalg/x86_64/fma/fma_mmm_f32_32x1.S.j2
@@ -330,7 +330,7 @@ Windows ABI:
     jne     {{L}}add_unicast_generic_f16
 
     {% for row in range(0, 4) %}
-        vcvtph2ps   ymm12, [ r10 + {{ row * 16 }} ]
+        vcvtph2ps   ymm12, xmmword ptr [ r10 + {{ row * 16 }} ]
         vaddps      ymm{{row}}, ymm{{row}}, ymm12
     {% endfor %}
     jmp    {{L}}non_linear_loop

--- a/linalg/x86_64/fma/fma_mmm_f32_32x3.S.j2
+++ b/linalg/x86_64/fma/fma_mmm_f32_32x3.S.j2
@@ -231,7 +231,7 @@ Windows ABI:
 
 {% for col in range(0, 3) %}
     {% for row in range(0, 4) %}
-        vcvtph2ps   ymm12, [ r{{ col + 8 }} ]
+        vcvtph2ps   ymm12, xmmword ptr [ r{{ col + 8 }} ]
         add         r{{ col + 8 }}, 16
         vaddps      ymm{{ col * 4 + row }}, ymm{{ col * 4 + row }}, ymm12
     {% endfor %}


### PR DESCRIPTION
… unicast operand with a bare memory reference (vcvtph2ps ymm12, [mem]). MASM cannot infer the 128-bit source width from the 256-bit ymm destination and rejects it with A2070, breaking the Windows build. Qualify the operand with xmmword ptr; gas already inferred it.