### PR TITLE
feat(arm64): activate silu_f16 on native fp16 arm64

### DIFF
--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -507,6 +507,8 @@ pub fn plug(ops: &mut Ops) {
         ops.max_f16 = Box::new(|| arm64fp16_max_f16_32n::red());
         ops.sum_f16 = Box::new(|| arm64fp16_sum_f16_32n::red());
         ops.mul_by_scalar_f16 = Box::new(|| arm64fp16_mul_by_scalar_f16_32n::ew());
+        // TODO: Change this SiLU kernel once we have a native-FP16 one
+        ops.silu_f16 = Box::new(|| arm64simd_silu_f16_4n::ew());
     } else {
         log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 and silu_f16 activated");
         ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_4n::ew());


### PR DESCRIPTION
The native fp16 arm64 path left silu_f16 on its default; wire it to the f32-roundtrip NEON kernel so silu_f16 is covered there too, pending a native-FP16 implementation. This way, we can still benefit from the f32-roundtrip NEON kernel improvement over the SiLU's generic version.

See also: #2509