### PR TITLE
metal: route skinny f16 matmuls through mlx gemv_wide (~2.9x on M4)

### DIFF
--- a/metal/src/kernels/matmul/mlx_gemm/mlx_gemv.metal
+++ b/metal/src/kernels/matmul/mlx_gemm/mlx_gemv.metal
@@ -1022,3 +1022,252 @@ template <
 // clang-format off
 instantiate_gemv_t_bs_blocks(f32, float);
 instantiate_gemv_t_bs_blocks(f16, half);
+
+
+///////////////////////////////////////////////////////////////////////////////
+// gemv_wide, ported from
+// https://github.com/ml-explore/mlx/blob/main/mlx/backend/metal/kernels/gemv.h
+// Copyright (c) 2023-2025 Apple Inc., MIT. Verbatim apart from the accumulator
+// default (mlx's DefaultAccT<T> is float for both instantiated types) and the
+// explicit instantiations below, which follow this file's existing style.
+
+///////////////////////////////////////////////////////////////////////////////
+/// Multi-vector matrix-vector multiplication (wide gemv)
+///////////////////////////////////////////////////////////////////////////////
+
+constant bool gemv_wide_has_batch [[function_constant(0)]];
+constant bool gemv_wide_do_axpby [[function_constant(1)]];
+
+// out[M, N] = x[M, K] @ mat[N, K]^T for small M: each threadgroup streams a
+// block of matrix rows once and applies it to vecs_per_tg input vectors, so
+// the matrix is read ceil(M / vecs_per_tg) times instead of once per padded
+// GEMM tile. k_lanes lanes reduce K for one row, 32 / k_lanes rows per
+// simdgroup, k_lanes / 8 simdgroups per threadgroup.
+template <
+    typename T,
+    const int vecs_per_tg,
+    const int k_lanes,
+    typename AccT = float>
+struct GemvWide {
+  static constexpr constant int unroll = 8;
+  static constexpr constant int num_simdgroups = k_lanes / 8;
+
+  static METAL_FUNC void run(
+      const device T* mat,
+      const device T* in_vec,
+      const device T* bias,
+      device T* out_vec,
+      int in_vec_size,
+      int out_vec_size,
+      int M,
+      int matrix_ld,
+      int vector_ld,
+      float alpha,
+      float beta,
+      int bias_ld,
+      int bias_fd,
+      uint3 tid [[threadgroup_position_in_grid]],
+      uint3 tgpg [[threadgroups_per_grid]],
+      uint simd_gid [[simdgroup_index_in_threadgroup]],
+      uint simd_lid [[thread_index_in_simdgroup]]) {
+    constexpr int rows_per_simdgroup = 32 / k_lanes;
+    constexpr int rows_per_tg = rows_per_simdgroup * num_simdgroups;
+
+    const short k_lane =
+        simd_lid % k_lanes; // this lane's slot in the K reduction
+    const short sg_row =
+        simd_lid / k_lanes; // which output row of the simdgroup
+
+    const int out_row =
+        tid.y * rows_per_tg + rows_per_simdgroup * simd_gid + sg_row;
+
+    // Clamped tail rows/vectors read valid memory; the guarded writes
+    // below never store them.
+    const int row = min(out_row, out_vec_size - 1);
+    const device T* wrow = mat + int64_t(row) * matrix_ld;
+    const device vec<T, 4>* w4 = (const device vec<T, 4>*)wrow;
+    const int n_v4 = in_vec_size / 4;
+    const int n_main = n_v4 - n_v4 % (k_lanes * unroll);
+
+    // Vector chunks beyond grid.x round-robin onto the same threadgroups:
+    // re-walking the row block hits cache where an extra grid column would
+    // re-stream it from DRAM.
+    const device vec<T, 4>* x4 = (const device vec<T, 4>*)in_vec;
+    const int x_ld4 = vector_ld / 4;
+    const int n_chunks = (M + vecs_per_tg - 1) / vecs_per_tg;
+    for (int chunk = tid.x; chunk < n_chunks; chunk += tgpg.x) {
+      const int vec0 = chunk * vecs_per_tg;
+
+      int x_off4[vecs_per_tg];
+      for (int v = 0; v < vecs_per_tg; v++) {
+        x_off4[v] = min(vec0 + v, M - 1) * x_ld4;
+      }
+
+      AccT result[vecs_per_tg] = {0};
+
+      // Adjacent lanes read adjacent blocks so every transaction lands on
+      // whole cachelines; the unroll keeps loads in flight on short rows.
+      for (int base = 0; base < n_main; base += k_lanes * unroll) {
+        vec<AccT, 4> wf[unroll];
+        MLX_MTL_PRAGMA_UNROLL
+        for (int i = 0; i < unroll; i++) {
+          wf[i] = vec<AccT, 4>(w4[base + i * k_lanes + k_lane]);
+        }
+        MLX_MTL_PRAGMA_UNROLL
+        for (int v = 0; v < vecs_per_tg; v++) {
+          AccT acc = 0;
+          MLX_MTL_PRAGMA_UNROLL
+          for (int i = 0; i < unroll; i++) {
+            acc +=
+                dot(wf[i],
+                    vec<AccT, 4>(x4[x_off4[v] + base + i * k_lanes + k_lane]));
+          }
+          result[v] += acc;
+        }
+      }
+      for (int idx = n_main + k_lane; idx < n_v4; idx += k_lanes) {
+        const vec<AccT, 4> wf = vec<AccT, 4>(w4[idx]);
+        MLX_MTL_PRAGMA_UNROLL
+        for (int v = 0; v < vecs_per_tg; v++) {
+          result[v] += dot(wf, vec<AccT, 4>(x4[x_off4[v] + idx]));
+        }
+      }
+
+      // The halving shuffles reduce each row's k_lanes while rows sharing
+      // the simdgroup stay separate.
+      MLX_MTL_PRAGMA_UNROLL
+      for (int v = 0; v < vecs_per_tg; v++) {
+        MLX_MTL_PRAGMA_UNROLL
+        for (ushort off = k_lanes / 2; off >= 1; off >>= 1) {
+          result[v] += simd_shuffle_down(result[v], off);
+        }
+      }
+
+      if (k_lane == 0 && out_row < out_vec_size) {
+        for (int v = 0; v < vecs_per_tg; v++) {
+          if (vec0 + v < M) {
+            int64_t out_idx = int64_t(vec0 + v) * out_vec_size + out_row;
+            if (gemv_wide_do_axpby) {
+              AccT bias_val = static_cast<AccT>(
+                  bias[int64_t(vec0 + v) * bias_ld + out_row * bias_fd]);
+              out_vec[out_idx] =
+                  static_cast<T>(alpha * result[v] + beta * bias_val);
+            } else {
+              out_vec[out_idx] = static_cast<T>(result[v]);
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+template <typename T, const int vecs_per_tg, const int k_lanes>
+[[kernel]] void gemv_wide(
+    const device T* mat [[buffer(0)]],
+    const device T* in_vec [[buffer(1)]],
+    const device T* bias [[buffer(2), function_constant(gemv_wide_do_axpby)]],
+    device T* out_vec [[buffer(3)]],
+    const constant int& in_vec_size [[buffer(4)]],
+    const constant int& out_vec_size [[buffer(5)]],
+    const constant int& M [[buffer(6)]],
+    const constant int& matrix_ld [[buffer(7)]],
+    const constant int& vector_ld [[buffer(8)]],
+    const constant float& alpha
+    [[buffer(9), function_constant(gemv_wide_do_axpby)]],
+    const constant float& beta
+    [[buffer(10), function_constant(gemv_wide_do_axpby)]],
+    const constant int& batch_ndim [[buffer(11)]],
+    const constant int* batch_shape [[buffer(12)]],
+    const constant int64_t* vector_batch_stride [[buffer(13)]],
+    const constant int64_t* matrix_batch_stride [[buffer(14)]],
+    const constant int64_t* bias_batch_stride
+    [[buffer(15), function_constant(gemv_wide_do_axpby)]],
+    const constant int& bias_ld
+    [[buffer(16), function_constant(gemv_wide_do_axpby)]],
+    const constant int& bias_fd
+    [[buffer(17), function_constant(gemv_wide_do_axpby)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tgpg [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (gemv_wide_has_batch) {
+    in_vec += elem_to_loc(tid.z, batch_shape, vector_batch_stride, batch_ndim);
+    mat += elem_to_loc(tid.z, batch_shape, matrix_batch_stride, batch_ndim);
+
+    if (gemv_wide_do_axpby) {
+      bias += elem_to_loc(tid.z, batch_shape, bias_batch_stride, batch_ndim);
+    }
+  } else {
+    in_vec += tid.z * vector_batch_stride[0];
+    mat += tid.z * matrix_batch_stride[0];
+
+    if (gemv_wide_do_axpby) {
+      bias += tid.z * bias_batch_stride[0];
+    }
+  }
+  out_vec += int64_t(tid.z) * M * out_vec_size;
+
+  GemvWide<T, vecs_per_tg, k_lanes>::run(
+      mat,
+      in_vec,
+      bias,
+      out_vec,
+      in_vec_size,
+      out_vec_size,
+      M,
+      matrix_ld,
+      vector_ld,
+      alpha,
+      beta,
+      bias_ld,
+      bias_fd,
+      tid,
+      tgpg,
+      simd_gid,
+      simd_lid);
+}
+
+#define instantiate_gemv_wide_helper(name, itype, nv, kl)                    \
+  template [[host_name("gemv_wide_" #name "_nv" #nv "_kl" #kl)]] [[kernel]]  \
+  void gemv_wide<itype, nv, kl>(                                             \
+      const device itype* mat [[buffer(0)]],                                 \
+      const device itype* in_vec [[buffer(1)]],                              \
+      const device itype* bias [[buffer(2),                                  \
+          function_constant(gemv_wide_do_axpby)]],                           \
+      device itype* out_vec [[buffer(3)]],                                   \
+      const constant int& in_vec_size [[buffer(4)]],                         \
+      const constant int& out_vec_size [[buffer(5)]],                        \
+      const constant int& M [[buffer(6)]],                                   \
+      const constant int& matrix_ld [[buffer(7)]],                           \
+      const constant int& vector_ld [[buffer(8)]],                           \
+      const constant float& alpha [[buffer(9),                               \
+          function_constant(gemv_wide_do_axpby)]],                           \
+      const constant float& beta [[buffer(10),                               \
+          function_constant(gemv_wide_do_axpby)]],                           \
+      const constant int& batch_ndim [[buffer(11)]],                         \
+      const constant int* batch_shape [[buffer(12)]],                        \
+      const constant int64_t* vector_batch_stride [[buffer(13)]],            \
+      const constant int64_t* matrix_batch_stride [[buffer(14)]],            \
+      const constant int64_t* bias_batch_stride [[buffer(15),                \
+          function_constant(gemv_wide_do_axpby)]],                           \
+      const constant int& bias_ld [[buffer(16),                              \
+          function_constant(gemv_wide_do_axpby)]],                           \
+      const constant int& bias_fd [[buffer(17),                              \
+          function_constant(gemv_wide_do_axpby)]],                           \
+      uint3 tid [[threadgroup_position_in_grid]],                            \
+      uint3 tgpg [[threadgroups_per_grid]],                                  \
+      uint simd_gid [[simdgroup_index_in_threadgroup]],                      \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
+// clang-format off
+#define instantiate_gemv_wide(name, itype, kl)     \
+  instantiate_gemv_wide_helper(name, itype, 2, kl) \
+  instantiate_gemv_wide_helper(name, itype, 3, kl) \
+  instantiate_gemv_wide_helper(name, itype, 4, kl) \
+  instantiate_gemv_wide_helper(name, itype, 5, kl) // clang-format on
+
+instantiate_gemv_wide(f16, half, 16);
+instantiate_gemv_wide(f16, half, 32);
+instantiate_gemv_wide(f32, float, 16);
+instantiate_gemv_wide(f32, float, 32);

--- a/metal/src/kernels/matmul/mlx_gemm/mod.rs
+++ b/metal/src/kernels/matmul/mlx_gemm/mod.rs
@@ -503,3 +503,187 @@ mod tests {
         Ok(())
     }
 }
+
+/// Launch parameters for `gemv_wide`, mirroring mlx `gemv_wide_config`.
+pub(crate) struct GemvWideConfig {
+    vecs_per_tg: usize,
+    k_lanes: usize,
+    grid_x: usize,
+}
+
+/// mlx routes `x[M, K] @ w[N, K]^T` here for M in 2..=15: a padded GEMM tile
+/// wastes most of its rows, while this streams the weight block once per
+/// register tile of vectors. mlx keeps it off below architecture generation 15
+/// (M3), where load issue rate rather than bandwidth is the limit.
+pub(crate) fn gemv_wide_config(
+    m: usize,
+    n: usize,
+    k: usize,
+    arch_gen: Option<u32>,
+) -> Option<GemvWideConfig> {
+    if arch_gen.is_none_or(|g| g < 15) {
+        return None;
+    }
+    if !(2..=15).contains(&m) || n <= 1 || !k.is_multiple_of(4) {
+        return None;
+    }
+    let passes = m.div_ceil(5);
+    if passes > 3 {
+        return None;
+    }
+    let full_simd = passes == 1 || n <= 64;
+    Some(GemvWideConfig {
+        vecs_per_tg: m.div_ceil(passes),
+        k_lanes: if full_simd { 32 } else { 16 },
+        grid_x: if n >= 65536 { 1 } else { passes },
+    })
+}
+
+/// `c[m, n] = a[m, k] @ b[n, k]^T` for a small number of rows. Contiguous,
+/// single-batch, f16/f32 only.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dispatch_metal_mlx_gemv_wide(
+    stream: &MetalStream,
+    dt: DatumType,
+    (m, n, k): (usize, usize, usize),
+    config: &GemvWideConfig,
+    a_buffer: &Buffer,
+    a_offset: usize,
+    b_buffer: &Buffer,
+    b_offset: usize,
+    output: &Buffer,
+    output_offset: usize,
+) -> TractResult<()> {
+    let tname = DeviceTensor::tname(dt)?;
+    let name = format!("gemv_wide_{tname}_nv{}_kl{}", config.vecs_per_tg, config.k_lanes);
+    let constants = Some(ConstantValues::new(vec![
+        (0, Value::Bool(false)), // gemv_wide_has_batch
+        (1, Value::Bool(false)), // gemv_wide_do_axpby
+    ]));
+    let pipeline = stream.load_pipeline_with_constants(LibraryName::MlxGemv, &name, constants)?;
+
+    let command_buffer = stream.command_buffer();
+    command_buffer.encode(|encoder| {
+        encoder.set_compute_pipeline_state(&pipeline);
+        encoder.set_buffer(0, Some(b_buffer), b_offset as _);
+        encoder.set_buffer(1, Some(a_buffer), a_offset as _);
+        encoder.set_buffer(3, Some(output), output_offset as _);
+        let i32_at = |encoder: &metal::ComputeCommandEncoderRef, ix: u64, v: i32| {
+            encoder.set_bytes(
+                ix,
+                std::mem::size_of::<i32>() as u64,
+                &v as *const i32 as *const c_void,
+            )
+        };
+        i32_at(encoder, 4, k as i32); // in_vec_size
+        i32_at(encoder, 5, n as i32); // out_vec_size
+        i32_at(encoder, 6, m as i32); // M
+        i32_at(encoder, 7, k as i32); // matrix_ld
+        i32_at(encoder, 8, k as i32); // vector_ld
+        i32_at(encoder, 11, 1); // batch_ndim
+        i32_at(encoder, 12, 1); // batch_shape
+        let zero = 0_i64;
+        encoder.set_bytes(13, 8, &zero as *const i64 as *const c_void);
+        encoder.set_bytes(14, 8, &zero as *const i64 as *const c_void);
+        let group = MTLSize { width: 32, height: (config.k_lanes / 8) as _, depth: 1 };
+        let grid = MTLSize { width: config.grid_x as _, height: n.div_ceil(4) as _, depth: 1 };
+        encoder.dispatch_thread_groups(grid, group);
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod gemv_wide_tests {
+    use super::*;
+    use crate::utils::{get_metal_buffer, with_borrowed_metal_stream};
+    use tract_gpu::tensor::IntoDevice;
+
+    fn ramp(dt: DatumType, shape: &[usize], seed: usize) -> TractResult<Tensor> {
+        let len: usize = shape.iter().product();
+        let v: Vec<f32> =
+            (0..len).map(|i| (((i * 7 + seed * 13) % 29) as f32 - 14.0) / 64.0).collect();
+        Ok(Tensor::from_shape(shape, &v)?.cast_to_dt(dt)?.into_owned())
+    }
+
+    // The mlx gate keeps gemv_wide off below architecture generation 15, so the
+    // config is built by hand here to exercise the kernel on any device.
+    fn check(dt: DatumType, m: usize, n: usize, k: usize) -> TractResult<()> {
+        let a = ramp(dt, &[m, k], 1)?;
+        let b = ramp(dt, &[n, k], 2)?;
+        let expected = {
+            let a32 = a.cast_to::<f32>()?.into_owned();
+            let b32 = b.cast_to::<f32>()?.into_owned();
+            let (av, bv) = unsafe {
+                (a32.as_slice_unchecked::<f32>().to_vec(), b32.as_slice_unchecked::<f32>().to_vec())
+            };
+            let mut out = vec![0f32; m * n];
+            for i in 0..m {
+                for j in 0..n {
+                    out[i * n + j] = (0..k).map(|x| av[i * k + x] * bv[j * k + x]).sum::<f32>();
+                }
+            }
+            Tensor::from_shape(&[m, n], &out)?.cast_to_dt(dt)?.into_owned()
+        };
+        let config = gemv_wide_config(m, n, k, Some(15))
+            .with_context(|| format!("no config for m={m} n={n} k={k}"))?;
+        let got = with_borrowed_metal_stream(|stream| {
+            let ad = a.clone().into_device()?;
+            let bd = b.clone().into_device()?;
+            let cd = unsafe { DeviceTensor::uninitialized_dt(dt, &[m, n])? };
+            dispatch_metal_mlx_gemv_wide(
+                stream,
+                dt,
+                (m, n, k),
+                &config,
+                &get_metal_buffer(&ad),
+                ad.buffer_offset(),
+                &get_metal_buffer(&bd),
+                bd.buffer_offset(),
+                &get_metal_buffer(&cd),
+                cd.buffer_offset(),
+            )?;
+            stream.wait_until_completed()?;
+            Ok(cd.to_host()?.into_tensor())
+        })?;
+        expected.close_enough(&got, Approximation::Approximate).with_context(|| {
+            format!("dt={dt:?} m={m} n={n} k={k} nv={} kl={}", config.vecs_per_tg, config.k_lanes)
+        })
+    }
+
+    #[test]
+    fn gemv_wide_f16() -> TractResult<()> {
+        for m in 2..=15 {
+            check(DatumType::F16, m, 128, 256)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn gemv_wide_f32() -> TractResult<()> {
+        for m in [2usize, 5, 8, 15] {
+            check(DatumType::F32, m, 128, 256)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn gemv_wide_tail_rows() -> TractResult<()> {
+        check(DatumType::F16, 3, 130, 260)?;
+        check(DatumType::F16, 7, 63, 2048)?;
+        check(DatumType::F32, 4, 2, 512)
+    }
+
+    #[test]
+    fn gemv_wide_config_matches_mlx_gate() {
+        assert!(gemv_wide_config(2, 128, 256, Some(13)).is_none()); // pre-M3
+        assert!(gemv_wide_config(1, 128, 256, Some(16)).is_none()); // M == 1 -> gemv
+        assert!(gemv_wide_config(16, 128, 256, Some(16)).is_none()); // 4 passes
+        assert!(gemv_wide_config(2, 128, 254, Some(16)).is_none()); // K % 4
+        let c = gemv_wide_config(8, 128, 256, Some(16)).unwrap();
+        assert_eq!((c.vecs_per_tg, c.k_lanes, c.grid_x), (4, 16, 2));
+        let c = gemv_wide_config(4, 128, 256, Some(16)).unwrap();
+        assert_eq!((c.vecs_per_tg, c.k_lanes, c.grid_x), (4, 32, 1));
+        let c = gemv_wide_config(4, 131072, 256, Some(16)).unwrap();
+        assert_eq!(c.grid_x, 1);
+    }
+}

--- a/metal/src/kernels/matmul/mlx_gemm/mod.rs
+++ b/metal/src/kernels/matmul/mlx_gemm/mod.rs
@@ -504,3 +504,187 @@ mod tests {
         Ok(())
     }
 }
+
+/// Launch parameters for `gemv_wide`, mirroring mlx `gemv_wide_config`.
+pub(crate) struct GemvWideConfig {
+    vecs_per_tg: usize,
+    k_lanes: usize,
+    grid_x: usize,
+}
+
+/// mlx routes `x[M, K] @ w[N, K]^T` here for M in 2..=15: a padded GEMM tile
+/// wastes most of its rows, while this streams the weight block once per
+/// register tile of vectors. mlx keeps it off below architecture generation 15
+/// (M3), where load issue rate rather than bandwidth is the limit.
+pub(crate) fn gemv_wide_config(
+    m: usize,
+    n: usize,
+    k: usize,
+    arch_gen: Option<u32>,
+) -> Option<GemvWideConfig> {
+    if arch_gen.is_none_or(|g| g < 15) {
+        return None;
+    }
+    if !(2..=15).contains(&m) || n <= 1 || !k.is_multiple_of(4) {
+        return None;
+    }
+    let passes = m.div_ceil(5);
+    if passes > 3 {
+        return None;
+    }
+    let full_simd = passes == 1 || n <= 64;
+    Some(GemvWideConfig {
+        vecs_per_tg: m.div_ceil(passes),
+        k_lanes: if full_simd { 32 } else { 16 },
+        grid_x: if n >= 65536 { 1 } else { passes },
+    })
+}
+
+/// `c[m, n] = a[m, k] @ b[n, k]^T` for a small number of rows. Contiguous,
+/// single-batch, f16/f32 only.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dispatch_metal_mlx_gemv_wide(
+    stream: &MetalStream,
+    dt: DatumType,
+    (m, n, k): (usize, usize, usize),
+    config: &GemvWideConfig,
+    a_buffer: &Buffer,
+    a_offset: usize,
+    b_buffer: &Buffer,
+    b_offset: usize,
+    output: &Buffer,
+    output_offset: usize,
+) -> TractResult<()> {
+    let tname = DeviceTensor::tname(dt)?;
+    let name = format!("gemv_wide_{tname}_nv{}_kl{}", config.vecs_per_tg, config.k_lanes);
+    let constants = Some(ConstantValues::new(vec![
+        (0, Value::Bool(false)), // gemv_wide_has_batch
+        (1, Value::Bool(false)), // gemv_wide_do_axpby
+    ]));
+    let pipeline = stream.load_pipeline_with_constants(LibraryName::MlxGemv, &name, constants)?;
+
+    let command_buffer = stream.command_buffer();
+    command_buffer.encode(|encoder| {
+        encoder.set_compute_pipeline_state(&pipeline);
+        encoder.set_buffer(0, Some(b_buffer), b_offset as _);
+        encoder.set_buffer(1, Some(a_buffer), a_offset as _);
+        encoder.set_buffer(3, Some(output), output_offset as _);
+        let i32_at = |encoder: &metal::ComputeCommandEncoderRef, ix: u64, v: i32| {
+            encoder.set_bytes(
+                ix,
+                std::mem::size_of::<i32>() as u64,
+                &v as *const i32 as *const c_void,
+            )
+        };
+        i32_at(encoder, 4, k as i32); // in_vec_size
+        i32_at(encoder, 5, n as i32); // out_vec_size
+        i32_at(encoder, 6, m as i32); // M
+        i32_at(encoder, 7, k as i32); // matrix_ld
+        i32_at(encoder, 8, k as i32); // vector_ld
+        i32_at(encoder, 11, 1); // batch_ndim
+        i32_at(encoder, 12, 1); // batch_shape
+        let zero = 0_i64;
+        encoder.set_bytes(13, 8, &zero as *const i64 as *const c_void);
+        encoder.set_bytes(14, 8, &zero as *const i64 as *const c_void);
+        let group = MTLSize { width: 32, height: (config.k_lanes / 8) as _, depth: 1 };
+        let grid = MTLSize { width: config.grid_x as _, height: n.div_ceil(4) as _, depth: 1 };
+        encoder.dispatch_thread_groups(grid, group);
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod gemv_wide_tests {
+    use super::*;
+    use crate::utils::{get_metal_buffer, with_borrowed_metal_stream};
+    use tract_gpu::tensor::IntoDevice;
+
+    fn ramp(dt: DatumType, shape: &[usize], seed: usize) -> TractResult<Tensor> {
+        let len: usize = shape.iter().product();
+        let v: Vec<f32> =
+            (0..len).map(|i| (((i * 7 + seed * 13) % 29) as f32 - 14.0) / 64.0).collect();
+        Ok(Tensor::from_shape(shape, &v)?.cast_to_dt(dt)?.into_owned())
+    }
+
+    // The mlx gate keeps gemv_wide off below architecture generation 15, so the
+    // config is built by hand here to exercise the kernel on any device.
+    fn check(dt: DatumType, m: usize, n: usize, k: usize) -> TractResult<()> {
+        let a = ramp(dt, &[m, k], 1)?;
+        let b = ramp(dt, &[n, k], 2)?;
+        let expected = {
+            let a32 = a.cast_to::<f32>()?.into_owned();
+            let b32 = b.cast_to::<f32>()?.into_owned();
+            let (av, bv) = unsafe {
+                (a32.as_slice_unchecked::<f32>().to_vec(), b32.as_slice_unchecked::<f32>().to_vec())
+            };
+            let mut out = vec![0f32; m * n];
+            for i in 0..m {
+                for j in 0..n {
+                    out[i * n + j] = (0..k).map(|x| av[i * k + x] * bv[j * k + x]).sum::<f32>();
+                }
+            }
+            Tensor::from_shape(&[m, n], &out)?.cast_to_dt(dt)?.into_owned()
+        };
+        let config = gemv_wide_config(m, n, k, Some(15))
+            .with_context(|| format!("no config for m={m} n={n} k={k}"))?;
+        let got = with_borrowed_metal_stream(|stream| {
+            let ad = a.clone().into_device()?;
+            let bd = b.clone().into_device()?;
+            let cd = unsafe { DeviceTensor::uninitialized_dt(dt, &[m, n])? };
+            dispatch_metal_mlx_gemv_wide(
+                stream,
+                dt,
+                (m, n, k),
+                &config,
+                &get_metal_buffer(&ad),
+                ad.buffer_offset(),
+                &get_metal_buffer(&bd),
+                bd.buffer_offset(),
+                &get_metal_buffer(&cd),
+                cd.buffer_offset(),
+            )?;
+            stream.wait_until_completed()?;
+            Ok(cd.to_host()?.into_tensor())
+        })?;
+        expected.close_enough(&got, Approximation::Approximate).with_context(|| {
+            format!("dt={dt:?} m={m} n={n} k={k} nv={} kl={}", config.vecs_per_tg, config.k_lanes)
+        })
+    }
+
+    #[test]
+    fn gemv_wide_f16() -> TractResult<()> {
+        for m in 2..=15 {
+            check(DatumType::F16, m, 128, 256)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn gemv_wide_f32() -> TractResult<()> {
+        for m in [2usize, 5, 8, 15] {
+            check(DatumType::F32, m, 128, 256)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn gemv_wide_tail_rows() -> TractResult<()> {
+        check(DatumType::F16, 3, 130, 260)?;
+        check(DatumType::F16, 7, 63, 2048)?;
+        check(DatumType::F32, 4, 2, 512)
+    }
+
+    #[test]
+    fn gemv_wide_config_matches_mlx_gate() {
+        assert!(gemv_wide_config(2, 128, 256, Some(13)).is_none()); // pre-M3
+        assert!(gemv_wide_config(1, 128, 256, Some(16)).is_none()); // M == 1 -> gemv
+        assert!(gemv_wide_config(16, 128, 256, Some(16)).is_none()); // 4 passes
+        assert!(gemv_wide_config(2, 128, 254, Some(16)).is_none()); // K % 4
+        let c = gemv_wide_config(8, 128, 256, Some(16)).unwrap();
+        assert_eq!((c.vecs_per_tg, c.k_lanes, c.grid_x), (4, 16, 2));
+        let c = gemv_wide_config(4, 128, 256, Some(16)).unwrap();
+        assert_eq!((c.vecs_per_tg, c.k_lanes, c.grid_x), (4, 32, 1));
+        let c = gemv_wide_config(4, 131072, 256, Some(16)).unwrap();
+        assert_eq!(c.grid_x, 1);
+    }
+}

--- a/metal/src/kernels/matmul/mlx_gemm/mod.rs
+++ b/metal/src/kernels/matmul/mlx_gemm/mod.rs
@@ -77,7 +77,23 @@ impl GemmKernel for MlxGemm {
             dts[2]
         );
 
-        if m == 1 || n == 1 {
+        let wide = (dts[0] == DatumType::F16 && !transpose_a && transpose_b && a_batch == 1)
+            .then(|| gemv_wide_config(m, n, k, device_arch_gen::get()))
+            .flatten();
+        if let Some(config) = wide {
+            dispatch_metal_mlx_gemv_wide(
+                stream,
+                dts[0],
+                (m, n, k),
+                &config,
+                a_buffer,
+                a_offset,
+                b_buffer,
+                b_offset,
+                c_buffer,
+                c_offset,
+            )?;
+        } else if m == 1 || n == 1 {
             dispatch_metal_mlx_gemv(
                 stream,
                 dts[0],
@@ -505,6 +521,50 @@ mod tests {
     }
 }
 
+/// Apple GPU architecture generation from `-[MTLDevice architecture].name`
+/// ("applegpu_g16g" -> 16). mlx gates several kernels on it: M1=13, M3=15,
+/// M4=16.
+// The objc msg_send!/sel! macros expand to a cargo-clippy cfg check that older
+// toolchains report at the call site; the module-level allow covers it.
+#[allow(unexpected_cfgs)]
+mod device_arch_gen {
+    use metal::foreign_types::ForeignTypeRef;
+    use objc::runtime::Object;
+    use objc::{msg_send, sel, sel_impl};
+
+    pub fn get() -> Option<u32> {
+        static GEN: std::sync::OnceLock<Option<u32>> = std::sync::OnceLock::new();
+        *GEN.get_or_init(|| unsafe {
+            let device = metal::Device::system_default()?;
+            let dev: *mut Object = device.as_ref().as_ptr() as *mut Object;
+            let responds: bool = msg_send![dev, respondsToSelector: sel!(architecture)];
+            if !responds {
+                return None;
+            }
+            let arch: *mut Object = msg_send![dev, architecture];
+            if arch.is_null() {
+                return None;
+            }
+            let name_obj: *mut Object = msg_send![arch, name];
+            if name_obj.is_null() {
+                return None;
+            }
+            let cstr: *const std::os::raw::c_char = msg_send![name_obj, UTF8String];
+            if cstr.is_null() {
+                return None;
+            }
+            std::ffi::CStr::from_ptr(cstr)
+                .to_string_lossy()
+                .chars()
+                .skip_while(|c| !c.is_ascii_digit())
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse()
+                .ok()
+        })
+    }
+}
+
 /// Launch parameters for `gemv_wide`, mirroring mlx `gemv_wide_config`.
 pub(crate) struct GemvWideConfig {
     vecs_per_tg: usize,
@@ -672,6 +732,22 @@ mod gemv_wide_tests {
         check(DatumType::F16, 3, 130, 260)?;
         check(DatumType::F16, 7, 63, 2048)?;
         check(DatumType::F32, 4, 2, 512)
+    }
+
+    // Skinny f16 through the real MlxGemm dispatch: on an M3-or-later GPU this
+    // is the gemv_wide path, elsewhere the pre-existing one.
+    #[test]
+    fn mlx_gemm_skinny_f16_matches_reference() -> TractResult<()> {
+        for m in 2..=15 {
+            crate::kernels::matmul::tests::run_mmm_test_case::<MlxGemm>(
+                (1, m, 256, 128),
+                false,
+                true,
+                DatumType::F16,
+                DatumType::F16,
+            )?;
+        }
+        Ok(())
     }
 
     #[test]

--- a/metal/src/kernels/matmul/mlx_gemm/mod.rs
+++ b/metal/src/kernels/matmul/mlx_gemm/mod.rs
@@ -77,7 +77,23 @@ impl GemmKernel for MlxGemm {
             dts[2]
         );
 
-        if m == 1 || n == 1 {
+        let wide = (dts[0] == DatumType::F16 && !transpose_a && transpose_b && a_batch == 1)
+            .then(|| gemv_wide_config(m, n, k, device_arch_gen::get()))
+            .flatten();
+        if let Some(config) = wide {
+            dispatch_metal_mlx_gemv_wide(
+                stream,
+                dts[0],
+                (m, n, k),
+                &config,
+                a_buffer,
+                a_offset,
+                b_buffer,
+                b_offset,
+                c_buffer,
+                c_offset,
+            )?;
+        } else if m == 1 || n == 1 {
             dispatch_metal_mlx_gemv(
                 stream,
                 dts[0],
@@ -504,6 +520,50 @@ mod tests {
     }
 }
 
+/// Apple GPU architecture generation from `-[MTLDevice architecture].name`
+/// ("applegpu_g16g" -> 16). mlx gates several kernels on it: M1=13, M3=15,
+/// M4=16.
+// The objc msg_send!/sel! macros expand to a cargo-clippy cfg check that older
+// toolchains report at the call site; the module-level allow covers it.
+#[allow(unexpected_cfgs)]
+mod device_arch_gen {
+    use metal::foreign_types::ForeignTypeRef;
+    use objc::runtime::Object;
+    use objc::{msg_send, sel, sel_impl};
+
+    pub fn get() -> Option<u32> {
+        static GEN: std::sync::OnceLock<Option<u32>> = std::sync::OnceLock::new();
+        *GEN.get_or_init(|| unsafe {
+            let device = metal::Device::system_default()?;
+            let dev: *mut Object = device.as_ref().as_ptr() as *mut Object;
+            let responds: bool = msg_send![dev, respondsToSelector: sel!(architecture)];
+            if !responds {
+                return None;
+            }
+            let arch: *mut Object = msg_send![dev, architecture];
+            if arch.is_null() {
+                return None;
+            }
+            let name_obj: *mut Object = msg_send![arch, name];
+            if name_obj.is_null() {
+                return None;
+            }
+            let cstr: *const std::os::raw::c_char = msg_send![name_obj, UTF8String];
+            if cstr.is_null() {
+                return None;
+            }
+            std::ffi::CStr::from_ptr(cstr)
+                .to_string_lossy()
+                .chars()
+                .skip_while(|c| !c.is_ascii_digit())
+                .take_while(char::is_ascii_digit)
+                .collect::<String>()
+                .parse()
+                .ok()
+        })
+    }
+}
+
 /// Launch parameters for `gemv_wide`, mirroring mlx `gemv_wide_config`.
 pub(crate) struct GemvWideConfig {
     vecs_per_tg: usize,
@@ -671,6 +731,22 @@ mod gemv_wide_tests {
         check(DatumType::F16, 3, 130, 260)?;
         check(DatumType::F16, 7, 63, 2048)?;
         check(DatumType::F32, 4, 2, 512)
+    }
+
+    // Skinny f16 through the real MlxGemm dispatch: on an M3-or-later GPU this
+    // is the gemv_wide path, elsewhere the pre-existing one.
+    #[test]
+    fn mlx_gemm_skinny_f16_matches_reference() -> TractResult<()> {
+        for m in 2..=15 {
+            crate::kernels::matmul::tests::run_mmm_test_case::<MlxGemm>(
+                (1, m, 256, 128),
+                false,
+                true,
+                DatumType::F16,
+                DatumType::F16,
+            )?;
+        }
+        Ok(())
     }
 
     #[test]

--- a/metal/src/kernels/matmul/mod.rs
+++ b/metal/src/kernels/matmul/mod.rs
@@ -458,6 +458,94 @@ mod tests {
         })
     }
 
+    // Skinny-M bake-off: which GEMM kernel wins for the shapes a decode step
+    // produces (M small, N large). The winner is device-dependent, so this
+    // prints a table rather than asserting.
+    //   cargo test -p tract-metal bench_skinny_gemm -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn bench_skinny_gemm() -> TractResult<()> {
+        use std::time::Instant;
+        with_borrowed_metal_stream(|stream| {
+            let device = metal::Device::system_default().unwrap();
+            let arch: String = unsafe {
+                use metal::foreign_types::ForeignTypeRef;
+                use objc::runtime::Object;
+                use objc::{msg_send, sel, sel_impl};
+                let dev: *mut Object = device.as_ref().as_ptr() as *mut Object;
+                let a: *mut Object = msg_send![dev, architecture];
+                let n: *mut Object = msg_send![a, name];
+                let c: *const std::os::raw::c_char = msg_send![n, UTF8String];
+                std::ffi::CStr::from_ptr(c).to_string_lossy().into_owned()
+            };
+            println!("  device: {} arch: {arch}", device.name());
+            for dt in [DatumType::F16, DatumType::F32] {
+                for (k, n) in [(2048usize, 2048usize), (2048, 32000)] {
+                    println!("\n  {dt:?} K={k} N={n} (x @ w.T)");
+                    println!("    M  |    Mlx ms |   Ggml ms | Ggml/Mlx | gemv_wide ms");
+                    for m in [1usize, 2, 4, 8, 16] {
+                        let a = Tensor::zero_dt(dt, &[1, m, k])?.into_device()?;
+                        // transposed weights: [n, k], the layout a Linear keeps
+                        let b = Tensor::zero_dt(dt, &[1, n, k])?.into_device()?;
+                        let c = unsafe { DeviceTensor::uninitialized_dt(dt, &[1, m, n])? };
+                        let time = |run: &dyn Fn() -> TractResult<()>| -> TractResult<f64> {
+                            for _ in 0..3 {
+                                run()?;
+                                stream.wait_until_completed()?;
+                            }
+                            let mut best = f64::MAX;
+                            for _ in 0..5 {
+                                let t = Instant::now();
+                                for _ in 0..20 {
+                                    run()?;
+                                }
+                                stream.wait_until_completed()?;
+                                best = best.min(t.elapsed().as_secs_f64() / 20.0);
+                            }
+                            Ok(best)
+                        };
+                        let mlx = time(&|| {
+                            GemmImpl::<MlxGemm>::new(false, true).dispatch_eval(stream, &a, &b, &c)
+                        })?;
+                        let ggml = time(&|| {
+                            GemmImpl::<GgmlGemm>::new(false, true).dispatch_eval(stream, &a, &b, &c)
+                        })?;
+                        // forced past mlx's own arch gate, to get a number here
+                        let wide = mlx_gemm::gemv_wide_config(m, n, k, Some(15))
+                            .map(|cfg| {
+                                time(&|| {
+                                    mlx_gemm::dispatch_metal_mlx_gemv_wide(
+                                        stream,
+                                        dt,
+                                        (m, n, k),
+                                        &cfg,
+                                        &get_metal_buffer(&a),
+                                        a.buffer_offset(),
+                                        &get_metal_buffer(&b),
+                                        b.buffer_offset(),
+                                        &get_metal_buffer(&c),
+                                        c.buffer_offset(),
+                                    )
+                                })
+                            })
+                            .transpose()?;
+                        println!(
+                            "    {m:<2} | {:9.4} | {:9.4} | {:8.2}x | {}",
+                            mlx * 1e3,
+                            ggml * 1e3,
+                            ggml / mlx,
+                            match wide {
+                                Some(w) => format!("{:9.4} ({:.2}x vs Mlx)", w * 1e3, mlx / w),
+                                None => "        - ".to_string(),
+                            }
+                        );
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+
     #[test]
     fn test_gemm_dispatches_params() -> TractResult<()> {
         let dt = DatumType::F32;

--- a/metal/src/kernels/matmul/mod.rs
+++ b/metal/src/kernels/matmul/mod.rs
@@ -462,6 +462,94 @@ mod tests {
         })
     }
 
+    // Skinny-M bake-off: which GEMM kernel wins for the shapes a decode step
+    // produces (M small, N large). The winner is device-dependent, so this
+    // prints a table rather than asserting.
+    //   cargo test -p tract-metal bench_skinny_gemm -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn bench_skinny_gemm() -> TractResult<()> {
+        use std::time::Instant;
+        with_borrowed_metal_stream(|stream| {
+            let device = metal::Device::system_default().unwrap();
+            let arch: String = unsafe {
+                use metal::foreign_types::ForeignTypeRef;
+                use objc::runtime::Object;
+                use objc::{msg_send, sel, sel_impl};
+                let dev: *mut Object = device.as_ref().as_ptr() as *mut Object;
+                let a: *mut Object = msg_send![dev, architecture];
+                let n: *mut Object = msg_send![a, name];
+                let c: *const std::os::raw::c_char = msg_send![n, UTF8String];
+                std::ffi::CStr::from_ptr(c).to_string_lossy().into_owned()
+            };
+            println!("  device: {} arch: {arch}", device.name());
+            for dt in [DatumType::F16, DatumType::F32] {
+                for (k, n) in [(2048usize, 2048usize), (2048, 32000)] {
+                    println!("\n  {dt:?} K={k} N={n} (x @ w.T)");
+                    println!("    M  |    Mlx ms |   Ggml ms | Ggml/Mlx | gemv_wide ms");
+                    for m in [1usize, 2, 4, 8, 16] {
+                        let a = Tensor::zero_dt(dt, &[1, m, k])?.into_device()?;
+                        // transposed weights: [n, k], the layout a Linear keeps
+                        let b = Tensor::zero_dt(dt, &[1, n, k])?.into_device()?;
+                        let c = unsafe { DeviceTensor::uninitialized_dt(dt, &[1, m, n])? };
+                        let time = |run: &dyn Fn() -> TractResult<()>| -> TractResult<f64> {
+                            for _ in 0..3 {
+                                run()?;
+                                stream.wait_until_completed()?;
+                            }
+                            let mut best = f64::MAX;
+                            for _ in 0..5 {
+                                let t = Instant::now();
+                                for _ in 0..20 {
+                                    run()?;
+                                }
+                                stream.wait_until_completed()?;
+                                best = best.min(t.elapsed().as_secs_f64() / 20.0);
+                            }
+                            Ok(best)
+                        };
+                        let mlx = time(&|| {
+                            GemmImpl::<MlxGemm>::new(false, true).dispatch_eval(stream, &a, &b, &c)
+                        })?;
+                        let ggml = time(&|| {
+                            GemmImpl::<GgmlGemm>::new(false, true).dispatch_eval(stream, &a, &b, &c)
+                        })?;
+                        // forced past mlx's own arch gate, to get a number here
+                        let wide = mlx_gemm::gemv_wide_config(m, n, k, Some(15))
+                            .map(|cfg| {
+                                time(&|| {
+                                    mlx_gemm::dispatch_metal_mlx_gemv_wide(
+                                        stream,
+                                        dt,
+                                        (m, n, k),
+                                        &cfg,
+                                        &get_metal_buffer(&a),
+                                        a.buffer_offset(),
+                                        &get_metal_buffer(&b),
+                                        b.buffer_offset(),
+                                        &get_metal_buffer(&c),
+                                        c.buffer_offset(),
+                                    )
+                                })
+                            })
+                            .transpose()?;
+                        println!(
+                            "    {m:<2} | {:9.4} | {:9.4} | {:8.2}x | {}",
+                            mlx * 1e3,
+                            ggml * 1e3,
+                            ggml / mlx,
+                            match wide {
+                                Some(w) => format!("{:9.4} ({:.2}x vs Mlx)", w * 1e3, mlx / w),
+                                None => "        - ".to_string(),
+                            }
+                        );
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+
     // Expected offsets keep their `1 *` batch-index factor so each one reads as
     // `batch * stride`, matching the batch being dispatched.
     #[allow(clippy::identity_op)]


### PR DESCRIPTION
f16 products of a few rows against a large transposed weight — `x[M,K] @ w[N,K]ᵀ`
with M in 2..15, which is what a small batch or a speculative decode step
produces — currently go to a GEMM tile that pads M to 64 and leaves most of the
bandwidth unused. `MlxGemm` only takes the gemv path at M == 1.

This ports mlx's `gemv_wide` kernel (ml-explore/mlx#3888) into `mlx_gemv.metal`,
same vendoring idiom as the rest of that file, and routes those shapes to it,
keeping mlx's own gate: f16, K a multiple of 4, N > 1, and architecture
generation ≥ 15.

### Numbers

`bench_skinny_gemm` (added here), K=2048, ms/dispatch, f16, `x @ w.T`.

**M4, 8-core GPU** (`applegpu_g16g`, macOS 26.6) — before vs after, through the
real `MlxGemm` dispatch:

| M | before | after | |
|---|---|---|---|
| 2 | 0.218 | 0.073 | **2.99×** |
| 4 | 0.220 | 0.078 | **2.83×** |
| 8 | 0.218 | 0.077 | **2.83×** |

M == 1 and M ≥ 16 are untouched. At N=32000 the same band gains 1.34×.

The kernel also beats routing these shapes to `GgmlGemm`, which was the other
option: after this change Ggml is 1.10× (M=2) to 1.80× (M=8) slower than the MLX
path at N=2048.

### On the architecture gate

mlx keeps `gemv_wide` off below generation 15 on the grounds that pre-M3 parts
are limited by load issue rate rather than bandwidth. That gate is kept here, but
for what it is worth the kernel is a clear win on an M1 Pro too (`applegpu_g13s`,
generation 13): 0.123 → 0.043 ms at M=2, 0.064 at M=4, 0.083 at M=8, i.e.
1.5–2.9×. Happy to widen the gate if you would rather take that; I have no M2 to
check the rest of the pre-M3 range, which is why I left mlx's rule alone.

f32 is deliberately excluded, matching mlx, which instantiates f16/bf16 only:
measured on the M4 it is 0.50–0.67× at M ≥ 4, i.e. a regression.

### Validation

`cargo test -p tract-metal --release` on the M4 (where the gate is live): 81
passed, 1 failed — that one failure is `test_mfa_attention_causal_const_is_noop`,
pre-existing on main and unrelated (#2546). Same on an M1 Pro, where the gate
leaves the path inactive. New tests: `gemv_wide_*` cover f16 M=2..15, f32, tail
rows and the gate itself against a host reference, and
`mlx_gemm_skinny_f16_matches_reference` drives M=2..15 through the real dispatch.
fmt and clippy clean.

mlx (ml-explore/mlx) is MIT, Copyright (c) 2023-2025 Apple Inc.; attributed in
the source header.

🍍
