### PR TITLE
fix: bound the x86 SiLU negative tail

### DIFF
--- a/linalg/src/frame/silu.rs
+++ b/linalg/src/frame/silu.rs
@@ -38,6 +38,15 @@ pub mod test {
                         .unwrap();
                 }
             }
+            #[test]
+            fn tails() {
+                if $cond {
+                    $crate::frame::silu::test::test_silu::<$ker, $t>(&[
+                        -100.0, -30.0, -18.6, -15.0, 15.0, 18.6, 30.0, 100.0,
+                    ])
+                    .unwrap();
+                }
+            }
         };
     }
 

--- a/linalg/src/x86_64_fma/act.rs
+++ b/linalg/src/x86_64_fma/act.rs
@@ -175,11 +175,23 @@ pub mod test_x86_64_avx512_leaky_relu_f32_64n {
     );
 }
 
-// SiLU(x) = x * sigmoid(x). Composed at the kernel level (mirrors arm64): save
-// the input chunk, run the AVX-512 sigmoid kernel in place, then multiply back
-// by the saved original. nr() and CHUNK (256) are multiples of 16 so the
-// sigmoid kernel always receives a 64-byte-aligned slice whose length is a
-// multiple of 16.
+// SiLU(x) = f * sigmoid(z), with z = clamp(x, -18.0, 18.0) and f = max(x, -18.0).
+// The kernel-level composition mirrors the arm64 fused SiLU clamping strategy, not its
+// exact bounds: save the input chunk, run the AVX-512 sigmoid kernel in place (it clamps
+// its argument to z internally), then multiply back by the factor f. The factor floor
+// must equal the sigmoid kernel's own clamp, which here is -18.0 (the AVX-512 sigmoid's
+// range).
+//
+// The factor f is clamped below at -18.0 but left unbounded above: SiLU(x) ~ x as
+// x -> +inf, so the factor must grow, whereas the upper clamp on z is only there to
+// keep the sigmoid polynomial in range. Clamping f below keeps the negative tail
+// bounded: since sigmoid is floored at sigmoid(-18.0), an unclamped factor would let
+// x * sigmoid(-18.0) diverge toward -inf, while the clamped factor saturates at the
+// constant -18.0 * sigmoid(-18.0) ~= -2.74e-7, which the true SiLU approaches from
+// below as x -> -inf.
+//
+// nr() and CHUNK (256) are multiples of 16 so the sigmoid kernel always receives a
+// 64-byte-aligned slice whose length is a multiple of 16.
 ew_impl_wrap!(
     f32,
     x86_64_avx512_silu_f32_16n,
@@ -200,7 +212,7 @@ ew_impl_wrap!(
             scratch[..n].copy_from_slice(chunk);
             super::avx512_sigmoid_f32::run(chunk, ());
             for i in 0..n {
-                chunk[i] *= scratch[i];
+                chunk[i] *= scratch[i].max(-18.0);
             }
             start = end;
         }

--- a/linalg/src/x86_64_fma/act_f16.rs
+++ b/linalg/src/x86_64_fma/act_f16.rs
@@ -214,8 +214,8 @@ pub mod test_x86_64_avx512_tanh_f16_16n {
     tanh_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_tanh_f16_16n);
 }
 
-// silu_f16: x * sigmoid(x).  Mirror the f32 silu pattern: save the input
-// (in f32), run sigmoid in place on the scratch, then multiply back.
+// silu_f16: f * sigmoid(z), with z = clamp(x, -18.0, 18.0) and f = max(x, -18.0). The
+// factor floor matches the AVX-512 sigmoid's own clamp (see act.rs silu_f32).
 ew_impl_wrap!(
     f16,
     x86_64_avx512_silu_f16_16n,
@@ -240,7 +240,7 @@ ew_impl_wrap!(
             v[..n].copy_from_slice(&w[..n]);
             super::avx512_sigmoid_f32::run(&mut w[..n], ());
             for j in 0..n {
-                w[j] *= v[j];
+                w[j] *= v[j].max(-18.0);
             }
             unsafe { cvt_f32_to_f16(&w[..n], &mut buf[i..i + n]) };
             i += n;


### PR DESCRIPTION
The AVX-512 SiLU kernels multiplied the sigmoid by the unclamped input, so for large negative x — where the sigmoid kernel floors its output at the constant sigmoid(-18.0) — the result x * sigmoid(-18.0) diverged toward -inf instead of decaying to 0 as true SiLU does. This is the same thing that we did in commit 2aca983fed6ce5b5f6ab948fb340a6763a37704d for the ARMv8.0 SiLU kernel.

I also made the SiLU testing suite more exhaustive: the proptest and trivial cases stay within [-10, 10], so the tail behavior of the SiLU kernels was untested: the arm64 and x86 kernels clamp the sigmoid argument and each saturates the tails differently, while the generic kernels compute exact sigmoid. Add a deterministic case spanning [-100, 100] to pin all of them at and beyond the clamp boundary.

