### PR TITLE
linalg: exclude sigmoid_f16_arm64 bench from non-arm64 builds

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -104,6 +104,7 @@ name = "sigmoid"
 harness = false
 
 [[bench]]
+bench = false
 name = "sigmoid_f16_arm64"
 harness = false
 


### PR DESCRIPTION
The bench file is gated with #![cfg(target_arch = "aarch64")], so on x86 the whole file including criterion_main! is stripped, leaving the bench target with no main (E0601) and breaking the harness. Register it with bench = false like every other arch-specific bench so it is not compiled on the wrong arch.