### PR TITLE
Bound eager const-eval by memory rather than element count

### DIFF
--- a/core/src/optim/mod.rs
+++ b/core/src/optim/mod.rs
@@ -22,6 +22,15 @@ use self::slice::PushSliceUp;
 use self::uniform_mask::FoldUniformMask;
 use op_optim::OpOptim;
 
+/// Memory a single constant fold may materialize.
+///
+/// Bounds every eager evaluation of a constant subgraph, both during inference
+/// and in `prop_const`: a fold under the budget is cheap enough to pay for at
+/// load time, and one over it is left in the graph rather than risk turning a
+/// large weight into several copies. Shape and index arithmetic sits far below
+/// it, decoded weight tensors far above.
+pub const CONST_FOLD_MEM_BUDGET: u64 = 8 << 20;
+
 pub trait TypedPass: Debug + Send + Sync + dyn_clone::DynClone {
     fn reset(&mut self) -> TractResult<()>;
     fn next(

--- a/core/src/optim/mod.rs
+++ b/core/src/optim/mod.rs
@@ -29,7 +29,7 @@ use op_optim::OpOptim;
 /// load time, and one over it is left in the graph rather than risk turning a
 /// large weight into several copies. Shape and index arithmetic sits far below
 /// it, decoded weight tensors far above.
-pub const CONST_FOLD_MEM_BUDGET: u64 = 8 << 20;
+pub const CONST_FOLD_MEM_BUDGET: u64 = 4 << 20;
 
 pub trait TypedPass: Debug + Send + Sync + dyn_clone::DynClone {
     fn reset(&mut self) -> TractResult<()>;

--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -5,8 +5,12 @@ use crate::ops::array::Slice;
 use crate::ops::dummy::Dummy;
 use crate::ops::konst::Const;
 use crate::ops::source::TypedSource;
-use crate::optim::OptimizerSession;
+use crate::optim::{CONST_FOLD_MEM_BUDGET, OptimizerSession};
 
+/// Replaces stateless nodes whose inputs are all constant with the constant they
+/// evaluate to, walking forward through single-successor chains so one patch can
+/// collapse a whole run. Folds are bounded by [`CONST_FOLD_MEM_BUDGET`] so a large
+/// weight is not duplicated once per consumer.
 #[derive(Clone, Debug, Default)]
 pub struct PropConst(usize);
 
@@ -39,7 +43,10 @@ impl super::TypedPass for PropConst {
                         && (model.node(outlet.node).outputs[outlet.slot].successors.len() == 1
                             || node.op_is::<Slice>()
                             || (fact.datum_type.is_number()
-                                && fact.shape.volume().as_i64().is_some_and(|d| d <= 1024)))
+                                && fact
+                                    .mem_size()
+                                    .as_i64()
+                                    .is_some_and(|m| m as u64 <= CONST_FOLD_MEM_BUDGET)))
                 })
             {
                 let inputs =
@@ -56,7 +63,7 @@ impl super::TypedPass for PropConst {
                             .iter()
                             .map(|t| (t.datum_type().size_of() * t.volume()) as u64)
                             .sum();
-                        if output_mem > input_mem.max(1 << 20) {
+                        if output_mem > input_mem.max(CONST_FOLD_MEM_BUDGET) {
                             continue;
                         }
                         let mut node = node;
@@ -78,7 +85,7 @@ impl super::TypedPass for PropConst {
                                 .iter()
                                 .map(|t| (t.datum_type().size_of() * t.volume()) as u64)
                                 .sum();
-                            if succ_mem > input_mem.max(1 << 20) {
+                            if succ_mem > input_mem.max(CONST_FOLD_MEM_BUDGET) {
                                 break;
                             }
                             res = succ_res;
@@ -118,5 +125,72 @@ impl super::TypedPass for PropConst {
             }
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::math;
+
+    fn const_i64(model: &mut TypedModel, name: &str, shape: [usize; 2]) -> TractResult<OutletId> {
+        let len = shape[0] * shape[1];
+        let t = Tensor::from_shape(&shape, &(0..len as i64).collect::<Vec<_>>())?;
+        model.add_const(name, t)
+    }
+
+    /// Sides are derived from the budget rather than fixed, so changing
+    /// [`CONST_FOLD_MEM_BUDGET`] cannot silently move a case to the other side of
+    /// the guard.
+    fn side_for(bytes: u64) -> usize {
+        (bytes / std::mem::size_of::<i64>() as u64).isqrt() as usize
+    }
+
+    /// Two consumers of one constant, both foldable. The constant is well over the
+    /// element count the guard used to allow but inside the memory budget, so the
+    /// graph must collapse entirely: once both consumers are constant the shared
+    /// input is dead and nothing has been duplicated.
+    #[test]
+    fn fold_through_shared_const_inside_mem_budget() -> TractResult<()> {
+        let mut model = TypedModel::default();
+        let side = side_for(CONST_FOLD_MEM_BUDGET / 16);
+        let shared = const_i64(&mut model, "shared", [side, side])?;
+        let one = model.add_const("one", tensor2(&[[1i64]]))?;
+        let two = model.add_const("two", tensor2(&[[2i64]]))?;
+        let a = model.wire_node("a", math::mul(), &[shared, two])?[0];
+        let b = model.wire_node("b", math::add(), &[shared, one])?[0];
+        let sum = model.wire_node("sum", math::add(), &[a, b])?[0];
+        model.select_output_outlets(&[sum])?;
+
+        let decluttered = model.into_decluttered()?;
+        let live: Vec<&str> = decluttered
+            .nodes
+            .iter()
+            .filter(|n| !n.op_is::<Const>() && !n.op_is::<Dummy>())
+            .map(|n| n.name.as_str())
+            .collect();
+        assert!(live.is_empty(), "expected a fully folded graph, got {live:?}");
+        Ok(())
+    }
+
+    /// The same shape of graph with a constant over the budget keeps its consumers,
+    /// so a large weight is not turned into one copy per consumer.
+    #[test]
+    fn keep_shared_const_over_mem_budget() -> TractResult<()> {
+        let mut model = TypedModel::default();
+        let side = side_for(CONST_FOLD_MEM_BUDGET * 2);
+        let shared = const_i64(&mut model, "shared", [side, side])?;
+        let one = model.add_const("one", tensor2(&[[1i64]]))?;
+        let two = model.add_const("two", tensor2(&[[2i64]]))?;
+        let a = model.wire_node("a", math::mul(), &[shared, two])?[0];
+        let b = model.wire_node("b", math::add(), &[shared, one])?[0];
+        model.select_output_outlets(&[a, b])?;
+
+        let decluttered = model.into_decluttered()?;
+        assert!(
+            decluttered.nodes.iter().any(|n| !n.op_is::<Const>() && !n.op_is::<Dummy>()),
+            "a shared constant over the memory budget must not be folded per consumer"
+        );
+        Ok(())
     }
 }

--- a/hir/src/infer/ops.rs
+++ b/hir/src/infer/ops.rs
@@ -1,9 +1,14 @@
 use super::Factoid;
 use crate::infer::*;
 use std::fmt;
+use tract_core::optim::CONST_FOLD_MEM_BUDGET;
 use tract_data::TooEarly;
 
 tract_core::dyn_clone::clone_trait_object!(InferenceOp);
+
+fn tensor_mem(t: &Tensor) -> u64 {
+    (t.volume() * t.datum_type().size_of()) as u64
+}
 
 /// An operation with tensor type inference
 pub trait InferenceOp: Op {
@@ -35,18 +40,22 @@ pub trait InferenceOp: Op {
                 .map(|i| {
                     i.value
                         .concretize()
-                        .filter(|t| t.volume() < 16 && t.is_plain())
+                        .filter(|t| t.is_plain() && tensor_mem(t) <= CONST_FOLD_MEM_BUDGET)
                         .map(|t| t.into_tvalue())
                 })
                 .collect::<Option<TVec<_>>>()
         {
+            let input_mem: u64 = input_values.iter().map(|t| tensor_mem(t)).sum();
             match self.eval(input_values) {
                 Ok(values) => {
-                    let output_values = values
-                        .into_iter()
-                        .map(|t| t.into_arc_tensor().try_into())
-                        .collect::<TractResult<TVec<_>>>()?;
-                    return Ok((infered_inputs, output_values, observed));
+                    let output_mem: u64 = values.iter().map(|t| tensor_mem(t)).sum();
+                    if output_mem <= input_mem.max(CONST_FOLD_MEM_BUDGET) {
+                        let output_values = values
+                            .into_iter()
+                            .map(|t| t.into_arc_tensor().try_into())
+                            .collect::<TractResult<TVec<_>>>()?;
+                        return Ok((infered_inputs, output_values, observed));
+                    }
                 }
                 Err(e) if e.root_cause().downcast_ref::<TooEarly>().is_some() => (),
                 Err(e) => return Err(e).context("Eager eval during inference"),


### PR DESCRIPTION
Follow-up to #2445. Limiting eager const-eval to tensors under 16 elements stopped it partway through shape-derived index arithmetic, which `prop_const` then declines to finish because its own fallback gates a *shared* constant input on 1024 elements. Both are element counts sitting next to a guard that already works in bytes, so this replaces them with one shared byte budget and bounds the inference-time fold by the memory it materializes, the way `prop_const` already does.

The model that surfaced it is Llama Prompt Guard 2 86M, a DeBERTa-v3: with input shapes frozen, its whole disentangled-attention relative-position table is constant, and it stopped being folded. Prompt Guard 2 at sequence length 128, single-threaded, optimized graph:

| | ms/inference | nodes | non-const nodes | `OptMatMul` |
|---|--:|--:|--:|--:|
| before #2445 | 99.3 | 908 | 651 | 122 |
| main today | 143.2 | 1030 | 760 | 146 |
| this branch | 102.2 | 908 | 651 | 122 |

The graph is back to exactly the shape it had before #2445, and output is bit-identical to that build (`--assert-output-bundle --approx exact`). The 24 extra matmuls on main are the relative-position embedding projection, about 1.5 MiB, being redone per inference instead of once at load. The same regression reproduces on a Graviton3 `c7g.2xlarge`, where it is 0.68x at sequence length 128 and 0.81x at 256.

The intent of #2445 is kept: a decoded weight tensor is orders of magnitude past the budget, and the new output-size check means an op whose eval expands its inputs is no longer folded during inference even when the inputs themselves are small.

`cargo fmt --all --check` and `cargo clippy --workspace` clean. `tract-core` 268, `tract-hir` 63, `test-unit-core` 810, `test-onnx-core` 4428, `test-nnef-cycle` 2412, all passing. Two tests added next to the pass; the first fails on main.

I left the `volume() < 16` fast path in `TypedModel::wire_node` alone, since `prop_const` is the fallback there and this asymmetry is the whole reason inference needed a different bound.

🍍
