### PR TITLE
refactor(linalg): wrap x86 f16 silu/gelu over the fused f32 kernels

### DIFF
--- a/linalg/src/x86_64_fma/act_f16.rs
+++ b/linalg/src/x86_64_fma/act_f16.rs
@@ -214,8 +214,7 @@ pub mod test_x86_64_avx512_tanh_f16_16n {
     tanh_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_tanh_f16_16n);
 }
 
-// silu_f16: f * sigmoid(z), with z = clamp(x, -18.0, 18.0) and f = max(x, -18.0). The
-// factor floor matches the AVX-512 sigmoid's own clamp (see act.rs silu_f32).
+// silu_f16: chunk f16 -> f32 scratch, run the fused f32 SiLU kernel, convert back.
 ew_impl_wrap!(
     f16,
     x86_64_avx512_silu_f16_16n,
@@ -229,20 +228,14 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        let mut work = AlignedScratch::new();
-        let mut save = AlignedScratch::new();
-        let w = &mut work.0;
-        let v = &mut save.0;
+        let mut scratch = AlignedScratch::new();
+        let s = &mut scratch.0;
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut w[..n]) };
-            v[..n].copy_from_slice(&w[..n]);
-            super::avx512_sigmoid_f32::run(&mut w[..n], ());
-            for j in 0..n {
-                w[j] *= v[j].max(-18.0);
-            }
-            unsafe { cvt_f32_to_f16(&w[..n], &mut buf[i..i + n]) };
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::act::x86_64_avx512_silu_f32_16n::run(&mut s[..n], ());
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
             i += n;
         }
     }
@@ -254,8 +247,7 @@ pub mod test_x86_64_avx512_silu_f16_16n {
     silu_frame_tests!(is_x86_feature_detected!("avx512f"), f16, x86_64_avx512_silu_f16_16n);
 }
 
-// Tanh-form GELU (matches tract's GeluApproximate, pow=3, see act.rs gelu_f32):
-//   gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+// gelu_f16: chunk f16 -> f32 scratch, run the fused f32 GELU kernel, convert back.
 ew_impl_wrap!(
     f16,
     x86_64_avx512_gelu_f16_16n,
@@ -269,25 +261,14 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        const SQRT_2_OVER_PI: f32 = 0.7978845608028654;
-        const COEF: f32 = 0.044715;
-        let mut work = AlignedScratch::new();
-        let mut save = AlignedScratch::new();
-        let w = &mut work.0;
-        let v = &mut save.0;
+        let mut scratch = AlignedScratch::new();
+        let s = &mut scratch.0;
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);
-            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut v[..n]) };
-            for j in 0..n {
-                let x = v[j];
-                w[j] = SQRT_2_OVER_PI * (x + COEF * x * x * x);
-            }
-            super::avx512_tanh_f32::run(&mut w[..n], ());
-            for j in 0..n {
-                w[j] = 0.5 * v[j] * (1.0 + w[j]);
-            }
-            unsafe { cvt_f32_to_f16(&w[..n], &mut buf[i..i + n]) };
+            unsafe { cvt_f16_to_f32(&buf[i..i + n], &mut s[..n]) };
+            super::act::x86_64_avx512_gelu_f32_16n::run(&mut s[..n], ());
+            unsafe { cvt_f32_to_f16(&s[..n], &mut buf[i..i + n]) };
             i += n;
         }
     }

--- a/linalg/src/x86_64_fma/act_f16.rs
+++ b/linalg/src/x86_64_fma/act_f16.rs
@@ -16,16 +16,12 @@
 // macros at SuperApproximate tolerance, which covers the precision delta
 // between scalar f16 arithmetic and f32-internal computation.
 
+use std::mem::MaybeUninit;
+
 use tract_data::internal::f16;
 
 #[repr(C, align(64))]
 struct AlignedScratch([f32; 256]);
-
-impl AlignedScratch {
-    fn new() -> Self {
-        Self([0f32; 256])
-    }
-}
 
 const CHUNK: usize = 256;
 
@@ -86,8 +82,11 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        let mut scratch = AlignedScratch::new();
-        let s = &mut scratch.0;
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
+        // reads it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);
@@ -124,8 +123,11 @@ ew_impl_wrap!(
             return;
         }
         let alpha_f32 = alpha.to_f32();
-        let mut scratch = AlignedScratch::new();
-        let s = &mut scratch.0;
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
+        // reads it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);
@@ -162,8 +164,11 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        let mut scratch = AlignedScratch::new();
-        let s = &mut scratch.0;
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
+        // reads it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);
@@ -195,8 +200,11 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        let mut scratch = AlignedScratch::new();
-        let s = &mut scratch.0;
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
+        // reads it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);
@@ -228,8 +236,11 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        let mut scratch = AlignedScratch::new();
-        let s = &mut scratch.0;
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
+        // reads it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);
@@ -261,8 +272,11 @@ ew_impl_wrap!(
         if buf.is_empty() {
             return;
         }
-        let mut scratch = AlignedScratch::new();
-        let s = &mut scratch.0;
+        let mut scratch = MaybeUninit::<AlignedScratch>::uninit();
+        // SAFETY: f32 has no invalid bit patterns, and every `s[..n]` element is
+        // written by `cvt_f16_to_f32` before the f32 kernel or `cvt_f32_to_f16`
+        // reads it, so the scratch never needs zero-initialising.
+        let s = unsafe { &mut (*scratch.as_mut_ptr()).0 };
         let mut i = 0;
         while i < buf.len() {
             let n = (CHUNK).min(buf.len() - i);


### PR DESCRIPTION
The AVX-512 f16 SiLU and GELU kernels re-implemented, on their f32 scratch, the exact composition already performed by the fused f32 SiLU and GELU kernels. Collapse them into thin f16<->f32 conversion wrappers around those kernels, matching how the hardswish/leaky_relu f16 kernels already delegate. The math is unchanged; a single scratch buffer now suffices since the f32 kernels keep their own internal save buffer.

Also, the x86 f16 activation kernels zero-initialised their f32 round-trip scratch even though every element is written by cvt_f16_to_f32 before the f32 kernel or cvt_f32_to_f16 reads it. Use MaybeUninit instead, as the arm64 f16 activations already do, avoiding the pointless clear.