### PR TITLE
refactor(linalg): unify-f32-roundtrip-f16-behind-macro

### DIFF
--- a/linalg/src/arm64/arm64simd/act_f16.rs
+++ b/linalg/src/arm64/arm64simd/act_f16.rs
@@ -6,27 +6,13 @@
 //! by converting into an f32 scratch, running the existing f32 kernel, and
 //! converting back — rather than dropping to the generic scalar path.
 
-use std::mem::MaybeUninit;
-
 use tract_data::internal::f16;
 
 /// f32 scratch length for the f16 round-trip, in elements. Kept small so the
 /// scratch stays cache-hot across the three passes over each chunk (convert in,
 /// run the f32 kernel in place, convert out) instead of being sized to fill a
-/// cache level. Must stay a multiple of 4: we call the f32 kernels' `run`
-/// directly rather than through `ew()`/`run_with_params`, so nothing trims a
-/// tail — the kernel steps 4 lanes at a time down to a zero count, and a
-/// non-multiple length would run off the scratch. The conversions handle any
-/// length, so nothing else constrains it.
+/// cache level. The conversions handle any length, so nothing else constrains it.
 const CHUNK: usize = 256;
-
-const _: () = assert!(
-    CHUNK % 4 == 0,
-    "f32 kernels step 4 lanes with no tail; CHUNK must stay a multiple of 4"
-);
-
-#[repr(C, align(16))]
-struct AlignedScratch([f32; CHUNK]);
 
 /// Convert `src` (f16) into `dst` (f32) via FCVTL/FCVTL2 for any length: a
 /// 32-lane unrolled main loop, an 8-lane fallback loop, then a scalar-step
@@ -153,32 +139,15 @@ unsafe fn cvt_f32_to_f16(src: &[f32], dst: &mut [f16]) {
     }
 }
 
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     arm64simd_sigmoid_f16_4n,
     4,
     4,
-    (),
-    #[inline(never)]
-    fn run(buf: &mut [f16], _: ()) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the kernel or `cvt_f32_to_f16` reads
-        // it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = CHUNK.min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::arm64simd_sigmoid_f32_4n::run(&mut s[..n], ());
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    CHUNK,
+    16,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::arm64simd_sigmoid_f32_4n
 );
 
 #[cfg(test)]
@@ -188,32 +157,15 @@ pub mod test_arm64simd_sigmoid_f16_4n {
 }
 
 // f32-roundtrip f16 SiLU for arm64 cores without FEAT_FP16.
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     arm64simd_silu_f16_4n,
     4,
     4,
-    (),
-    #[inline(never)]
-    fn run(buf: &mut [f16], _: ()) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the kernel or `cvt_f32_to_f16` reads
-        // it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = CHUNK.min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::arm64simd_silu_f32_4n_fused::run(&mut s[..n], ());
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    CHUNK,
+    16,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::arm64simd_silu_f32_4n_fused
 );
 
 #[cfg(test)]

--- a/linalg/src/frame/element_wise.rs
+++ b/linalg/src/frame/element_wise.rs
@@ -33,6 +33,70 @@ macro_rules! ew_impl_wrap {
     };
 }
 
+/// Define an f16 element-wise kernel for cores without native f16 arithmetic by
+/// round-tripping through an existing f32 kernel: convert each `CHUNK`-sized f16
+/// slice into an aligned f32 scratch, run the f32 kernel in place, convert back.
+///
+/// Callers supply the `unsafe` f16<->f32 conversion fns (their target-feature
+/// gating, if any, lives on those fns — this macro is architecture-agnostic), the
+/// f32 kernel to reuse, the f32-scratch `CHUNK`, and the scratch alignment (must
+/// satisfy the f32 kernel's input-alignment contract, since `run` is called
+/// directly, bypassing `map_slice_with_alignment`). The remaining arguments match
+/// `ew_impl_wrap!`.
+///
+/// `CHUNK` must be a multiple of `nr`: the f32 kernel steps `nr` lanes with no
+/// tail, and each chunk length passed to it is a multiple of `nr` only because
+/// both `CHUNK` and every buffer length are.
+///
+/// The param arm converts the f16-side param into the f32 kernel's param via
+/// `$pname => $pconv` (e.g. `f16, alpha => alpha.to_f32()`), computed once per call.
+macro_rules! ew_impl_f16_via_f32 {
+    ($func:ident, $nr:expr, $alignment_items:expr, $chunk:expr, $scratch_align:literal,
+     $cvt_in:path, $cvt_out:path, $f32_kernel:ty) => {
+        ew_impl_f16_via_f32!(@build $func, $nr, $alignment_items, $chunk, $scratch_align,
+            $cvt_in, $cvt_out, $f32_kernel, (), _params, ());
+    };
+    ($func:ident, $nr:expr, $alignment_items:expr, $chunk:expr, $scratch_align:literal,
+     $cvt_in:path, $cvt_out:path, $f32_kernel:ty, $params:ty, $pname:ident => $pconv:expr) => {
+        ew_impl_f16_via_f32!(@build $func, $nr, $alignment_items, $chunk, $scratch_align,
+            $cvt_in, $cvt_out, $f32_kernel, $params, $pname, $pconv);
+    };
+    (@build $func:ident, $nr:expr, $alignment_items:expr, $chunk:expr, $scratch_align:literal,
+     $cvt_in:path, $cvt_out:path, $f32_kernel:ty, $params:ty, $pname:ident, $pconv:expr) => {
+        ew_impl_wrap!(
+            f16, $func, $nr, $alignment_items, $params,
+            #[inline(never)]
+            fn run(buf: &mut [f16], $pname: $params) {
+                const _: () = assert!(
+                    $chunk % $nr == 0,
+                    "CHUNK must be a multiple of nr; the f32 kernel steps nr lanes with no tail"
+                );
+                #[repr(C, align($scratch_align))]
+                struct AlignedScratch([f32; $chunk]);
+                debug_assert!(buf.len() % Self::nr() == 0);
+                debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+                if buf.is_empty() {
+                    return;
+                }
+                let f32_params = $pconv;
+                let mut scratch = std::mem::MaybeUninit::<AlignedScratch>::uninit();
+                // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+                // written by `$cvt_in` before the f32 kernel or `$cvt_out` reads it, so the
+                // scratch never needs zero-initialising.
+                let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
+                let mut i = 0;
+                while i < buf.len() {
+                    let n = ($chunk).min(buf.len() - i);
+                    unsafe { $cvt_in(&buf[i..i + n], &mut s[..n]) };
+                    <$f32_kernel>::run(&mut s[..n], f32_params);
+                    unsafe { $cvt_out(&s[..n], &mut buf[i..i + n]) };
+                    i += n;
+                }
+            }
+        );
+    };
+}
+
 macro_rules! ew_impl {
     ($ti: ident, $func: ident, $nr: expr, $alignment_items: expr) => {
         paste! {

--- a/linalg/src/x86_64_fma/act_f16.rs
+++ b/linalg/src/x86_64_fma/act_f16.rs
@@ -1,27 +1,13 @@
-// AVX-512 f16 element-wise activations. Each kernel chunks f16 -> 64-byte-aligned
-// f32 scratch via vcvtph2ps (cvt_f16_to_f32 below), runs the matching f32
-// AVX-512 kernel (or the avx512_sigmoid_f32 / avx512_tanh_f32 wrappers from
-// x86_64_fma.rs), and converts back to f16 via vcvtps2ph (cvt_f32_to_f16).
-// Conversion is driven through std::arch intrinsics directly because the
-// scalar f16::to_f32 / f16::from_f32 loops are not autovectorized by
-// rustc + LLVM (branches / call overhead in the half crate's methods),
-// which leaves a naive port stuck around 7 Melem/s.
-//
-// The f32 AVX-512 activation kernels assume 64-byte aligned input (alignment
-// bytes = nr * 4 for nr >= 16). The local scratch is wrapped in
-// #[repr(C, align(64))] so the contained [f32; 256] sits at a 64-byte boundary.
-//
-// Validated against the generic f16 reference (HHardSwish8 / HLeakyRelu8 /
-// HSigmoid8 / HTanh8 / HSiLU8 / HGelu8) via the existing *_frame_tests!
-// macros at SuperApproximate tolerance, which covers the precision delta
-// between scalar f16 arithmetic and f32-internal computation.
-
-use std::mem::MaybeUninit;
+//! AVX-512 f16 element-wise activations for cores without native f16 arithmetic.
+//!
+//! Each kernel round-trips through the matching f32 AVX-512 kernel via
+//! `ew_impl_f16_via_f32!`: convert an f16 chunk into a 64-byte-aligned f32 scratch
+//! (the f32 kernels assume 64-byte-aligned input), run the f32 kernel, convert
+//! back. Conversion is driven through `std::arch` intrinsics directly (see the
+//! helpers below) because rustc + LLVM do not autovectorize the scalar
+//! `f16::to_f32` / `f16::from_f32` loops.
 
 use tract_data::internal::f16;
-
-#[repr(C, align(64))]
-struct AlignedScratch([f32; 256]);
 
 const CHUNK: usize = 256;
 
@@ -69,33 +55,15 @@ unsafe fn cvt_f32_to_f16(src: &[f32], dst: &mut [f16]) {
 }
 
 // hardswish_f16
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     x86_64_avx512_hardswish_f16_64n,
     64,
     32,
-    (),
-    #[inline(never)]
-    fn run(buf: &mut [f16], _: ()) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
-        // reads it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::act::x86_64_avx512_hardswish_f32_64n::run(&mut s[..n], ());
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    CHUNK,
+    64,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::act::x86_64_avx512_hardswish_f32_64n
 );
 
 #[cfg(test)]
@@ -108,35 +76,17 @@ pub mod test_x86_64_avx512_hardswish_f16_64n {
     );
 }
 
-// leaky_relu_f16  (parameter: alpha as f16)
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     x86_64_avx512_leaky_relu_f16_64n,
     64,
     32,
+    CHUNK,
+    64,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::act::x86_64_avx512_leaky_relu_f32_64n,
     f16,
-    #[inline(never)]
-    fn run(buf: &mut [f16], alpha: f16) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let alpha_f32 = alpha.to_f32();
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
-        // reads it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::act::x86_64_avx512_leaky_relu_f32_64n::run(&mut s[..n], alpha_f32);
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    alpha => alpha.to_f32()
 );
 
 #[cfg(test)]
@@ -149,35 +99,15 @@ pub mod test_x86_64_avx512_leaky_relu_f16_64n {
     );
 }
 
-// sigmoid_f16  (calls the avx512_sigmoid_f32 wrapper from x86_64_fma.rs;
-// its nr() is 16 so CHUNK=256 is always a clean multiple)
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     x86_64_avx512_sigmoid_f16_16n,
     16,
     16,
-    (),
-    #[inline(never)]
-    fn run(buf: &mut [f16], _: ()) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
-        // reads it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::avx512_sigmoid_f32::run(&mut s[..n], ());
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    CHUNK,
+    64,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::avx512_sigmoid_f32
 );
 
 #[cfg(test)]
@@ -186,34 +116,15 @@ pub mod test_x86_64_avx512_sigmoid_f16_16n {
     sigmoid_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_sigmoid_f16_16n);
 }
 
-// tanh_f16
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     x86_64_avx512_tanh_f16_16n,
     16,
     16,
-    (),
-    #[inline(never)]
-    fn run(buf: &mut [f16], _: ()) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
-        // reads it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::avx512_tanh_f32::run(&mut s[..n], ());
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    CHUNK,
+    64,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::avx512_tanh_f32
 );
 
 #[cfg(test)]
@@ -222,34 +133,15 @@ pub mod test_x86_64_avx512_tanh_f16_16n {
     tanh_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_tanh_f16_16n);
 }
 
-// silu_f16: chunk f16 -> f32 scratch, run the fused f32 SiLU kernel, convert back.
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     x86_64_avx512_silu_f16_16n,
     16,
     16,
-    (),
-    #[inline(never)]
-    fn run(buf: &mut [f16], _: ()) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
-        // reads it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::act::x86_64_avx512_silu_f32_16n::run(&mut s[..n], ());
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    CHUNK,
+    64,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::act::x86_64_avx512_silu_f32_16n
 );
 
 #[cfg(test)]
@@ -258,34 +150,15 @@ pub mod test_x86_64_avx512_silu_f16_16n {
     silu_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_silu_f16_16n);
 }
 
-// gelu_f16: chunk f16 -> f32 scratch, run the fused f32 GELU kernel, convert back.
-ew_impl_wrap!(
-    f16,
+ew_impl_f16_via_f32!(
     x86_64_avx512_gelu_f16_16n,
     16,
     16,
-    (),
-    #[inline(never)]
-    fn run(buf: &mut [f16], _: ()) {
-        debug_assert!(buf.len() % Self::nr() == 0);
-        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
-        if buf.is_empty() {
-            return;
-        }
-        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
-        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
-        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
-        // reads it, so the scratch never needs zero-initialising.
-        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
-        let mut i = 0;
-        while i < buf.len() {
-            let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
-            super::act::x86_64_avx512_gelu_f32_16n::run(&mut s[..n], ());
-            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
-            i += n;
-        }
-    }
+    CHUNK,
+    64,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::act::x86_64_avx512_gelu_f32_16n
 );
 
 #[cfg(test)]


### PR DESCRIPTION
The non-native f16 activation kernels on arm64 and AVX-512 each repeated the same convert-to-f32-scratch, run-the-f32-kernel, convert-back body. Introduce ew_impl_f16_via_f32! to express that pattern once, so a new fallback kernel only names its conversion fns, the f32 kernel to reuse, and its chunk/alignment.

On x86 the f16 SiLU and GELU are now thin wrappers over the fused f32 SiLU/GELU kernels instead of re-deriving the same math inline, keeping the two paths from drifting.

This will be ready for review after #2511 has been merged.