### PR TITLE
core/einsum: sink unmerge reshape below matmul epilogue to restore fu…

### DIFF
--- a/core/src/ops/einsum/einsum_matmul.rs
+++ b/core/src/ops/einsum/einsum_matmul.rs
@@ -20,6 +20,7 @@ use crate::ops::nn::{Reduce, Reducer};
 pub fn merge_consecutive_same_role_axes(model: &mut TypedModel) -> TractResult<()> {
     Rewriter::default()
         .with_rule_for("merge-same-role-axes", merge_same_role_axes_rule)
+        .with_rule_for("push-reshape-below-binop", push_reshape_below_binop_rule)
         .rewrite(&(), model)
 }
 
@@ -366,6 +367,68 @@ fn merge_same_role_axes_rule(
     }
 
     Ok(None)
+}
+
+/// Slides a `Reshape` past a following binary so a matmul's epilogue — the
+/// summed partial products of a concat-split matmul, the per-channel BatchNorm
+/// affine, the Relu — sits directly on the matmul output and can be fused.
+/// `merge-same-role-axes` folds spatial axes into the matmul M axis and splits
+/// them back with an `unmerge_out` reshape; that split touches only the merged
+/// axis. Two operand shapes ride through it:
+/// - a per-channel constant, which broadcasts over the merged axis (extent 1),
+///   re-shaped through the split — trivial, since those extents are 1;
+/// - the identically-reshaped output of a sibling matmul, where
+///   `reshape(a) ∘ reshape(b) == reshape(a ∘ b)` lets the reshape hoist below
+///   the binary and the accumulation happen in merged space.
+fn push_reshape_below_binop_rule(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &AxisOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    let AxisOp::Reshape(at, from_dims, to_dims) = op else { return Ok(None) };
+    rule_if!(node.outputs.len() == 1);
+    rule_if!(node.outputs[0].successors.len() == 1);
+    rule_if!(!model.output_outlets()?.contains(&node.id.into()));
+
+    let inlet = node.outputs[0].successors[0];
+    let succ = model.node(inlet.node);
+    rule_if!(succ.inputs.len() == 2);
+    rule_if_some!(binop = succ.op_as::<crate::ops::binary::TypedBinOp>());
+    rule_if!(binop.0.as_linalg_binop().is_some());
+    let other = succ.inputs[1 - inlet.slot];
+
+    let mut patch = TypedModelPatch::new(format!("push {node} below {succ}"));
+    let act = patch.tap_model(model, node.inputs[0])?;
+
+    let sibling = if let Some(k) = model.outlet_fact(other)?.konst.clone() {
+        let at = *at;
+        let (from_len, to_len) = (from_dims.len(), to_dims.len());
+        let kshape = k.shape();
+        rule_if!(at + to_len <= kshape.len());
+        rule_if!(kshape[at..at + to_len].iter().all(|&d| d == 1));
+        let mut new_shape: TVec<usize> = kshape[..at].iter().copied().collect();
+        new_shape.extend(std::iter::repeat_n(1, from_len));
+        new_shape.extend(kshape[at + to_len..].iter().copied());
+        let k = k.as_ref().clone().into_shape(&new_shape)?;
+        patch.add_const(format!("{}.through_reshape", model.node(other.node).name), k)?
+    } else {
+        let other_node = model.node(other.node);
+        rule_if!(other_node.op_as::<AxisOp>() == Some(op));
+        patch.tap_model(model, other_node.inputs[0])?
+    };
+
+    let operands = if inlet.slot == 0 { [act, sibling] } else { [sibling, act] };
+    let applied = crate::ops::change_axes::wire_with_rank_broadcast(
+        format!("{}.prefused", succ.name),
+        &mut patch,
+        binop.clone(),
+        &operands,
+    )?;
+    let reshaped = patch.wire_node(format!("{node_name}.pushed"), op.clone(), &applied)?;
+    patch.shunt_outside(model, inlet.node.into(), reshaped[0])?;
+    Ok(Some(patch))
 }
 
 pub fn detect_all(model: &mut TypedModel) -> TractResult<()> {


### PR DESCRIPTION
…sion

The merge-same-role-axes rule folds spatial axes into the matmul M axis and splits them back with an unmerge reshape placed on the matmul output. That reshape sat between the matmul and its epilogue (concat-split partial-product sums, per-channel BatchNorm affine, Relu), blocking OptMatMul fusion and leaving those as standalone elementwise passes. A companion rule now sinks the reshape below such binaries — collapsing a per-channel constant through the split, or hoisting an identical sibling reshape out of a sum — so the epilogue fuses into the matmul again.