### PR TITLE
STFT: gather each frame from a contiguous signal buffer

### DIFF
--- a/core/src/ops/fft.rs
+++ b/core/src/ops/fft.rs
@@ -181,16 +181,11 @@ impl Stft {
                     (c..=c).into()
                 }
             });
+            let signal: Vec<Complex<T>> =
+                islice.iter().tuples().map(|(re, im)| Complex::new(*re, *im)).collect();
             for f in 0..frames {
                 v.clear();
-                v.extend(
-                    islice
-                        .iter()
-                        .tuples()
-                        .skip(self.stride * f)
-                        .take(self.frame)
-                        .map(|(re, im)| Complex::new(*re, *im)),
-                );
+                v.extend_from_slice(&signal[self.stride * f..self.stride * f + self.frame]);
                 if let Some(win) = &self.window {
                     let win = win.try_as_plain()?.as_slice::<T>()?;
                     // symmetric padding in case window is smaller than frames (aka n fft)


### PR DESCRIPTION
The per-frame window was rebuilt by re-walking the strided input view with iter().tuples().skip(stride*f).take(frame), an O(frames^2) gather whose hot ndarray iterator was also left to the optimizer's inlining whims. Collect the signal into a contiguous Vec<Complex> once per outer coordinate and copy each frame out of it with extend_from_slice.