### PR TITLE
feat(linalg): add NEON silu_f16 fallback on non-fp16 arm64

### DIFF
--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -508,8 +508,9 @@ pub fn plug(ops: &mut Ops) {
         ops.sum_f16 = Box::new(|| arm64fp16_sum_f16_32n::red());
         ops.mul_by_scalar_f16 = Box::new(|| arm64fp16_mul_by_scalar_f16_32n::ew());
     } else {
-        log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 activated");
+        log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 and silu_f16 activated");
         ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_4n::ew());
+        ops.silu_f16 = Box::new(|| arm64simd_silu_f16_4n::ew());
     }
     #[cfg(any(target_os = "macos", all(target_os = "ios", feature = "apple-amx-ios")))]
     {

--- a/linalg/src/arm64/arm64simd.rs
+++ b/linalg/src/arm64/arm64simd.rs
@@ -15,6 +15,7 @@ mod sum;
 mod unicast;
 
 pub use act_f16::arm64simd_sigmoid_f16_4n;
+pub use act_f16::arm64simd_silu_f16_4n;
 pub use by_scalar::*;
 pub use gelu::arm64simd_gelu_f32_4n;
 pub use gelu_fused::arm64simd_gelu_f32_4n_fused;

--- a/linalg/src/arm64/arm64simd/act_f16.rs
+++ b/linalg/src/arm64/arm64simd/act_f16.rs
@@ -13,16 +13,16 @@ use tract_data::internal::f16;
 /// f32 scratch length for the f16 round-trip, in elements. Kept small so the
 /// scratch stays cache-hot across the three passes over each chunk (convert in,
 /// run the f32 kernel in place, convert out) instead of being sized to fill a
-/// cache level. Must stay a multiple of 4: we call the f32 sigmoid kernel's
-/// `run` directly rather than through `ew()`/`run_with_params`, so nothing
-/// trims a tail — the kernel steps 4 lanes at a time down to a zero count, and
-/// a non-multiple length would run off the scratch. The conversions handle any
+/// cache level. Must stay a multiple of 4: we call the f32 kernels' `run`
+/// directly rather than through `ew()`/`run_with_params`, so nothing trims a
+/// tail — the kernel steps 4 lanes at a time down to a zero count, and a
+/// non-multiple length would run off the scratch. The conversions handle any
 /// length, so nothing else constrains it.
 const CHUNK: usize = 256;
 
 const _: () = assert!(
     CHUNK % 4 == 0,
-    "f32 sigmoid kernel steps 4 lanes with no tail; CHUNK must stay a multiple of 4"
+    "f32 kernels step 4 lanes with no tail; CHUNK must stay a multiple of 4"
 );
 
 #[repr(C, align(16))]
@@ -185,4 +185,39 @@ ew_impl_wrap!(
 pub mod test_arm64simd_sigmoid_f16_4n {
     use super::*;
     sigmoid_frame_tests!(true, f16, arm64simd_sigmoid_f16_4n);
+}
+
+// f32-roundtrip f16 SiLU for arm64 cores without FEAT_FP16.
+ew_impl_wrap!(
+    f16,
+    arm64simd_silu_f16_4n,
+    4,
+    4,
+    (),
+    #[inline(never)]
+    fn run(buf: &mut [f16], _: ()) {
+        debug_assert!(buf.len() % Self::nr() == 0);
+        if buf.is_empty() {
+            return;
+        }
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the kernel or `cvt_f32_to_f16` reads
+        // it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
+        let mut i = 0;
+        while i < buf.len() {
+            let n = CHUNK.min(buf.len() - i);
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::arm64simd_silu_f32_4n_fused::run(&mut s[..n], ());
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
+            i += n;
+        }
+    }
+);
+
+#[cfg(test)]
+pub mod test_arm64simd_silu_f16_4n {
+    use super::*;
+    silu_frame_tests!(true, f16, arm64simd_silu_f16_4n);
 }


### PR DESCRIPTION
arm64 cores without FEAT_FP16 had no accelerated f16 SiLU and fell back to the generic scalar path. Register an f32-roundtrip NEON silu_f16 that converts each chunk to f32, runs the fused f32 SiLU kernel, and converts back, matching the sigmoid_f16 fallback already in place.

This also addresses the temporary solution mentioned in #2509 

@kali I wanted to submit this work first because it's short, then implement the macro which automatically handles f16<->f32 conversions (the macro [you suggested](https://github.com/sonos/tract/pull/2492#issuecomment-5037597671)). This macro will be implemented in #2512 .