### PR TITLE
Multi-thread the OptBinUnicast / OptBinByScalar elementwise fast paths

### DIFF
--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -1,10 +1,10 @@
 use crate::internal::*;
-use crate::ndarray::Dimension;
 use downcast_rs::Downcast;
 use dyn_eq::DynEq;
 use std::fmt::{self, Debug};
 use tract_data::itertools::izip;
 use tract_itertools::Itertools;
+use tract_linalg::multithread::BShare;
 use tract_linalg::{BinOp, LinalgFn};
 
 use super::math::{Add, Max, Min, Mul, Sub};
@@ -679,9 +679,7 @@ impl EvalOp for OptBinByScalar {
             return Ok(tvec!(self.binop.eval(a, b, c_dt)?.into_tvalue()));
         }
 
-        // Not a requirement as TensorView doesn't require a owned tensor but in reality
-        // "a "should be mutable (it's omitted here as Rust compiler advise to remove it)
-        let a = a.into_tensor();
+        let mut a = a.into_tensor();
         let b_shape = b.shape();
 
         let first_unary_axis = b_shape
@@ -693,20 +691,12 @@ impl EvalOp for OptBinByScalar {
             .last()
             .context("Cannot use by_scalar when no trailing dimensions are unary")?;
 
-        let iterating_shape = &a.shape()[..first_unary_axis];
-        if !iterating_shape.is_empty() {
-            for it_coords in tract_ndarray::indices(iterating_shape) {
-                let mut view = TensorView::at_prefix(&a, it_coords.slice())?;
-                let b_view = TensorView::at_prefix(&b, it_coords.slice())?;
-                debug_assert_eq!(b_view.shape().iter().product::<usize>(), 1);
-                (self.eval_fn)(&mut view, &b_view)?;
-            }
-        } else {
-            let mut view = a.view();
-            let b_view = b.view();
-            debug_assert_eq!(b_view.shape().iter().product::<usize>(), 1);
-            (self.eval_fn)(&mut view, &b_view)?;
-        }
+        // b carries one scalar per block of a, the blocks being a's axes before
+        // first_unary_axis; check_input_shapes makes b's match a's there.
+        let n_blocks: usize = a.shape()[..first_unary_axis].iter().product();
+        // A zero-sized dim zeroes n_blocks, and par_bin no-ops on an empty a.
+        let period = a.len().checked_div(n_blocks).unwrap_or(0);
+        tract_linalg::multithread::par_bin(&*self.eval_fn, &mut a, &b, period, BShare::PerBlock)?;
         Ok(tvec!(a.into_tvalue()))
     }
 }
@@ -828,27 +818,18 @@ impl EvalOp for OptBinUnicast {
             return Ok(tvec!(self.binop.eval(a, b, c_dt)?.into_tvalue()));
         }
 
-        // Not a requirement as TensorView doesn't require a owned tensor but in reality
-        // "a "should be mutable (it's omitted here as Rust compiler advise to remove it)
-        let a = a.into_tensor();
-        let b_shape = b.shape();
-        let b_view = b.view();
-        let first_non_unary_axis =
-            b_shape.iter().enumerate().take_while(|&(_, &dim)| dim == 1).map(|(i, _)| i + 1).last();
-
-        if let Some(first_non_unary_axis) = first_non_unary_axis {
-            // Iterate on outter dimensions and evaluate with unicast subviews
-            let iterating_shape = a.shape()[..first_non_unary_axis].to_vec();
-            for it_coords in tract_ndarray::indices(iterating_shape) {
-                let mut view = TensorView::at_prefix(&a, it_coords.slice())?;
-                debug_assert_eq!(view.shape(), &b_view.shape()[it_coords.slice().len()..]);
-                (self.eval_fn)(&mut view, &b_view)?;
-            }
-        } else {
-            let mut view = a.view();
-            debug_assert_eq!(view.shape(), b_view.shape());
-            (self.eval_fn)(&mut view, &b_view)?;
-        }
+        let mut a = a.into_tensor();
+        // b's leading unary axes are the ones a repeats over; past them b matches
+        // a exactly (check_input_shapes), so one kernel call covers b.len()
+        // elements of a and b is consumed in lockstep within each.
+        debug_assert!(
+            b.shape().iter().zip(a.shape()).skip_while(|(b, _)| **b == 1).all(|(b, a)| b == a),
+            "unicast b {:?} does not line up with a {:?}",
+            b.shape(),
+            a.shape()
+        );
+        let period = b.len();
+        tract_linalg::multithread::par_bin(&*self.eval_fn, &mut a, &b, period, BShare::Lockstep)?;
 
         Ok(tvec!(a.into_tvalue()))
     }
@@ -1281,5 +1262,29 @@ mod tests {
         for (i, v) in out_slice.iter().enumerate() {
             assert_eq!(*v, i as f32 + 1.0, "mismatch at {i}");
         }
+    }
+
+    /// A zero-sized outer dim (a symbolic batch or sequence resolving to 0) has
+    /// no elements to write, so both fast paths must no-op. The kernels cannot
+    /// be handed the empty tensor: `as_slice_mut` builds a slice from the null
+    /// data pointer, and the by-scalar kernel reads `b[0]` off a zero-length
+    /// slice.
+    #[test]
+    fn zero_sized_outer_dim_is_a_noop() {
+        let a = Tensor::zero::<f32>(&[0, 4, 8]).unwrap();
+        let b = Tensor::zero::<f32>(&[0, 4, 1]).unwrap();
+        let linalg_fn = tract_linalg::bin_by_scalar(f32::datum_type(), BinOp::Add)
+            .expect("f32 by_scalar Add kernel available");
+        let op = OptBinByScalar { binop: Box::new(Add), eval_fn: Arc::from(linalg_fn) };
+        let out = op.eval(tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
+        assert_eq!(out[0].shape(), &[0, 4, 8]);
+
+        let a = Tensor::zero::<f32>(&[0, 4, 16]).unwrap();
+        let b = Tensor::zero::<f32>(&[1, 4, 16]).unwrap();
+        let linalg_fn = tract_linalg::bin_unicast(f32::datum_type(), BinOp::Add)
+            .expect("f32 unicast Add kernel available");
+        let op = OptBinUnicast { binop: Box::new(Add), eval_fn: Arc::from(linalg_fn) };
+        let out = op.eval(tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
+        assert_eq!(out[0].shape(), &[0, 4, 16]);
     }
 }

--- a/harness/nnef-test-cases/parallel-bin/graph.nnef
+++ b/harness/nnef-test-cases/parallel-bin/graph.nnef
@@ -1,0 +1,33 @@
+version 1.0;
+
+# Exercises every shape par_bin splits, at two block/period ratios so the
+# intra-block offset is covered for both BShare variants.
+#
+# On [1, 256, 768] there are 256 blocks of 768, so each block is one chunk:
+#   add(input, row)  OptAddByScalar, one b scalar per block
+#   mul(a, col)      OptMulUnicast, b is one 768-element row per block
+#   mul(b, same)     OptMulUnicast over a single block, so the split has to
+#                    happen inside the block
+# On [1, 8, 24576] there are only 8 blocks, so each splits into several chunks
+# and both shares run at a nonzero offset within their block.
+#
+# Both operands of every binary derive from the input, so none const-folds away.
+# runme.sh asserts the threaded output is bit-identical to the same-platform
+# single-threaded run.
+graph parallel_bin(input) -> (output)
+{
+    input = external<scalar>(shape = [1, 256, 768]);
+    row = sum_reduce(input, axes = [2]);
+    col = sum_reduce(input, axes = [1]);
+    same = tanh(input);
+    a = add(input, row);
+    b = mul(a, col);
+    c = mul(b, same);
+
+    wide = reshape(c, shape = [1, 8, 24576]);
+    wrow = sum_reduce(wide, axes = [2]);
+    wcol = sum_reduce(wide, axes = [1]);
+    d = add(wide, wrow);
+    e = mul(d, wcol);
+    output = reshape(e, shape = [1, 256, 768]);
+}

--- a/harness/nnef-test-cases/parallel-bin/runme.sh
+++ b/harness/nnef-test-cases/parallel-bin/runme.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+trap 'rm -f ref.npz' EXIT
+
+# --allow-random-input is seeded from a fixed constant, so both runs below get
+# byte-identical input without committing a bundle.
+#
+# Serial reference on this same binary/platform (the default executor is serial).
+$TRACT_RUN . -O run --allow-random-input --save-outputs ref.npz
+
+# par_bin only splits `a` on boundaries the kernels already tolerate, so the
+# threaded result must be bit-identical to the serial one (--approx exact =
+# atol=rtol=0). Comparing against a same-platform serial run keeps this
+# independent of which SIMD kernel the host registers.
+#
+# A default build (including the CI cli-tests harness) has no multithread-mm, so
+# `--threads` bails; drive this case with a multithread-mm TRACT_RUN (the plan's
+# verification step does) to exercise the parallel leg. We warn rather than skip
+# silently so a serial-only run is never mistaken for threaded coverage.
+if $TRACT_RUN --threads 2 . dump -q >/dev/null 2>&1; then
+    $TRACT_RUN --threads 8 --threading-threshold 0 . -O run \
+        --allow-random-input --assert-output-bundle ref.npz --approx exact
+else
+    echo "WARNING: TRACT_RUN has no multithread-mm; parallel bit-identity leg NOT run." >&2
+fi

--- a/linalg/src/multithread.rs
+++ b/linalg/src/multithread.rs
@@ -7,7 +7,11 @@ use std::sync::{Arc, Mutex};
 #[cfg(feature = "multithread-mm")]
 use rayon::{ThreadPool, ThreadPoolBuilder};
 
-use tract_data::internal::TractResult;
+#[cfg(feature = "multithread-mm")]
+use tract_data::internal::vector_size;
+use tract_data::internal::{Tensor, TensorView, TractResult, ensure};
+
+use crate::LinalgFn;
 
 #[derive(Debug, Clone, Default)]
 pub enum Executor {
@@ -172,4 +176,135 @@ pub fn par_chunks_mut<T: Send>(
         let _ = (row_len, total_elems);
         f(0, out)
     }
+}
+
+/// How `b` maps onto the blocks [`par_bin`] splits `a` into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BShare {
+    /// `b` is one `period`-element row that every block of `a` consumes in
+    /// lockstep, as the unicast kernels do. Requires `b.len() == period`.
+    Lockstep,
+    /// `b` holds one scalar per block of `a`, as the by-scalar kernels do:
+    /// block `i` reads `b[i]`. Requires `b.len() == a.len() / period`.
+    PerBlock,
+}
+
+/// Apply the linalg binary kernel `eval_fn` to `a` in place, splitting the work
+/// across the executor installed by [`multithread_tract_scope`].
+///
+/// `a` is `a.len() / period` blocks of `period` elements, `period` being how many
+/// `a` elements one kernel call covers; `share` says how `b` lines up with those
+/// blocks. A block is the coarsest unit a single call may span, because the
+/// unicast kernels walk `b` in lockstep and index past its end once `a` runs
+/// beyond one period. Inside a block the split lands on `vector_size()`-element
+/// boundaries, which keeps `a`'s and `b`'s offsets congruent modulo the kernel
+/// alignment — `unicast_with_alignment` hard-asserts that congruence.
+/// `OptBinUnicast::check_b_alignement` is what guarantees `period` itself is such
+/// a multiple whenever there is more than one block.
+///
+/// An empty `a` is a no-op: the kernels cannot take one, as `as_slice_mut` would
+/// build a slice from the null data pointer.
+///
+/// Both tensors must have natural C-order strides, which the callers' stride
+/// guards establish, and plain storage, which holds because no linalg binary
+/// kernel is registered for a datum type that lacks it. The byte offsets computed
+/// here are only correct under both.
+///
+/// These kernels are pure elementwise, so no chunk boundary can change a result:
+/// the output is bit-identical to the serial path at any thread count.
+pub fn par_bin(
+    eval_fn: &LinalgFn,
+    a: &mut Tensor,
+    b: &Tensor,
+    period: usize,
+    share: BShare,
+) -> TractResult<()> {
+    if a.len() == 0 {
+        return Ok(());
+    }
+    ensure!(
+        a.len().is_multiple_of(period),
+        "par_bin: period {period} does not divide a.len() {}",
+        a.len()
+    );
+    let n_blocks = a.len() / period;
+    match share {
+        BShare::Lockstep => ensure!(
+            b.len() == period,
+            "par_bin: Lockstep wants b.len() {} == period {period}",
+            b.len()
+        ),
+        BShare::PerBlock => ensure!(
+            b.len() == n_blocks,
+            "par_bin: PerBlock wants b.len() {} == {n_blocks} blocks",
+            b.len()
+        ),
+    }
+
+    let a_item = a.datum_type().size_of() as isize;
+    let b_item = b.datum_type().size_of() as isize;
+    let a = &*a;
+    // `len` elements of block `block`, starting `offset` elements into it. Both
+    // tensors are naturally strided, so a's flat element index is
+    // `block * period + offset` and b's is `offset` (Lockstep) or `block`
+    // (PerBlock).
+    let call = |block: usize, offset: usize, len: usize| -> TractResult<()> {
+        static STRIDES: [isize; 1] = [1];
+        let a_shape = [len];
+        let (b_offset, b_shape) = match share {
+            BShare::Lockstep => (offset as isize * b_item, [len]),
+            BShare::PerBlock => (block as isize * b_item, [1]),
+        };
+        let a_offset = (block * period + offset) as isize * a_item;
+        // `offset + len <= period` and blocks are disjoint, so the byte range
+        // `[a_offset, a_offset + len * a_item)` is disjoint across every
+        // (block, offset) the dispatch below enumerates. That is what makes the
+        // concurrent writes through these views non-aliasing; keep it true if the
+        // chunk arithmetic changes.
+        unsafe {
+            let mut a_chunk = TensorView::from_bytes(a, a_offset, &a_shape, &STRIDES);
+            let b_chunk = TensorView::from_bytes(b, b_offset, &b_shape, &STRIDES);
+            eval_fn(&mut a_chunk, &b_chunk)
+        }
+    };
+
+    #[cfg(feature = "multithread-mm")]
+    {
+        use rayon::prelude::*;
+        // Threshold first: reading the executor takes a global lock, and a graph
+        // has hundreds of these nodes sitting below the threshold.
+        if a.len() >= current_threading_element_threshold() {
+            let executor = current_tract_executor();
+            let nth = match &executor {
+                Executor::MultiThread(pool) => pool.current_num_threads(),
+                Executor::RayonGlobal => rayon::current_num_threads(),
+                Executor::SingleThread => 1,
+            };
+            if nth > 1 {
+                let per_block = (4 * nth).div_ceil(n_blocks).max(1);
+                let chunk = period.div_ceil(per_block).next_multiple_of(vector_size()).min(period);
+                let per_block = period.div_ceil(chunk);
+                if n_blocks * per_block > 1 {
+                    let run = || {
+                        (0..n_blocks * per_block).into_par_iter().try_for_each(|i| {
+                            let offset = (i % per_block) * chunk;
+                            call(i / per_block, offset, chunk.min(period - offset))
+                        })
+                    };
+                    return match executor {
+                        Executor::MultiThread(pool) => pool.install(run),
+                        _ => run(),
+                    };
+                }
+            }
+        }
+    }
+
+    // A single block is the whole tensor, so hand the kernel the natural view
+    // rather than a rank-1 one: fewer shapes for a future kernel to have to
+    // tolerate on the overwhelmingly common path.
+    if n_blocks == 1 {
+        return eval_fn(&mut a.view(), &b.view());
+    }
+    (0..n_blocks).try_for_each(|block| call(block, 0, period))
 }


### PR DESCRIPTION
Multi-threads the two optimised elementwise binary ops, `OptBinUnicast` and `OptBinByScalar`, which until now always ran on one thread. On a transformer encoder these are the biggest group of nodes after `Const` and about 7.7% of single-threaded runtime, so they cap how far the model can scale once the matmuls are already threaded.

**This PR builds on #2523 and cannot compile without it.** See "Relationship to #2523" at the bottom.

---

## Background: what was single-threaded

tract multi-threads the matmul microkernel. Everything else in a graph runs on the calling thread. `codegen` lowers most elementwise binary ops to one of two fast-path ops:

- **`OptBinUnicast`** — `b` matches `a` except for some leading size-1 axes. The classic case is a residual add, `[1, seq, hidden] + [1, 1, hidden]`.
- **`OptBinByScalar`** — `b` has trailing size-1 axes, so one `b` value applies to a whole slab of `a`. Example: `[1, seq, hidden] * [1, seq, 1]`.

Both had an `eval` that looped over the outer axes and called the linalg kernel once per iteration, on one thread.

I profiled a real encoder to check this was worth doing at all (a GLiNER PII model, ModernBERT backbone, sequence length 384, Apple Silicon). Every binary op in it lowers to one of these two — there are **zero** generic `Add`/`Mul` nodes left:

| op | nodes | share of single-threaded runtime |
|---|--:|--:|
| `OptMulUnicast` | 153 | 2.9% |
| `OptMulByScalar` | 77 | 1.2% |
| `OptAddUnicast` | 57 | 2.4% |
| `OptSubByScalar` | 39 | 0.9% |
| `OptAddByScalar` | 19 | 0.3% |
| `OptSubFByScalar` | 1 | 0.0% |
| **total** | **346** | **7.7%** |

## What this PR does

Adds `tract_linalg::multithread::par_bin` and routes both `eval` methods through it. Each one collapses to a single call — their old two-branch outer loop turns out to be just "one block" versus "many blocks".

`par_bin` treats `a` as **blocks** of `period` elements, where `period` is how many elements of `a` a single kernel call covers, and hands blocks to the executor that is already installed during eval (the same one the matmul dispatcher reads, so there is no new plumbing or configuration). A `BShare` argument says how `b` lines up with the blocks:

- `Lockstep` — `b` is one `period`-element row that every block consumes in step. This is what the unicast kernels want.
- `PerBlock` — `b` holds one scalar per block. This is what the by-scalar kernels want.

### Why blocks, and why the split also goes *inside* a block

Two properties of the existing kernels constrain this, and both are easy to get wrong:

**1. A block is the largest region one kernel call may cover.** `UnicastKer::bin` walks `b` in lockstep with `a`, indexing `b[num_element_processed..]`. It does not wrap around. If you hand it more than one period of `a` against a single `b`, it indexes past the end of `b` and panics. So the old per-iteration loop was doing real work, not just bookkeeping, and `par_bin` keeps that loop rather than merging iterations. It is deliberately **not** behind the `multithread-mm` feature flag for that reason: a build without the feature needs it too.

**2. Splits inside a block have to preserve `a`/`b` alignment.** `unicast_with_alignment` asserts that `a` and `b` have the same `align_offset`. So chunk boundaries inside a block land on `vector_size()`-element multiples, which keeps the two offsets congruent. `OptBinUnicast::check_b_alignement` already guarantees `period` itself is such a multiple whenever there is more than one block, which is what makes this work out.

Splitting inside a block is not an optimisation — it is required. At batch size 1 the outer axis has length 1, so a block-only split would give exactly one task and no parallelism at all, on the shape that matters most.

## Correctness

These kernels are pure elementwise, so **no chunk boundary can change a result**. Output is bit-identical to the single-threaded path at any thread count. Nothing here splits a reduction, which is the case where a split would reorder float accumulation.

Verification, in order of how much I trust it:

1. **Bit-exact A/B on the real encoder.** Ran it single-threaded, saved the outputs, then re-ran at 2, 4, 8 and 14 threads asserting `--approx exact` (atol = rtol = 0, so any difference at all fails). All exact, at both the default threshold and with the threshold forced to 0 so even small tensors take the parallel path.
2. **Repeated under a debug build.** The `unsafe` here is byte-offset arithmetic, so this is about memory safety, not just values. Debug asserts and overflow checks on, same result.
3. **New harness case** `harness/nnef-test-cases/parallel-bin`. One graph covering every split shape at two block/period ratios, so both `BShare` variants run at a nonzero offset inside a block. It generates its own single-threaded reference on the same binary and platform, then asserts the threaded run matches exactly — so it does not depend on which SIMD kernel the host happens to register.
4. **Existing suites**: `test-unit-core` 783 pass, `test-nnef-cycle` 2392 pass, `tract-core` 262 pass. `cargo clippy --workspace` and `cargo clippy -p tract-linalg --features multithread-mm` clean. Formatted with the pinned stable rustfmt.

I mutation-tested the new harness case rather than assume it works, and it is worth knowing what it does and does not catch. It compares two runs of the *same* binary, so it detects a parallel-vs-serial divergence but not a bug both paths share. Forcing the intra-block `b` offset to 0 (code only the parallel path runs) fails the case. Forcing the per-block `b` offset to 0 (code both paths run) passes it — and instead fails `test-unit-core` and three `test-nnef-cycle` layer-norm tests, which compare against a real reference. Both layers are needed; neither is sufficient alone.

## About the `unsafe`

`par_bin` contains one `unsafe` block, which builds sub-`TensorView`s over disjoint byte ranges via `TensorView::from_bytes`. It lives in linalg so that `tract-core` gains no `unsafe` and no rayon dependency from this change.

Flagging it explicitly because `linalg/src/multithread.rs` is a dispatcher rather than a kernel: the safety argument is that `offset + len <= period` and blocks are disjoint, so no two tasks ever touch the same byte. That invariant is spelled out in a comment next to the block. Happy to restructure if you would rather this be expressed differently.

## Performance

Isolated the three code paths in a graph of just three `OptBin*` ops over 4.19M f32 each, minimum of 5 runs, compared against this PR's own merge base:

| threads | before | after | speedup |
|--:|--:|--:|--:|
| 1 | 1.32 ms | 1.30 ms | 1.01× |
| 2 | 1.40 ms | 0.88 ms | 1.60× |
| 4 | 1.30 ms | 0.67 ms | 1.94× |
| 8 | 1.38 ms | 0.67 ms | 2.07× |

"Before" is flat across thread counts, as expected for ops that ignored the executor entirely. One thread is unchanged, so there is no cost to the single-threaded path.

The plateau at 4 threads is memory bandwidth, not a threading problem: roughly 150 MB of traffic in 0.67 ms is about 224 GB/s, which is this machine's ceiling. These ops are bandwidth-bound by nature, so the ceiling will differ on other hardware — lower headroom on a bandwidth-rich desktop part, more on a bandwidth-constrained server CPU.

**I am not claiming an end-to-end win on the full encoder from this PR.** I measured 1.08× at 4 threads and 1.00× at 8, but the machine was heavily loaded during benchmarking (load average 8–27 from unrelated work) and that spread is inside the noise. A trustworthy whole-model number needs a quiet machine, and I would rather say so than present a figure I do not believe. The op-level numbers above are robust because they use a minimum over repeats.

## Relationship to #2523

This is stacked directly on #2523, and depends on it in two concrete ways:

- `par_bin` calls `current_threading_element_threshold()`, the size gate #2523 introduces. Below that threshold, dispatch overhead costs more than the parallelism gains.
- The new harness case uses the `--threading-threshold` CLI flag from #2523 to force the parallel path on.

Neither exists on `main` today, so this does not build standalone. **The diff you see currently includes #2523's commit**; once #2523 lands it will shrink to just the second commit. Reviewing that second commit alone is enough.

If you would prefer this squashed into #2523, or split differently, say so and I will restructure — I kept them separate because #2523 is safe code and this one carries the `unsafe`, so they seemed worth reviewing independently.

Happy to rebase onto current `main` whenever suits; `main` has moved 4 commits ahead of #2523's base, though the merge is clean today.

🍍
