### PR TITLE
core: add a last-axis fast path to GatherElements

### DIFF
--- a/core/src/ops/array/gather_elements.rs
+++ b/core/src/ops/array/gather_elements.rs
@@ -1,6 +1,10 @@
 use crate::internal::*;
 use ndarray::*;
 
+/// For every coordinate of `indices`, reads `data` at that same coordinate with
+/// `axis` replaced by the index value found there. The output has `indices`'
+/// shape. A negative index counts from the end of `axis`. `data` and `indices`
+/// must have the same rank; off `axis`, `indices` may be smaller than `data`.
 #[derive(Debug, Clone, new, Hash, PartialEq, Eq)]
 pub struct GatherElements {
     pub axis: usize,
@@ -15,6 +19,57 @@ impl Op for GatherElements {
 }
 
 impl GatherElements {
+    /// Gathers when `axis` is the last one and the leading dimensions of both
+    /// operands are identical. Every leading coordinate then addresses one whole
+    /// row of both operands, so the op is a flat per-row lookup and none of the
+    /// per-element dynamic-rank stride arithmetic of the generic path is needed.
+    /// `Ok(None)` means the operands do not qualify and the caller must use the
+    /// generic path.
+    ///
+    /// Index resolution is identical to the generic path, but an out-of-range
+    /// index is reported as an error instead of panicking inside `ndarray`.
+    fn eval_contiguous_last_axis<T: Datum>(
+        &self,
+        data: &ArrayViewD<T>,
+        indices: &ArrayViewD<i64>,
+    ) -> TractResult<Option<ArrayD<T>>> {
+        let rank = data.ndim();
+        let Some(last_axis) = rank.checked_sub(1) else { return Ok(None) };
+        if self.axis != last_axis
+            || indices.ndim() != rank
+            || data.shape()[..last_axis] != indices.shape()[..last_axis]
+        {
+            return Ok(None);
+        }
+        // Both views come from a plain tract tensor, so they are contiguous and
+        // this never declines; it is handled rather than asserted.
+        let (Some(data_slice), Some(index_slice)) = (data.as_slice(), indices.as_slice()) else {
+            return Ok(None);
+        };
+        let row_len = data.shape()[last_axis];
+        let gathered_len = indices.shape()[last_axis];
+        // A zero gathered length still has leading coordinates to walk, and
+        // walking them would be pure waste for an empty output.
+        let rows = if indices.is_empty() { 0 } else { indices.len() / gathered_len };
+        let mut output = Vec::with_capacity(indices.len());
+        for row in 0..rows {
+            let data_row = &data_slice[row * row_len..][..row_len];
+            for &index in &index_slice[row * gathered_len..][..gathered_len] {
+                let resolved = if index < 0 { index + row_len as i64 } else { index };
+                let value = usize::try_from(resolved)
+                    .ok()
+                    .and_then(|resolved| data_row.get(resolved))
+                    .with_context(|| {
+                        format!(
+                            "Invalid GatherElements index {index} in row {row} on axis of len {row_len}"
+                        )
+                    })?;
+                output.push(value.clone());
+            }
+        }
+        Ok(Some(ArrayD::from_shape_vec(indices.shape(), output)?))
+    }
+
     unsafe fn eval_t<T: Datum>(
         &self,
         data: TValue,
@@ -22,13 +77,16 @@ impl GatherElements {
     ) -> TractResult<TValue> {
         let data_plain = data.try_as_plain()?;
         let data_view = unsafe { data_plain.to_array_view_unchecked::<T>() };
-        let output = ArrayD::<T>::from_shape_fn(indices.shape(), |mut coords| {
-            let index = indices[&coords];
-            coords[self.axis] =
-                if index < 0 { index + data_view.shape()[self.axis] as i64 } else { index }
-                    as usize;
-            data_view[coords].clone()
-        });
+        let output = match self.eval_contiguous_last_axis::<T>(&data_view, indices)? {
+            Some(output) => output,
+            None => ArrayD::<T>::from_shape_fn(indices.shape(), |mut coords| {
+                let index = indices[&coords];
+                coords[self.axis] =
+                    if index < 0 { index + data_view.shape()[self.axis] as i64 } else { index }
+                        as usize;
+                data_view[coords].clone()
+            }),
+        };
         let mut tensor = output.into_tensor();
         unsafe { tensor.set_datum_type(data.datum_type()) };
         Ok(tensor.into_tvalue())
@@ -39,6 +97,18 @@ impl TypedOp for GatherElements {
     as_op!();
 
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        ensure!(
+            inputs[0].rank() == inputs[1].rank(),
+            "GatherElements data and indices must have the same rank, got {} and {}",
+            inputs[0].rank(),
+            inputs[1].rank()
+        );
+        ensure!(
+            self.axis < inputs[0].rank(),
+            "GatherElements axis {} is out of range for rank {}",
+            self.axis,
+            inputs[0].rank()
+        );
         Ok(tvec!(inputs[0].datum_type.fact(&*inputs[1].shape)))
     }
 }
@@ -57,5 +127,43 @@ impl EvalOp for GatherElements {
                 self, data, &indices
             ))?))
         }
+    }
+}
+
+/// The out-of-range branches are only reachable on the contiguous last-axis path
+/// (the generic path panics inside `ndarray` instead), so they cannot be covered
+/// by the output-comparing `suite-unit` cases.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gather(data_shape: &[usize], indices: &[i64]) -> TractResult<TValue> {
+        let len = data_shape.iter().product::<usize>();
+        let data = Tensor::from_shape(data_shape, &(0..len).map(|i| i as f32).collect::<Vec<_>>())?;
+        let indices = Tensor::from_shape(&[1, indices.len()], indices)?;
+        let mut outputs = GatherElements::new(data_shape.len() - 1)
+            .eval(tvec!(data.into_tvalue(), indices.into_tvalue()))?;
+        Ok(outputs.remove(0))
+    }
+
+    #[test]
+    fn last_axis_resolves_negative_indices() {
+        let output = gather(&[1, 4], &[-1, 0, -4, 2]).unwrap();
+        assert_eq!(output.try_as_plain().unwrap().as_slice::<f32>().unwrap(), [3., 0., 0., 2.]);
+    }
+
+    #[test]
+    fn last_axis_rejects_index_past_the_end() {
+        assert!(gather(&[1, 4], &[0, 4]).is_err());
+    }
+
+    #[test]
+    fn last_axis_rejects_index_before_the_start() {
+        assert!(gather(&[1, 4], &[0, -5]).is_err());
+    }
+
+    #[test]
+    fn last_axis_rejects_any_index_into_an_empty_axis() {
+        assert!(gather(&[1, 0], &[0]).is_err());
     }
 }

--- a/harness/nnef-test-cases/gather-elements-last-axis/graph.nnef
+++ b/harness/nnef-test-cases/gather-elements-last-axis/graph.nnef
@@ -1,0 +1,31 @@
+version 1.0;
+
+extension tract_registry tract_core;
+
+# Two spellings of the same gather, so `mismatch` is 0 only if they agree.
+#
+# `fast` gathers along the last axis with matching leading dims, which is the
+# contiguous fast path. `slow` transposes both operands so the gather runs on
+# axis 0, which the fast path rejects, then transposes the result back:
+#   slow[i,j,k] = dataT[indicesT[k,j,i], j, i] = data[i, j, indices[i,j,k]]
+# The indices mix in-range positive and negative values.
+graph gather_elements_last_axis(data) -> (mismatch)
+{
+    data = external<scalar>(shape = [2, 3, 8]);
+
+    indices = [[[ 0.0,  7.0, -1.0,  3.0, -8.0],
+                [ 1.0,  1.0,  1.0,  6.0, -2.0],
+                [ 7.0,  0.0,  4.0, -5.0,  2.0]],
+               [[ 2.0,  2.0, -3.0,  5.0,  0.0],
+                [-1.0,  6.0,  3.0,  3.0,  7.0],
+                [ 4.0, -7.0,  1.0,  0.0, -4.0]]];
+
+    fast = tract_core_gather_elements(data, indices, axis = 2);
+
+    data_t = transpose(data, axes = [2, 1, 0]);
+    indices_t = transpose(indices, axes = [2, 1, 0]);
+    slow_t = tract_core_gather_elements(data_t, indices_t, axis = 0);
+    slow = transpose(slow_t, axes = [2, 1, 0]);
+
+    mismatch = sum_reduce(abs(sub(fast, slow)), axes = [0, 1, 2]);
+}

--- a/harness/nnef-test-cases/gather-elements-last-axis/runme.sh
+++ b/harness/nnef-test-cases/gather-elements-last-axis/runme.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# --allow-random-input is seeded from a fixed constant, so `data` is the same
+# every run. The graph gathers the same elements twice, once on the contiguous
+# last-axis fast path and once forced onto the generic path, and outputs the
+# summed absolute difference: any divergence between the two makes it non-zero.
+# The two legs live in one graph rather than in an --assert-output-bundle pair
+# because the reference here is the op's own other code path, not a golden value.
+#
+# --assert-op-count pins that both gathers survive as distinct nodes, so no pass
+# folded one leg into the other and left the comparison trivially true. It says
+# nothing about which internal path each node took; that is what the suite-unit
+# gather_elements cases cover.
+#
+# Both configurations are run because -O is what production uses. GatherElements
+# implements only output_facts today, so no pass can touch either leg and the two
+# graphs are currently identical; --assert-op-count is what would notice if that
+# ever changed.
+$TRACT_RUN . run --allow-random-input \
+    --assert-op-count GatherElements 2 \
+    --assert-output 'mismatch:1,1,1,f32=0'
+
+$TRACT_RUN . -O run --allow-random-input \
+    --assert-op-count GatherElements 2 \
+    --assert-output 'mismatch:1,1,1,f32=0'

--- a/test-rt/suite-unit/src/gather_elements.rs
+++ b/test-rt/suite-unit/src/gather_elements.rs
@@ -1,0 +1,152 @@
+use infra::{Test, TestResult, TestSuite};
+use proptest::collection::vec;
+use proptest::prelude::*;
+use tract_core::internal::*;
+use tract_core::ndarray::ArrayD;
+use tract_core::ndarray::Dimension;
+use tract_core::ops::array::GatherElements;
+
+/// `data` is filled with its own flat offsets, so the expected value at a given
+/// output coordinate is the offset the op is supposed to read from, computed
+/// here from the shape alone.
+#[derive(Debug, Clone)]
+struct GatherElementsProblem {
+    data_shape: Vec<usize>,
+    indices: ArrayD<i64>,
+    axis: usize,
+}
+
+impl GatherElementsProblem {
+    fn data(&self) -> TractResult<Tensor> {
+        let len = self.data_shape.iter().product::<usize>();
+        let values = (0..len).map(|ix| ix as f32).collect::<Vec<_>>();
+        Tensor::from_shape(&self.data_shape, &values)
+    }
+
+    fn reference(&self) -> ArrayD<f32> {
+        let strides = natural_strides(&self.data_shape);
+        ArrayD::from_shape_fn(self.indices.shape(), |coords| {
+            let index = self.indices[&coords];
+            let resolved =
+                if index < 0 { index + self.data_shape[self.axis] as i64 } else { index } as usize;
+            let offset: isize = coords
+                .slice()
+                .iter()
+                .enumerate()
+                .map(|(coord_axis, &coord)| {
+                    strides[coord_axis]
+                        * if coord_axis == self.axis { resolved } else { coord } as isize
+                })
+                .sum();
+            offset as f32
+        })
+    }
+
+    fn tract(&self) -> TractResult<TypedModel> {
+        let mut model = TypedModel::default();
+        let data = model.add_source("data", f32::fact(&self.data_shape))?;
+        let indices = model.add_const("indices", self.indices.clone())?;
+        let output =
+            model.wire_node("gather_elements", GatherElements::new(self.axis), &[data, indices])?;
+        model.select_output_outlets(&output)?;
+        Ok(model)
+    }
+}
+
+impl Arbitrary for GatherElementsProblem {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<GatherElementsProblem>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        vec(1usize..6, 1usize..5)
+            .prop_flat_map(|data_shape| {
+                let rank = data_shape.len();
+                (Just(data_shape), 0..rank)
+            })
+            .prop_flat_map(|(data_shape, axis)| {
+                // Off `axis`, indices are allowed to be smaller than data, which
+                // is what takes the op off the contiguous last-axis fast path.
+                // `Just(dim)` is drawn explicitly so equal leading dimensions
+                // stay common as rank grows instead of being a coincidence.
+                let indices_shape = data_shape
+                    .iter()
+                    .enumerate()
+                    .map(|(ax, &dim)| {
+                        if ax == axis {
+                            (1usize..6).boxed()
+                        } else {
+                            prop_oneof![Just(dim), 1..=dim].boxed()
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                (Just(data_shape), Just(axis), indices_shape)
+            })
+            .prop_flat_map(|(data_shape, axis, indices_shape)| {
+                let len = indices_shape.iter().product::<usize>();
+                let axis_len = data_shape[axis] as i64;
+                (
+                    Just(data_shape),
+                    Just(axis),
+                    Just(indices_shape),
+                    vec(-axis_len..axis_len, len..=len),
+                )
+            })
+            .prop_map(|(data_shape, axis, indices_shape, indices)| GatherElementsProblem {
+                indices: ArrayD::from_shape_vec(indices_shape, indices).unwrap(),
+                data_shape,
+                axis,
+            })
+            .boxed()
+    }
+}
+
+impl Test for GatherElementsProblem {
+    fn run_with_approx(
+        &self,
+        id: &str,
+        runtime: &dyn Runtime,
+        approx: Approximation,
+    ) -> TestResult {
+        let reference = self.reference().into_tensor();
+        let mut model = self.tract()?;
+        model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));
+        let mut output = runtime.prepare(model)?.run(tvec!(self.data()?.into_tvalue()))?;
+        output.remove(0).into_tensor().close_enough(&reference, approx)
+    }
+}
+
+fn problem(
+    data_shape: &[usize],
+    axis: usize,
+    indices_shape: &[usize],
+    indices: impl Fn(usize) -> i64,
+) -> GatherElementsProblem {
+    let len = indices_shape.iter().product::<usize>();
+    let indices = (0..len).map(indices).collect::<Vec<_>>();
+    GatherElementsProblem {
+        data_shape: data_shape.into(),
+        indices: ArrayD::from_shape_vec(indices_shape.to_vec(), indices).unwrap(),
+        axis,
+    }
+}
+
+pub fn suite() -> TractResult<TestSuite> {
+    let mut suite = TestSuite::default();
+    suite.add_arbitrary::<GatherElementsProblem>("proptest", ());
+
+    suite.add("last_axis", problem(&[2, 3, 8], 2, &[2, 3, 5], |ix| (ix * 3 % 8) as i64));
+    suite.add(
+        "last_axis_negative",
+        problem(&[2, 3, 8], 2, &[2, 3, 5], |ix| (ix * 3 % 8) as i64 - 8),
+    );
+    suite.add("last_axis_rank_1", problem(&[8], 0, &[5], |ix| (ix * 3 % 8) as i64));
+    suite.add("first_axis", problem(&[4, 8], 0, &[3, 8], |ix| (ix % 4) as i64));
+    // A reduced OUTERMOST dim leaves the flat row offset accidentally correct, so
+    // it does not on its own prove the fast path checks the leading dims.
+    suite.add("mismatched_inner_dim", problem(&[2, 3, 8], 2, &[2, 2, 5], |ix| (ix % 8) as i64));
+    suite.add("mismatched_outer_dim", problem(&[2, 3, 8], 2, &[1, 3, 5], |ix| (ix % 8) as i64));
+    suite.add("empty_rows", problem(&[2, 0, 8], 2, &[2, 0, 5], |_| 0));
+    suite.add("empty_last_axis", problem(&[2, 3, 8], 2, &[2, 3, 0], |_| 0));
+
+    Ok(suite)
+}

--- a/test-rt/suite-unit/src/lib.rs
+++ b/test-rt/suite-unit/src/lib.rs
@@ -17,6 +17,7 @@ pub mod conv_q;
 pub mod deconv;
 pub mod downsample;
 pub mod elmwise;
+pub mod gather_elements;
 pub mod gelu_approximate;
 pub mod matmul_q40;
 pub mod q_binary;
@@ -37,6 +38,7 @@ pub fn suite() -> TractResult<TestSuite> {
     suite.add("conv_q", conv_q::suite()?);
     suite.add("deconv", deconv::suite()?);
     suite.add("downsample", downsample::suite()?);
+    suite.add("gather_elements", gather_elements::suite()?);
     suite.add("matmul_q40", matmul_q40::suite()?);
     suite.add("q_flavours", q_flavours::suite()?);
     suite.add("rms_norm", rms_norm::suite()?);

--- a/test-rt/test-cuda/suite.rs
+++ b/test-rt/test-cuda/suite.rs
@@ -54,12 +54,6 @@ fn ignore_unit(t: &[String], case: &dyn Test) -> bool {
     if let Some(sdpab) = case.downcast_ref::<SdpaProblem<half::f16>>() {
         return !compatible_sdpa::<half::f16>(sdpab);
     }
-    // A zero-volume const reaches CudaTensor::from_tensor with an empty byte
-    // slice, which the host-to-device copy does not guard the way Metal does
-    // (metal/src/context.rs substitutes a 1-byte buffer).
-    if t[0] == "gather_elements" && (t[1] == "empty_rows" || t[1] == "empty_last_axis") {
-        return true;
-    }
 
     t[0] == "sdpa" && t[1] == "proptest_f32"
 }

--- a/test-rt/test-cuda/suite.rs
+++ b/test-rt/test-cuda/suite.rs
@@ -54,6 +54,13 @@ fn ignore_unit(t: &[String], case: &dyn Test) -> bool {
     if let Some(sdpab) = case.downcast_ref::<SdpaProblem<half::f16>>() {
         return !compatible_sdpa::<half::f16>(sdpab);
     }
+    // A zero-volume const reaches CudaTensor::from_tensor with an empty byte
+    // slice, which the host-to-device copy does not guard the way Metal does
+    // (metal/src/context.rs substitutes a 1-byte buffer).
+    if t[0] == "gather_elements" && (t[1] == "empty_rows" || t[1] == "empty_last_axis") {
+        return true;
+    }
+
     t[0] == "sdpa" && t[1] == "proptest_f32"
 }
 

--- a/test-rt/test-tflite/suite.rs
+++ b/test-rt/test-tflite/suite.rs
@@ -171,6 +171,7 @@ fn ignore_unit(t: &[String], case: &dyn Test) -> bool {
         "conv_f16",
         "deconv",
         "elmwise",
+        "gather_elements",
         "gelu_approximate",
         "q_flavours",
         "q_binary",


### PR DESCRIPTION
`GatherElements` reads every output element through two dynamic-rank multi-dimensional index
operations, each one a runtime stride dot-product with bounds checks. That costs about 9 ns
per element. This adds a fast path for the case where the gather axis is the tensor's last
axis, which cuts the op by 9x to 13x, and leaves every other case on the existing code.

## What changed

When the gather axis is the last axis, and the other dimensions of `data` and `indices` are
equal, each leading coordinate addresses one whole row of both operands. The gather is then a
flat lookup inside that row and needs none of the per-element index arithmetic. Any other
shape falls through to the generic path, unchanged.

Two behavior changes worth calling out:

- `output_facts` now rejects an out-of-range `axis`, and a `data` / `indices` rank mismatch.
  Both used to build a model fine and then panic during eval, which unwinds through `api/c`
  and `api/py`. For example `tract_core_gather_elements(..., axis = -1)` arrives as
  `usize::MAX` through `usize::coerce` in `nnef/src/deser.rs`, builds, and panics at run.
  `Gather` already validates this way in `compute_output_shape`. All 4428 ONNX conformance
  tests still pass, so this rejects nothing that used to work.
- On the fast path an out-of-range index value returns an error. On the generic path it still
  panics inside `ndarray`. More on that below.

## Where the win comes from

DeBERTa-v2 and v3 use relative-position attention, and computing it runs 24 of these gathers
per inference, pulling `[heads, seq, seq]` out of `[heads, seq, 2 * buckets]`. They do no
arithmetic at all, so they were pure overhead and the largest cost after matmul.

The op on its own, on those shapes with 12 heads and 512 buckets (Apple M4 Pro):

| output shape | before | after | faster by |
| --- | --: | --: | --: |
| `[12, 128, 128]` | 1.682 ms | 0.128 ms | 13.1x |
| `[12, 256, 256]` | 7.124 ms | 0.823 ms | 8.7x |
| `[12, 512, 512]` | 26.664 ms | 2.233 ms | 11.9x |

End to end on a DeBERTa-v3-base classifier (86M params, fp32, frozen shapes, 1 thread, same
machine):

| seq | total before | total after | this op before | this op after |
| --: | --: | --: | --: | --: |
| 128 | 149.4 ms | 132.2 ms | 46.8 ms (27.8%) | 14.4 ms (9.8%) |
| 256 | 576.7 ms | 344.4 ms | 319.2 ms (42.0%) | 72.3 ms (18.5%) |

The op is serial, so the gain grows with thread count. On an AWS Graviton3 (`c7g.2xlarge`,
8 vCPU) the same change measured 1.50x total at seq 128 on 8 threads, and 1.75x at seq 256 on
8 threads.

## How often the fast path fires

Narrow, but it covers the shape that costs. I instrumented both branches and counted every
`GatherElements` call:

| | on fast path, by node | on fast path, by element |
| --- | --: | --: |
| the DeBERTa-v3 model above, per inference | 24 of 24 (100%) | 100% |
| ONNX conformance suite | 11 of 82 (13%) | 0.1% |
| the new `suite-unit` proptest | 101 of 256 (39%) | |

Every conformance miss was a gather on axis 1 of an `[N, C, d1...]` tensor, coming from the
loss-function expansions (`NegativeLogLikelihoodLoss` and friends). That is the most common
`GatherElements` shape in your test suite and it keeps the generic path.

Two caveats on reading those numbers. I have one real model that uses this op, so 100% is a
single data point. And the conformance suite is a set of small shape fixtures, so its 13% and
0.1% say nothing about real inference time either. The guard is three cheap comparisons before
any work, so shapes that miss pay almost nothing for it.

## Testing

- New `gather_elements` suite in `suite-unit`: a proptest over ranks 1 to 4 that reaches both
  paths, plus explicit cases for last axis, negative indices, rank 1, non-last axis,
  mismatched dimensions, and two zero-element shapes. 9 cases against each of the raw,
  decluttered and optimized runtimes. `data` is filled with its own flat offsets, so the
  expected answer comes from the shape alone rather than from re-running the op's own logic.
- New harness case `harness/nnef-test-cases/gather-elements-last-axis`: gathers the same
  elements twice in one graph, once on the fast path and once transposed onto the generic
  path, then asserts the difference is 0. `--assert-op-count` keeps a future pass from folding
  one leg into the other and making the check vacuous.
- Mutation tested. Deleting the leading-dimension check, the negative-index handling, or the
  row offset each fails both the unit suite and the harness case.
- The model output is bit-identical before and after at both sequence lengths
  (`--approx exact`).
- Four tests in `core` for the out-of-range and empty-axis errors. Those are only reachable on
  the fast path, and the suite framework compares outputs rather than errors, so I could not
  express them there. `core/src/ops/array/gather.rs` already tests op `eval` this way. Happy
  to move them if you would rather have the harness extended instead.
- `test-unit-core` (810), `test-nnef-cycle` (2412), `test-tflite` (1369) and `test-onnx-core`
  (4428) all pass. `cargo clippy --workspace` and `cargo fmt --all` clean.

## Two things I need your eyes on

**A CUDA skip I could not verify.** The two new zero-element cases put a zero-byte constant
through `CudaTensor::from_tensor`, which calls `clone_htod` with an empty slice.
`metal/src/context.rs` guards exactly this by substituting a 1-byte buffer, and CUDA has no
equivalent, so I added those two cases to `ignore_unit` in `test-rt/test-cuda/suite.rs` with a
comment. I have no NVIDIA hardware, so this is reasoning from the code, not a reproduction. If
your GPU CI is fine with them, drop the skip. `gather_elements` is also skipped in
`test-tflite`, which has no serializer for the op.

**Two pre-existing issues this made visible**, both left alone:

1. On 32-bit targets (`armv7-unknown-linux-musleabihf` is a release target) the generic path's
   `... as usize` truncates an out-of-range index into an in-range one and silently returns
   the wrong element. The fast path's `usize::try_from` reports it. Worth a separate fix, and
   it is the reason the two paths now disagree on bad input.
2. When the indices reach the op as `TDim`, `eval` casts the whole tensor to `i64` on every
   inference. In the model above that is a 786k-element cast costing roughly 2.2 ms of the
   3.0 ms per node at seq 256, and the same cause makes two `MultiBroadcastTo` nodes 9.3 ms
   each. That is now the dominant cost in this op, not the gather, and it is why the op is
   still second in the profile at seq 256.

## Deliberately not done

- **Writing straight into the output tensor.** The fast path builds a `Vec` and then pays a
  copy in `ArrayD::into_tensor()`. Writing into the tensor directly is 1.4x to 1.8x faster in
  a microbenchmark, but `Tensor::zero_dt` does not cover `String` or `Blob`, so it needs a
  datum-type gate, and I did not want to narrow the fast path for a gain that the `TDim` cast
  above dwarfs on real models. `Gather::eval_t` does this with `Tensor::uninitialized`; I left
  it alone rather than add `unsafe` here.
- **Threading the loop.** It scales only 1.6x to 2.3x on 8 threads at these shapes, so it is
  bandwidth-bound, and the op is a small share of runtime now.
- **Handling any axis, not just the last one.** The general outer/axis/inner form needs a
  multiply per element, which would slow down the case this is for.

🍍
