### PR TITLE
linalg/mmm: opt-in row-major store tile for aligned bulk stores

### DIFF
--- a/linalg/src/arm64/apple_amx.rs
+++ b/linalg/src/arm64/apple_amx.rs
@@ -9,7 +9,7 @@ use super::{arm64fp16_mmm_f16_16x8_gen, arm64simd_mmm_f32_8x8_gen, arm64simd_mmm
 const AMX: fn() -> bool = crate::arm64::has_amx;
 const CAN_FUSE: fn(&FusedSpec) -> bool = |f| !matches!(f, &FusedSpec::LeakyRelu(_));
 
-MMMExternKernel!(apple_amx_mmm_f32_32x32<f32>(32, 32)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
+MMMExternKernel!(apple_amx_mmm_f32_32x32<f32>(32, 32)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized) row_major_store(true));
 MMMExternKernel!(apple_amx_mmm_f32_32x1<f32>(32, 1)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
 MMMExternKernel!(apple_amx_mmm_f16_64x32<f16>(64, 32)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
 MMMExternKernel!(apple_amx_mmm_f16_64x1<f16>(64, 1)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized));

--- a/linalg/src/arm64/apple_amx.rs
+++ b/linalg/src/arm64/apple_amx.rs
@@ -11,7 +11,7 @@ const CAN_FUSE: fn(&FusedSpec) -> bool = |f| !matches!(f, &FusedSpec::LeakyRelu(
 
 MMMExternKernel!(apple_amx_mmm_f32_32x32<f32>(32, 32)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized) row_major_store(true));
 MMMExternKernel!(apple_amx_mmm_f32_32x1<f32>(32, 1)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
-MMMExternKernel!(apple_amx_mmm_f16_64x32<f16>(64, 32)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
+MMMExternKernel!(apple_amx_mmm_f16_64x32<f16>(64, 32)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized) row_major_store(true));
 MMMExternKernel!(apple_amx_mmm_f16_64x1<f16>(64, 1)@(128, 128) where(AMX) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
 
 pub fn plug(ops: &mut Ops) {

--- a/linalg/src/frame/mmm/kernel.rs
+++ b/linalg/src/frame/mmm/kernel.rs
@@ -29,6 +29,13 @@ pub trait MatMatMulKer: Clone + Debug + Send + Sync + 'static {
     fn is_supported_here(&self) -> bool {
         true
     }
+
+    /// Whether the border-tile store scratch should be laid out row-major
+    /// (n contiguous) instead of the default column-major (mr contiguous).
+    /// Set by kernels whose store has an aligned row-major bulk path.
+    fn stores_row_major_tile(&self) -> bool {
+        false
+    }
 }
 
 type Kernel<Acc> = unsafe fn(&[FusedKerSpec<Acc>]) -> isize;
@@ -43,6 +50,7 @@ pub struct DynKernel<const MR: usize, const NR: usize, Acc: LADatum> {
     pub supported_predicate: fn() -> bool,
     pub boost: fn() -> isize,
     pub can_fuse: fn(&FusedSpec) -> bool,
+    pub row_major_store: bool,
 }
 
 impl<const MR: usize, const NR: usize, Acc: LADatum> DynKernel<MR, NR, Acc> {
@@ -62,6 +70,7 @@ impl<const MR: usize, const NR: usize, Acc: LADatum> DynKernel<MR, NR, Acc> {
             supported_predicate: || true,
             boost: || 0,
             can_fuse: |_| true,
+            row_major_store: false,
         };
         kernel.with_packing(packing_a, packing_b)
     }
@@ -155,5 +164,9 @@ impl<const MR: usize, const NR: usize, Acc: LADatum> MatMatMulKer for DynKernel<
 
     fn dynamic_boost(&self) -> isize {
         (self.boost)()
+    }
+
+    fn stores_row_major_tile(&self) -> bool {
+        self.row_major_store
     }
 }

--- a/linalg/src/frame/mmm/macros.rs
+++ b/linalg/src/frame/mmm/macros.rs
@@ -8,6 +8,7 @@ macro_rules! MMMExternKernel {
             $(quality($quality:expr))?
             $(boost($boost:expr))?
             $(store($($store:ty),*))?
+            $(row_major_store($rms:expr))?
      ) => {
         paste! {
             mod [<sys_ $func>] {
@@ -31,6 +32,7 @@ macro_rules! MMMExternKernel {
                 $(quality($quality))?
                 $(boost($boost))?
                 $(store($($store),*))?
+                $(row_major_store($rms))?
             );
         }
     };
@@ -44,6 +46,7 @@ macro_rules! MMMRustKernel {
             $(packing[$pnum:literal] = $pid:ident => $packing:expr;)*
             $(quality($quality:expr))?
             $(store($($store:ty),*))?
+            $(row_major_store($rms:expr))?
      ) => {
         paste! {
             mod [<sys_ $id>] {
@@ -63,6 +66,7 @@ macro_rules! MMMRustKernel {
                 $(packing[$pnum] = $pid => $packing;)*
                 $(quality($quality))?
                 $(store($($store),*))?
+                $(row_major_store($rms))?
             );
         }
     }
@@ -80,6 +84,7 @@ macro_rules! MMMKernel {
             $(quality($quality:expr))?
             $(boost($boost:expr))?
             $(store($($store:ty),*))?
+            $(row_major_store($rms:expr))?
      ) => {
         paste! {
             lazy_static::lazy_static! {
@@ -108,6 +113,7 @@ macro_rules! MMMKernel {
                     $(k.can_fuse = $can_fuse;)?
                     $(k.quality = $quality;)?
                     $(k = k.with_boost($boost);)?
+                    $(k.row_major_store = $rms;)?
                     k
                 };
             }

--- a/linalg/src/frame/mmm/scratch.rs
+++ b/linalg/src/frame/mmm/scratch.rs
@@ -158,6 +158,12 @@ impl<TI: LADatum> ScratchSpaceImpl<TI> {
                     FusedKerSpec::Done
                 }
                 FS::Store(store) => {
+                    if ker.stores_row_major_tile() {
+                        // 128-align the row-major store tile so the kernel can hit
+                        // its aligned bulk-store path (e.g. Apple AMX stz-direct).
+                        align = align.lcm(&128);
+                        offset = Integer::next_multiple_of(&offset, &128);
+                    }
                     self.loc_dependant.push(ld(ix, self.ker_specs.len(), offset));
                     offset += store.item_size * ker.mr() * ker.nr();
                     FusedKerSpec::Done
@@ -481,11 +487,16 @@ impl<TI: LADatum> ScratchSpaceImpl<TI> {
                         })
                     }
                     FS::Store(c_store) => {
+                        let (row_byte_stride, col_byte_stride) = if ker.stores_row_major_tile() {
+                            ((c_store.item_size * ker.nr()) as isize, c_store.item_size as isize)
+                        } else {
+                            (c_store.item_size as isize, (c_store.item_size * ker.mr()) as isize)
+                        };
                         let tmpc = OutputStoreKer {
                             ptr: loc as _,
                             item_size: c_store.item_size,
-                            row_byte_stride: c_store.item_size as isize,
-                            col_byte_stride: (c_store.item_size * ker.mr()) as isize,
+                            row_byte_stride,
+                            col_byte_stride,
                         };
                         FKS::Store(tmpc)
                     }

--- a/linalg/src/frame/mmm/scratch.rs
+++ b/linalg/src/frame/mmm/scratch.rs
@@ -158,14 +158,18 @@ impl<TI: LADatum> ScratchSpaceImpl<TI> {
                     FusedKerSpec::Done
                 }
                 FS::Store(store) => {
-                    if ker.stores_row_major_tile() {
-                        // 128-align the row-major store tile so the kernel can hit
-                        // its aligned bulk-store path (e.g. Apple AMX stz-direct).
+                    let tile_bytes = if ker.stores_row_major_tile() {
+                        // 128-align the row-major store tile, with rows padded to
+                        // 128 bytes, so the kernel can hit its aligned bulk-store
+                        // path (e.g. Apple AMX stz-direct).
                         align = align.lcm(&128);
                         offset = Integer::next_multiple_of(&offset, &128);
-                    }
+                        Integer::next_multiple_of(&(store.item_size * ker.nr()), &128) * ker.mr()
+                    } else {
+                        store.item_size * ker.mr() * ker.nr()
+                    };
                     self.loc_dependant.push(ld(ix, self.ker_specs.len(), offset));
-                    offset += store.item_size * ker.mr() * ker.nr();
+                    offset += tile_bytes;
                     FusedKerSpec::Done
                 }
                 FS::LeakyRelu(t) => FKS::LeakyRelu(*t.try_as_plain()?.to_scalar()?),
@@ -488,7 +492,11 @@ impl<TI: LADatum> ScratchSpaceImpl<TI> {
                     }
                     FS::Store(c_store) => {
                         let (row_byte_stride, col_byte_stride) = if ker.stores_row_major_tile() {
-                            ((c_store.item_size * ker.nr()) as isize, c_store.item_size as isize)
+                            // Pad the row stride to 128 bytes so it stays aligned
+                            // for the kernel's bulk-store path.
+                            let row =
+                                Integer::next_multiple_of(&(c_store.item_size * ker.nr()), &128);
+                            (row as isize, c_store.item_size as isize)
                         } else {
                             (c_store.item_size as isize, (c_store.item_size * ker.mr()) as isize)
                         };

--- a/linalg/src/frame/mmm/scratch.rs
+++ b/linalg/src/frame/mmm/scratch.rs
@@ -158,7 +158,12 @@ impl<TI: LADatum> ScratchSpaceImpl<TI> {
                     FusedKerSpec::Done
                 }
                 FS::Store(store) => {
-                    let tile_bytes = if ker.stores_row_major_tile() {
+                    // Only worth a row-major tile when the destination is itself
+                    // n-contiguous: set_from_tile then copies without transposing
+                    // and the kernel's aligned bulk-store path applies.
+                    let row_major = ker.stores_row_major_tile()
+                        && store.col_byte_stride == store.item_size as isize;
+                    let tile_bytes = if row_major {
                         // 128-align the row-major store tile, with rows padded to
                         // 128 bytes, so the kernel can hit its aligned bulk-store
                         // path (e.g. Apple AMX stz-direct).
@@ -491,7 +496,9 @@ impl<TI: LADatum> ScratchSpaceImpl<TI> {
                         })
                     }
                     FS::Store(c_store) => {
-                        let (row_byte_stride, col_byte_stride) = if ker.stores_row_major_tile() {
+                        let row_major = ker.stores_row_major_tile()
+                            && c_store.col_byte_stride == c_store.item_size as isize;
+                        let (row_byte_stride, col_byte_stride) = if row_major {
                             // Pad the row stride to 128 bytes so it stays aligned
                             // for the kernel's bulk-store path.
                             let row =

--- a/linalg/src/frame/mmm/storage.rs
+++ b/linalg/src/frame/mmm/storage.rs
@@ -153,7 +153,6 @@ pub struct OutputStore {
     pub(crate) panel_col_byte_stride: isize,
     pub(crate) item_size: usize,
     pub(crate) item_count: usize,
-    pub(crate) mr: usize,
 }
 
 unsafe impl Send for OutputStore {}
@@ -170,7 +169,6 @@ impl OutputStoreSpec {
             panel_row_byte_stride: row_byte_stride * mr as isize,
             panel_col_byte_stride: col_byte_stride * nr as isize,
             item_size: tensor.datum_type().size_of(),
-            mr,
             item_count: tensor.len(),
         }
     }

--- a/linalg/src/frame/mmm/storage.rs
+++ b/linalg/src/frame/mmm/storage.rs
@@ -250,14 +250,16 @@ impl OutputStore {
         tile: &OutputStoreKer,
     ) {
         unsafe {
-            let tile = tile.ptr as *mut T;
+            let src = tile.ptr as *const u8;
+            let src_rs = tile.row_byte_stride;
+            let src_cs = tile.col_byte_stride;
             let dst = self.ptr.add(
                 self.panel_row_byte_stride as usize * down
                     + self.panel_col_byte_stride as usize * right,
             );
             for y in 0..height as isize {
                 for x in 0..width as isize {
-                    let value = tile.offset(y + x * self.mr as isize);
+                    let value = src.offset(y * src_rs + x * src_cs) as *const T;
                     let dst = dst.offset(y * self.row_byte_stride + x * self.col_byte_stride);
                     *(dst as *mut T) = *value;
                 }


### PR DESCRIPTION
Border-tile stores went through a column-major, unaligned scratch tile, forcing kernels onto their per-lane store fallback. Add a stores_row_major_tile() kernel hook; when set, the store scratch is laid out row-major and 128-aligned so the kernel takes its aligned bulk-store path. Apple AMX f32 32x32 opts in (stz-direct store); set_from_tile now reads the tile via its own byte strides so both layouts stay correct. Other kernels keep the column-major default.