### PR TITLE
Resize PR 1: Only lower a nearest Resize to Tile when it actually replicates pixels

### DIFF
--- a/core/src/ops/nn/resize.rs
+++ b/core/src/ops/nn/resize.rs
@@ -314,9 +314,48 @@ impl TypedOp for Resize {
             scales.iter().zip(&int_scales).all(|(&s, &i)| (s - i as f32).abs() <= 1e-5 && i != 0)
         );
         rule_if!(int_scales.iter().any(|&s| s != 1));
+        let input_shape = &model.outlet_fact(node.inputs[0])?.shape;
+        for (axis, &scale) in int_scales.iter().enumerate().filter(|&(_, &s)| s > 1) {
+            let Some(len_in) = probe_length(&self.coord_transformer, &input_shape[axis]) else {
+                return Ok(None);
+            };
+            rule_if!(is_pixel_replication(&self.coord_transformer, len_in, scale, |frac| self
+                .nearest
+                .prefers_right(frac)));
+        }
 
         lower_nearest_integer_upsample(model, node, &int_scales)
     }
+}
+
+/// Whether nearest-neighbour resampling by `scale` reads input `x / scale` for
+/// every output `x`, which is the pattern [`lower_nearest_integer_upsample`]
+/// produces. Only some coordinate transform and tie-break pairs round that way,
+/// so both Resize declutters must check before lowering.
+pub fn is_pixel_replication(
+    coord_transformer: &CoordTransformer,
+    len_in: usize,
+    scale: usize,
+    prefers_right: impl Fn(f32) -> bool,
+) -> bool {
+    let len_out = len_in * scale;
+    (0..len_out).all(|x| {
+        let x_in = coord_transformer.transform(x, scale as f32, len_in, len_out);
+        let x_floor = x_in.floor() as isize;
+        let picked =
+            (x_floor + prefers_right(x_in - x_floor as f32) as isize).clamp(0, len_in as isize - 1);
+        picked == (x / scale) as isize
+    })
+}
+
+/// An axis length to probe [`is_pixel_replication`] on. `HalfPixel` and
+/// `Asymmetric` map coordinates without consulting the axis lengths, so a
+/// symbolic axis can still be probed on a stand-in; the others cannot.
+pub fn probe_length(coord_transformer: &CoordTransformer, len: &TDim) -> Option<usize> {
+    len.to_usize().ok().or(match coord_transformer {
+        CoordTransformer::HalfPixel | CoordTransformer::Asymmetric => Some(4),
+        _ => None,
+    })
 }
 
 /// Lowers a nearest-neighbour integer upsample to Reshape → Tile → Reshape: each
@@ -445,5 +484,18 @@ mod tests {
             &[2.0, 2.0],
         );
         assert_eq!(out.shape(), &[4, 4]);
+    }
+
+    fn replicates(coord_transformer: CoordTransformer, nearest: Nearest, scale: usize) -> bool {
+        is_pixel_replication(&coord_transformer, 4, scale, |frac| nearest.prefers_right(frac))
+    }
+
+    #[test]
+    fn only_some_nearest_modes_replicate_pixels() {
+        assert!(replicates(CoordTransformer::Asymmetric, Nearest::Floor, 2));
+        assert!(replicates(CoordTransformer::HalfPixel, Nearest::RoundPreferCeil, 2));
+        assert!(replicates(CoordTransformer::HalfPixel, Nearest::RoundPreferCeil, 3));
+        assert!(!replicates(CoordTransformer::HalfPixel, Nearest::Floor, 2));
+        assert!(!replicates(CoordTransformer::Asymmetric, Nearest::RoundPreferCeil, 2));
     }
 }

--- a/onnx-opl/src/resize.rs
+++ b/onnx-opl/src/resize.rs
@@ -1,6 +1,7 @@
 use tract_nnef::internal::*;
 use tract_nnef::tract_core::ops::nn::resize::{
-    self, CoordTransformer, Interpolator, cubic_kernel, lower_nearest_integer_upsample,
+    self, CoordTransformer, Interpolator, cubic_kernel, is_pixel_replication,
+    lower_nearest_integer_upsample, probe_length,
 };
 
 /// Nearest-neighbour tie-breaking, the full ONNX set. `Floor` and
@@ -309,6 +310,15 @@ impl TypedOp for Resize {
             scales.iter().zip(&int_scales).all(|(&s, &i)| (s - i as f32).abs() <= 1e-5 && i != 0)
         );
         rule_if!(int_scales.iter().any(|&s| s != 1));
+        let input_shape = &model.outlet_fact(node.inputs[0])?.shape;
+        for (axis, &scale) in int_scales.iter().enumerate().filter(|&(_, &s)| s > 1) {
+            let Some(len_in) = probe_length(&self.coord_transformer, &input_shape[axis]) else {
+                return Ok(None);
+            };
+            rule_if!(is_pixel_replication(&self.coord_transformer, len_in, scale, |frac| self
+                .nearest
+                .prefers_right(frac)));
+        }
 
         lower_nearest_integer_upsample(model, node, &int_scales)
     }

--- a/test-rt/suite-onnx/node.txt
+++ b/test-rt/suite-onnx/node.txt
@@ -500,6 +500,7 @@ test_resize_upsample_scales_cubic_asymmetric                                    
 test_resize_upsample_scales_cubic_A_n0p5_exclude_outside                            input:X
 test_resize_upsample_scales_linear_align_corners                                    input:X not-nnef
 test_resize_upsample_sizes_cubic                                                    input:X
+test_resize_upsample_sizes_nearest_ceil_half_pixel                                  input:X
 test_rnn_seq_length
 test_round
 test_scan9_sum


### PR DESCRIPTION
The nearest-neighbour `Resize` declutter lowers any integer scale to `Reshape → Tile → Reshape`, but that replication pattern only holds for some `coordinate_transformation_mode` / `nearest_mode` pairs — so `half_pixel` or `ceil` rounding silently produced shifted output. Both declutters now probe the rounding of each upsampled axis and lower only when the result really is pixel replication.

Three models differing only in those two attributes all returned identical output before this change, where ONNX specifies three different results (`scales=[1,1,2,2]`, input `1..16` reshaped `1,1,4,4`, first output row):

| mode | before | ONNX reference |
|---|---|---|
| `half_pixel` + `floor` | `1 1 2 2 3 3 4 4` | `1 1 1 2 2 3 3 4` ❌ |
| `asymmetric` + `floor` | `1 1 2 2 3 3 4 4` | `1 1 2 2 3 3 4 4` ✅ |
| `half_pixel` + `ceil` | `1 1 2 2 3 3 4 4` | `1 2 2 3 3 4 4 4` ❌ |

`asymmetric` + `floor` — what PyTorch's nearest upsample and opset-10 `Upsample` emit — is the common real-model case and still lowers to `Tile`, so the optimisation is kept where it matters.

The check probes the plan the op would actually evaluate rather than enumerating the valid attribute pairs by hand. Axes with symbolic length can still be probed for `half_pixel`/`asymmetric`, whose coordinate map does not consult the axis lengths; other transforms with a symbolic axis decline to lower.

`test_resize_upsample_sizes_nearest_ceil_half_pixel` is enabled in the ONNX manifest as the regression test — it passes directly but failed through `test-nnef-cycle` before this change (that cycle materialises `sizes` into constant `scales`, which is what lets the lowering fire).

Tested: `onnx-tests.sh` on both `1_13_0` and `1_19_1`, `test-unit-core`, `test-f16`, `test-metal`, and the crate unit tests all green; `cargo fmt --all` and `cargo clippy --workspace` clean.

🍍