### PR TITLE
prop_const: widen small-const fold exemption to volume <= 1024

### DIFF
--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -39,7 +39,7 @@ impl super::TypedPass for PropConst {
                         && (model.node(outlet.node).outputs[outlet.slot].successors.len() == 1
                             || node.op_is::<Slice>()
                             || (fact.datum_type.is_number()
-                                && fact.shape.volume().as_i64().is_some_and(|d| d < 1024)))
+                                && fact.shape.volume().as_i64().is_some_and(|d| d <= 1024)))
                 })
             {
                 let inputs =


### PR DESCRIPTION
PropConst skips folding a stateless node whose constant input is shared (>1 successor) unless that input is tiny. The threshold was volume < 1024, so per-channel batch-norm scale vectors on 1024-wide layers (a common hidden width) missed the exemption: their weight-side batch-norm fold, reshape and pack were left to run on every inference instead of once at optimize time. Widen the exemption to volume <= 1024.