### PR TITLE
arm32: register the NEON i8 matmul kernels in mmm_impls

### DIFF
--- a/linalg/src/arm32/armv7neon.rs
+++ b/linalg/src/arm32/armv7neon.rs
@@ -39,6 +39,8 @@ pub fn plug(ops: &mut Ops) {
         armv7neon_mmm_f32_32x1_cortexa7.mmm(),
         armv7neon_mmm_f32_32x1_cortexa9.mmm(),
         armv7neon_mmm_f32_32x1_generic.mmm(),
+        armv7neon_mmm_i32_8x4.mmm(),
+        armv7neon_mmm_i32_32x1.mmm(),
     ]);
 }
 


### PR DESCRIPTION
The armv7 NEON i8 kernels armv7neon_mmm_i32_8x4 and _32x1 were wired into the qmmm_i32/qmmv_i32 picker pointers but never added to ops.mmm_impls, so the einsum kernel selection — which enumerates mmm_impls — never saw them and fell back to the generic i32 kernels, ~2x slower on 32-bit ARM for quantized models. Add both to armv7neon::plug().