### PR TITLE
core: write the sum when SumPool does not normalize

### DIFF
--- a/core/src/ops/cnn/sumpool.rs
+++ b/core/src/ops/cnn/sumpool.rs
@@ -221,10 +221,8 @@ impl OptSumPool {
                             .map(|v| *input_ptr.offset(v + input_offset as isize))
                             .sum::<T>();
 
-                        if let Some(div) = div {
-                            *values_ptr.offset(output_offset as isize + visitor.output_offset) =
-                                sum * div;
-                        }
+                        *values_ptr.offset(output_offset as isize + visitor.output_offset) =
+                            if let Some(div) = div { sum * div } else { sum };
                     }
                 }
             });
@@ -535,6 +533,33 @@ mod tests {
         .into_tensor()
         .into_tvalue();
         (model, tvec!(input))
+    }
+
+    // NNEF's `box` fragment defaults normalize to false, so this path is
+    // reachable from a model file: the sum has to actually be written.
+    #[test]
+    fn sum_pool_without_normalize_writes_the_sum() {
+        let mut model = TypedModel::default();
+        let source = model.add_source("input", f32::fact([1, 1, 4, 4])).unwrap();
+        let pool_spec = PoolSpec::new(
+            DataFormat::NCHW,
+            tvec![2, 2],
+            PaddingSpec::Valid,
+            None,
+            Some(tvec![2, 2]),
+            1,
+            1,
+        );
+        let op = SumPool { pool_spec, count_include_pad: false, normalize: false };
+        let out = model.wire_node("pool", op, &[source]).unwrap();
+        model.select_output_outlets(&out).unwrap();
+        let input = ndarray::Array4::from_shape_fn((1, 1, 4, 4), |(_, _, y, x)| (y * 4 + x) as f32)
+            .into_tensor()
+            .into_tvalue();
+        let out = model.into_runnable().unwrap().run(tvec!(input)).unwrap();
+        // windows are [0,1,4,5], [2,3,6,7], [8,9,12,13], [10,11,14,15]
+        let expected = tensor4(&[[[[10.0f32, 18.0], [42.0, 50.0]]]]);
+        out[0].close_enough(&expected, Approximation::Exact).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
`SumPool::eval_t` only stores a value inside `if let Some(div)`:

```rust
let div: Option<T> = if self.normalize { Some(...) } else { None };
...
if let Some(div) = div {
    *values_ptr.offset(...) = sum * div;
}
```

`div` is `None` exactly when `normalize` is false, so in that case nothing is
ever written and the op returns whatever the output buffer happened to hold —
zeros in practice. The sum is computed and thrown away.

It is reachable from a model file rather than only through hand-built graphs:
NNEF's `box` fragment declares `normalize: logical = false`, and
`nnef/src/ops/nnef/deser.rs` passes that straight into `SumPool`, so a `box`
pool without an explicit `normalize = true` currently evaluates to zeros.

The fix writes the plain sum when there is no divisor. Added a test that pools a
known 4×4 with a 2×2 valid window and checks the four window sums, which fails
on main and passes here.

Found while giving the Metal backend a pooling kernel — the GPU result and the
CPU reference disagreed, and the CPU one was wrong.

`cargo test -p tract-core --release`: 269 passed, 0 failed.

🍍
