### PR TITLE
metal: split multi-axis Reduce into single-axis reduces

### DIFF
--- a/metal/src/transform.rs
+++ b/metal/src/transform.rs
@@ -14,6 +14,7 @@ use tract_core::ops::cnn::conv::rewrite_kernel_conv_in_oihw;
 use tract_core::ops::cnn::{Conv, rewrite_conv_with_n_axis};
 use tract_core::ops::einsum::prefix_matmul::{PrefixMatMul, rewrite_einsum_to_prefix_matmul};
 use tract_core::ops::konst::Const;
+use tract_core::ops::nn::Reduce;
 use tract_core::tract_linalg::block_quant::Q4_0;
 use tract_core::transform::ModelTransform;
 use tract_gpu::fact::{DeviceFact, DeviceTypedFactExt};
@@ -150,6 +151,7 @@ impl MetalTransform {
             .with_rule_for("rewrite_kernel_conv_in_oihw", rewrite_kernel_conv_in_oihw)
             .with_rule_for("rewrite_conv_with_n_axis", rewrite_conv_with_n_axis)
             .with_rule_for("remove_rms_norm_cast", remove_rms_norm_cast)
+            .with_rule_for("split_multi_axis_reduce", split_multi_axis_reduce)
             .rewrite(&(), model)?;
 
         if stop_at_phase == 1 {
@@ -502,4 +504,29 @@ fn convert_const(op: &Const) -> TractResult<Const> {
 
     let metal_const = op.val().clone().into_device()?.into_tensor().into_arc_tensor();
     Const::new_with_exotic_fact(metal_const, Box::new(metal_fact))
+}
+
+/// Rewrites a `Reduce` over several axes into a chain of single-axis reduces, which is
+/// what `GpuReduce` accepts. Only reducers that compose associatively per axis qualify:
+/// `MeanOfSquares` over a chain is not the multi-axis result.
+fn split_multi_axis_reduce(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &Reduce,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_if!(op.axes.len() > 1);
+    use tract_core::ops::nn::Reducer::*;
+    rule_if!(matches!(op.reducer, Sum | Prod | Min | Max | Any | All));
+    let mut patch = TypedModelPatch::default();
+    let mut wire = patch.tap_model(model, node.inputs[0])?;
+    let mut axes = op.axes.clone();
+    axes.sort();
+    for (i, &axis) in axes.iter().rev().enumerate() {
+        let single = Reduce { axes: tvec![axis], reducer: op.reducer };
+        wire = patch.wire_node(format!("{node_name}.axis_{i}"), single, &[wire])?[0];
+    }
+    patch.shunt_outside(model, node.id.into(), wire)?;
+    Ok(Some(patch))
 }


### PR DESCRIPTION
Ports the `split_multi_axis_reduce` rule from #2077 (cuda) to the Metal transform: a `Reduce` over several axes is rewritten into a chain of single-axis reduces before translation, so it stops falling back to CPU. `GpuReduce` only ever dispatches `axes[0]`, so a multi-axis reduce could not translate and the graph had to round-trip through the host in the middle.

`MeanOfSquares` is excluded, as in the cuda rule, since chaining it per axis is not the multi-axis result.

### Effect on MobileNet v2 (`--metal -O`, `dump --audit-json`)

The global average pool (`Reduce<Sum>` over two axes) was the only op left on host:

| | nodes | sync nodes | ops still on CPU |
|---|---|---|---|
| before | 376 | 4 | `Reduce<Sum>` |
| after | 375 | 2 | none |

The two remaining syncs are the model's own input and output.

Same seeded input through both binaries: max absolute difference `9.5e-07` over the 1000 logits, identical argmax.

Interleaved A/B, 5 rounds each, 300 loops per run, M-series:

```
before  13.119  12.629  11.616  12.842  13.183   best 11.616  mean 12.68
after   11.417  11.335  11.340  11.499  11.671   best 11.335  mean 11.45
```

Best-to-best that is 2.4%; the wider mean gap is mostly the run-to-run jitter the mid-graph flush was adding (before spans 1.57 ms, after 0.34 ms). The point of the change is removing the fallback rather than the timing.

### Checks

`cargo fmt --all` clean, `cargo clippy --workspace` clean, `tract-core` 268/268.

Two failures in `tract-gpu` / `tract-metal` reproduce identically on `main` with this commit stashed out, so they are not from this change: `tensor::tests::test_device_tensor` ("GPU Context not initialized") and `kernels::matmul::mfa::tests::test_mfa_attention_causal_const_is_noop` (the causal probe returns `full=0.08356` where it expects the triangular-const-alone value). Happy to open a separate issue for the latter if it is not already known.

🍍
