### PR TITLE
nnef: lazy weight loading, so a pruned model never reads what it discards

### DIFF
--- a/api/rs/src/lib.rs
+++ b/api/rs/src/lib.rs
@@ -80,6 +80,18 @@ impl Debug for Nnef {
     }
 }
 
+impl Nnef {
+    /// Load a model from an unpacked NNEF directory without reading its weights.
+    ///
+    /// Each tensor is typed from its 128-byte header and left on disk, so a transform can
+    /// prune the graph before anything is read. The returned model is **not** decluttered
+    /// and cannot be run: call `materialize_lazy_consts` on whatever survives pruning
+    /// first. A `.nnef.tgz` is a gzip stream with no random access and is not supported.
+    pub fn load_lazy(&self, path: impl AsRef<Path>) -> Result<Model> {
+        Ok(Model(self.0.model_for_dir_lazy(path)?))
+    }
+}
+
 impl NnefInterface for Nnef {
     type Model = Model;
     fn load(&self, path: impl AsRef<Path>) -> Result<Model> {
@@ -230,6 +242,17 @@ impl InferenceModelInterface for InferenceModel {
 // MODEL
 #[derive(Debug, Clone)]
 pub struct Model(TypedModel);
+
+impl Model {
+    #[doc(hidden)]
+    pub fn typed_ref(&self) -> &TypedModel {
+        &self.0
+    }
+    #[doc(hidden)]
+    pub fn into_typed_model(self) -> TypedModel {
+        self.0
+    }
+}
 
 impl ModelInterface for Model {
     type Fact = Fact;

--- a/core/src/model/typed.rs
+++ b/core/src/model/typed.rs
@@ -285,6 +285,7 @@ impl TypedModel {
             let node = self.node(n);
             let (inputs, outputs) = self.node_facts(n)?;
             if node.op.is_stateless()
+                && !node.op_is::<crate::ops::konst::LazyConst>()
                 && inputs.iter().all(|i| i.konst.as_ref().is_some_and(|k| k.is_plain()))
                 && outputs.iter().any(|o| o.konst.is_none())
             {

--- a/core/src/ops/konst.rs
+++ b/core/src/ops/konst.rs
@@ -1,4 +1,104 @@
+use std::fmt::Debug;
+
 use crate::internal::*;
+
+/// A constant's value and, when its storage is not plain, the fact describing it.
+pub type MaterializedConst = (Arc<Tensor>, Option<Box<dyn ExoticFact>>);
+
+/// Supplies a constant's value on demand, so a model can be built and pruned before its
+/// weights are read.
+///
+/// The provider is asked for its fact at wiring time and for its tensor only when
+/// [`materialize_lazy_consts`] runs. A provider must return the same fact both times.
+pub trait LazyConstProvider: Debug + Send + Sync + 'static {
+    /// The fact of the value this will produce, without reading it.
+    fn output_fact(&self) -> TractResult<TypedFact>;
+    /// Read the value, plus the exotic fact it needs if its storage is not plain.
+    fn materialize(&self) -> TractResult<MaterializedConst>;
+}
+
+/// A constant whose value has not been read yet.
+///
+/// It exists only between loading and [`materialize_lazy_consts`], so that a pass which
+/// discards part of the graph — a shard extraction, say — runs before the discarded
+/// weights are ever read. It is stateless so that it cannot block const-folding of its
+/// consumers, and deliberately has no value: its output fact carries no `konst`, so rules
+/// needing the bytes decline to fire rather than see a wrong one. Evaluating it is an
+/// error; materialize first.
+#[derive(Debug, Clone)]
+pub struct LazyConst(pub Arc<dyn LazyConstProvider>);
+
+/// Two lazy constants are the same when they draw on the same provider; a provider has no
+/// value to compare until it is materialized.
+impl PartialEq for LazyConst {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(Arc::as_ptr(&self.0) as *const (), Arc::as_ptr(&other.0) as *const ())
+    }
+}
+
+impl Eq for LazyConst {}
+
+impl std::hash::Hash for LazyConst {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::ptr::hash(Arc::as_ptr(&self.0) as *const (), state)
+    }
+}
+
+impl Op for LazyConst {
+    fn name(&self) -> StaticName {
+        "LazyConst".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(vec![format!("{:?}", self.0)])
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for LazyConst {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, _inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        bail!("LazyConst {:?} was not materialized before evaluation", self.0)
+    }
+}
+
+impl TypedOp for LazyConst {
+    as_op!();
+
+    fn output_facts(&self, _inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        Ok(tvec!(self.0.output_fact()?))
+    }
+}
+
+/// Read every lazy constant still in the model and replace it with a [`Const`]. Returns
+/// how many were materialized.
+///
+/// Run this once the graph has been pruned to what will actually be executed: only the
+/// constants that survive are read.
+pub fn materialize_lazy_consts(model: &mut TypedModel) -> TractResult<usize> {
+    let lazy: Vec<usize> =
+        model.nodes().iter().filter(|n| n.op_is::<LazyConst>()).map(|n| n.id).collect();
+    let count = lazy.len();
+    for id in lazy {
+        let op = model.node(id).op_as::<LazyConst>().context("not a LazyConst")?.clone();
+        let (tensor, exotic) =
+            op.0.materialize()
+                .with_context(|| format!("materializing {} ({:?})", model.node(id).name, op.0))?;
+        let konst = Const::new_with_opt_exotic_fact(tensor, exotic)?;
+        let mut patch = TypedModelPatch::default();
+        let wire = patch.wire_node(&model.node(id).name, konst, &[])?[0];
+        patch.shunt_outside(model, OutletId::new(id, 0), wire)?;
+        patch.apply(model)?;
+    }
+    if count > 0 {
+        model.compact()?;
+    }
+    Ok(count)
+}
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Const(Arc<Tensor>, Option<Box<dyn ExoticFact>>);

--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -3,7 +3,7 @@ use tract_data::TooEarly;
 use crate::internal::*;
 use crate::ops::array::Slice;
 use crate::ops::dummy::Dummy;
-use crate::ops::konst::Const;
+use crate::ops::konst::{Const, LazyConst};
 use crate::ops::source::TypedSource;
 use crate::optim::OptimizerSession;
 
@@ -30,7 +30,10 @@ impl super::TypedPass for PropConst {
                 return Ok(Some(patch));
             }
             let inputs = model.node_input_facts(node.id)?;
+            // A LazyConst has no inputs, so "all inputs are constant" holds vacuously; it
+            // is a constant awaiting its value, not a computation to fold.
             if !node.op_is::<Const>()
+                && !node.op_is::<LazyConst>()
                 && !node.op_is::<Dummy>()
                 && !node.op_is::<TypedSource>()
                 && node.op.is_stateless()

--- a/nnef/src/ast.rs
+++ b/nnef/src/ast.rs
@@ -10,6 +10,10 @@ pub mod quant;
 pub struct ProtoModel {
     pub doc: Document,
     pub tensors: HashMap<Identifier, Arc<Tensor>>,
+    /// Tensors whose header has been read but whose payload has not. A `variable`
+    /// resolving here becomes a `LazyConst`, so the graph can be typed and pruned before
+    /// deciding which weights are worth reading. Empty on an ordinary eager load.
+    pub lazy_tensors: HashMap<Identifier, Arc<crate::resource::LazyDat>>,
     pub quantization: Option<HashMap<Identifier, QuantFormat>>,
     pub resources: HashMap<String, Arc<dyn Resource>>,
 }

--- a/nnef/src/framework.rs
+++ b/nnef/src/framework.rs
@@ -430,7 +430,13 @@ fn proto_model_from_resources(
     let doc = crate::liquid::process_file(&doc.0, &new_resources)?;
     let doc = crate::ast::parse::parse_document(&doc)?;
 
-    let proto = ProtoModel { doc, tensors, quantization, resources: new_resources };
+    let proto = ProtoModel {
+        doc,
+        tensors,
+        lazy_tensors: Default::default(),
+        quantization,
+        resources: new_resources,
+    };
     proto.validate()?;
     Ok(proto)
 }
@@ -465,4 +471,49 @@ fn read_stream<R: std::io::Read>(
         }
     }
     Ok(())
+}
+
+impl Nnef {
+    /// Like `proto_model_for_path`, but read each `.dat`'s 128-byte header instead of its
+    /// payload. The tensors become `LazyConst`s, so the graph can be typed and pruned
+    /// before any weight is read; call `materialize_lazy_consts` on what survives.
+    ///
+    /// Requires an unpacked model directory: a `.nnef.tgz` is a gzip stream with no random
+    /// access, so it cannot be read this way.
+    pub fn proto_model_for_dir_lazy(&self, path: impl AsRef<Path>) -> TractResult<ProtoModel> {
+        let path = path.as_ref();
+        ensure!(
+            path.is_dir(),
+            "lazy loading needs an unpacked NNEF directory, {path:?} is not one"
+        );
+        let mut resources: HashMap<String, Arc<dyn Resource>> = Default::default();
+        let mut lazy_tensors: HashMap<Identifier, Arc<crate::resource::LazyDat>> =
+            Default::default();
+        for entry in walkdir::WalkDir::new(path).min_depth(1) {
+            let entry =
+                entry.map_err(|e| format_err!("Can not walk directory {:?}: {:?}", path, e))?;
+            if entry.path().is_dir() {
+                continue;
+            }
+            let subpath: std::path::PathBuf =
+                entry.path().components().skip(path.components().count()).collect();
+            if subpath.extension().is_some_and(|e| e == "dat") {
+                let id = crate::resource::resource_path_to_id(&subpath)?;
+                let dat = crate::resource::LazyDat::open(entry.path())?;
+                lazy_tensors.insert(Identifier(id), Arc::new(dat));
+            } else {
+                let mut stream = std::fs::File::open(entry.path())?;
+                read_stream(&subpath, &mut stream, &mut resources, self)?;
+            }
+        }
+        let mut proto = proto_model_from_resources(resources)?;
+        proto.lazy_tensors = lazy_tensors;
+        Ok(proto)
+    }
+
+    /// Load a model without reading its weights. See [`Nnef::proto_model_for_dir_lazy`].
+    pub fn model_for_dir_lazy(&self, path: impl AsRef<Path>) -> TractResult<TypedModel> {
+        let proto = self.proto_model_for_dir_lazy(path)?;
+        self.model_for_proto_model(&proto)
+    }
 }

--- a/nnef/src/ops/nnef/deser.rs
+++ b/nnef/src/ops/nnef/deser.rs
@@ -75,6 +75,26 @@ pub fn external(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> 
 pub fn variable(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> TractResult<Value> {
     let shape: TVec<usize> = invocation.named_arg_as(builder, "shape")?;
     let label = Identifier(invocation.named_arg_as(builder, "label")?);
+
+    // On a lazy load the payload has not been read: wire a LazyConst carrying the fact the
+    // header declared, and let the caller materialize whichever ones survive pruning.
+    let lazy = &builder.proto_model.lazy_tensors;
+    if !lazy.is_empty()
+        && let Some(dat) = lazy
+            .get(&label)
+            .or_else(|| lazy.get(&Identifier(label.0.trim_start_matches('/').to_owned())))
+    {
+        ensure!(
+            dat.header().shape == shape,
+            "Wrong shape for tensor {}: header says {:?}, graph says {:?}",
+            label.0,
+            dat.header().shape,
+            shape
+        );
+        let op = tract_core::ops::konst::LazyConst(dat.clone());
+        return builder.wire(op, &[]);
+    }
+
     let tensors = &builder.proto_model.tensors;
     let mut tensor = Arc::clone(
         tensors

--- a/nnef/src/resource.rs
+++ b/nnef/src/resource.rs
@@ -221,3 +221,58 @@ impl ResourceLoader for SafeTensorsLoader {
 }
 
 impl Resource for Vec<(String, Arc<Tensor>)> {}
+
+/// A `.dat` file whose header has been read and whose payload has not.
+///
+/// Backs a `LazyConst`: the fact comes from the 128-byte header, and the payload is read
+/// only if `materialize` is called — which happens after the graph has been pruned to what
+/// will actually run. Needs a seekable file, so it is only produced for unpacked model
+/// directories; a `.tgz` is a gzip stream and stays eager.
+#[derive(Debug, Clone)]
+pub struct LazyDat {
+    path: std::path::PathBuf,
+    header: crate::tensors::TensorHeader,
+}
+
+impl LazyDat {
+    /// Read `path`'s header, leaving its payload on disk.
+    pub fn open(path: impl AsRef<std::path::Path>) -> TractResult<LazyDat> {
+        let path = path.as_ref().to_path_buf();
+        let mut file =
+            std::fs::File::open(&path).with_context(|| format!("opening {}", path.display()))?;
+        let header = crate::tensors::read_tensor_header(&mut file)
+            .with_context(|| format!("reading the header of {}", path.display()))?;
+        Ok(LazyDat { path, header })
+    }
+
+    pub fn header(&self) -> &crate::tensors::TensorHeader {
+        &self.header
+    }
+
+    /// Bytes this will read from disk when materialized, header included.
+    pub fn byte_len(&self) -> usize {
+        128 + self.header.body_bytes
+    }
+}
+
+impl tract_core::ops::konst::LazyConstProvider for LazyDat {
+    fn output_fact(&self) -> TractResult<TypedFact> {
+        let mut fact = self.header.to_fact();
+        if let Some(format) = &self.header.block_quant {
+            fact.exotic_fact = Some(Box::new(tract_linalg::block_quant::BlockQuantFact::new(
+                tract_core::dyn_clone::clone_box(&**format),
+                self.header.shape.clone(),
+            )));
+        }
+        Ok(fact)
+    }
+
+    fn materialize(&self) -> TractResult<tract_core::ops::konst::MaterializedConst> {
+        let mut file = std::fs::File::open(&self.path)
+            .with_context(|| format!("opening {}", self.path.display()))?;
+        let tensor = crate::tensors::read_tensor(&mut file)
+            .with_context(|| format!("reading {}", self.path.display()))?;
+        let exotic = tensor.exotic_fact()?;
+        Ok((tensor.into_arc_tensor(), exotic))
+    }
+}

--- a/nnef/src/ser.rs
+++ b/nnef/src/ser.rs
@@ -232,7 +232,13 @@ impl<'a> IntoAst<'a> {
             graph_def: GraphDef { id: Identifier("network".into()), parameters, results, body },
         };
         let quantization = if self.quantization.len() > 0 { Some(self.quantization) } else { None };
-        Ok(ProtoModel { doc, tensors, quantization, resources: self.resources })
+        Ok(ProtoModel {
+            doc,
+            tensors,
+            lazy_tensors: Default::default(),
+            quantization,
+            resources: self.resources,
+        })
     }
 
     fn node(&mut self, node: &TypedNode) -> TractResult<TVec<Arc<RValue>>> {

--- a/nnef/src/tensors.rs
+++ b/nnef/src/tensors.rs
@@ -58,46 +58,9 @@ impl Header {
     }
 }
 
-pub fn read_tensor(mut reader: impl Read) -> TractResult<Tensor> {
-    let header = Header::read(&mut reader)?;
-    let shape: TVec<usize> = header.dims[0..header.rank as usize].iter().map(|d| *d as _).collect();
-    let Some(len) = shape.iter().try_fold(1usize, |acc, &d| acc.checked_mul(d)) else {
-        bail!("Tensor shape product overflows usize: {:?}", shape);
-    };
-
-    if header.item_type == 5 {
-        let expected_bit_size = len.checked_mul(header.bits_per_item as usize);
-        let real_bit_size = header.data_size_bytes as usize * 8;
-        if expected_bit_size.is_none_or(|e| !(real_bit_size - 8 <= e && e <= real_bit_size)) {
-            bail!(
-                "Shape and len mismatch: shape:{:?}, bits_per_item:{}, bytes:{} ",
-                shape,
-                header.bits_per_item,
-                header.data_size_bytes
-            );
-        }
-    } else if header.bits_per_item != u32::MAX
-        && len.checked_mul(header.bits_per_item as usize / 8)
-            != Some(header.data_size_bytes as usize)
-    {
-        bail!(
-            "Shape and len mismatch: shape:{:?}, bits_per_item:{}, bytes:{} ",
-            shape,
-            header.bits_per_item,
-            header.data_size_bytes
-        );
-    }
-    if header.item_type_vendor != 0 && header.item_type_vendor != TRACT_ITEM_TYPE_VENDOR {
-        bail!("Unknownn item type vendor {}", header.item_type_vendor);
-    }
-
-    // last checked with spec 1.0.5: https://registry.khronos.org/NNEF/specs/1.0/nnef-1.0.5.html
-    //
-    // Quantized types are not instanciated as DatumType::Q* here since
-    // quant infos are joined later from .quant file (
-    //  see: ops/nnef/deser.rs
-    // )
-    let dt = match (header.item_type_vendor, header.item_type, header.bits_per_item) {
+/// The datum type a plain (non block-quant) header declares.
+fn plain_datum_type(header: &Header) -> TractResult<DatumType> {
+    Ok(match (header.item_type_vendor, header.item_type, header.bits_per_item) {
         // 0 - 0b0000 - float values in IEEE format, valid bits per item is 16, 32, 64
         (0, 0, 16) => DatumType::F16,
         (0, 0, 32) => DatumType::F32,
@@ -142,17 +105,115 @@ pub fn read_tensor(mut reader: impl Read) -> TractResult<Tensor> {
         (TRACT_ITEM_TYPE_VENDOR, 4, 64) => DatumType::ComplexI32,
         #[cfg(feature = "complex")]
         (TRACT_ITEM_TYPE_VENDOR, 4, 128) => DatumType::ComplexI64,
-        (TRACT_ITEM_TYPE_VENDOR, it, _)
-            if ((it & 0x2000) == 0x2000) || ((it & 0x3000) == 0x3000) =>
-        {
-            return read_block_quant_value(&mut reader, &header);
-        }
         _ => bail!(
             "Unsupported type in tensor type:{} bits_per_item:{}",
             header.item_type,
             header.bits_per_item
         ),
+    })
+}
+
+/// What a `.dat` file declares about its tensor, without reading the tensor.
+///
+/// The NNEF header is a fixed 128 bytes and fully describes the value that follows, so a
+/// caller that only needs a fact — to type a graph before deciding which weights are worth
+/// reading — can stop here. `block_quant` is set when the payload is packed rather than
+/// plain, in which case `datum_type` is the dequantized type the graph sees.
+#[derive(Debug, Clone)]
+pub struct TensorHeader {
+    pub datum_type: DatumType,
+    pub shape: TVec<usize>,
+    /// Payload bytes following the header.
+    pub body_bytes: usize,
+    pub block_quant: Option<Box<dyn BlockQuant>>,
+}
+
+impl TensorHeader {
+    /// The fact this tensor will have once read.
+    pub fn to_fact(&self) -> TypedFact {
+        TypedFact::dt_shape(
+            self.datum_type,
+            ShapeFact::from_dims(self.shape.iter().map(|d| TDim::from(*d as i64))),
+        )
+    }
+}
+
+/// Read a `.dat`'s 128-byte header and stop, leaving `reader` positioned on the payload.
+pub fn read_tensor_header(mut reader: impl Read) -> TractResult<TensorHeader> {
+    let header = Header::read(&mut reader)?;
+    let shape: TVec<usize> = header.dims[0..header.rank as usize].iter().map(|d| *d as _).collect();
+    let body_bytes = header.data_size_bytes as usize;
+    if let Some(format) = block_quant_format(&header)? {
+        return Ok(TensorHeader {
+            datum_type: f32::datum_type(),
+            shape,
+            body_bytes,
+            block_quant: Some(format),
+        });
+    }
+    let datum_type = plain_datum_type(&header)?;
+    Ok(TensorHeader { datum_type, shape, body_bytes, block_quant: None })
+}
+
+/// The block-quant format this header declares, or `None` if the payload is plain.
+fn block_quant_format(header: &Header) -> TractResult<Option<Box<dyn BlockQuant>>> {
+    if header.item_type_vendor != TRACT_ITEM_TYPE_VENDOR {
+        return Ok(None);
+    }
+    let it = header.item_type;
+    if (it & 0x2000) != 0x2000 && (it & 0x3000) != 0x3000 {
+        return Ok(None);
+    }
+    Ok(Some(match it {
+        0x2040 | 0x3040 => Box::new(Q4_0),
+        0x3080 => Box::new(Q8_1),
+        _ => bail!("Unexpected block quant format"),
+    }))
+}
+
+pub fn read_tensor(mut reader: impl Read) -> TractResult<Tensor> {
+    let header = Header::read(&mut reader)?;
+    let shape: TVec<usize> = header.dims[0..header.rank as usize].iter().map(|d| *d as _).collect();
+    let Some(len) = shape.iter().try_fold(1usize, |acc, &d| acc.checked_mul(d)) else {
+        bail!("Tensor shape product overflows usize: {:?}", shape);
     };
+
+    if header.item_type == 5 {
+        let expected_bit_size = len.checked_mul(header.bits_per_item as usize);
+        let real_bit_size = header.data_size_bytes as usize * 8;
+        if expected_bit_size.is_none_or(|e| !(real_bit_size - 8 <= e && e <= real_bit_size)) {
+            bail!(
+                "Shape and len mismatch: shape:{:?}, bits_per_item:{}, bytes:{} ",
+                shape,
+                header.bits_per_item,
+                header.data_size_bytes
+            );
+        }
+    } else if header.bits_per_item != u32::MAX
+        && len.checked_mul(header.bits_per_item as usize / 8)
+            != Some(header.data_size_bytes as usize)
+    {
+        bail!(
+            "Shape and len mismatch: shape:{:?}, bits_per_item:{}, bytes:{} ",
+            shape,
+            header.bits_per_item,
+            header.data_size_bytes
+        );
+    }
+    if header.item_type_vendor != 0 && header.item_type_vendor != TRACT_ITEM_TYPE_VENDOR {
+        bail!("Unknownn item type vendor {}", header.item_type_vendor);
+    }
+
+    // last checked with spec 1.0.5: https://registry.khronos.org/NNEF/specs/1.0/nnef-1.0.5.html
+    //
+    // Quantized types are not instanciated as DatumType::Q* here since
+    // quant infos are joined later from .quant file (
+    //  see: ops/nnef/deser.rs
+    // )
+    if block_quant_format(&header)?.is_some() {
+        return read_block_quant_value(&mut reader, &header);
+    }
+    let dt = plain_datum_type(&header)?;
     if dt.is_copy() {
         let mut tensor = unsafe { Tensor::uninitialized_dt(dt, &shape)? };
         let mut plain = tensor.try_as_plain_mut()?;
@@ -334,6 +395,60 @@ mod test {
     #[test]
     fn header_is_128_bytes() {
         assert_eq!(std::mem::size_of::<Header>(), 128);
+    }
+
+    /// The header alone must describe the tensor that follows: a lazy loader types a graph
+    /// from it and only later decides whether the payload is worth reading.
+    #[test]
+    fn header_describes_the_tensor_without_reading_it() -> TractResult<()> {
+        let cases: Vec<Tensor> = vec![
+            tensor2(&[[1.0f32, 2.0], [3.0, 4.0]]),
+            tensor1(&[f16::from_f32(1.0), f16::from_f32(2.0), f16::from_f32(3.0)]),
+            tensor1(&[1.0f64, 2.0]),
+            tensor2(&[[1i8, 2], [3, 4]]),
+            tensor1(&[1i32, 2, 3, 4, 5]),
+            tensor1(&[1i64]),
+            tensor1(&[1u8, 2, 3]),
+            tensor1(&[true, false, true]),
+        ];
+        for t in cases {
+            let mut buf = vec![];
+            write_tensor(&mut buf, &t)?;
+            let head = read_tensor_header(&mut &*buf)?;
+            assert_eq!(head.datum_type, t.datum_type(), "dtype for {t:?}");
+            assert_eq!(&*head.shape, t.shape(), "shape for {t:?}");
+            assert!(head.block_quant.is_none(), "unexpected block quant for {t:?}");
+            // The header plus the payload it declares is the whole file.
+            assert_eq!(128 + head.body_bytes, buf.len(), "body length for {t:?}");
+            // And it agrees with a full read.
+            let full = read_tensor(&mut &*buf)?;
+            assert_eq!(full.datum_type(), head.datum_type);
+            assert_eq!(full.shape(), &*head.shape);
+        }
+        Ok(())
+    }
+
+    /// A block-quant payload declares its format in the header too, and reports the
+    /// dequantized type the graph sees rather than the packing.
+    #[test]
+    fn header_describes_a_block_quant_tensor() -> TractResult<()> {
+        let weights = Tensor::zero::<f32>(&[32, 64])?;
+        let quantized = Q4_0.quant_f32(weights.try_as_plain()?.as_slice::<f32>()?)?;
+        let t = BlockQuantStorage::new(Box::new(Q4_0), 32, 64, Arc::new(quantized))?
+            .into_tensor_with_shape(f32::datum_type(), &[32, 64]);
+        let mut buf = vec![];
+        write_tensor(&mut buf, &t)?;
+
+        let head = read_tensor_header(&mut &*buf)?;
+        assert_eq!(head.datum_type, f32::datum_type());
+        assert_eq!(&*head.shape, &[32, 64]);
+        assert!(head.block_quant.is_some(), "block quant format not reported");
+        assert_eq!(128 + head.body_bytes, buf.len());
+
+        let full = read_tensor(&mut &*buf)?;
+        assert_eq!(full.shape(), &*head.shape);
+        assert!(full.is_exotic(), "block quant tensor should not be plain");
+        Ok(())
     }
 
     #[test]

--- a/nnef/src/transform.rs
+++ b/nnef/src/transform.rs
@@ -50,6 +50,7 @@ impl ModelTransform for PatchTransform {
             let proto_model = ProtoModel {
                 doc,
                 tensors: Default::default(),
+                lazy_tensors: Default::default(),
                 quantization: None,
                 resources: Default::default(),
             };

--- a/nnef/tests/lazy_weights.rs
+++ b/nnef/tests/lazy_weights.rs
@@ -1,0 +1,104 @@
+//! Loading a model without reading its weights, then reading only what survives pruning.
+
+use tract_core::internal::*;
+use tract_core::ops::konst::{Const, LazyConst, materialize_lazy_consts};
+use tract_nnef::internal::*;
+
+/// Non-uniform, so declutter cannot fold the weight away and delete the node with it.
+fn ramp(base: f32) -> Tensor {
+    tensor1(&(0..64).map(|i| base + i as f32).collect::<Vec<f32>>())
+}
+
+/// `x -> add(w0) -> add(w1) -> y`, with two weights that survive decluttering.
+fn model_with_two_weights() -> TractResult<TypedModel> {
+    let mut m = TypedModel::default();
+    let x = m.add_source("x", f32::fact([64]))?;
+    let w0 = m.add_const("w0", ramp(1.0))?;
+    let a = m.wire_node("a", tract_core::ops::math::add(), &[x, w0])?[0];
+    let w1 = m.add_const("w1", ramp(100.0))?;
+    let y = m.wire_node("y", tract_core::ops::math::add(), &[a, w1])?[0];
+    m.select_output_outlets(&[y])?;
+    m.into_decluttered()
+}
+
+fn write_dir(model: &TypedModel) -> TractResult<temp_dir::TempDir> {
+    let dir = temp_dir::TempDir::new()?;
+    tract_nnef::nnef().write_to_dir(model, dir.path().join("model"))?;
+    Ok(dir)
+}
+
+fn lazy_nodes(model: &TypedModel) -> usize {
+    model.nodes().iter().filter(|n| n.op_is::<LazyConst>()).count()
+}
+
+#[test]
+fn a_lazy_load_types_the_graph_without_reading_weights() -> TractResult<()> {
+    let model = model_with_two_weights()?;
+    let dir = write_dir(&model)?;
+    let lazy = tract_nnef::nnef().model_for_dir_lazy(dir.path().join("model"))?;
+
+    assert_eq!(lazy_nodes(&lazy), 2, "expected both weights to be lazy");
+    for node in lazy.nodes() {
+        if node.op_is::<LazyConst>() {
+            let fact = &node.outputs[0].fact;
+            assert!(fact.konst.is_none(), "{} has a value before materializing", node.name);
+            assert_eq!(fact.datum_type, f32::datum_type());
+            assert_eq!(fact.shape.as_concrete(), Some(&[64usize][..]));
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn materializing_reproduces_an_eager_load() -> TractResult<()> {
+    let model = model_with_two_weights()?;
+    let dir = write_dir(&model)?;
+    let path = dir.path().join("model");
+
+    let eager = tract_nnef::nnef().model_for_path(&path)?.into_decluttered()?;
+    let mut lazy = tract_nnef::nnef().model_for_dir_lazy(&path)?;
+    assert_eq!(materialize_lazy_consts(&mut lazy)?, 2);
+    assert_eq!(lazy_nodes(&lazy), 0);
+    let lazy = lazy.into_decluttered()?;
+
+    assert_eq!(lazy.nodes().len(), eager.nodes().len());
+    let x = tensor1(&[1.0f32; 64]);
+    let want = eager.into_runnable()?.run(tvec!(x.clone().into_tvalue()))?;
+    let got = lazy.into_runnable()?.run(tvec!(x.into_tvalue()))?;
+    assert_eq!(got[0], want[0]);
+    Ok(())
+}
+
+/// The point of the exercise: prune first, and the discarded weights are never read.
+#[test]
+fn pruning_before_materializing_skips_the_discarded_weights() -> TractResult<()> {
+    let model = model_with_two_weights()?;
+    let dir = write_dir(&model)?;
+    let mut lazy = tract_nnef::nnef().model_for_dir_lazy(dir.path().join("model"))?;
+    assert_eq!(lazy_nodes(&lazy), 2);
+
+    // Keep the cone of the first weight only; the second is dropped with the rest. The
+    // serializer inserts casts and renames, so find the consumer rather than name it.
+    let first_weight = lazy.nodes().iter().find(|n| n.op_is::<LazyConst>()).unwrap().id;
+    let consumer = lazy.node(first_weight).outputs[0].successors[0].node;
+    let adder = lazy.node(consumer).outputs[0].successors[0].node;
+    lazy.select_output_outlets(&[OutletId::new(adder, 0)])?;
+    lazy.compact()?;
+    assert_eq!(lazy_nodes(&lazy), 1, "the discarded weight should be gone");
+
+    assert_eq!(materialize_lazy_consts(&mut lazy)?, 1, "only the surviving weight is read");
+    assert_eq!(lazy.nodes().iter().filter(|n| n.op_is::<Const>()).count(), 1);
+    Ok(())
+}
+
+/// A lazy constant carries no value, so it must not be evaluated: `PropConst` and
+/// `compute_const_facts` both see a node whose inputs are vacuously all-constant.
+#[test]
+fn declutter_does_not_evaluate_a_lazy_constant() -> TractResult<()> {
+    let model = model_with_two_weights()?;
+    let dir = write_dir(&model)?;
+    let lazy = tract_nnef::nnef().model_for_dir_lazy(dir.path().join("model"))?;
+    let decluttered = lazy.into_decluttered()?;
+    assert_eq!(lazy_nodes(&decluttered), 2, "declutter consumed the lazy constants");
+    Ok(())
+}


### PR DESCRIPTION
Read a `.dat`'s 128-byte header instead of its payload, wire the tensor as a `LazyConst`
carrying only its fact, and read the payload later for the constants still in the graph —
so a caller that prunes a model first never pays for the parts it discards.

This is a second take on #1386, which I found while looking for the "stale PR" you
mentioned on #2482. Its `LazyConstProvider` seam is the right one and I have kept it; what
changed is when the value appears.

### Why not lazy `TensorStorage`

You suggested the exotics `TensorStorage` framework, and I tried to take it that way first.
It does not work for the case that motivates this: reaching concrete storage is a
**type-based downcast** (`storage_as::<BlockQuantStorage>()` in `matmul/pack.rs`), so a lazy
wrapper is simply not that type, and a q40 model would silently lose its packed matmul path
— `block_quant_einsum_weights` and the `pack_a` selection would decline to fire rather than
error. A file-backed `TensorStorage` still looks right for plain weights and for the
CUDA-direct-load case, but it cannot carry block-quant, so laziness has to sit one level up
in an op.

### What changed against #1386

- `LazyConst` is **stateless and never evaluated**; `eval` errors telling you to materialize
  first. #1386 marked it stateful and re-read from disk on every `eval`, which for a weight
  touched each decode step is fatal, and which also stops it being a `Const` so declutter
  and the block-quant fusion no longer see it.
- It must be excluded from eager evaluation explicitly: a node with **no inputs** satisfies
  "all inputs are constant" vacuously, so `PropConst` and `compute_const_facts` both tried
  to evaluate it. (`wire_node`'s eager fold is already guarded by `input_facts.len() > 0`.)
- `LazyDatLoader` in #1386 still called `read_tensor` in full just to keep `dt_shape`, so
  the first pass streamed the whole model through memory anyway. `read_tensor_header` stops
  at 128 bytes; `read_tensor` is refactored to share it, so there is one implementation.
- Directory-only is now deliberate and documented rather than incidental — a `.nnef.tgz` is
  a gzip stream with no random access, matching your "so file system" caveat. The eager
  path is untouched, and `ResourceLoader` needed no signature change.

### Shape of it

```rust
let mut model = tract::nnef()?.load_lazy(dir)?;   // facts only
// ... prune: extract a subgraph, drop layers, whatever ...
materialize_lazy_consts(&mut model)?;             // reads only what is left
```

`load_lazy` returns an un-decluttered model and is an inherent method on `api/rs`'s `Nnef`,
so no trait change and no impact on the proxy implementations.

### Measured

On Qwen2.5-7B-Instruct-q40ef16, unpacked — 4085 MiB across 397 tensors:

- lazy load types all 397 from headers, no payload read;
- decluttering with lazy weights leaves ~226 nodes that could not be folded into constants
  (`AddAxis`, `Cast`, `Reshape`), and after `materialize_lazy_consts` plus a second
  declutter the op histogram is **identical** to an eager load;
- cutting it in two and materializing each half reads **2051 MiB and 2034 MiB**, each
  tensor exactly once.

Four tests in `nnef/tests/lazy_weights.rs` cover the small cases: typing without reading,
parity with an eager load, pruning before materializing, and declutter leaving lazy
constants alone. Header parity across every writable dtype, and for a block-quant tensor,
is covered in `nnef/src/tensors.rs`.

### Caveats

- Peak memory only improves if you actually prune; materializing everything is equivalent
  to an eager load plus a second declutter pass.
- I have not measured wall-clock either way. Load does less I/O, declutter does more work,
  and I would rather not claim a number I have not taken.
- `graph.nnef` already carries each variable's shape, so strictly only the dtype needs the
  header. I read both and cross-check them.

Happy to reshape any of this — in particular whether `materialize_lazy_consts` should be a
registered `ModelTransform` instead of a free function, and whether `load_lazy` belongs on
`NnefInterface` rather than as an inherent method. 🍍
