### PR TITLE
feat(linalg): add ARMv7 NEON fused SiLU f32 kernel

### DIFF
--- a/linalg/arm32/armv7neon/armv7neon_silu_f32_4n.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_silu_f32_4n.S.j2
@@ -1,0 +1,200 @@
+// vim: ft=arm
+
+    .arm
+    .text
+    .global armv7neon_silu_f32_4n_{{suffix}}
+    .type armv7neon_silu_f32_4n_{{suffix}}, %function
+
+/*
+    Fused SiLU kernel.
+
+    Per element (z = clamp(x, -18.6, 18.6), w = z^2):
+        SiLU(x) = f * (0.5 + z * P(w) / Q(w))
+    where P is the degree-6 Horner polynomial over the numerator coeffs, Q the
+    degree-3 Horner polynomial over the denominator coeffs, and f = max(x, -18.6)
+    the factor the sigmoid multiplies. Reuses the sigmoid coefficients and
+    reciprocal of armv7neon_sigmoid_f32_4n.S.j2.
+
+    f is clamped below at -18.6 but left unclamped above: the upper clamp only
+    keeps the sigmoid polynomial argument z in range, whereas SiLU(x) ~ x as
+    x -> +inf so the factor must stay unbounded above. The lower clamp keeps the
+    negative tail bounded: x < -18.6 saturates at -18.6 * sigmoid(-18.6), which
+    the true SiLU approaches from below as x -> -inf.
+
+    ARMv7 has only 16 q registers, so f (q4/q5) is kept across a 2-group
+    (8-element) main loop.
+
+    s16-s31 (d8-d15, q4-q7) must be preserved
+    s0-s15 (d0-d7, q0-q3) and d16-d31 (q8-q15) do not need to be preserved
+*/
+
+armv7neon_silu_f32_4n_{{suffix}}:
+    cmp         r1, #0
+    blxeq       lr
+
+    vpush       { q4-q7 }
+
+    adr         r2, .coeffs_num
+    vldmia      r2!, { s0-s13 }
+
+    cmp         r1, #8
+    blt         .loop
+
+.loop_2:
+    vldmia      r0, { q6, q7 }             // q6,q7 <- x
+
+    vdup.32     q15, d0[0]
+    vmax.f32    q4, q6, q15
+    vmax.f32    q5, q7, q15                // q4,q5 <- f = max(x, -18.6)
+    vdup.32     q15, d0[1]
+    vmin.f32    q6, q4, q15
+    vmin.f32    q7, q5, q15                // q6,q7 <- z = min(f, 18.6)
+
+    vmul.f32    q8, q6, q6                 // q8,q9 <- w = z^2
+    vmul.f32    q9, q7, q7
+
+    vdup.32     q10, d1[0]
+    vdup.32     q11, d1[0]
+    vdup.32     q12, d1[1]
+    vdup.32     q13, d1[1]
+    vmla.f32    q12, q8, q10
+    vmla.f32    q13, q9, q11
+    vdup.32     q10, d2[0]
+    vdup.32     q11, d2[0]
+    vmla.f32    q10, q12, q8
+    vmla.f32    q11, q13, q9
+    vdup.32     q12, d2[1]
+    vdup.32     q13, d2[1]
+    vmla.f32    q12, q8, q10
+    vmla.f32    q13, q9, q11
+    vdup.32     q10, d3[0]
+    vdup.32     q11, d3[0]
+    vmla.f32    q10, q12, q8
+    vmla.f32    q11, q13, q9
+    vdup.32     q12, d3[1]
+    vdup.32     q13, d3[1]
+    vmla.f32    q12, q8, q10
+    vmla.f32    q13, q9, q11
+    vdup.32     q10, d4[0]
+    vdup.32     q11, d4[0]
+    vmla.f32    q10, q12, q8               // q10,q11 <- P(w)
+    vmla.f32    q11, q13, q9
+    vmul.f32    q6, q6, q10                // q6,q7 <- numerator = z * P(w)
+    vmul.f32    q7, q7, q11
+
+    vdup.32     q10, d4[1]
+    vdup.32     q11, d4[1]
+    vdup.32     q12, d5[0]
+    vdup.32     q13, d5[0]
+    vmla.f32    q12, q8, q10
+    vmla.f32    q13, q9, q11
+    vdup.32     q10, d5[1]
+    vdup.32     q11, d5[1]
+    vmla.f32    q10, q12, q8
+    vmla.f32    q11, q13, q9
+    vdup.32     q12, d6[0]
+    vdup.32     q13, d6[0]
+    vmla.f32    q12, q8, q10               // q12,q13 <- denum = Q(w)
+    vmla.f32    q13, q9, q11
+
+    vrecpe.f32  q8, q12
+    vrecpe.f32  q9, q13
+    vrecps.f32  q10, q8, q12
+    vrecps.f32  q11, q9, q13
+    vmul.f32    q8, q8, q10
+    vmul.f32    q9, q9, q11
+    vrecps.f32  q10, q8, q12
+    vrecps.f32  q11, q9, q13
+    vmul.f32    q8, q8, q10                // q8,q9 <- 1/denum
+    vmul.f32    q9, q9, q11
+
+    vdup.32     q10, d6[1]
+    vdup.32     q11, d6[1]
+    vmla.f32    q10, q6, q8                // q10,q11 <- sigmoid = 0.5 + num/denum
+    vmla.f32    q11, q7, q9
+
+    vmul.f32    q10, q10, q4               // q10,q11 <- SiLU = sigmoid * f
+    vmul.f32    q11, q11, q5
+
+    vstmia      r0!, { q10, q11 }
+
+    subs        r1, #8
+    cmp         r1, #8
+    bge         .loop_2
+
+    cmp         r1, #0
+    beq         .return
+
+.loop:
+    vldmia      r0, { q6 }                 // q6 <- x
+
+    vdup.32     q15, d0[0]
+    vmax.f32    q4, q6, q15                // q4 <- f = max(x, -18.6)
+    vdup.32     q15, d0[1]
+    vmin.f32    q6, q4, q15                // q6 <- z = min(f, 18.6)
+
+    vmul.f32    q8, q6, q6                 // q8 <- w = z^2
+
+    vdup.32     q10, d1[0]
+    vdup.32     q12, d1[1]
+    vmla.f32    q12, q8, q10
+    vdup.32     q10, d2[0]
+    vmla.f32    q10, q12, q8
+    vdup.32     q12, d2[1]
+    vmla.f32    q12, q8, q10
+    vdup.32     q10, d3[0]
+    vmla.f32    q10, q12, q8
+    vdup.32     q12, d3[1]
+    vmla.f32    q12, q8, q10
+    vdup.32     q10, d4[0]
+    vmla.f32    q10, q12, q8               // q10 <- P(w)
+    vmul.f32    q6, q6, q10                // q6 <- numerator = z * P(w)
+
+    vdup.32     q10, d4[1]
+    vdup.32     q12, d5[0]
+    vmla.f32    q12, q8, q10
+    vdup.32     q10, d5[1]
+    vmla.f32    q10, q12, q8
+    vdup.32     q12, d6[0]
+    vmla.f32    q12, q8, q10               // q12 <- denum = Q(w)
+
+    vrecpe.f32  q8, q12
+    vrecps.f32  q10, q8, q12
+    vmul.f32    q8, q8, q10
+    vrecps.f32  q10, q8, q12
+    vmul.f32    q8, q8, q10                // q8 <- 1/denum
+
+    vdup.32     q10, d6[1]
+    vmla.f32    q10, q6, q8                // q10 <- sigmoid = 0.5 + num/denum
+
+    vmul.f32    q10, q10, q4               // q10 <- SiLU = sigmoid * f
+
+    vstmia      r0!, { q10 }
+
+    subs        r1, #4
+    bne         .loop
+
+.return:
+    vpop        { q4-q7 }
+    bx          lr
+
+.coeffs_num:
+    .float -18.6                    // low
+    .float 18.6                     // high
+    .float -4.433153405e-18         // alpha_13
+    .float 1.169974371e-14
+
+    .float -1.875289645e-11
+    .float 4.257889523e-8
+    .float 0.00004811817576
+    .float 0.008163842030
+
+    .float 0.2499999971
+    .float 3.922935744e-6           // beta_6
+    .float 0.001524872358
+    .float 0.1159886749
+
+    .float 1.0
+    .float 0.5
+    .float 0.0                      // padding
+    .float 0.0

--- a/linalg/src/arm32.rs
+++ b/linalg/src/arm32.rs
@@ -100,6 +100,7 @@ pub fn plug(ops: &mut Ops) {
         ops.qmmm_i32 = Box::new(|_, _, _| armv7neon::armv7neon_mmm_i32_8x4.mmm());
         ops.qmmv_i32 = Box::new(|_, _| armv7neon::armv7neon_mmm_i32_32x1.mmm());
         ops.sigmoid_f32 = Box::new(|| armv7neon_sigmoid_f32_4n::ew());
+        ops.silu_f32 = Box::new(|| armv7neon_silu_f32_4n::ew());
         ops.tanh_f32 = Box::new(|| armv7neon_tanh_f32_4n::ew());
     } else {
         armvfpv2::plug(ops);

--- a/linalg/src/arm32/armv7neon.rs
+++ b/linalg/src/arm32/armv7neon.rs
@@ -45,4 +45,5 @@ pub fn plug(ops: &mut Ops) {
 }
 
 sigmoid_impl!(f32, armv7neon_sigmoid_f32_4n, 4, 4, crate::arm32::has_neon());
+silu_impl!(f32, armv7neon_silu_f32_4n, 4, 4, crate::arm32::has_neon());
 tanh_impl!(f32, armv7neon_tanh_f32_4n, 4, 4, crate::arm32::has_neon());


### PR DESCRIPTION
Provide a hand-written NEON SiLU activation for f32 on ARMv7, wired in as ops.silu_f32 when NEON is available. Previously ARMv7 fell back to the generic scalar SiLU; this gives it a vectorized path matching the existing sigmoid/tanh kernels.

Tested on a Cortex-A9 CPU.

I couldn't keep the same loop unrolling as the ARMv7 NEON Sigmoid kernel because we need to keep the input around for the final multiplication, which requires to have enough free registers (or reloading the input once, introducing extra latency I wanted to avoid). ARMv7 NEON only has 16 q-registers, and the Sigmoid kernel's 3-group pipeline already uses them all, so there's no room left. As a result, I dropped the main loop from 3 groups (12 elements) down to 2 groups (8 elements).