### PR TITLE
bench: stop the jetson cuda build colliding with the no-cuda dinghy b…

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -157,7 +157,9 @@ jobs:
             triple: aarch64-unknown-linux-gnu-stretch
             # GPU-only box: its arm64 CPU is redundant with apple-m1-max for the net
             # suite, so skip CPU runs and bench only the Orin GPU (cuda).
-            bench_args: --skip-cpu
+            # --no-cache: the Orin's disk is too small to hold the multi-GB LLM weights, so
+            # stream each model from the proxy straight into tract instead of caching it locally.
+            bench_args: --skip-cpu --no-cache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -120,7 +120,9 @@ jobs:
           # (CARGO_TARGET_DIR); cache that verbatim so the container's aarch64 artifacts survive —
           # rust-cache's own target/ cleanup is host-target-only and would drop them. The container
           # also bind-mounts the host cargo registry (see cross.sh) so crate downloads persist.
-          key: ${{ matrix.triple }}
+          # -gpu keeps this build's cache off the bare-triple key that the no-cuda dinghy and
+          # cross-platform stretch builds share, which would otherwise clobber the cuda artifacts.
+          key: ${{ matrix.triple }}-gpu
           cache-directories: .cross-cache/target
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: ${{ matrix.build }}
@@ -272,7 +274,7 @@ jobs:
           PLATFORM=${{ matrix.triple }} ./.travis/cross.sh
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: tract-cli-${{ matrix.triple }}
+          name: tract-cli-${{ matrix.triple }}-dinghy
           path: .cross-cache/target/${{ matrix.rustc_triple }}/release/tract
 
   bench-dinghy:
@@ -312,7 +314,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: tract-cli-${{ matrix.triple }}
+          name: tract-cli-${{ matrix.triple }}-dinghy
           path: tract-cli
       - name: Bench on the dinghy target
         env:
@@ -597,7 +599,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: tract-cli-${{ matrix.triple }}
+          name: tract-cli-${{ matrix.triple }}-dinghy
           path: tract-cli
       - name: Assert kernel picks on the dinghy target
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -120,8 +120,7 @@ jobs:
           # (CARGO_TARGET_DIR); cache that verbatim so the container's aarch64 artifacts survive —
           # rust-cache's own target/ cleanup is host-target-only and would drop them. The container
           # also bind-mounts the host cargo registry (see cross.sh) so crate downloads persist.
-          # -gpu keeps this build's cache off the bare-triple key that the no-cuda dinghy and
-          # cross-platform stretch builds share, which would otherwise clobber the cuda artifacts.
+          # -gpu: keep the cuda build's cache off the bare-triple key the no-cuda builds share.
           key: ${{ matrix.triple }}-gpu
           cache-directories: .cross-cache/target
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -155,11 +154,7 @@ jobs:
           - target: jetson-orin-nx
             runner: orin-nx-16g
             triple: aarch64-unknown-linux-gnu-stretch
-            # GPU-only box: its arm64 CPU is redundant with apple-m1-max for the net
-            # suite, so skip CPU runs and bench only the Orin GPU (cuda). It caches models
-            # locally (38 GB free): load stays a local read rather than a LAN stream folded
-            # into the load metric, and the Pi mirror serves each model to it only once, so
-            # it is not saturated streaming multi-GB to the Orin while the small boards fetch.
+            # GPU-only box; skip the CPU net suite (redundant with apple-m1-max).
             bench_args: --skip-cpu
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -156,10 +156,11 @@ jobs:
             runner: orin-nx-16g
             triple: aarch64-unknown-linux-gnu-stretch
             # GPU-only box: its arm64 CPU is redundant with apple-m1-max for the net
-            # suite, so skip CPU runs and bench only the Orin GPU (cuda).
-            # --no-cache: the Orin's disk is too small to hold the multi-GB LLM weights, so
-            # stream each model from the proxy straight into tract instead of caching it locally.
-            bench_args: --skip-cpu --no-cache
+            # suite, so skip CPU runs and bench only the Orin GPU (cuda). It caches models
+            # locally (38 GB free): load stays a local read rather than a LAN stream folded
+            # into the load metric, and the Pi mirror serves each model to it only once, so
+            # it is not saturated streaming multi-GB to the Orin while the small boards fetch.
+            bench_args: --skip-cpu
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -504,10 +504,12 @@ fn bench_run(
 ) -> TractResult<Vec<(String, f64)>> {
     let mut best: BTreeMap<String, f64> = run()?.into_iter().collect();
     if !expectations.is_empty() {
-        let mut tries = 0;
-        while tries < retry_max && out_of_threshold(&best, expectations) {
-            tries += 1;
-            eprintln!("    retry {tries} (off expectation)");
+        for tries in 1..=retry_max {
+            let off = offenders(&best, expectations);
+            if off.is_empty() {
+                break;
+            }
+            eprintln!("    retry {tries} (off expectation: {})", off.join(", "));
             match run() {
                 Ok(cand) => merge_best(&mut best, cand),
                 Err(e) => eprintln!("    retry {tries} failed: {e:#}"),
@@ -612,16 +614,29 @@ fn out_of_threshold(
     metrics: &BTreeMap<String, f64>,
     expectations: &HashMap<String, (f64, f64)>,
 ) -> bool {
-    metrics.iter().any(|(name, &v)| {
-        expectations.get(name).is_some_and(|&(expected, thr)| {
+    !offenders(metrics, expectations).is_empty()
+}
+
+/// Metrics worse than their expectation, each formatted `name +NN%` (signed change
+/// from expected), worst first — for reporting which metric tripped a retry.
+fn offenders(
+    metrics: &BTreeMap<String, f64>,
+    expectations: &HashMap<String, (f64, f64)>,
+) -> Vec<String> {
+    let mut hits: Vec<(f64, String)> = metrics
+        .iter()
+        .filter_map(|(name, &v)| {
+            let &(expected, thr) = expectations.get(name)?;
             if expected <= 0.0 {
-                return false;
+                return None;
             }
             let pct = (v - expected) / expected * 100.0;
             let worse = if higher_better(name) { -pct } else { pct };
-            worse >= thr
+            (worse >= thr).then(|| (worse, format!("{name} {pct:+.0}%")))
         })
-    })
+        .collect();
+    hits.sort_by(|a, b| b.0.total_cmp(&a.0));
+    hits.into_iter().map(|(_, s)| s).collect()
 }
 
 /// Fold `cand` into `best`, keeping the better value per metric (max for throughput,

--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -101,9 +101,8 @@ impl RuntimeKind {
         }
     }
 
-    /// `(global flags, subcommand flags)` for this runtime. `streamed` (no local
-    /// cache, so the child fetches the model itself) folds a multi-GB download into
-    /// the run, so the GPU watchdog gets a far larger budget than a cached load-and-run.
+    /// `(global, subcommand)` flags. `streamed` widens the GPU watchdog: the child
+    /// then also fetches the model.
     fn flags(&self, streamed: bool) -> (&'static [&'static str], &'static [&'static str]) {
         match (self, streamed) {
             (RuntimeKind::Cpu, _) => (&["--timeout", "180"], &[]),
@@ -274,10 +273,8 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
     let filter = params.filter.as_deref();
 
     let mut expectations = expectations(&params)?;
-    // An http-loaded asset folds the network transfer into the load wall-clocks
-    // (`time_to_*`), so they are not comparable to a file-loaded reference and would
-    // retry-storm against it. Drop them from the gate when the model is a URL; they
-    // are still recorded, just not gated or retried on. evaltime/memory are unaffected.
+    // http-loaded assets fold the fetch into the load wall-clocks (`time_to_*`), which
+    // would retry-storm against a file-loaded reference; drop those from the gate.
     if matches!(model_source, ModelSource::Url(_)) {
         let before = expectations.len();
         expectations.retain(|name, _| !name.contains("time_to_"));
@@ -617,8 +614,7 @@ fn out_of_threshold(
     !offenders(metrics, expectations).is_empty()
 }
 
-/// Metrics worse than their expectation, each formatted `name +NN%` (signed change
-/// from expected), worst first — for reporting which metric tripped a retry.
+/// Metrics worse than expectation, `name +NN%` (signed), worst first — for retry logs.
 fn offenders(
     metrics: &BTreeMap<String, f64>,
     expectations: &HashMap<String, (f64, f64)>,

--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -773,13 +773,16 @@ pub fn diff(matches: &clap::ArgMatches) -> TractResult<()> {
     Ok(())
 }
 
-/// Fetch `bench`'s model into the cache dir if missing, unpacking the archive
-/// first when the model ships inside one.
+/// Fetch `bench`'s model into the cache dir if missing, unpacking the archive first
+/// when the model ships inside one. A plain (non-archive) model already in cache is
+/// kept only if its size matches the origin's `Content-Length`; a truncated or stale
+/// copy is re-fetched. An origin that can't be reached leaves the cache trusted, so an
+/// offline `--no-fetch`-adjacent run still works.
 fn fetch(base_url: &str, cache_dir: &Path, bench: &Bench) -> TractResult<()> {
-    if cache_dir.join(&bench.model).exists() {
-        return Ok(());
-    }
     if let Some(archive) = &bench.archive {
+        if cache_dir.join(&bench.model).exists() {
+            return Ok(());
+        }
         let archive_path = cache_dir.join(archive);
         download(base_url, archive, &archive_path)?;
         let file = std::fs::File::open(&archive_path)?;
@@ -787,9 +790,32 @@ fn fetch(base_url: &str, cache_dir: &Path, bench: &Bench) -> TractResult<()> {
             .unpack(cache_dir)
             .with_context(|| format!("unpacking {}", archive_path.display()))?;
     } else {
-        download(base_url, &bench.model, &cache_dir.join(&bench.model))?;
+        let dest = cache_dir.join(&bench.model);
+        if dest.exists() {
+            let local = dest.metadata()?.len();
+            match remote_len(base_url, &bench.model) {
+                Some(expected) if local != expected => eprintln!(
+                    "  cached {} is {local} bytes, origin has {expected}; re-fetching",
+                    bench.model
+                ),
+                _ => return Ok(()),
+            }
+        }
+        download(base_url, &bench.model, &dest)?;
     }
     Ok(())
+}
+
+/// The origin's `Content-Length` for `name` (a HEAD), or `None` when it can't be
+/// determined (offline, no such header) — the caller then trusts whatever is cached.
+fn remote_len(base_url: &str, name: &str) -> Option<u64> {
+    let url = format!("{}/{}", base_url.trim_end_matches('/'), name);
+    let resp = crate::params::http_client().ok()?.head(&url).send().ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    // `content_length()` reports the (empty) HEAD body, not the header; read the header.
+    resp.headers().get(reqwest::header::CONTENT_LENGTH)?.to_str().ok()?.parse().ok()
 }
 
 fn download(base_url: &str, name: &str, dest: &Path) -> TractResult<()> {
@@ -798,13 +824,23 @@ fn download(base_url: &str, name: &str, dest: &Path) -> TractResult<()> {
     eprintln!("  fetching {name}");
     let mut resp = crate::params::http_client()?.get(&url).send()?;
     ensure!(resp.status().is_success(), "GET {url} -> {}", resp.status());
+    let expected = resp.content_length();
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)?;
     }
     let tmp = dest.with_extension("part");
     let mut file = std::fs::File::create(&tmp)?;
-    std::io::copy(&mut resp, &mut file)?;
+    let written = std::io::copy(&mut resp, &mut file)?;
     file.sync_all()?;
+    // A short body that arrives as a clean EOF must not be renamed into place as good,
+    // or the cache-hit check above would trust the truncated file forever.
+    if let Some(expected) = expected {
+        ensure!(
+            written == expected,
+            "short download of {name}: {written} of {expected} bytes (kept {})",
+            tmp.display()
+        );
+    }
     std::fs::rename(&tmp, dest)?;
     Ok(())
 }

--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -273,7 +273,21 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
     let smoke = params.smoke;
     let filter = params.filter.as_deref();
 
-    let expectations = expectations(&params)?;
+    let mut expectations = expectations(&params)?;
+    // An http-loaded asset folds the network transfer into the load wall-clocks
+    // (`time_to_*`), so they are not comparable to a file-loaded reference and would
+    // retry-storm against it. Drop them from the gate when the model is a URL; they
+    // are still recorded, just not gated or retried on. evaltime/memory are unaffected.
+    if matches!(model_source, ModelSource::Url(_)) {
+        let before = expectations.len();
+        expectations.retain(|name, _| !name.contains("time_to_"));
+        let dropped = before - expectations.len();
+        if dropped > 0 {
+            eprintln!(
+                "http asset: dropped {dropped} time_to_* expectations (load includes the fetch)"
+            );
+        }
+    }
     let retry_max = params.retry_max;
     let second_pass_max = params.second_pass_max;
     let samples = params.samples;

--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -101,12 +101,24 @@ impl RuntimeKind {
         }
     }
 
-    /// `(global flags, subcommand flags)` for this runtime.
-    fn flags(&self) -> (&'static [&'static str], &'static [&'static str]) {
-        match self {
-            RuntimeKind::Cpu => (&["--timeout", "180"], &[]),
-            RuntimeKind::Metal => (&["--metal", "--timeout", "60"], &["--warmup-loops", "1"]),
-            RuntimeKind::Cuda => (&["--cuda", "--timeout", "60"], &["--warmup-loops", "1"]),
+    /// `(global flags, subcommand flags)` for this runtime. `streamed` (no local
+    /// cache, so the child fetches the model itself) folds a multi-GB download into
+    /// the run, so the GPU watchdog gets a far larger budget than a cached load-and-run.
+    fn flags(&self, streamed: bool) -> (&'static [&'static str], &'static [&'static str]) {
+        match (self, streamed) {
+            (RuntimeKind::Cpu, _) => (&["--timeout", "180"], &[]),
+            (RuntimeKind::Metal, false) => {
+                (&["--metal", "--timeout", "60"], &["--warmup-loops", "1"])
+            }
+            (RuntimeKind::Metal, true) => {
+                (&["--metal", "--timeout", "600"], &["--warmup-loops", "1"])
+            }
+            (RuntimeKind::Cuda, false) => {
+                (&["--cuda", "--timeout", "60"], &["--warmup-loops", "1"])
+            }
+            (RuntimeKind::Cuda, true) => {
+                (&["--cuda", "--timeout", "600"], &["--warmup-loops", "1"])
+            }
         }
     }
 }
@@ -408,7 +420,8 @@ fn run_one(
     variant: &str,
     smoke: bool,
 ) -> TractResult<Vec<(String, f64)>> {
-    let (global_flags, sub_flags) = runtime.map(|b| b.flags()).unwrap_or((&[], &[]));
+    let (global_flags, sub_flags) =
+        runtime.map(|b| b.flags(matches!(source, ModelSource::Url(_)))).unwrap_or((&[], &[]));
 
     // Smoke: a single load-optimize-run, success measured by exit status only.
     // Nets go through `run` (one shot); LLMs keep `llm-bench` (it concretises the

--- a/tools/asset-mirror/src/main.rs
+++ b/tools/asset-mirror/src/main.rs
@@ -128,7 +128,7 @@ fn get(
             let fill = Arc::new(Fill {
                 written: AtomicU64::new(0),
                 state: AtomicU8::new(FILL_RUNNING),
-                len: content_length(&resp).map(|l| l as u64),
+                len: content_length(&resp),
             });
             if let Some(parent) = cache_path.parent() {
                 let _ = fs::create_dir_all(parent);
@@ -213,12 +213,19 @@ fn serve_tail(req: Request, part: &Path, cache_path: &Path, fill: Arc<Fill>) {
         Err(_) if cache_path.is_file() => return serve_file(req, cache_path, "HIT"),
         Err(e) => return reply(req, 502, &format!("fill unavailable: {e}")),
     };
-    let ct = Header::from_bytes(&b"Content-Type"[..], &b"application/octet-stream"[..]).unwrap();
-    let len = fill.len.map(|l| l as usize);
+    let len = fill.len;
     let reader = TailReader { file, fill, pos: 0 };
-    let resp = Response::new(StatusCode(200), vec![ct], reader, len, None)
-        .with_chunked_threshold(usize::MAX);
-    let _ = req.respond(resp);
+    match len {
+        Some(len) => respond_body(req, len, reader),
+        // Origin sent no Content-Length: fall back to tiny_http's chunked encoding.
+        None => {
+            let ct =
+                Header::from_bytes(&b"Content-Type"[..], &b"application/octet-stream"[..]).unwrap();
+            let resp = Response::new(StatusCode(200), vec![ct], reader, None, None)
+                .with_chunked_threshold(usize::MAX);
+            let _ = req.respond(resp);
+        }
+    }
 }
 
 /// Reads a `.part` as a background download fills it: yields flushed bytes, waits
@@ -257,27 +264,23 @@ fn head(req: Request, cfg: &Config, agent: &ureq::Agent, key: &str, cache_path: 
     if let Ok(meta) = fs::metadata(cache_path) {
         if meta.is_file() {
             eprintln!("HEAD 200 {key} (cached, {} bytes)", meta.len());
-            let resp = Response::new(
-                StatusCode(200),
-                vec![],
-                io::empty(),
-                Some(meta.len() as usize),
-                None,
-            )
-            .with_chunked_threshold(usize::MAX);
-            let _ = req.respond(resp);
-            return;
+            return respond_head(req, meta.len());
         }
     }
     let url = join(&cfg.origin, key);
     match agent.head(&url).call() {
-        Ok(r) => {
-            let len: Option<usize> = content_length(&r);
-            eprintln!("HEAD {} {key} (origin)", r.status());
-            let resp = Response::new(StatusCode(r.status()), vec![], io::empty(), len, None)
-                .with_chunked_threshold(usize::MAX);
-            let _ = req.respond(resp);
-        }
+        Ok(r) => match content_length(&r) {
+            Some(len) if (200..300).contains(&r.status()) => {
+                eprintln!("HEAD {} {key} (origin, {len} bytes)", r.status());
+                respond_head(req, len);
+            }
+            _ => {
+                eprintln!("HEAD {} {key} (origin)", r.status());
+                let resp =
+                    Response::new(StatusCode(r.status()), vec![], io::empty(), Some(0), None);
+                let _ = req.respond(resp);
+            }
+        },
         Err(ureq::Error::Status(code, _)) => reply(req, code, "upstream status"),
         Err(e) => reply(req, 502, &format!("upstream error: {e}")),
     }
@@ -296,16 +299,45 @@ fn origin_get(
 }
 
 fn serve_file(req: Request, path: &Path, tag: &str) {
-    match fs::File::open(path) {
-        Ok(f) => {
-            eprintln!("GET 200 {} ({tag})", path.display());
-            let ct =
-                Header::from_bytes(&b"Content-Type"[..], &b"application/octet-stream"[..]).unwrap();
-            let resp = Response::from_file(f).with_header(ct).with_chunked_threshold(usize::MAX);
-            let _ = req.respond(resp);
-        }
-        Err(e) => reply(req, 500, &format!("open cache: {e}")),
+    let f = match fs::File::open(path) {
+        Ok(f) => f,
+        Err(e) => return reply(req, 500, &format!("open cache: {e}")),
+    };
+    let len = match f.metadata() {
+        Ok(m) => m.len(),
+        Err(e) => return reply(req, 500, &format!("stat cache: {e}")),
+    };
+    eprintln!("GET 200 {} ({tag}, {len} bytes)", path.display());
+    respond_body(req, len, f);
+}
+
+/// The status line + headers for a 200 with a real `u64` content length. Written
+/// straight to the socket via `Request::into_writer`, bypassing tiny_http's `usize`
+/// `Content-Length` (which wraps any length >= 4 GiB on the 32-bit Pi). `Connection:
+/// close` keeps the raw-write framing simple.
+fn head_200(len: u64) -> String {
+    format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: application/octet-stream\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\r\n"
+    )
+}
+
+/// Stream `body` as a 200 with a `u64` content length (for GET).
+fn respond_body(req: Request, len: u64, mut body: impl Read) {
+    let mut w = req.into_writer();
+    if w.write_all(head_200(len).as_bytes()).is_ok() {
+        let _ = io::copy(&mut body, &mut w);
     }
+    let _ = w.flush();
+}
+
+/// Send the headers of a 200 with a `u64` content length and no body (for HEAD).
+fn respond_head(req: Request, len: u64) {
+    let mut w = req.into_writer();
+    let _ = w.write_all(head_200(len).as_bytes());
+    let _ = w.flush();
 }
 
 fn reply(req: Request, code: u16, msg: &str) {
@@ -336,7 +368,9 @@ fn safe_rel(key: &str) -> Option<PathBuf> {
 }
 
 /// Case-insensitive: ureq lowercases header names and its `.header()` is exact-match.
-fn content_length(r: &ureq::Response) -> Option<usize> {
+/// Parsed as `u64` (not `usize`): the Pi is 32-bit, and a `usize` would wrap any
+/// length >= 4 GiB.
+fn content_length(r: &ureq::Response) -> Option<u64> {
     r.headers_names()
         .iter()
         .find(|n| n.eq_ignore_ascii_case("content-length"))

--- a/tools/asset-mirror/src/main.rs
+++ b/tools/asset-mirror/src/main.rs
@@ -217,8 +217,14 @@ impl Read for TeeReader {
                 }
             }
         }
-        let complete =
-            self.tmp.is_some() && (n == 0 || self.expected.is_some_and(|e| self.written >= e));
+        // Only publish once the whole body is in. On a short read (upstream EOF
+        // before Content-Length) leave it unpublished, so a truncated download is
+        // never renamed into the cache and served as if complete.
+        let complete = self.tmp.is_some()
+            && match self.expected {
+                Some(e) => self.written >= e,
+                None => n == 0,
+            };
         if complete && !self.done {
             if let Some(mut f) = self.tmp.take() {
                 let ok = f.flush().is_ok() && f.sync_all().is_ok();

--- a/tools/asset-mirror/src/main.rs
+++ b/tools/asset-mirror/src/main.rs
@@ -1,9 +1,13 @@
 //! LAN caching reverse-proxy for tract's CI/bench model assets.
 //!
 //! Serves plain HTTP (fine on a trusted LAN). On `GET /<key>` it serves the file
-//! from the local cache dir if present, otherwise streams it from the R2 origin
-//! (`https://tract-test-assets.tract.rs/<key>`) to the client while teeing it into
-//! the cache, so the first byte is immediate even on a cold miss.
+//! from the local cache dir if present, otherwise starts a background download of
+//! it from the R2 origin (`https://tract-test-assets.tract.rs/<key>`) into a
+//! `.part` file and streams that to the client as it grows. The download runs on
+//! its own thread and always runs to completion, so a client that disconnects
+//! (e.g. a bench watchdog kill) still leaves the model fully cached for next time
+//! -- the mirror is self-warming. The `.part` is published (atomic rename) only
+//! once the whole Content-Length has landed, so a truncated fetch is never cached.
 //! Keys are immutable (generation-tagged), so a cached file is never revalidated.
 //! `HEAD` is proxied to the origin so a size probe does not pull the body.
 //!
@@ -16,9 +20,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 
@@ -29,10 +34,21 @@ struct Config {
     threads: usize,
 }
 
-/// Coalesces concurrent first-misses for the same key so it is fetched once.
-type KeyLocks = Mutex<HashMap<String, Arc<Mutex<()>>>>;
+const FILL_RUNNING: u8 = 0;
+const FILL_DONE: u8 = 1;
+const FILL_FAILED: u8 = 2;
 
-static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+/// Progress of one background download, shared with every client tailing its
+/// `.part`. `written` is bytes flushed so far; `state` moves RUNNING -> DONE/FAILED.
+struct Fill {
+    written: AtomicU64,
+    state: AtomicU8,
+    len: Option<u64>,
+}
+
+/// Downloads in flight, so concurrent requests for the same key share one download
+/// (and its `.part`) instead of racing.
+type Inflight = Mutex<HashMap<String, Arc<Fill>>>;
 
 fn main() {
     let cfg = Arc::new(parse_config());
@@ -45,7 +61,7 @@ fn main() {
         std::process::exit(1);
     }));
     let agent = ureq::AgentBuilder::new().build();
-    let locks: Arc<KeyLocks> = Arc::new(Mutex::new(HashMap::new()));
+    let inflight: Arc<Inflight> = Arc::new(Mutex::new(HashMap::new()));
 
     eprintln!(
         "tract-asset-mirror: http://{} -> {} (cache {}, {} threads)",
@@ -60,10 +76,10 @@ fn main() {
         let server = server.clone();
         let cfg = cfg.clone();
         let agent = agent.clone();
-        let locks = locks.clone();
+        let inflight = inflight.clone();
         handles.push(thread::spawn(move || {
             while let Ok(req) = server.recv() {
-                handle(req, &cfg, &agent, &locks);
+                handle(req, &cfg, &agent, &inflight);
             }
         }));
     }
@@ -72,7 +88,7 @@ fn main() {
     }
 }
 
-fn handle(req: Request, cfg: &Config, agent: &ureq::Agent, locks: &KeyLocks) {
+fn handle(req: Request, cfg: &Config, agent: &ureq::Agent, inflight: &Arc<Inflight>) {
     let method = req.method().clone();
     let key = match req.url().split('?').next().unwrap_or("").trim_start_matches('/') {
         "" => return reply(req, 400, "empty key"),
@@ -85,7 +101,7 @@ fn handle(req: Request, cfg: &Config, agent: &ureq::Agent, locks: &KeyLocks) {
     let cache_path = cfg.cache_dir.join(&rel);
 
     match method {
-        Method::Get => get(req, cfg, agent, locks, &key, &cache_path),
+        Method::Get => get(req, cfg, agent, inflight, &key, &cache_path),
         Method::Head => head(req, cfg, agent, &key, &cache_path),
         _ => reply(req, 405, "method not allowed"),
     }
@@ -95,24 +111,159 @@ fn get(
     req: Request,
     cfg: &Config,
     agent: &ureq::Agent,
-    locks: &KeyLocks,
+    inflight: &Arc<Inflight>,
     key: &str,
     cache_path: &Path,
 ) {
     if cache_path.is_file() {
         return serve_file(req, cache_path, "HIT");
     }
-    let lock = key_lock(locks, key);
-    let _guard = lock.lock().unwrap();
-    // Another thread may have fetched it while we waited on the lock.
-    if cache_path.is_file() {
-        return serve_file(req, cache_path, "HIT");
+    let part = part_path(cache_path);
+    // Join an in-flight download for this key, or become the one that starts it.
+    let fill = {
+        let mut map = inflight.lock().unwrap();
+        if cache_path.is_file() {
+            drop(map);
+            return serve_file(req, cache_path, "HIT");
+        }
+        if let Some(f) = map.get(key) {
+            f.clone()
+        } else {
+            let resp = match origin_get(agent, &cfg.origin, key) {
+                Ok(r) => r,
+                Err((code, msg)) => {
+                    drop(map);
+                    eprintln!("{code} {key} (upstream: {msg})");
+                    return reply(req, code, &msg);
+                }
+            };
+            let fill = Arc::new(Fill {
+                written: AtomicU64::new(0),
+                state: AtomicU8::new(FILL_RUNNING),
+                len: content_length(&resp).map(|l| l as u64),
+            });
+            if let Some(parent) = cache_path.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            if fs::File::create(&part).is_err() {
+                drop(map);
+                return reply(req, 500, "cannot create cache temp");
+            }
+            map.insert(key.to_string(), fill.clone());
+            eprintln!("GET 200 {key} (streaming + background fill)");
+            spawn_downloader(
+                resp,
+                cache_path.to_path_buf(),
+                part.clone(),
+                key.to_string(),
+                fill.clone(),
+                inflight.clone(),
+            );
+            fill
+        }
+    };
+    serve_tail(req, &part, cache_path, fill);
+}
+
+/// Background thread: pull the whole body into `part`, publish on completion. Runs
+/// to the end regardless of whether any client is still reading, so the cache warms
+/// even when the requesting client (a bench) is killed mid-stream.
+fn spawn_downloader(
+    resp: ureq::Response,
+    cache_path: PathBuf,
+    part: PathBuf,
+    key: String,
+    fill: Arc<Fill>,
+    inflight: Arc<Inflight>,
+) {
+    thread::spawn(move || {
+        let ok = download(resp, &part, &fill);
+        if ok && fs::rename(&part, &cache_path).is_ok() {
+            fill.state.store(FILL_DONE, Ordering::SeqCst);
+            eprintln!("fill {key}: cached ({} bytes)", fill.written.load(Ordering::SeqCst));
+        } else {
+            fill.state.store(FILL_FAILED, Ordering::SeqCst);
+            let _ = fs::remove_file(&part);
+            eprintln!("fill {key}: FAILED (incomplete upstream / cache io)");
+        }
+        inflight.lock().unwrap().remove(&key);
+    });
+}
+
+/// Copy the origin body into `part`, bumping `fill.written` as bytes are flushed.
+/// Returns whether the full Content-Length landed (always true when length unknown).
+fn download(resp: ureq::Response, part: &Path, fill: &Fill) -> bool {
+    let mut reader = resp.into_reader();
+    let mut file = match fs::OpenOptions::new().write(true).truncate(true).open(part) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let mut buf = vec![0u8; 256 * 1024];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                if file.write_all(&buf[..n]).is_err() {
+                    return false;
+                }
+                fill.written.fetch_add(n as u64, Ordering::Release);
+            }
+            Err(_) => return false,
+        }
     }
-    match origin_get(agent, &cfg.origin, key) {
-        Ok(resp) => stream_and_cache(req, resp, cache_path, key),
-        Err((code, msg)) => {
-            eprintln!("{code} {key} (upstream: {msg})");
-            reply(req, code, &msg);
+    let _ = file.flush();
+    let _ = file.sync_all();
+    match fill.len {
+        Some(e) => fill.written.load(Ordering::Acquire) >= e,
+        None => true,
+    }
+}
+
+/// Serve a client by tailing the `.part` as the background download fills it.
+fn serve_tail(req: Request, part: &Path, cache_path: &Path, fill: Arc<Fill>) {
+    let file = match fs::File::open(part) {
+        Ok(f) => f,
+        // The download finished and renamed `part` away between join and open.
+        Err(_) if cache_path.is_file() => return serve_file(req, cache_path, "HIT"),
+        Err(e) => return reply(req, 502, &format!("fill unavailable: {e}")),
+    };
+    let ct = Header::from_bytes(&b"Content-Type"[..], &b"application/octet-stream"[..]).unwrap();
+    let len = fill.len.map(|l| l as usize);
+    let reader = TailReader { file, fill, pos: 0 };
+    let resp = Response::new(StatusCode(200), vec![ct], reader, len, None)
+        .with_chunked_threshold(usize::MAX);
+    let _ = req.respond(resp);
+}
+
+/// `Read` over a `.part` being written by a background download: yields whatever
+/// has been flushed, waits for more, ends at EOF when the fill completes, and
+/// errors if the fill failed (so a truncated download is never served as complete).
+struct TailReader {
+    file: fs::File,
+    fill: Arc<Fill>,
+    pos: u64,
+}
+
+impl Read for TailReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let written = self.fill.written.load(Ordering::Acquire);
+            if written > self.pos {
+                let want = ((written - self.pos) as usize).min(buf.len());
+                let n = self.file.read(&mut buf[..want])?;
+                self.pos += n as u64;
+                return Ok(n);
+            }
+            match self.fill.state.load(Ordering::SeqCst) {
+                FILL_DONE => return Ok(0),
+                FILL_FAILED => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "upstream fill failed",
+                    ))
+                }
+                _ => thread::sleep(Duration::from_millis(20)),
+            }
         }
     }
 }
@@ -160,94 +311,6 @@ fn origin_get(
     }
 }
 
-/// Stream the origin response to the client while teeing it into the cache. The
-/// first byte reaches the client immediately (no fetch-then-serve stall), and the
-/// cache file is only published (temp + atomic rename) once the full body has
-/// been written, so an interrupted transfer never leaves a partial file. If the
-/// cache write fails (e.g. mirror disk full) it degrades to plain pass-through.
-fn stream_and_cache(req: Request, resp: ureq::Response, cache_path: &Path, key: &str) {
-    let expected = content_length(&resp).map(|l| l as u64);
-    if let Some(parent) = cache_path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-    let tmp = cache_path.with_file_name(format!(
-        ".{}.tmp.{}.{}",
-        cache_path.file_name().and_then(|s| s.to_str()).unwrap_or("part"),
-        std::process::id(),
-        TMP_SEQ.fetch_add(1, Ordering::Relaxed),
-    ));
-    let tee = TeeReader {
-        src: Box::new(resp.into_reader()),
-        tmp: fs::File::create(&tmp).ok(),
-        tmp_path: tmp,
-        final_path: cache_path.to_path_buf(),
-        expected,
-        written: 0,
-        done: false,
-    };
-    eprintln!("GET 200 {key} (streaming)");
-    let ct = Header::from_bytes(&b"Content-Type"[..], &b"application/octet-stream"[..]).unwrap();
-    let resp = Response::new(StatusCode(200), vec![ct], tee, expected.map(|l| l as usize), None)
-        .with_chunked_threshold(usize::MAX);
-    let _ = req.respond(resp);
-}
-
-/// Reader that copies everything it yields into a cache temp file, renaming it
-/// into place once the whole body is seen. See [`stream_and_cache`].
-struct TeeReader {
-    src: Box<dyn Read + Send>,
-    tmp: Option<fs::File>,
-    tmp_path: PathBuf,
-    final_path: PathBuf,
-    expected: Option<u64>,
-    written: u64,
-    done: bool,
-}
-
-impl Read for TeeReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = self.src.read(buf)?;
-        if n > 0 {
-            if let Some(f) = self.tmp.as_mut() {
-                if f.write_all(&buf[..n]).is_err() {
-                    self.tmp = None; // mirror disk trouble: stop caching, keep serving
-                    let _ = fs::remove_file(&self.tmp_path);
-                } else {
-                    self.written += n as u64;
-                }
-            }
-        }
-        // Only publish once the whole body is in. On a short read (upstream EOF
-        // before Content-Length) leave it unpublished, so a truncated download is
-        // never renamed into the cache and served as if complete.
-        let complete = self.tmp.is_some()
-            && match self.expected {
-                Some(e) => self.written >= e,
-                None => n == 0,
-            };
-        if complete && !self.done {
-            if let Some(mut f) = self.tmp.take() {
-                let ok = f.flush().is_ok() && f.sync_all().is_ok();
-                drop(f);
-                if ok && fs::rename(&self.tmp_path, &self.final_path).is_ok() {
-                    self.done = true;
-                } else {
-                    let _ = fs::remove_file(&self.tmp_path);
-                }
-            }
-        }
-        Ok(n)
-    }
-}
-
-impl Drop for TeeReader {
-    fn drop(&mut self) {
-        if !self.done {
-            let _ = fs::remove_file(&self.tmp_path);
-        }
-    }
-}
-
 fn serve_file(req: Request, path: &Path, tag: &str) {
     match fs::File::open(path) {
         Ok(f) => {
@@ -264,6 +327,14 @@ fn serve_file(req: Request, path: &Path, tag: &str) {
 fn reply(req: Request, code: u16, msg: &str) {
     let _ =
         req.respond(Response::from_string(format!("{msg}\n")).with_status_code(StatusCode(code)));
+}
+
+/// Sibling `.part` path for a cache entry (deterministic per key so concurrent
+/// tailers open the same one).
+fn part_path(cache_path: &Path) -> PathBuf {
+    let mut s = cache_path.as_os_str().to_owned();
+    s.push(".part");
+    PathBuf::from(s)
 }
 
 /// Reject anything that would escape the cache dir (`..`, absolute paths); keep
@@ -291,10 +362,6 @@ fn content_length(r: &ureq::Response) -> Option<usize> {
         .find(|n| n.eq_ignore_ascii_case("content-length"))
         .and_then(|n| r.header(n))
         .and_then(|s| s.parse().ok())
-}
-
-fn key_lock(locks: &KeyLocks, key: &str) -> Arc<Mutex<()>> {
-    locks.lock().unwrap().entry(key.to_string()).or_insert_with(|| Arc::new(Mutex::new(()))).clone()
 }
 
 fn join(origin: &str, key: &str) -> String {

--- a/tools/asset-mirror/src/main.rs
+++ b/tools/asset-mirror/src/main.rs
@@ -1,20 +1,11 @@
-//! LAN caching reverse-proxy for tract's CI/bench model assets.
-//!
-//! Serves plain HTTP (fine on a trusted LAN). On `GET /<key>` it serves the file
-//! from the local cache dir if present, otherwise starts a background download of
-//! it from the R2 origin (`https://tract-test-assets.tract.rs/<key>`) into a
-//! `.part` file and streams that to the client as it grows. The download runs on
-//! its own thread and always runs to completion, so a client that disconnects
-//! (e.g. a bench watchdog kill) still leaves the model fully cached for next time
-//! -- the mirror is self-warming. The `.part` is published (atomic rename) only
-//! once the whole Content-Length has landed, so a truncated fetch is never cached.
-//! Keys are immutable (generation-tagged), so a cached file is never revalidated.
-//! `HEAD` is proxied to the origin so a size probe does not pull the body.
+//! LAN caching reverse-proxy for tract's CI/bench model assets. `GET /<key>`
+//! serves the cached file, or streams it from the R2 origin while a background
+//! thread fills the cache to completion (so a client that disconnects still warms
+//! it). `HEAD` is proxied to the origin. Plain HTTP; keys are immutable.
 //!
 //!   tract-asset-mirror [--listen 0.0.0.0:8080] [--cache-dir ./asset-cache]
 //!                      [--origin https://tract-test-assets.tract.rs] [--threads 16]
-//!
-//! Each flag also reads an env fallback: LISTEN, CACHE_DIR, ORIGIN, THREADS.
+//! Flags also read env: LISTEN, CACHE_DIR, ORIGIN, THREADS.
 
 use std::collections::HashMap;
 use std::fs;
@@ -38,16 +29,14 @@ const FILL_RUNNING: u8 = 0;
 const FILL_DONE: u8 = 1;
 const FILL_FAILED: u8 = 2;
 
-/// Progress of one background download, shared with every client tailing its
-/// `.part`. `written` is bytes flushed so far; `state` moves RUNNING -> DONE/FAILED.
+/// Progress of one background download, shared with the clients tailing its `.part`.
 struct Fill {
     written: AtomicU64,
     state: AtomicU8,
     len: Option<u64>,
 }
 
-/// Downloads in flight, so concurrent requests for the same key share one download
-/// (and its `.part`) instead of racing.
+/// In-flight downloads, so concurrent requests for a key share one download.
 type Inflight = Mutex<HashMap<String, Arc<Fill>>>;
 
 fn main() {
@@ -119,7 +108,6 @@ fn get(
         return serve_file(req, cache_path, "HIT");
     }
     let part = part_path(cache_path);
-    // Join an in-flight download for this key, or become the one that starts it.
     let fill = {
         let mut map = inflight.lock().unwrap();
         if cache_path.is_file() {
@@ -165,9 +153,9 @@ fn get(
     serve_tail(req, &part, cache_path, fill);
 }
 
-/// Background thread: pull the whole body into `part`, publish on completion. Runs
-/// to the end regardless of whether any client is still reading, so the cache warms
-/// even when the requesting client (a bench) is killed mid-stream.
+/// Pull the whole body into `part` and publish it (atomic rename) on completion,
+/// regardless of whether any client is still reading — this is what warms the cache
+/// even when the requesting client is killed mid-stream.
 fn spawn_downloader(
     resp: ureq::Response,
     cache_path: PathBuf,
@@ -190,7 +178,6 @@ fn spawn_downloader(
     });
 }
 
-/// Copy the origin body into `part`, bumping `fill.written` as bytes are flushed.
 /// Returns whether the full Content-Length landed (always true when length unknown).
 fn download(resp: ureq::Response, part: &Path, fill: &Fill) -> bool {
     let mut reader = resp.into_reader();
@@ -219,11 +206,10 @@ fn download(resp: ureq::Response, part: &Path, fill: &Fill) -> bool {
     }
 }
 
-/// Serve a client by tailing the `.part` as the background download fills it.
 fn serve_tail(req: Request, part: &Path, cache_path: &Path, fill: Arc<Fill>) {
     let file = match fs::File::open(part) {
         Ok(f) => f,
-        // The download finished and renamed `part` away between join and open.
+        // Race: the fill completed and renamed `part` away between join and open.
         Err(_) if cache_path.is_file() => return serve_file(req, cache_path, "HIT"),
         Err(e) => return reply(req, 502, &format!("fill unavailable: {e}")),
     };
@@ -235,9 +221,8 @@ fn serve_tail(req: Request, part: &Path, cache_path: &Path, fill: Arc<Fill>) {
     let _ = req.respond(resp);
 }
 
-/// `Read` over a `.part` being written by a background download: yields whatever
-/// has been flushed, waits for more, ends at EOF when the fill completes, and
-/// errors if the fill failed (so a truncated download is never served as complete).
+/// Reads a `.part` as a background download fills it: yields flushed bytes, waits
+/// for more, EOF on completion, error if the fill failed (never a silent truncation).
 struct TailReader {
     file: fs::File,
     fill: Arc<Fill>,
@@ -298,7 +283,6 @@ fn head(req: Request, cfg: &Config, agent: &ureq::Agent, key: &str, cache_path: 
     }
 }
 
-/// Open the origin GET for `key`; the body is not read yet.
 fn origin_get(
     agent: &ureq::Agent,
     origin: &str,
@@ -329,16 +313,13 @@ fn reply(req: Request, code: u16, msg: &str) {
         req.respond(Response::from_string(format!("{msg}\n")).with_status_code(StatusCode(code)));
 }
 
-/// Sibling `.part` path for a cache entry (deterministic per key so concurrent
-/// tailers open the same one).
 fn part_path(cache_path: &Path) -> PathBuf {
     let mut s = cache_path.as_os_str().to_owned();
     s.push(".part");
     PathBuf::from(s)
 }
 
-/// Reject anything that would escape the cache dir (`..`, absolute paths); keep
-/// only normal path components.
+/// Keep only normal path components, rejecting `..` / absolute paths.
 fn safe_rel(key: &str) -> Option<PathBuf> {
     let mut out = PathBuf::new();
     for comp in Path::new(key).components() {
@@ -354,8 +335,7 @@ fn safe_rel(key: &str) -> Option<PathBuf> {
     }
 }
 
-/// Case-insensitive Content-Length lookup (ureq lowercases header names, and
-/// origins vary in casing).
+/// Case-insensitive: ureq lowercases header names and its `.header()` is exact-match.
 fn content_length(r: &ureq::Response) -> Option<usize> {
     r.headers_names()
         .iter()


### PR DESCRIPTION
…uild

The aarch64-unknown-linux-gnu-stretch triple is built both with cuda (the `build` job, for the jetson) and without (the `build-dinghy` job, for the boards), yet both keyed the rust-cache and the uploaded artifact on the bare triple. The no-cuda build could then clobber the cuda one, and the jetson would load a tract with no cuda runtime registered ("Runtime `cuda' not found"). Give the cuda build a `-gpu` cache key and the dinghy artifacts a `-dinghy` name so the two never share a slot.