### PR TITLE
bench: compile bench-suite with multithread-mm

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -101,7 +101,7 @@ tf = ["tract-tensorflow", "tract-libcli/hir"]
 tflite = ["tract-tflite"]
 transformers = ["tract-transformers", "tract-libcli/transformers"]
 multithread-mm = ["tract-linalg/multithread-mm"]
-bench-suite = ["dep:toml", "dep:tar", "dep:minijinja", "dep:time"]
+bench-suite = ["dep:toml", "dep:tar", "dep:minijinja", "dep:time", "multithread-mm"]
 
 # Marker feature implicitly enabled by every cuda-XXXXX selector below.
 # Use to gate cudarc-specific code paths in tract-cli. Not meant to be


### PR DESCRIPTION
Pulls the rayon multithread-mm feature into the bench-suite build so CI benches exercise the multithread codegen. Runtime stays single-threaded (the suite never passes --threads), so this measures the compile-in cost of the feature; a local i9 A/B pass showed it in the noise floor.