### PR TITLE
linalg/mmm: decouple parallel chunking from cache blocking

### DIFF
--- a/harness/nnef-test-cases/parallel-matmul/graph.nnef
+++ b/harness/nnef-test-cases/parallel-matmul/graph.nnef
@@ -1,0 +1,30 @@
+version 1.0;
+
+# Exercises the multithreaded MMM chunked dispatch at shapes that make it pick
+# different chunk grids: a skewed grid (n much longer than m, so the chunks band
+# along n), a square one (a genuinely 2D grid), a tall-thin one, and a batched
+# matmul (one dispatch per prefix coordinate). Every shape stays above the default
+# 64-panel threading threshold even on a 32x32-tile kernel (the widest tile any
+# f32 mmm kernel here uses, e.g. Apple AMX and SME), so all four reach the
+# parallel path without tuning the threshold: 96, 256, 128 and 96 panels
+# respectively.
+#
+# runme.sh asserts the threaded output is bit-identical to the same-platform
+# single-threaded run: chunking and the in-chunk cache-blocked walk only reorder
+# independent tiles, and each output tile still accumulates the whole k in one
+# kernel call.
+graph parallel_matmul(skew_a, skew_b, sq_a, sq_b, thin_a, thin_b, batch_a, batch_b) -> (skew, sq, thin, batch)
+{
+    skew_a = external<scalar>(shape = [128, 768]);
+    skew_b = external<scalar>(shape = [768, 768]);
+    sq_a = external<scalar>(shape = [512, 512]);
+    sq_b = external<scalar>(shape = [512, 512]);
+    thin_a = external<scalar>(shape = [1024, 256]);
+    thin_b = external<scalar>(shape = [256, 128]);
+    batch_a = external<scalar>(shape = [4, 256, 256]);
+    batch_b = external<scalar>(shape = [4, 256, 384]);
+    skew = matmul(skew_a, skew_b);
+    sq = matmul(sq_a, sq_b);
+    thin = matmul(thin_a, thin_b);
+    batch = matmul(batch_a, batch_b);
+}

--- a/harness/nnef-test-cases/parallel-matmul/runme.sh
+++ b/harness/nnef-test-cases/parallel-matmul/runme.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+trap 'rm -f ref.npz' EXIT
+
+# --allow-random-input is seeded from a fixed constant, so both runs below get
+# byte-identical input without committing a bundle.
+#
+# Serial reference on this same binary/platform (the default executor is serial).
+$TRACT_RUN . -O run --allow-random-input --save-outputs ref.npz
+
+# The chunked MMM dispatch splits the panel grid across threads and walks each
+# chunk cache-blocked; both only reorder independent tiles, so the threaded
+# result must be bit-identical to the serial one (--approx exact = atol=rtol=0).
+# Comparing against a same-platform serial run keeps this independent of which
+# kernel the host registers.
+#
+# A default build (including the CI cli-tests harness) has no multithread-mm, so
+# `--threads` bails; drive this case with a multithread-mm TRACT_RUN (the plan's
+# verification step does) to exercise the parallel leg. We warn rather than skip
+# silently so a serial-only run is never mistaken for threaded coverage.
+if $TRACT_RUN --threads 2 . dump -q >/dev/null 2>&1; then
+    for threads in 2 3 8; do
+        $TRACT_RUN --threads $threads . -O run \
+            --allow-random-input --assert-output-bundle ref.npz --approx exact
+    done
+else
+    echo "WARNING: TRACT_RUN has no multithread-mm; parallel bit-identity leg NOT run." >&2
+fi

--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -84,6 +84,11 @@ name = "mm_for_asr_am"
 harness = false
 
 [[bench]]
+name = "mm_threads"
+harness = false
+required-features = ["multithread-mm"]
+
+[[bench]]
 name = "qmmm_i8"
 harness = false
 

--- a/linalg/benches/mm_threads.rs
+++ b/linalg/benches/mm_threads.rs
@@ -1,0 +1,111 @@
+//! Wall-clock scaling of the parallel MMM dispatcher across thread counts.
+//!
+//! Exercises the chunk-grid / cache-blocking split: each shape is run under a
+//! rayon pool of 1, 2, 4 and 8 threads. t1 is the regression guard (the serial
+//! path must stay neutral); the larger squares are where re-read traffic and
+//! load-balance slack decide multi-thread scaling.
+//!
+//! Compare two revisions with criterion baselines:
+//!   cargo bench -p tract-linalg --features multithread-mm --bench mm_threads -- --save-baseline main
+//!   # switch revision
+//!   cargo bench -p tract-linalg --features multithread-mm --bench mm_threads -- --baseline main
+//!
+//! `MM_THREADS` overrides the thread sweep (comma list), `MM_DT` picks `f32`
+//! (default) or `i8`.
+
+use criterion::*;
+use tract_data::internal::*;
+use tract_linalg::mmm::{AsInputValue, FusedSpec};
+use tract_linalg::multithread::{Executor, multithread_tract_scope};
+
+use DatumType::*;
+
+/// (label, m, k, n). Element dims of the shapes in the PR's re-read table,
+/// plus a tall-thin and a batched-ish wide case mirroring the harness cases.
+const SHAPES: &[(&str, usize, usize, usize)] = &[
+    ("gliner_qkv_128", 128, 768, 768), // 16x96 panels @ 8x8
+    ("ffn_up_256", 256, 768, 3072),    // 32x384 panels
+    ("sq512", 512, 512, 512),          // 64x64
+    ("sq1024", 1024, 1024, 1024),      // 128x128
+    ("sq2048", 2048, 2048, 2048),      // interpolation point
+    ("sq4096", 4096, 4096, 4096),      // 512x512 — headline re-read case
+    ("tall_thin", 4096, 512, 128),     // skewed
+    ("wide", 128, 512, 4096),          // skewed the other way
+];
+
+fn threads() -> Vec<usize> {
+    match std::env::var("MM_THREADS") {
+        Ok(s) => s.split(',').filter_map(|t| t.trim().parse().ok()).collect(),
+        Err(_) => vec![1, 2, 4, 8],
+    }
+}
+
+fn dt() -> DatumType {
+    match std::env::var("MM_DT").as_deref() {
+        Ok("i8") => I8,
+        _ => F32,
+    }
+}
+
+fn bench_shape(c: &mut Criterion, dt: DatumType, label: &str, m: usize, k: usize, n: usize) {
+    let mut group = c.benchmark_group(format!("{label}/{m}x{k}x{n}"));
+    group.throughput(Throughput::Elements((m * k * n) as u64));
+
+    let mmm = tract_linalg::ops().mmm(dt, Some(m), Some(k), Some(n)).unwrap();
+    let a = Tensor::zero_dt(dt, &[m, k]).unwrap();
+    let b = Tensor::zero_dt(dt, &[k, n]).unwrap();
+    let packing = &mmm.packings()[0];
+    let pa = packing.0.prepare_one(&a, 1, 0).unwrap();
+    let pb = packing.1.prepare_one(&b, 0, 1).unwrap();
+    let mut cbuf = Tensor::zero_dt(dt, &[m, n]).unwrap();
+
+    for &nth in &threads() {
+        // A tract pool with <= 1 worker is treated by the dispatcher as "use the
+        // global rayon pool" (mod.rs), so `multithread(1)` would silently run on
+        // every core. The genuine serial path is `SingleThread`.
+        let pool = if nth <= 1 { Executor::SingleThread } else { Executor::multithread(nth) };
+        group.bench_function(BenchmarkId::from_parameter(format!("t{nth}")), |be| {
+            let mut scratch = unsafe { mmm.allocate_scratch_space() };
+            be.iter(|| {
+                multithread_tract_scope(pool.clone(), || unsafe {
+                    mmm.run_with_scratch_space(
+                        m,
+                        n,
+                        scratch.as_mut(),
+                        &[
+                            FusedSpec::AddMatMul {
+                                a: AsInputValue::Borrowed(&*pa),
+                                b: AsInputValue::Borrowed(&*pb),
+                                packing: 0,
+                            },
+                            FusedSpec::Store(mmm.c_view(Some(0), Some(1)).wrap(&cbuf.view_mut())),
+                        ],
+                    )
+                    .unwrap()
+                })
+            })
+        });
+    }
+    group.finish();
+}
+
+fn benches(c: &mut Criterion) {
+    let dt = dt();
+    for &(label, m, k, n) in SHAPES {
+        bench_shape(c, dt, label, m, k, n);
+    }
+}
+
+fn config() -> Criterion {
+    Criterion::default()
+        .sample_size(10)
+        .warm_up_time(std::time::Duration::from_millis(800))
+        .measurement_time(std::time::Duration::from_secs(4))
+}
+
+criterion::criterion_group! {
+    name = benches_group;
+    config = config();
+    targets = benches
+}
+criterion::criterion_main!(benches_group);

--- a/linalg/src/cache.rs
+++ b/linalg/src/cache.rs
@@ -25,6 +25,12 @@ pub struct CacheInfo {
     pub l2: usize,
     /// L3 / last-level cache, bytes. `0` if unknown.
     pub l3: usize,
+    /// How many physical cores share one L2 (1 == private per core, as on most
+    /// server/mobile Arm and x86). Greater than 1 on cluster-shared-L2 parts
+    /// (Cortex-A9/A53). `0` if the topology could not be read — callers treat
+    /// that as private. SMT siblings do not count: they already share the core's
+    /// L2, so a 2-thread core with a private L2 reports 1, not 2.
+    pub l2_sharers: usize,
 }
 
 impl CacheInfo {
@@ -43,6 +49,12 @@ impl CacheInfo {
     /// L2 cache, or a conservative 256 KiB guess when undetected.
     pub fn l2_or_default(&self) -> usize {
         if self.l2 > 0 { self.l2 } else { 256 * 1024 }
+    }
+
+    /// Physical cores sharing one L2, at least 1 — unknown topology (`0`) reads
+    /// as private, the regression-safe assumption (no shared-cache division).
+    pub fn l2_sharers_or_one(&self) -> usize {
+        self.l2_sharers.max(1)
     }
 }
 
@@ -239,27 +251,54 @@ fn detect() -> CacheInfo {
         l3: sysctl_usize("hw.perflevel0.l3cachesize")
             .or_else(|| sysctl_usize("hw.l3cachesize"))
             .unwrap_or(0),
+        // Apple L2 is per-cluster (shared across a perflevel's cores), but sysctl
+        // does not expose the sharing degree; report unknown (treated as private).
+        l2_sharers: 0,
     }
+}
+
+/// Count the CPUs named by a Linux cpu-list string (`"0-3"`, `"0,8"`,
+/// `"0-3,8-11"`). Malformed fields are skipped, so a garbled file counts 0.
+#[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(dead_code))]
+fn count_cpu_list(s: &str) -> usize {
+    s.split(',')
+        .filter_map(|part| {
+            let part = part.trim();
+            if part.is_empty() {
+                return None;
+            }
+            match part.split_once('-') {
+                Some((a, b)) => {
+                    let a: usize = a.trim().parse().ok()?;
+                    let b: usize = b.trim().parse().ok()?;
+                    (b >= a).then_some(b - a + 1)
+                }
+                None => part.parse::<usize>().ok().map(|_| 1),
+            }
+        })
+        .sum()
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn detect() -> CacheInfo {
     // Walk /sys/.../cache/indexN, keying off the reported level+type rather than
     // assuming a fixed index layout (it varies: SMT, unified vs split L2, …).
+    let read = |p: String| std::fs::read_to_string(p).ok();
     let mut ci = CacheInfo::default();
+    // SMT siblings share the core's L2 already; only cores beyond that set count
+    // as L2-sharing. Absent topology ⇒ assume no SMT (1).
+    let smt = read("/sys/devices/system/cpu/cpu0/topology/thread_siblings_list".to_string())
+        .map(|s| count_cpu_list(&s))
+        .filter(|&n| n > 0)
+        .unwrap_or(1);
     for idx in 0..16 {
         let base = format!("/sys/devices/system/cpu/cpu0/cache/index{idx}/");
-        let Ok(level) = std::fs::read_to_string(format!("{base}level")) else {
+        let Some(level) = read(format!("{base}level")) else {
             continue;
         };
         let level: usize = level.trim().parse().unwrap_or(0);
-        let ctype = std::fs::read_to_string(format!("{base}type"))
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase();
-        let size = std::fs::read_to_string(format!("{base}size"))
-            .map(|s| parse_cache_size(&s))
-            .unwrap_or(0);
+        let ctype = read(format!("{base}type")).unwrap_or_default().trim().to_ascii_lowercase();
+        let size = read(format!("{base}size")).map(|s| parse_cache_size(&s)).unwrap_or(0);
         if size == 0 {
             continue;
         }
@@ -269,7 +308,12 @@ fn detect() -> CacheInfo {
                     ci.l1_data = size;
                 }
             }
-            2 if ci.l2 == 0 => ci.l2 = size,
+            2 if ci.l2 == 0 => {
+                ci.l2 = size;
+                let cpus =
+                    read(format!("{base}shared_cpu_list")).map(|s| count_cpu_list(&s)).unwrap_or(0);
+                ci.l2_sharers = (cpus / smt).max(1);
+            }
             3 if ci.l3 == 0 => ci.l3 = size,
             _ => {}
         }
@@ -364,6 +408,16 @@ mod tests {
         assert_eq!(parse_cache_size("8M"), 8 * 1024 * 1024);
         assert_eq!(parse_cache_size(" 1024k "), 1024 * 1024);
         assert_eq!(parse_cache_size("garbage"), 0);
+    }
+
+    #[test]
+    fn cpu_list_counts() {
+        assert_eq!(count_cpu_list("0"), 1);
+        assert_eq!(count_cpu_list("0-15"), 16);
+        assert_eq!(count_cpu_list("0,8"), 2);
+        assert_eq!(count_cpu_list("0-3,8-11"), 8);
+        assert_eq!(count_cpu_list(""), 0);
+        assert_eq!(count_cpu_list("garbage"), 0);
     }
 
     #[test]

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -19,6 +19,7 @@ use crate::multithread::Executor;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::Debug;
+use std::ops::Range;
 use tract_data::internal::*;
 
 pub use cost_model::*;
@@ -256,8 +257,8 @@ impl<K: MatMatMulKer> MatMatMul for K {
                         prefer_row = (!col) as usize;
                     }
                 }
-                // k drives the single-thread cache-block size; read it from the
-                // first AddMatMul's packed input (0 if none → max block).
+                // k drives the cache-block size; read it from the first
+                // AddMatMul's packed input (0 if none → max block).
                 let k = non_linear
                     .iter()
                     .find_map(|f| match f {
@@ -265,11 +266,15 @@ impl<K: MatMatMulKer> MatMatMul for K {
                         _ => None,
                     })
                     .unwrap_or(0);
-                if prefer_col > prefer_row {
-                    run_with_scratch_space_col_outer(self, m, n, k, scratch, non_linear)
-                } else {
-                    run_with_scratch_space_row_outer(self, m, n, k, scratch, non_linear)
-                }
+                run_with_scratch_space_2d(
+                    self,
+                    m,
+                    n,
+                    k,
+                    prefer_col > prefer_row,
+                    scratch,
+                    non_linear,
+                )
             }
         }
     }
@@ -294,7 +299,9 @@ unsafe fn run_with_scratch_space_vec<K: MatMatMulKer>(
                 Some(&pool),
                 m.divceil(ker.mr()),
                 1,
-                |ia_start, ia_end, _, _| {
+                ker.mr(),
+                ker.nr(),
+                |ia_start, ia_end, _, _, _| {
                     scratch.run_in_tls_scope(|scratch, tls| {
                         for ia in ia_start..ia_end {
                             scratch.run_one_tile(ker, non_linear, tls, ia, 0)?;
@@ -304,27 +311,31 @@ unsafe fn run_with_scratch_space_vec<K: MatMatMulKer>(
                 },
             ),
             #[cfg(feature = "multithread-mm")]
-            Executor::RayonGlobal => {
-                chunked_dispatch_rayon(None, m.divceil(ker.mr()), 1, |ia_start, ia_end, _, _| {
+            Executor::RayonGlobal => chunked_dispatch_rayon(
+                None,
+                m.divceil(ker.mr()),
+                1,
+                ker.mr(),
+                ker.nr(),
+                |ia_start, ia_end, _, _, _| {
                     scratch.run_in_tls_scope(|scratch, tls| {
                         for ia in ia_start..ia_end {
                             scratch.run_one_tile(ker, non_linear, tls, ia, 0)?;
                         }
                         TractResult::Ok(())
                     })
-                })
-            }
+                },
+            ),
         }
     }
 }
 
-/// Upper bound on the inner (L2-resident) panel-block edge (matches the
-/// multithread `chunk_grid` default).
-const ST_BLK_MAX: usize = 16;
+/// Upper bound on the inner (L2-resident) panel-block edge.
+const BLK_MAX: usize = 16;
 
 /// Upper bound on the outer (L3-resident) super-block edge. 4× the inner cap so
 /// an L3 several times larger than L2 can hold a meaningfully bigger super-block.
-const ST_BLK_L3_MAX: usize = 64;
+const BLK_L3_MAX: usize = 64;
 
 /// Panel-block working-set budget (bytes) from a detected cache size: a fraction
 /// `num/den` of the cache (leaving room for the C accumulator tile + packing
@@ -345,11 +356,12 @@ fn l2_block_budget_bytes() -> usize {
 }
 
 /// Outer tier: `(llc_bytes, budget_bytes)` — the raw last-level-cache size and the
-/// fraction of it a single thread may budget for the outer super-block — but only
-/// when an L3/LLC larger than L2 is detected (otherwise an outer tier just
-/// duplicates the inner one). `None` ⇒ no outer tier; the walk stays single-level
-/// (identical to before). The raw size is returned alongside the budget so the
-/// caller can check whether the working set even spills the cache before blocking.
+/// fraction of it the outer super-block may budget — but only when an L3/LLC larger
+/// than L2 is detected (otherwise an outer tier just duplicates the inner one).
+/// `None` ⇒ no outer tier; the walk stays single-level. The raw size is returned
+/// alongside the budget so the caller can check whether the working set even
+/// spills the cache before blocking. Both numbers are for the *whole* cache;
+/// concurrent walkers each get a share (see [`outer_block_edge`]).
 fn l3_block_budget_bytes() -> Option<(usize, usize)> {
     use crate::cache::LlcKind;
     let (bytes, kind) = crate::cache::last_level_cache()?;
@@ -400,8 +412,14 @@ fn inner_tier_pays(panels: usize, r: usize, k: usize, elem_bytes: usize, l2_byte
 /// stream) when the streamed operand already fits L2 (see [`inner_tier_pays`]).
 /// The budget is **cache-size derived** (not a hard-coded constant), so it is
 /// correct across hardware.
+///
+/// Unlike [`outer_block_edge`], this does not divide the budget among concurrent
+/// walkers: it assumes an L2 private to the core running the rectangle. Where L2
+/// is instead shared across a cluster — [`crate::cache::CacheInfo::l2`] reports
+/// either and cannot tell them apart — sibling rectangles each budget the same
+/// bytes and can evict one another.
 #[inline]
-fn st_block_edge(
+fn inner_block_edge(
     mr: usize,
     nr: usize,
     k: usize,
@@ -414,7 +432,7 @@ fn st_block_edge(
     if !inner_tier_pays(panels, r, k, elem_bytes, crate::cache::cache_info().l2) {
         return usize::MAX;
     }
-    block_edge_for(l2_block_budget_bytes(), mr, nr, k, elem_bytes, ST_BLK_MAX)
+    block_edge_for(l2_block_budget_bytes(), mr, nr, k, elem_bytes, BLK_MAX)
 }
 
 /// Whether an L3 outer super-block can capture reuse the inner (L2) tier cannot.
@@ -443,11 +461,18 @@ fn outer_tier_pays(
     llc_bytes > 0 && working_set > llc_bytes
 }
 
-/// Outer (L3) super-block edge, or `usize::MAX` (one block over the whole grid,
-/// i.e. no outer tier) when no usable L3 is detected or the working set already
-/// fits it (see [`outer_tier_pays`]). Never smaller than the inner edge `inner`.
+/// Outer (L3) super-block edge, or `usize::MAX` (one block over the whole
+/// rectangle, i.e. no outer tier) when no usable L3 is detected or the working set
+/// already fits it (see [`outer_tier_pays`]). Never smaller than the inner edge
+/// `inner`.
+///
+/// `llc_share` is how many rectangles are walked concurrently: the LLC is shared,
+/// so each walker may only assume its slice of it. Sizing every chunk of a
+/// multi-threaded dispatch against the whole LLC would have them evict each
+/// other's super-blocks.
 #[inline]
-fn st_outer_block_edge(
+#[allow(clippy::too_many_arguments)]
+fn outer_block_edge(
     mr: usize,
     nr: usize,
     k: usize,
@@ -455,25 +480,27 @@ fn st_outer_block_edge(
     inner: usize,
     m_panels: usize,
     n_panels: usize,
+    llc_share: usize,
 ) -> usize {
     let Some((llc, budget)) = l3_block_budget_bytes() else { return usize::MAX };
-    if !outer_tier_pays(m_panels, n_panels, mr, nr, k, elem_bytes, llc) {
+    let share = llc_share.max(1);
+    if !outer_tier_pays(m_panels, n_panels, mr, nr, k, elem_bytes, llc / share) {
         return usize::MAX;
     }
-    block_edge_for(budget, mr, nr, k, elem_bytes, ST_BLK_L3_MAX).max(inner)
+    block_edge_for(budget / share, mr, nr, k, elem_bytes, BLK_L3_MAX).max(inner)
 }
 
-/// Visit every `(ia, ib)` tile of the `m_panels × n_panels` grid exactly once,
+/// Visit every `(ia, ib)` tile of the `m × n` panel rectangle exactly once,
 /// blocked two levels deep: an outer `blk_outer` super-block (L3-resident) holds
 /// inner `blk` blocks (L2-resident). `col_outer` selects the within-block inner
-/// order (B-reuse vs A-reuse). When `blk_outer >= max(m,n)` the outer loop runs
-/// once and this is exactly the single-level inner walk. Pure tile reordering ⇒
-/// no result changes; extracted so the nesting can be unit-tested independently
-/// of the kernel.
+/// order (B-reuse vs A-reuse). When `blk_outer` spans the whole rectangle the
+/// outer loop runs once and this is exactly the single-level inner walk. Pure
+/// tile reordering ⇒ no result changes; extracted so the nesting can be
+/// unit-tested independently of the kernel.
 #[inline]
 fn for_each_blocked_tile(
-    m_panels: usize,
-    n_panels: usize,
+    m: Range<usize>,
+    n: Range<usize>,
     blk: usize,
     blk_outer: usize,
     col_outer: bool,
@@ -481,18 +508,18 @@ fn for_each_blocked_tile(
 ) -> TractResult<()> {
     let blk = blk.max(1);
     let blk_outer = blk_outer.max(blk);
-    let mut jb3 = 0;
-    while jb3 < n_panels {
-        let jb3_end = jb3.saturating_add(blk_outer).min(n_panels);
-        let mut ja3 = 0;
-        while ja3 < m_panels {
-            let ja3_end = ja3.saturating_add(blk_outer).min(m_panels);
+    let mut jb3 = n.start;
+    while jb3 < n.end {
+        let jb3_end = jb3.saturating_add(blk_outer).min(n.end);
+        let mut ja3 = m.start;
+        while ja3 < m.end {
+            let ja3_end = ja3.saturating_add(blk_outer).min(m.end);
             let mut jb = jb3;
             while jb < jb3_end {
-                let jb_end = (jb + blk).min(jb3_end);
+                let jb_end = jb.saturating_add(blk).min(jb3_end);
                 let mut ja = ja3;
                 while ja < ja3_end {
-                    let ja_end = (ja + blk).min(ja3_end);
+                    let ja_end = ja.saturating_add(blk).min(ja3_end);
                     if col_outer {
                         for ib in jb..jb_end {
                             for ia in ja..ja_end {
@@ -517,183 +544,142 @@ fn for_each_blocked_tile(
     Ok(())
 }
 
-/// Single-thread tile walk over the `m_panels × n_panels` grid, blocked into
-/// cache-sized panel blocks for locality (the naive nested loop re-streams the
-/// whole inner operand per outer panel at large k; the multithread path already
-/// blocks this way via `chunk_grid`). Two tiers: an inner L2-resident block and,
-/// where an L3 is detected, an outer L3-resident super-block. Reordering
-/// independent tiles changes no result — bit-exact with the naive loop.
+/// Tile walk over one panel rectangle — the whole grid on the single-thread
+/// path, one dispatch chunk on the rayon path — blocked into cache-sized panel
+/// blocks for locality (the naive nested loop re-streams the whole inner operand
+/// per outer panel at large k). Two tiers: an inner L2-resident block and, where
+/// an L3 is detected, an outer L3-resident super-block sized for one of
+/// `llc_share` concurrent walkers. Both tiers are gated on the rectangle's own
+/// extents, so a rectangle whose streamed operand already fits cache walks
+/// exactly the naive order. Reordering independent tiles changes no result —
+/// bit-exact with the naive loop at any chunking.
 #[inline]
-unsafe fn run_single_thread_blocked<K: MatMatMulKer>(
+#[allow(clippy::too_many_arguments)]
+unsafe fn run_blocked<K: MatMatMulKer>(
     ker: &K,
-    m_panels: usize,
-    n_panels: usize,
+    m: Range<usize>,
+    n: Range<usize>,
     k: usize,
     col_outer: bool,
-    scratch: &mut ScratchSpaceImpl<K::Acc>,
+    llc_share: usize,
+    scratch: &ScratchSpaceImpl<K::Acc>,
     non_linear: &[FusedSpec],
 ) -> TractResult<()> {
     unsafe {
         let elem = K::Acc::datum_type().size_of();
-        let blk = st_block_edge(ker.mr(), ker.nr(), k, elem, m_panels, n_panels, col_outer);
-        let blk_outer = st_outer_block_edge(ker.mr(), ker.nr(), k, elem, blk, m_panels, n_panels);
+        let (mr, nr) = (ker.mr(), ker.nr());
+        let (m_panels, n_panels) = (m.len(), n.len());
+        let blk = inner_block_edge(mr, nr, k, elem, m_panels, n_panels, col_outer);
+        let blk_outer = outer_block_edge(mr, nr, k, elem, blk, m_panels, n_panels, llc_share);
         scratch.run_in_tls_scope(|scratch, tls| {
-            for_each_blocked_tile(m_panels, n_panels, blk, blk_outer, col_outer, |ia, ib| {
+            for_each_blocked_tile(m, n, blk, blk_outer, col_outer, |ia, ib| {
                 scratch.run_one_tile(ker, non_linear, tls, ia, ib)
             })
         })
     }
 }
 
-unsafe fn run_with_scratch_space_col_outer<K: MatMatMulKer>(
+/// Run the whole `m × n` output over the executor currently installed: as one
+/// rectangle when single-threaded, else split into the chunk grid
+/// [`chunk_grid`] picks. `col_outer` selects the tile order inside a rectangle
+/// (B-reuse vs A-reuse), from the fused ops' preference. `k` is only used to size
+/// the cache blocking.
+unsafe fn run_with_scratch_space_2d<K: MatMatMulKer>(
     ker: &K,
     m: usize,
     n: usize,
     k: usize,
-    scratch: &mut ScratchSpaceImpl<K::Acc>,
+    col_outer: bool,
+    scratch: &ScratchSpaceImpl<K::Acc>,
     non_linear: &[FusedSpec],
 ) -> TractResult<()> {
     unsafe {
-        match crate::multithread::current_tract_executor() {
-            Executor::SingleThread => run_single_thread_blocked(
+        let (m_panels, n_panels) = (m.divceil(ker.mr()), n.divceil(ker.nr()));
+        #[cfg(feature = "multithread-mm")]
+        let chunk = |ia_start, ia_end, ib_start, ib_end, concurrency| {
+            run_blocked(
                 ker,
-                m.divceil(ker.mr()),
-                n.divceil(ker.nr()),
+                ia_start..ia_end,
+                ib_start..ib_end,
                 k,
-                true,
+                col_outer,
+                concurrency,
                 scratch,
                 non_linear,
-            ),
+            )
+        };
+        match crate::multithread::current_tract_executor() {
+            Executor::SingleThread => {
+                run_blocked(ker, 0..m_panels, 0..n_panels, k, col_outer, 1, scratch, non_linear)
+            }
             #[cfg(feature = "multithread-mm")]
-            Executor::MultiThread(pool) => chunked_dispatch_rayon(
-                Some(&pool),
-                m.divceil(ker.mr()),
-                n.divceil(ker.nr()),
-                |ia_start, ia_end, ib_start, ib_end| {
-                    scratch.run_in_tls_scope(|scratch, tls| {
-                        for ib in ib_start..ib_end {
-                            for ia in ia_start..ia_end {
-                                scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
-                            }
-                        }
-                        TractResult::Ok(())
-                    })
-                },
-            ),
+            Executor::MultiThread(pool) => {
+                chunked_dispatch_rayon(Some(&pool), m_panels, n_panels, ker.mr(), ker.nr(), chunk)
+            }
             #[cfg(feature = "multithread-mm")]
-            Executor::RayonGlobal => chunked_dispatch_rayon(
-                None,
-                m.divceil(ker.mr()),
-                n.divceil(ker.nr()),
-                |ia_start, ia_end, ib_start, ib_end| {
-                    scratch.run_in_tls_scope(|scratch, tls| {
-                        for ib in ib_start..ib_end {
-                            for ia in ia_start..ia_end {
-                                scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
-                            }
-                        }
-                        TractResult::Ok(())
-                    })
-                },
-            ),
+            Executor::RayonGlobal => {
+                chunked_dispatch_rayon(None, m_panels, n_panels, ker.mr(), ker.nr(), chunk)
+            }
         }
     }
 }
 
-unsafe fn run_with_scratch_space_row_outer<K: MatMatMulKer>(
-    ker: &K,
-    m: usize,
-    n: usize,
-    k: usize,
-    scratch: &mut ScratchSpaceImpl<K::Acc>,
-    non_linear: &[FusedSpec],
-) -> TractResult<()> {
-    unsafe {
-        match crate::multithread::current_tract_executor() {
-            Executor::SingleThread => run_single_thread_blocked(
-                ker,
-                m.divceil(ker.mr()),
-                n.divceil(ker.nr()),
-                k,
-                false,
-                scratch,
-                non_linear,
-            ),
-            #[cfg(feature = "multithread-mm")]
-            Executor::MultiThread(pool) => chunked_dispatch_rayon(
-                Some(&pool),
-                m.divceil(ker.mr()),
-                n.divceil(ker.nr()),
-                |ia_start, ia_end, ib_start, ib_end| {
-                    scratch.run_in_tls_scope(|scratch, tls| {
-                        for ia in ia_start..ia_end {
-                            for ib in ib_start..ib_end {
-                                scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
-                            }
-                        }
-                        TractResult::Ok(())
-                    })
-                },
-            ),
-            #[cfg(feature = "multithread-mm")]
-            Executor::RayonGlobal => chunked_dispatch_rayon(
-                None,
-                m.divceil(ker.mr()),
-                n.divceil(ker.nr()),
-                |ia_start, ia_end, ib_start, ib_end| {
-                    scratch.run_in_tls_scope(|scratch, tls| {
-                        for ia in ia_start..ia_end {
-                            for ib in ib_start..ib_end {
-                                scratch.run_one_tile(ker, non_linear, tls, ia, ib)?;
-                            }
-                        }
-                        TractResult::Ok(())
-                    })
-                },
-            ),
-        }
-    }
-}
-
-/// Chunk grid for the 2D dispatch.
-///
-/// Mirrors ggml's `mul_mat` heuristic (`ggml/src/ggml-cpu/ggml-cpu.c:1378-1398`):
-///  * 16-tile panel chunks by default;
-///  * 64-tile chunks when one dimension is 1 (vec / vec-mat);
-///  * fallback to "block-per-thread along the longer axis" when the natural
-///    grid would have fewer than `4·nth` chunks.
-///
-/// Returns `(nchunks_m, nchunks_n, dr_m, dr_n)`.
+/// Chunks per thread the 2D dispatch aims for. Above one, rayon can steal work
+/// when threads progress unevenly — a contended core, an E-core on a big.LITTLE
+/// part, a chunk carrying more border tiles — so a straggler costs at most its
+/// share rather than the whole grid's tail. Each extra chunk also re-reads a band
+/// of the packed operands, and that cost grows as `sqrt(chunks)` against a linear
+/// gain in slack, which is what keeps this small.
 #[cfg(feature = "multithread-mm")]
-fn chunk_grid(n_panels_m: usize, n_panels_n: usize, nth: usize) -> (usize, usize, usize, usize) {
-    let chunk_size = if n_panels_m == 1 || n_panels_n == 1 { 64 } else { 16 };
-    let mut nchunks_m = n_panels_m.div_ceil(chunk_size);
-    let mut nchunks_n = n_panels_n.div_ceil(chunk_size);
-    if nchunks_m * nchunks_n < 4 * nth {
-        if n_panels_m > n_panels_n {
-            nchunks_m = nth;
-            nchunks_n = 1;
-        } else {
-            nchunks_m = 1;
-            nchunks_n = nth;
-        }
-    }
-    let dr_m = n_panels_m.div_ceil(nchunks_m).max(1);
-    let dr_n = n_panels_n.div_ceil(nchunks_n).max(1);
-    (nchunks_m, nchunks_n, dr_m, dr_n)
+const CHUNKS_PER_THREAD: usize = 4;
+
+/// Chunk grid for the 2D dispatch: `(nchunks_m, nchunks_n, dr_m, dr_n)`.
+///
+/// Aims for [`CHUNKS_PER_THREAD`]`· nth` chunks and shapes them to minimise how
+/// often the packed operands are re-read: a chunk covering `dr_m × dr_n` panels
+/// reads `dr_m·mr·k` of A and `dr_n·nr·k` of B, so over the whole grid A is read
+/// `nchunks_n` times and B `nchunks_m` times. Minimising
+/// `nchunks_n·m + nchunks_m·n` at a fixed chunk count puts
+/// `nchunks_m = sqrt(chunks · m / n)` — chunks as square as the operands'
+/// extents, rather than a band across one axis.
+///
+/// Cache locality *inside* a chunk is [`run_blocked`]'s job, not this function's;
+/// chunk count therefore tracks the thread count and not a cache size.
+///
+/// Both panel counts must be non-zero; the dispatcher returns early on an empty
+/// grid.
+#[cfg(feature = "multithread-mm")]
+fn chunk_grid(
+    n_panels_m: usize,
+    n_panels_n: usize,
+    mr: usize,
+    nr: usize,
+    nth: usize,
+) -> (usize, usize, usize, usize) {
+    let chunks = (CHUNKS_PER_THREAD * nth).max(1);
+    let (m, n) = (n_panels_m * mr, (n_panels_n * nr).max(1));
+    let nchunks_m = (chunks.saturating_mul(m) / n).isqrt().clamp(1, n_panels_m);
+    let nchunks_n = (chunks / nchunks_m).clamp(1, n_panels_n);
+    let nchunks_m = (chunks / nchunks_n).clamp(1, n_panels_m);
+    let dr_m = n_panels_m.div_ceil(nchunks_m);
+    let dr_n = n_panels_n.div_ceil(nchunks_n);
+    // Recount from the edges: `div_ceil` can make the last chunk of an axis land
+    // entirely outside the grid, and an empty work item is a wasted dispatch.
+    (n_panels_m.div_ceil(dr_m), n_panels_n.div_ceil(dr_n), dr_m, dr_n)
 }
 
-/// 2D chunked dispatcher across the (m_panels × n_panels) grid for the
-/// rayon path. Replaces a 1D `into_par_iter` over a single panel axis.
-/// Better-utilises threads on small/skewed shapes where one dimension has
-/// fewer panels than there are workers.
+/// Dispatch the `m_panels × n_panels` panel grid across the rayon path, split into
+/// the 2D chunk grid [`chunk_grid`] picks. Grids below
+/// [`crate::multithread::current_threading_panel_threshold`] run whole on the
+/// calling thread instead.
 ///
-/// The closure receives **chunk bounds** (`ia_start, ia_end, ib_start, ib_end`),
-/// not per-tile indices. This lets the caller amortise per-worker setup
-/// (e.g. `ScratchSpaceImpl::run_in_tls_scope`) across all tiles in the
-/// chunk, mirroring #2206 for the multi-threaded path. The closure is
-/// invoked exactly once per rayon work item (and once total when the
-/// small-graph fallback path is taken).
+/// The closure receives **chunk bounds** (`ia_start, ia_end, ib_start, ib_end`)
+/// plus the number of chunks running concurrently, not per-tile indices. Chunk
+/// bounds let it amortise per-worker setup (e.g.
+/// `ScratchSpaceImpl::run_in_tls_scope`) over all the tiles in the chunk; the
+/// concurrency lets it size shared-cache blocking against the share it actually
+/// gets. The closure is invoked exactly once per rayon work item, and once in
+/// total with a concurrency of 1 on the below-threshold path.
 ///
 /// `pool`:
 ///   * `Some(p)` with `p.current_num_threads() > 1` → scoped via `p.install`
@@ -707,10 +693,12 @@ unsafe fn chunked_dispatch_rayon<F>(
     pool: Option<&rayon::ThreadPool>,
     n_panels_m: usize,
     n_panels_n: usize,
+    mr: usize,
+    nr: usize,
     run_chunk: F,
 ) -> TractResult<()>
 where
-    F: Fn(usize, usize, usize, usize) -> TractResult<()> + Sync,
+    F: Fn(usize, usize, usize, usize, usize) -> TractResult<()> + Sync,
 {
     use rayon::prelude::*;
     if n_panels_m == 0 || n_panels_n == 0 {
@@ -719,13 +707,14 @@ where
     if n_panels_m * n_panels_n < crate::multithread::current_threading_panel_threshold() {
         // Below the threading threshold: run the whole grid as a single chunk
         // on the calling thread. Closure handles its own TLS scope.
-        return run_chunk(0, n_panels_m, 0, n_panels_n);
+        return run_chunk(0, n_panels_m, 0, n_panels_n, 1);
     }
     let use_global = pool.is_none_or(|p| p.current_num_threads() <= 1);
     let body = || {
         let nth = rayon::current_num_threads();
-        let (nchunks_m, nchunks_n, dr_m, dr_n) = chunk_grid(n_panels_m, n_panels_n, nth);
+        let (nchunks_m, nchunks_n, dr_m, dr_n) = chunk_grid(n_panels_m, n_panels_n, mr, nr, nth);
         let total = nchunks_m * nchunks_n;
+        let concurrency = nth.min(total);
         (0..total).into_par_iter().try_for_each(|idx| {
             let im = idx % nchunks_m;
             let in_ = idx / nchunks_m;
@@ -733,7 +722,7 @@ where
             let ia_end = (ia_start + dr_m).min(n_panels_m);
             let ib_start = in_ * dr_n;
             let ib_end = (ib_start + dr_n).min(n_panels_n);
-            run_chunk(ia_start, ia_end, ib_start, ib_end)
+            run_chunk(ia_start, ia_end, ib_start, ib_end, concurrency)
         })
     };
     if use_global { body() } else { pool.unwrap().install(body) }
@@ -745,8 +734,8 @@ mod blocked_walk_tests {
     use std::collections::HashSet;
 
     fn collect(
-        m: usize,
-        n: usize,
+        m: Range<usize>,
+        n: Range<usize>,
         blk: usize,
         blk_outer: usize,
         col_outer: bool,
@@ -760,27 +749,35 @@ mod blocked_walk_tests {
         v
     }
 
-    /// Every grid tile is visited exactly once, for both inner orders and a
-    /// range of (blk, blk_outer) — single-tier (outer = MAX), two-tier, and
+    /// Every tile of the rectangle is visited exactly once, for both inner orders
+    /// and a range of (blk, blk_outer) — single-tier (outer = MAX), two-tier, and
     /// degenerate edges. Coverage being a permutation is what makes the walk
-    /// bit-exact with the naive loop.
+    /// bit-exact with the naive loop. Offset rectangles are the dispatch chunks.
     #[test]
     fn covers_every_tile_once() {
         for &(m, n) in &[(1, 1), (3, 5), (16, 16), (40, 7), (7, 40), (80, 80)] {
-            for &blk in &[1, 3, 16] {
-                for &blk_outer in &[blk, blk + 1, 64, usize::MAX] {
-                    for &col_outer in &[false, true] {
-                        let tiles = collect(m, n, blk, blk_outer, col_outer);
-                        assert_eq!(tiles.len(), m * n, "m={m} n={n} blk={blk} outer={blk_outer}");
-                        let set: HashSet<_> = tiles.iter().copied().collect();
-                        assert_eq!(
-                            set.len(),
-                            m * n,
-                            "duplicate tiles m={m} n={n} blk={blk} outer={blk_outer}"
-                        );
-                        for ia in 0..m {
-                            for ib in 0..n {
-                                assert!(set.contains(&(ia, ib)), "missing ({ia},{ib})");
+            for &(m0, n0) in &[(0, 0), (3, 11)] {
+                // usize::MAX is how both tiers say "do not block"; on an offset
+                // rectangle the edge arithmetic must not overflow past the end.
+                for &blk in &[1, 3, 16, usize::MAX] {
+                    for &blk_outer in &[blk, blk.saturating_add(1), 64, usize::MAX] {
+                        for &col_outer in &[false, true] {
+                            let tiles = collect(m0..m0 + m, n0..n0 + n, blk, blk_outer, col_outer);
+                            assert_eq!(
+                                tiles.len(),
+                                m * n,
+                                "m={m} n={n} blk={blk} outer={blk_outer}"
+                            );
+                            let set: HashSet<_> = tiles.iter().copied().collect();
+                            assert_eq!(
+                                set.len(),
+                                m * n,
+                                "duplicate tiles m={m} n={n} blk={blk} outer={blk_outer}"
+                            );
+                            for ia in m0..m0 + m {
+                                for ib in n0..n0 + n {
+                                    assert!(set.contains(&(ia, ib)), "missing ({ia},{ib})");
+                                }
                             }
                         }
                     }
@@ -797,7 +794,7 @@ mod blocked_walk_tests {
         for &(m, n) in &[(40, 7), (80, 80), (13, 29)] {
             for &blk in &[1, 4, 16] {
                 for &col_outer in &[false, true] {
-                    let two_tier = collect(m, n, blk, usize::MAX, col_outer);
+                    let two_tier = collect(0..m, 0..n, blk, usize::MAX, col_outer);
                     let mut single = Vec::new();
                     let mut jb = 0;
                     while jb < n {
@@ -863,5 +860,112 @@ mod blocked_walk_tests {
         assert!(!inner_tier_pays(4096, 16, 4096, 4, 0));
         // k = 0 (empty reduction) has no working set.
         assert!(!inner_tier_pays(4096, 16, 0, 4, l2));
+    }
+
+    /// Grids, kernel aspect ratios and thread counts worth checking the chunk
+    /// grid against: skewed both ways, square, prime-ish, and the degenerate
+    /// single-panel cases.
+    #[cfg(feature = "multithread-mm")]
+    const GRIDS: &[(usize, usize)] = &[
+        (1, 1),
+        (1, 5),
+        (5, 1),
+        (2, 3),
+        (3, 3),
+        (16, 96),
+        (96, 16),
+        (17, 17),
+        (64, 64),
+        (32, 384),
+        (128, 128),
+        (1, 4096),
+        (4096, 1),
+        (9, 1000),
+    ];
+
+    #[cfg(feature = "multithread-mm")]
+    const RATIOS: &[(usize, usize)] = &[(8, 8), (16, 4), (32, 32), (64, 1)];
+
+    /// The four numbers `chunk_grid` returns must tile the panel grid exactly:
+    /// `chunked_dispatch_rayon` turns them into work items, so an empty chunk is
+    /// a wasted dispatch, an overlap would double-compute a tile, and a gap would
+    /// leave part of C uninitialised.
+    #[cfg(feature = "multithread-mm")]
+    #[test]
+    fn chunk_grid_tiles_the_panel_grid() {
+        for &(m, n) in GRIDS {
+            for &(mr, nr) in RATIOS {
+                for nth in [1usize, 2, 3, 4, 6, 8, 16, 64] {
+                    let (cm, cn, dr_m, dr_n) = chunk_grid(m, n, mr, nr, nth);
+                    let ctx = format!("{m}x{n} panels, {mr}x{nr} kernel, {nth} threads");
+                    let mut seen = vec![false; m * n];
+                    for idx in 0..cm * cn {
+                        let (im, in_) = (idx % cm, idx / cm);
+                        let (a0, a1) = (im * dr_m, (im * dr_m + dr_m).min(m));
+                        let (b0, b1) = (in_ * dr_n, (in_ * dr_n + dr_n).min(n));
+                        assert!(a0 < a1 && b0 < b1, "empty chunk {idx} in {ctx}");
+                        for ia in a0..a1 {
+                            for ib in b0..b1 {
+                                assert!(!seen[ia * n + ib], "tile ({ia},{ib}) twice in {ctx}");
+                                seen[ia * n + ib] = true;
+                            }
+                        }
+                    }
+                    assert!(seen.iter().all(|s| *s), "tile left out in {ctx}");
+                }
+            }
+        }
+    }
+
+    /// Enough chunks to keep every thread fed, whenever the grid has that many
+    /// panels to go round. Recounting the chunks from the edges is what makes this
+    /// hold: naming more chunks than the edges cover would idle the difference.
+    #[cfg(feature = "multithread-mm")]
+    #[test]
+    fn chunk_grid_feeds_every_thread() {
+        for &(m, n) in GRIDS {
+            for &(mr, nr) in RATIOS {
+                for nth in [1usize, 2, 3, 4, 6, 8, 16, 64] {
+                    let (cm, cn, ..) = chunk_grid(m, n, mr, nr, nth);
+                    assert!(
+                        cm * cn >= nth.min(m * n),
+                        "{cm}x{cn} chunks for {nth} threads on {m}x{n} panels"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The grid is shaped to minimise packed-operand re-reads: A is read once per
+    /// column of chunks and B once per row, so `nchunks_n·m + nchunks_m·n` is what
+    /// the shape trades off. It must never cost more than a band across either
+    /// axis at the same chunk count, which on a square grid costs 1.5x.
+    #[cfg(feature = "multithread-mm")]
+    #[test]
+    fn chunk_grid_shape_beats_a_band_on_operand_traffic() {
+        let traffic = |cm: usize, cn: usize, m: usize, n: usize| cn * m + cm * n;
+        for &(m, n) in GRIDS {
+            for &(mr, nr) in RATIOS {
+                for nth in [2usize, 4, 8, 16] {
+                    let (cm, cn, ..) = chunk_grid(m, n, mr, nr, nth);
+                    let chunks = cm * cn;
+                    // Only a band that fits along the axis is a real alternative:
+                    // one clamped shorter would be a different chunk count, and a
+                    // smaller chunk count trivially re-reads less.
+                    if chunks > m || chunks > n {
+                        continue;
+                    }
+                    let (m_ext, n_ext) = (m * mr, n * nr);
+                    let ours = traffic(cm, cn, m_ext, n_ext);
+                    let band_m = traffic(chunks, 1, m_ext, n_ext);
+                    let band_n = traffic(1, chunks, m_ext, n_ext);
+                    assert!(
+                        ours <= band_m.min(band_n),
+                        "{cm}x{cn} costs {ours}, bands cost {band_m}/{band_n} \
+                         on {m}x{n} panels, {mr}x{nr} kernel, {nth} threads"
+                    );
+                }
+            }
+        }
     }
 }

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -413,12 +413,14 @@ fn inner_tier_pays(panels: usize, r: usize, k: usize, elem_bytes: usize, l2_byte
 /// The budget is **cache-size derived** (not a hard-coded constant), so it is
 /// correct across hardware.
 ///
-/// Unlike [`outer_block_edge`], this does not divide the budget among concurrent
-/// walkers: it assumes an L2 private to the core running the rectangle. Where L2
-/// is instead shared across a cluster — [`crate::cache::CacheInfo::l2`] reports
-/// either and cannot tell them apart — sibling rectangles each budget the same
-/// bytes and can evict one another.
+/// `l2_share` is how many rectangles concurrently share this L2, so each walker
+/// may only assume its slice of it — like [`outer_block_edge`]'s `llc_share`, but
+/// bounded by the L2's physical sharing degree rather than the thread count. On a
+/// core-private L2 (`l2_share == 1`) this is the whole cache, unchanged; on a
+/// cluster-shared L2 (Cortex-A9/A53) it prevents sibling rectangles from evicting
+/// one another's blocks.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn inner_block_edge(
     mr: usize,
     nr: usize,
@@ -427,12 +429,14 @@ fn inner_block_edge(
     m_panels: usize,
     n_panels: usize,
     col_outer: bool,
+    l2_share: usize,
 ) -> usize {
     let (panels, r) = if col_outer { (m_panels, mr) } else { (n_panels, nr) };
-    if !inner_tier_pays(panels, r, k, elem_bytes, crate::cache::cache_info().l2) {
+    let share = l2_share.max(1);
+    if !inner_tier_pays(panels, r, k, elem_bytes, crate::cache::cache_info().l2 / share) {
         return usize::MAX;
     }
-    block_edge_for(l2_block_budget_bytes(), mr, nr, k, elem_bytes, BLK_MAX)
+    block_edge_for(l2_block_budget_bytes() / share, mr, nr, k, elem_bytes, BLK_MAX)
 }
 
 /// Whether an L3 outer super-block can capture reuse the inner (L2) tier cannot.
@@ -569,7 +573,8 @@ unsafe fn run_blocked<K: MatMatMulKer>(
         let elem = K::Acc::datum_type().size_of();
         let (mr, nr) = (ker.mr(), ker.nr());
         let (m_panels, n_panels) = (m.len(), n.len());
-        let blk = inner_block_edge(mr, nr, k, elem, m_panels, n_panels, col_outer);
+        let l2_share = llc_share.min(crate::cache::cache_info().l2_sharers_or_one());
+        let blk = inner_block_edge(mr, nr, k, elem, m_panels, n_panels, col_outer, l2_share);
         let blk_outer = outer_block_edge(mr, nr, k, elem, blk, m_panels, n_panels, llc_share);
         scratch.run_in_tls_scope(|scratch, tls| {
             for_each_blocked_tile(m, n, blk, blk_outer, col_outer, |ia, ib| {

--- a/linalg/src/frame/mmm/tests/packed_packed.rs
+++ b/linalg/src/frame/mmm/tests/packed_packed.rs
@@ -378,9 +378,9 @@ impl<K: MatMatMulKer> PackedPackedProblem<K> {
     }
 }
 
-// Large-shape frame tests that exercise the single-thread 2D-blocked tile walk
-// (`run_single_thread_blocked`): the existing `arbitrary_problem` frame proptests
-// only reach 3 panels per dim (m,n < 3·mr), below the ST_BLK=16 blocking
+// Large-shape frame tests that exercise the 2D-blocked tile walk (`run_blocked`):
+// the existing `arbitrary_problem` frame proptests only reach 3 panels per dim
+// (m,n < 3·mr), below the BLK_MAX=16 blocking
 // threshold, so the blocked path was otherwise uncovered. generic_f32_4x4 has
 // mr=nr=4, so m,n=80 → 20×20 panels → multiple blocks. Compares the frame
 // output against the naive reference (must be bit/approx-exact).
@@ -398,7 +398,7 @@ mod single_thread_blocking {
 
     #[test]
     fn blocked_80x80() -> TractResult<()> {
-        check_large(80, 80, 24) // 20×20 panels, multiple ST_BLK blocks
+        check_large(80, 80, 24) // 20×20 panels, multiple BLK_MAX blocks
     }
     #[test]
     fn blocked_skew_200x40() -> TractResult<()> {


### PR DESCRIPTION
The rayon MMM dispatcher used one number, the chunk size, for two jobs that want
different values: splitting work across threads, and keeping a worker's packed
operands cache-resident. This gives every dispatch chunk the two-tier
cache-blocked tile walk that only the single-thread path had, which frees
`chunk_grid` to track the thread count and to shape chunks for minimal operand
re-reading.

## What was wrong

A chunk covering `dr_m x dr_n` panels reads `dr_m*mr*k` elements of the packed A
and `dr_n*nr*k` of the packed B. Over the whole grid A is therefore read once per
column of chunks and B once per row, so both the number of chunks and their shape
decide how much memory traffic a split costs.

`chunk_grid` had three problems:

1. **Chunk size was the only cache-blocking mechanism.** Chunks were capped at 16
   panels per side so a worker's A and B sub-panels would stay in cache. On a grid
   that is large in both dimensions that produces far more chunks than threads: a
   4096-cube f32 GEMM on 8 threads got 1024 chunks, reading A and B 32 times each.
   Inside a chunk the tiles were walked with a plain nested loop, so the only
   locality came from the chunk being small.

2. **Grids below that cap collapsed to a band.** When the 16-panel grid yielded
   fewer than `4*nth` chunks, the whole grid became exactly `nth` chunks along the
   longer axis. Exactly `nth` chunks leaves rayon nothing to steal, so one slow
   worker (a contended core, or an E-core on a big.LITTLE phone) sets the wall
   clock for the whole GEMM. A band is also the worst shape for re-reads on a
   square-ish grid: at 512x512 panels on 8 threads it costs 1.5x the traffic of a
   2x4 grid with the same chunk count.

3. **Chunk counts could name an empty chunk.** `dr = panels.div_ceil(nchunks)` was
   used together with the *requested* `nchunks`, so the last chunk of an axis could
   start past the end of the grid. A 1x1 panel grid on 2 threads produced two
   chunks, one of them empty.

## What changed

- `for_each_blocked_tile` takes panel ranges instead of counts, and the blocked
  walk (`run_blocked`, previously `run_single_thread_blocked`) runs over one
  rectangle: the whole grid when single-threaded, one chunk per rayon work item.
  Both blocking tiers stay gated on the rectangle's own extents, so a chunk whose
  streamed operand already fits cache walks exactly the naive order, as before.
- `chunk_grid` aims for `CHUNKS_PER_THREAD * nth` chunks and shapes them to
  minimise `nchunks_n*m + nchunks_m*n`, which puts
  `nchunks_m = sqrt(chunks * m / n)`: chunks as square as the operands' extents
  rather than a band across one axis. Chunk counts are recomputed from the edges,
  so no chunk is ever empty.

  `CHUNKS_PER_THREAD` is 4, which is the same granularity the rule it replaces
  already treated as sufficient (its re-plan test was `nchunks < 4*nth`). Going
  lower trades a linear loss of load-balance slack for only a `sqrt` gain in
  re-reads, so it is not worth it. At 8 threads and an 8x8 kernel, in units of
  panel-rows re-read (`nchunks_n*m + nchunks_m*n`):

  | grid (panels) | old | old re-reads | new | new re-reads | new chunks |
  |---|---|--:|---|--:|--:|
  | 16x96 (GLiNER qkv, seq 128) | 1x8 | 224 | 2x16 | 448 | 32 |
  | 32x384 (FFN up, seq 256) | 2x24 | 1536 | 1x32 | 1408 | 32 |
  | 64x64 (512-cube) | 1x8 | 576 | 5x6 | 704 | 30 |
  | 128x128 (1024-cube) | 8x8 | 2048 | 5x6 | 1408 | 30 |
  | 512x512 (4096-cube) | 32x32 | 32768 | 5x6 | 5632 | 30 |

  The two rows that get more re-reads are the ones where the old grid had a single
  chunk per thread; there the extra traffic buys 4x the slack, and it lands on the
  small operand (A is `m*k`, 393 KB for the GLiNER row). The large grids get both
  less traffic and still ~4 chunks per thread.
- The L3 super-block is sized against the share of the last-level cache a
  concurrent walker actually gets, not the whole thing. Without that, N chunks
  each blocking for the full LLC would evict each other's super-blocks.
- `run_with_scratch_space_col_outer` and `_row_outer` were identical apart from one
  boolean, so they merge into `run_with_scratch_space_2d(.., col_outer, ..)`.
  Adding the blocked walk to both would otherwise have duplicated it four times.

## Results are unchanged

Chunking and both blocking tiers only reorder independent tiles, and every output
tile still accumulates the whole of k in a single kernel call, so the output is
bit-identical at any thread count. New harness case
`harness/nnef-test-cases/parallel-matmul` asserts that: a serial reference run
versus 2, 3 and 8 threads at `--approx exact`, over a skewed, a square, a
tall-thin and a batched matmul.

New unit tests cover the grid invariants directly: that the four numbers
`chunk_grid` returns tile the panel grid with no empty, overlapping or missing
chunk; that there are at least as many chunks as threads whenever the grid has
that many panels; and that the chosen shape never costs more re-reading than a
band along either axis at the same chunk count. Each is checked across 14 grid
shapes, 4 kernel aspect ratios and 8 thread counts.

`cargo test -p tract-linalg --features multithread-mm --lib` passes 4406 tests.
Four `arm64::sme::test_sme_qmmm_i32_32x32::store_i8::add_unicast_*` failures and
the `memory-arena` harness case fail identically on this machine with the diff
reverted, so they are pre-existing here and unrelated.

## Measurements, and what I could not measure

I could not get trustworthy multithreaded wall-clock numbers for this. The machine
I have is a 10P+4E Apple M4 Pro, whose heterogeneous cores confound thread scaling
on their own, and it sat at a load average between 30 and 90 throughout. That is
far too noisy for parallel timing: two configurations that were bit-for-bit
identical measured 28% apart.

What I could measure, because it needs only one core and so survives that load, is
the cost of replaying a chunk decomposition sequentially, which captures the
operand re-reading a chunking causes. Against the plain unchunked single-thread
walk, on the NEON 8x8 f32 kernel, the new decomposition costs 1.00x to 1.01x on
GLiNER encoder shapes (128 or 256 x 768 x 768/3072) and 0.68x to 0.90x on
512-cube and 256x768x3072. So it is neutral where the old decomposition was
already fine and cheaper where it was not. The large-square case stayed
inconclusive under the load.

The case above is arithmetic about re-read counts, not a measured speedup, so
wall-clock validation on a quiet many-core box is the one thing I would like
checked before this lands. A `/ci bench` run would cover it, and the multi-threaded
shapes are where I would look first.

## One limitation I want your read on

The L3 tier divides its budget by the number of concurrent walkers, but the L2 tier
does not: `inner_block_edge` budgets the whole detected L2 per rectangle. That is
right where L2 is private per core (Neoverse V1's 1 MB, most current server and
mobile Arm), and wrong where L2 is shared across a cluster, since sibling chunks
would then each budget the same bytes and could evict one another. `CacheInfo::l2`
reports either and cannot tell them apart, and its own doc says "per perf-core /
cluster", so I could not gate this on detection.

I left the behaviour undivided and documented the assumption rather than guessing,
because dividing unconditionally would under-block the private-L2 parts this change
is aimed at. Cortex-A7/A9 in the nightly bench matrix are the cluster-shared-L2
cases, and `bench-suite` does not enable `multithread-mm`, so those runs would not
catch it either way. You know that hardware matrix far better than I do, so tell me
if you would rather divide L2 too, or gate it on a new topology probe.

## Found on the way

`for_each_blocked_tile` overflowed when a range did not start at zero and blocking
was off (`blk == usize::MAX`), because `jb + blk` wrapped. Only the new per-chunk
caller can reach that (the single-thread walk always started at zero), so nothing
shipped with it, but the walk tests now cover `usize::MAX` edges on offset
rectangles.

Separately, and not part of this PR: the SVE kernels are gated on FEAT_SVE2, but
the f32 GEMM and GEMV kernels use only base SVE intrinsics (`svld1_f32`,
`svmla_n_f32_x`, `svst1_f32`, `svwhilelt_b32`, `svcntw`). Neoverse V1 implements
SVE but not SVE2, so it runs plain NEON today. That looks worth its own issue,
though V1's 2x256-bit SVE and 4x128-bit NEON have the same peak FMA throughput, so
it would be an instruction-count win rather than a throughput one.

🍍
