### PR TITLE
Resize PR 2: Complete ONNX Resize for opset 18/19, and make it fast

### DIFF
--- a/core/src/ops/nn/resize.rs
+++ b/core/src/ops/nn/resize.rs
@@ -1,7 +1,7 @@
 use crate::internal::*;
 use crate::ops::array::Tile;
 
-/// Maps an output coordinate back to the input axis. The four ONNX coordinate
+/// Maps an output coordinate back to the input axis. The ONNX coordinate
 /// transformation modes that have a well-defined inverse without an input ROI.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum CoordTransformer {
@@ -9,6 +9,7 @@ pub enum CoordTransformer {
     AlignCorners,
     Asymmetric,
     PytorchHalfPixel,
+    HalfPixelSymmetric,
 }
 
 impl CoordTransformer {
@@ -28,8 +29,13 @@ impl CoordTransformer {
                 if len_out > 1 {
                     (x_out as f32 + 0.5) / scale - 0.5
                 } else {
-                    0.0
+                    -0.5
                 }
+            }
+            CoordTransformer::HalfPixelSymmetric => {
+                let adjustment = len_out as f32 / (scale * len_in as f32);
+                let offset = len_in as f32 / 2.0 * (1.0 - adjustment);
+                offset + (x_out as f32 + 0.5) / scale - 0.5
             }
         }
     }
@@ -40,6 +46,7 @@ impl CoordTransformer {
             CoordTransformer::AlignCorners => "align_corners",
             CoordTransformer::Asymmetric => "asymmetric",
             CoordTransformer::PytorchHalfPixel => "pytorch_half_pixel",
+            CoordTransformer::HalfPixelSymmetric => "half_pixel_symmetric",
         }
     }
 
@@ -49,6 +56,7 @@ impl CoordTransformer {
             "align_corners" => CoordTransformer::AlignCorners,
             "asymmetric" => CoordTransformer::Asymmetric,
             "pytorch_half_pixel" => CoordTransformer::PytorchHalfPixel,
+            "half_pixel_symmetric" => CoordTransformer::HalfPixelSymmetric,
             s => bail!("coordinate_transformation_mode: {s}"),
         })
     }
@@ -79,6 +87,47 @@ impl Interpolator {
             "cubic" => Interpolator::Cubic,
             s => bail!("mode: {s}"),
         })
+    }
+}
+
+/// Number of input taps feeding one output element. Antialiasing widens the
+/// footprint of `Linear` and `Cubic` by `1/scale` when downscaling, which is
+/// what turns the interpolation into a low-pass filter.
+pub fn window_size(interpolator: &Interpolator, antialias: bool, scale: f32) -> usize {
+    let support = match interpolator {
+        Interpolator::Nearest | Interpolator::Linear => 1.0f32,
+        Interpolator::Cubic => 2.0,
+    };
+    if !antialias || scale >= 1.0 || matches!(interpolator, Interpolator::Nearest) {
+        return 2 * support as usize;
+    }
+    let first = (-support / scale).floor() as isize + 1;
+    (2 - 2 * first) as usize
+}
+
+/// Triangular kernel, low-passed by `scale` when antialiasing.
+pub fn linear_weights(r: f32, scale: f32, antialias: bool, weights: &mut [f32]) {
+    let scale = if antialias { scale.min(1.0) } else { 1.0 };
+    fill_weights(r, scale, weights, |x| (1.0 - x.abs()).clamp(0.0, 1.0));
+}
+
+/// Cubic convolution kernel of coefficient `a`, low-passed by `scale` when
+/// antialiasing.
+pub fn cubic_weights(r: f32, scale: f32, a: f32, antialias: bool, weights: &mut [f32]) {
+    let scale = if antialias { scale.min(1.0) } else { 1.0 };
+    fill_weights(r, scale, weights, |x| cubic_kernel(x, a));
+}
+
+/// Evaluates `kernel` at the offset of each tap in the window from the source
+/// coordinate, then renormalizes when the kernel was stretched by `scale`.
+fn fill_weights(r: f32, scale: f32, weights: &mut [f32], kernel: impl Fn(f32) -> f32) {
+    let first = 1.0 - (weights.len() / 2) as f32;
+    for (k, w) in weights.iter_mut().enumerate() {
+        *w = kernel((first + k as f32 - r) * scale);
+    }
+    if scale != 1.0 {
+        let sum: f32 = weights.iter().sum();
+        weights.iter_mut().for_each(|w| *w /= sum);
     }
 }
 
@@ -125,6 +174,122 @@ impl Nearest {
             "round_prefer_ceil" => Nearest::RoundPreferCeil,
             s => bail!("nearest_mode: {s}"),
         })
+    }
+}
+
+/// Resampling plan for one axis: for each output index, the `window` input taps
+/// it reads (already clamped into the axis) and their weights. `extrapolated`
+/// flags output indices that map outside the input, which are filled with a
+/// constant instead of being interpolated.
+#[derive(Clone, Debug)]
+pub struct AxisPlan {
+    pub window: usize,
+    pub indices: Vec<usize>,
+    pub weights: Vec<f32>,
+    pub extrapolated: Vec<bool>,
+}
+
+/// Builds the resampling plan for one axis. `coord` maps an output index to a
+/// source coordinate, or `None` when it falls outside the input. `weights`
+/// fills a window for a fractional offset in `(0, 1]`, the tap at index `k`
+/// sitting `k + 1 - window / 2` cells right of the source cell. With
+/// `exclude_outside` the taps falling off the axis are dropped and the
+/// remaining weights renormalized; otherwise they read the edge value.
+pub fn plan_axis(
+    len_in: usize,
+    len_out: usize,
+    window: usize,
+    exclude_outside: bool,
+    coord: impl Fn(usize) -> Option<f32>,
+    weights: impl Fn(f32, &mut [f32]),
+) -> AxisPlan {
+    let mut plan = AxisPlan {
+        window,
+        indices: vec![0; window * len_out],
+        weights: vec![0.0; window * len_out],
+        extrapolated: vec![false; len_out],
+    };
+    for x in 0..len_out {
+        let Some(x_in) = coord(x) else {
+            plan.extrapolated[x] = true;
+            continue;
+        };
+        let cell = x_in.ceil() - 1.0;
+        let taps = &mut plan.weights[x * window..][..window];
+        weights(x_in - cell, taps);
+        let first = cell as isize + 1 - (window / 2) as isize;
+        for (k, tap) in taps.iter_mut().enumerate() {
+            let raw = first + k as isize;
+            if exclude_outside && (raw < 0 || raw >= len_in as isize) {
+                *tap = 0.0;
+            }
+            plan.indices[x * window + k] = raw.clamp(0, len_in as isize - 1) as usize;
+        }
+        if exclude_outside {
+            let sum: f32 = taps.iter().sum();
+            if sum != 0.0 {
+                taps.iter_mut().for_each(|w| *w /= sum);
+            }
+        }
+    }
+    plan
+}
+
+/// Whether `plan` is exactly pixel replication — every output reading the
+/// single input `x / scale` — which is the pattern
+/// [`lower_nearest_integer_upsample`] produces. Only some coordinate transform
+/// and tie-break pairs round that way, so the plan itself is the arbiter.
+pub fn is_pixel_replication(plan: &AxisPlan, scale: usize) -> bool {
+    !plan.extrapolated.contains(&true)
+        && plan
+            .indices
+            .chunks_exact(plan.window)
+            .zip(plan.weights.chunks_exact(plan.window))
+            .enumerate()
+            .all(|(x, (indices, weights))| {
+                let mut taps = indices.iter().zip(weights).filter(|(_, w)| **w != 0.0);
+                taps.next().is_some_and(|(i, w)| *w == 1.0 && *i == x / scale)
+                    && taps.next().is_none()
+            })
+}
+
+/// Resamples `axis` of a row-major `input` of shape `shape` into `output`,
+/// which must be sized for the same shape with `axis` set to the plan length.
+pub fn resample_axis(
+    input: &[f32],
+    shape: &[usize],
+    axis: usize,
+    plan: &AxisPlan,
+    extrapolation_value: f32,
+    output: &mut [f32],
+) {
+    let len_in = shape[axis];
+    let len_out = plan.extrapolated.len();
+    let inner: usize = shape[axis + 1..].iter().product();
+    let window = plan.window;
+    if len_in * inner == 0 || len_out * inner == 0 {
+        return;
+    }
+    for (src, dst) in
+        input.chunks_exact(len_in * inner).zip(output.chunks_exact_mut(len_out * inner))
+    {
+        for (x, dst) in dst.chunks_exact_mut(inner).enumerate() {
+            if plan.extrapolated[x] {
+                dst.fill(extrapolation_value);
+                continue;
+            }
+            dst.fill(0.0);
+            let indices = &plan.indices[x * window..][..window];
+            let weights = &plan.weights[x * window..][..window];
+            for (&i, &w) in indices.iter().zip(weights) {
+                if w == 0.0 {
+                    continue;
+                }
+                for (d, s) in dst.iter_mut().zip(&src[i * inner..][..inner]) {
+                    *d += w * s;
+                }
+            }
+        }
     }
 }
 
@@ -186,6 +351,24 @@ impl Resize {
             input_sizes,
         );
     }
+
+    fn plan_axis(&self, scale: f32, len_in: usize, len_out: usize) -> AxisPlan {
+        let window = window_size(&self.interpolator, false, scale);
+        let coord = |x| Some(self.coord_transformer.transform(x, scale, len_in, len_out));
+        match self.interpolator {
+            Interpolator::Linear => plan_axis(len_in, len_out, window, false, coord, |r, w| {
+                linear_weights(r, scale, false, w)
+            }),
+            Interpolator::Cubic => plan_axis(len_in, len_out, window, false, coord, |r, w| {
+                cubic_weights(r, scale, -0.75, false, w)
+            }),
+            Interpolator::Nearest => plan_axis(len_in, len_out, window, false, coord, |r, w| {
+                let right = r == 1.0 || self.nearest.prefers_right(r);
+                w[0] = !right as u8 as f32;
+                w[1] = right as u8 as f32;
+            }),
+        }
+    }
 }
 
 impl Op for Resize {
@@ -217,67 +400,21 @@ impl EvalOp for Resize {
             output_shape.iter().zip(inputs[0].shape()).map(|(o, i)| *o as f32 / *i as f32).collect()
         };
         let input = inputs.remove(0).into_tensor();
-        let mut data = if input.datum_type() == f32::datum_type() {
-            input.into_plain_array::<f32>()?
-        } else {
-            input.cast_to::<f32>()?.into_owned().into_plain_array::<f32>()?
-        };
-        for (axis, scale) in scales.into_iter().enumerate().filter(|(_, s)| *s != 1.0) {
-            let mut new_shape: TVec<usize> = data.shape().into();
-            new_shape[axis] = output_shape[axis];
-            let input_len = data.shape()[axis];
-            data = match self.interpolator {
-                Interpolator::Cubic => {
-                    let a = -0.75f32;
-                    tract_ndarray::ArrayD::from_shape_fn(&*new_shape, |co_o| -> f32 {
-                        let x_out = co_o[axis];
-                        let x_in = self.coord_transformer.transform(
-                            x_out,
-                            scale,
-                            input_len,
-                            new_shape[axis],
-                        );
-                        let x_floor = x_in.floor() as isize;
-                        let t = x_in - x_floor as f32;
-                        let mut co_i = co_o;
-                        let mut acc = 0.0f32;
-                        for j in -1..=2isize {
-                            let w = cubic_kernel(t - j as f32, a);
-                            let idx = (x_floor + j).clamp(0, input_len as isize - 1) as usize;
-                            co_i[axis] = idx;
-                            acc += w * data[&co_i];
-                        }
-                        acc
-                    })
-                }
-                _ => tract_ndarray::ArrayD::from_shape_fn(&*new_shape, |co_o| -> f32 {
-                    let x_out = co_o[axis];
-                    let x_in =
-                        self.coord_transformer.transform(x_out, scale, input_len, new_shape[axis]);
-                    let mut co_i = co_o;
-                    let x_floor = x_in.floor() as isize;
-                    let x_left = x_floor.clamp(0, input_len as isize - 1) as usize;
-                    co_i[axis] = x_left;
-                    let y_left = data[&co_i];
-                    let x_right = (x_floor + 1).clamp(0, input_len as isize - 1) as usize;
-                    co_i[axis] = x_right;
-                    let y_right = data[&co_i];
-                    let x_frac = x_in - x_floor as f32;
-                    match self.interpolator {
-                        Interpolator::Linear => y_left * (1.0 - x_frac) + y_right * x_frac,
-                        Interpolator::Nearest => {
-                            if self.nearest.prefers_right(x_frac) {
-                                y_right
-                            } else {
-                                y_left
-                            }
-                        }
-                        Interpolator::Cubic => unreachable!(),
-                    }
-                }),
+        let input = input.cast_to::<f32>()?;
+        let mut shape: TVec<usize> = input.shape().into();
+        let mut data: Vec<f32> = input.try_as_plain()?.as_slice::<f32>()?.to_vec();
+        for (axis, scale) in scales.into_iter().enumerate() {
+            let (len_in, len_out) = (shape[axis], output_shape[axis]);
+            if len_in == len_out && scale == 1.0 {
+                continue;
             }
+            let plan = self.plan_axis(scale, len_in, len_out);
+            let mut resampled = vec![0f32; data.len() / len_in * len_out];
+            resample_axis(&data, &shape, axis, &plan, 0.0, &mut resampled);
+            data = resampled;
+            shape[axis] = len_out;
         }
-        let out = data.into_tensor();
+        let out = tract_ndarray::ArrayD::from_shape_vec(&*shape, data)?.into_tensor();
         let out =
             if out.datum_type() == input_dt { out } else { out.cast_to_dt(input_dt)?.into_owned() };
         Ok(tvec!(out.into_tvalue()))
@@ -319,38 +456,19 @@ impl TypedOp for Resize {
             let Some(len_in) = probe_length(&self.coord_transformer, &input_shape[axis]) else {
                 return Ok(None);
             };
-            rule_if!(is_pixel_replication(&self.coord_transformer, len_in, scale, |frac| self
-                .nearest
-                .prefers_right(frac)));
+            rule_if!(is_pixel_replication(
+                &self.plan_axis(scale as f32, len_in, len_in * scale),
+                scale
+            ));
         }
 
         lower_nearest_integer_upsample(model, node, &int_scales)
     }
 }
 
-/// Whether nearest-neighbour resampling by `scale` reads input `x / scale` for
-/// every output `x`, which is the pattern [`lower_nearest_integer_upsample`]
-/// produces. Only some coordinate transform and tie-break pairs round that way,
-/// so both Resize declutters must check before lowering.
-pub fn is_pixel_replication(
-    coord_transformer: &CoordTransformer,
-    len_in: usize,
-    scale: usize,
-    prefers_right: impl Fn(f32) -> bool,
-) -> bool {
-    let len_out = len_in * scale;
-    (0..len_out).all(|x| {
-        let x_in = coord_transformer.transform(x, scale as f32, len_in, len_out);
-        let x_floor = x_in.floor() as isize;
-        let picked =
-            (x_floor + prefers_right(x_in - x_floor as f32) as isize).clamp(0, len_in as isize - 1);
-        picked == (x / scale) as isize
-    })
-}
-
-/// An axis length to probe [`is_pixel_replication`] on. `HalfPixel` and
-/// `Asymmetric` map coordinates without consulting the axis lengths, so a
-/// symbolic axis can still be probed on a stand-in; the others cannot.
+/// An axis length to build a probe plan on. `HalfPixel` and `Asymmetric` map
+/// coordinates without consulting the axis lengths, so a symbolic axis can
+/// still be probed on a stand-in; the others cannot.
 pub fn probe_length(coord_transformer: &CoordTransformer, len: &TDim) -> Option<usize> {
     len.to_usize().ok().or(match coord_transformer {
         CoordTransformer::HalfPixel | CoordTransformer::Asymmetric => Some(4),
@@ -487,7 +605,14 @@ mod tests {
     }
 
     fn replicates(coord_transformer: CoordTransformer, nearest: Nearest, scale: usize) -> bool {
-        is_pixel_replication(&coord_transformer, 4, scale, |frac| nearest.prefers_right(frac))
+        let op = Resize {
+            coord_transformer,
+            interpolator: Interpolator::Nearest,
+            nearest,
+            optional_scales_input: Some(1),
+            optional_sizes_input: None,
+        };
+        is_pixel_replication(&op.plan_axis(scale as f32, 4, 4 * scale), scale)
     }
 
     #[test]

--- a/onnx-opl/src/resize.rs
+++ b/onnx-opl/src/resize.rs
@@ -1,7 +1,8 @@
 use tract_nnef::internal::*;
 use tract_nnef::tract_core::ops::nn::resize::{
-    self, CoordTransformer, Interpolator, cubic_kernel, is_pixel_replication,
-    lower_nearest_integer_upsample, probe_length,
+    self, AxisPlan, CoordTransformer, Interpolator, cubic_weights, is_pixel_replication,
+    linear_weights, lower_nearest_integer_upsample, plan_axis, probe_length, resample_axis,
+    window_size,
 };
 
 /// Nearest-neighbour tie-breaking, the full ONNX set. `Floor` and
@@ -45,14 +46,70 @@ impl Nearest {
     }
 }
 
+/// ONNX `coordinate_transformation_mode`. Every mode but `tf_crop_and_resize`
+/// inverts without an input ROI and is shared with tract-core.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum CoordTransform {
+    Plain(CoordTransformer),
+    TfCropAndResize,
+}
+
+impl CoordTransform {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CoordTransform::Plain(t) => t.as_str(),
+            CoordTransform::TfCropAndResize => "tf_crop_and_resize",
+        }
+    }
+
+    pub fn parse(s: &str) -> TractResult<Self> {
+        Ok(match s {
+            "tf_crop_and_resize" => CoordTransform::TfCropAndResize,
+            s => CoordTransform::Plain(CoordTransformer::parse(s)?),
+        })
+    }
+}
+
+/// ONNX `keep_aspect_ratio_policy`: reconciles the requested `sizes` into a
+/// single scale shared by every resized axis. Ignored when `scales` drives the
+/// resize.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum AspectRatio {
+    Stretch,
+    NotLarger,
+    NotSmaller,
+}
+
+impl AspectRatio {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AspectRatio::Stretch => "stretch",
+            AspectRatio::NotLarger => "not_larger",
+            AspectRatio::NotSmaller => "not_smaller",
+        }
+    }
+
+    pub fn parse(s: &str) -> TractResult<Self> {
+        Ok(match s {
+            "stretch" => AspectRatio::Stretch,
+            "not_larger" => AspectRatio::NotLarger,
+            "not_smaller" => AspectRatio::NotSmaller,
+            s => bail!("keep_aspect_ratio_policy: {s}"),
+        })
+    }
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Resize {
     pub axes: Option<Vec<i64>>,
-    pub coord_transformer: CoordTransformer,
+    pub coord_transformer: CoordTransform,
     pub interpolator: Interpolator,
     pub nearest: Nearest,
+    pub antialias: bool,
     pub cubic_coeff_a_bits: u32,
     pub exclude_outside: bool,
+    pub extrapolation_value_bits: u32,
+    pub keep_aspect_ratio_policy: AspectRatio,
     pub optional_roi_input: Option<usize>,
     pub optional_scales_input: Option<usize>,
     pub optional_sizes_input: Option<usize>,
@@ -63,42 +120,62 @@ impl Resize {
         f32::from_bits(self.cubic_coeff_a_bits)
     }
 
+    pub fn extrapolation_value(&self) -> f32 {
+        f32::from_bits(self.extrapolation_value_bits)
+    }
+
+    /// The axes `scales`, `sizes` and `roi` describe, negatives resolved. Axes
+    /// left out keep their input length.
+    pub fn resized_axes(&self, rank: usize) -> TractResult<TVec<usize>> {
+        let Some(axes) = &self.axes else { return Ok((0..rank).collect()) };
+        axes.iter()
+            .map(|a| {
+                let a = if *a < 0 { a + rank as i64 } else { *a };
+                ensure!((0..rank as i64).contains(&a), "Resize axes {axes:?} out of rank {rank}");
+                Ok(a as usize)
+            })
+            .collect()
+    }
+
     pub fn compute_output_shape<D: DimLike>(
         &self,
         input_shape: &[D],
         input_scale: Option<&Tensor>,
         input_sizes: Option<&Tensor>,
     ) -> TractResult<TVec<D>> {
-        if let Some(scale) = input_scale
-            && scale.len() == input_shape.len()
-        {
-            let mut shape = tvec!();
-            for (i, s) in input_shape
-                .iter()
-                .zip(scale.cast_to::<f32>()?.try_as_plain()?.as_slice::<f32>()?.iter())
-            {
-                if s.round() == *s {
-                    shape.push(i.clone() * (*s as usize));
+        let axes = self.resized_axes(input_shape.len())?;
+        let mut shape: TVec<D> = input_shape.into();
+        if let Some(scale) = input_scale.filter(|s| s.len() == axes.len()) {
+            let scale = scale.cast_to::<f32>()?;
+            for (&axis, s) in axes.iter().zip(scale.try_as_plain()?.as_slice::<f32>()?) {
+                let i = &input_shape[axis];
+                shape[axis] = if s.round() == *s {
+                    i.clone() * (*s as usize)
                 } else if let Ok(i) = i.to_usize() {
-                    shape.push(((i as f32 * s) as usize).into());
+                    ((i as f32 * s) as usize).into()
                 } else {
                     bail!(
                         "Can not compute output shape. inputs are {input_shape:?} and scale {scale:?}"
                     )
-                }
+                };
             }
             return Ok(shape);
         }
-        if let Some(sizes) = input_sizes
-            && sizes.len() == input_shape.len()
-        {
-            return sizes
-                .cast_to::<TDim>()?
-                .try_as_plain()?
-                .as_slice::<TDim>()?
-                .iter()
-                .map(|i| i.try_into())
-                .collect();
+        if let Some(sizes) = input_sizes.filter(|s| s.len() == axes.len()) {
+            let sizes = sizes.cast_to::<TDim>()?;
+            let sizes = sizes.try_as_plain()?.as_slice::<TDim>()?;
+            if self.keep_aspect_ratio_policy == AspectRatio::Stretch {
+                for (&axis, s) in axes.iter().zip(sizes) {
+                    shape[axis] = s.try_into()?;
+                }
+            } else {
+                let scale = self.aspect_ratio_scale(input_shape, &axes, sizes)?;
+                for &axis in &axes {
+                    let len = input_shape[axis].to_usize()?;
+                    shape[axis] = ((scale * len as f32 + 0.5) as usize).into();
+                }
+            }
+            return Ok(shape);
         }
         bail!(
             "Neither sizes nor scales makes sense: input_shape: {:?}, scale: {:?}, sizes: {:?}",
@@ -108,13 +185,122 @@ impl Resize {
         );
     }
 
+    /// The scale every resized axis takes under a non-`Stretch` policy: the
+    /// smallest requested ratio to stay within `sizes`, the largest to cover it.
+    fn aspect_ratio_scale<D: DimLike>(
+        &self,
+        input_shape: &[D],
+        axes: &[usize],
+        sizes: &[TDim],
+    ) -> TractResult<f32> {
+        let mut ratios: TVec<f32> = tvec!();
+        for (&axis, size) in axes.iter().zip(sizes) {
+            ratios.push(size.to_usize()? as f32 / input_shape[axis].to_usize()? as f32);
+        }
+        let pick = if self.keep_aspect_ratio_policy == AspectRatio::NotLarger {
+            f32::min
+        } else {
+            f32::max
+        };
+        ratios.into_iter().reduce(pick).context("Resize sizes must not be empty")
+    }
+
+    /// Per-axis scale and output length over the full rank.
+    fn resolve(
+        &self,
+        input_shape: &[usize],
+        scales: Option<&Tensor>,
+        sizes: Option<&Tensor>,
+    ) -> TractResult<(TVec<f32>, TVec<usize>)> {
+        let axes = self.resized_axes(input_shape.len())?;
+        let output_shape = self.compute_output_shape(input_shape, scales, sizes)?;
+        let mut per_axis: TVec<f32> = tvec!(1.0; input_shape.len());
+        if let Some(scales) = scales.filter(|s| s.len() == axes.len()) {
+            let scales = scales.cast_to::<f32>()?;
+            for (&axis, s) in axes.iter().zip(scales.try_as_plain()?.as_slice::<f32>()?) {
+                per_axis[axis] = *s;
+            }
+        } else if self.keep_aspect_ratio_policy != AspectRatio::Stretch {
+            let sizes =
+                sizes.context("Resize aspect ratio policy needs sizes")?.cast_to::<TDim>()?;
+            let scale =
+                self.aspect_ratio_scale(input_shape, &axes, sizes.try_as_plain()?.as_slice()?)?;
+            for &axis in &axes {
+                per_axis[axis] = scale;
+            }
+        } else {
+            for &axis in &axes {
+                per_axis[axis] = output_shape[axis] as f32 / input_shape[axis] as f32;
+            }
+        }
+        Ok((per_axis, output_shape))
+    }
+
+    /// Normalized ROI `(start, end)` per axis, `(0, 1)` for the axes left out.
+    fn roi(&self, rank: usize, roi: Option<&Tensor>) -> TractResult<TVec<(f32, f32)>> {
+        let axes = self.resized_axes(rank)?;
+        let Some(roi) = roi.filter(|r| r.len() == 2 * axes.len()) else {
+            bail!("Resize in tf_crop_and_resize mode needs a roi of 2 x {} elements", axes.len())
+        };
+        let roi = roi.cast_to::<f32>()?;
+        let roi = roi.try_as_plain()?.as_slice::<f32>()?;
+        let mut per_axis: TVec<(f32, f32)> = tvec!((0.0, 1.0); rank);
+        for (i, &axis) in axes.iter().enumerate() {
+            per_axis[axis] = (roi[i], roi[i + axes.len()]);
+        }
+        Ok(per_axis)
+    }
+
+    fn plan_axis(&self, scale: f32, len_in: usize, len_out: usize, roi: (f32, f32)) -> AxisPlan {
+        let window = window_size(&self.interpolator, self.antialias, scale);
+        let coord: Box<dyn Fn(usize) -> Option<f32>> = match &self.coord_transformer {
+            CoordTransform::Plain(t) => {
+                let t = t.clone();
+                Box::new(move |x| Some(t.transform(x, scale, len_in, len_out)))
+            }
+            CoordTransform::TfCropAndResize => {
+                let last = len_in as f32 - 1.0;
+                let span = last * (roi.1 - roi.0);
+                let width = scale * len_in as f32;
+                Box::new(move |x| {
+                    let offset =
+                        if width == 1.0 { span / 2.0 } else { x as f32 * span / (width - 1.0) };
+                    let x = offset + roi.0 * last;
+                    (x >= 0.0 && x <= last).then_some(x)
+                })
+            }
+        };
+        let exclude = self.exclude_outside;
+        let (antialias, a) = (self.antialias, self.cubic_coeff_a());
+        match self.interpolator {
+            Interpolator::Linear => plan_axis(len_in, len_out, window, exclude, coord, |r, w| {
+                linear_weights(r, scale, antialias, w)
+            }),
+            Interpolator::Cubic => plan_axis(len_in, len_out, window, exclude, coord, |r, w| {
+                cubic_weights(r, scale, a, antialias, w)
+            }),
+            Interpolator::Nearest => plan_axis(len_in, len_out, window, exclude, coord, |r, w| {
+                let right = r == 1.0 || self.nearest.prefers_right(r);
+                w[0] = !right as u8 as f32;
+                w[1] = right as u8 as f32;
+            }),
+        }
+    }
+
     /// The clean subset reachable by `tract_core::ops::nn::resize::Resize`:
-    /// default `cubic_coeff_a`, no `exclude_outside`, no ROI and a nearest mode
-    /// core understands. `None` keeps the op as an ONNX edge-case op.
+    /// default `cubic_coeff_a`, no `exclude_outside`, no antialiasing, no ROI,
+    /// a stretching aspect ratio and a nearest mode core understands. `None`
+    /// keeps the op as an ONNX edge-case op.
     fn as_core(&self) -> Option<resize::Resize> {
-        if self.exclude_outside || self.optional_roi_input.is_some() {
+        if self.exclude_outside
+            || self.antialias
+            || self.keep_aspect_ratio_policy != AspectRatio::Stretch
+        {
             return None;
         }
+        let CoordTransform::Plain(coord_transformer) = &self.coord_transformer else {
+            return None;
+        };
         if self.interpolator == Interpolator::Cubic && self.cubic_coeff_a() != -0.75 {
             return None;
         }
@@ -129,12 +315,41 @@ impl Resize {
             _ => return None,
         };
         Some(resize::Resize {
-            coord_transformer: self.coord_transformer.clone(),
+            coord_transformer: coord_transformer.clone(),
             interpolator: self.interpolator.clone(),
             nearest,
             optional_scales_input: Some(1),
             optional_sizes_input: None,
         })
+    }
+
+    /// Spreads a per-`axes` `scales`/`sizes` constant over the full rank, so the
+    /// core op — which carries no `axes` of its own — can take the node over.
+    fn full_rank_aux(
+        &self,
+        input_shape: &ShapeFact,
+        axes: &[usize],
+        konst: &Tensor,
+        sizes: bool,
+    ) -> TractResult<Arc<Tensor>> {
+        if sizes {
+            let mut full: Vec<i64> = vec![0; input_shape.rank()];
+            for (slot, dim) in full.iter_mut().zip(input_shape.iter()) {
+                *slot = dim.to_usize()? as i64;
+            }
+            let konst = konst.cast_to::<i64>()?;
+            for (&axis, v) in axes.iter().zip(konst.try_as_plain()?.as_slice::<i64>()?) {
+                full[axis] = *v;
+            }
+            Ok(tract_ndarray::arr1(&full).into_arc_tensor())
+        } else {
+            let mut full = vec![1.0f32; input_shape.rank()];
+            let konst = konst.cast_to::<f32>()?;
+            for (&axis, v) in axes.iter().zip(konst.try_as_plain()?.as_slice::<f32>()?) {
+                full[axis] = *v;
+            }
+            Ok(tract_ndarray::arr1(&full).into_arc_tensor())
+        }
     }
 }
 
@@ -153,97 +368,34 @@ impl EvalOp for Resize {
 
     fn eval(&self, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_dt = inputs[0].datum_type();
-        let scales = self.optional_scales_input.and_then(|ix| inputs.get(ix));
-        let sizes = self.optional_sizes_input.and_then(|ix| inputs.get(ix));
-        let output_shape = self.compute_output_shape(
+        let rank = inputs[0].rank();
+        let tf_crop = self.coord_transformer == CoordTransform::TfCropAndResize;
+        let roi = if tf_crop {
+            self.roi(rank, self.optional_roi_input.and_then(|ix| inputs.get(ix)).map(|t| &**t))?
+        } else {
+            tvec!((0.0, 1.0); rank)
+        };
+        let (scales, output_shape) = self.resolve(
             inputs[0].shape(),
-            scales.map(|t| &**t),
-            sizes.map(|t| &**t),
+            self.optional_scales_input.and_then(|ix| inputs.get(ix)).map(|t| &**t),
+            self.optional_sizes_input.and_then(|ix| inputs.get(ix)).map(|t| &**t),
         )?;
-        let scales: TVec<f32> = if let Some(scales) = scales.filter(|s| s.len() == inputs[0].rank())
-        {
-            scales.try_as_plain()?.as_slice::<f32>()?.into()
-        } else {
-            output_shape.iter().zip(inputs[0].shape()).map(|(o, i)| *o as f32 / *i as f32).collect()
-        };
         let input = inputs.remove(0).into_tensor();
-        let mut data = if input.datum_type() == f32::datum_type() {
-            input.into_plain_array::<f32>()?
-        } else {
-            input.cast_to::<f32>()?.into_owned().into_plain_array::<f32>()?
-        };
-        for (axis, scale) in scales.into_iter().enumerate().filter(|(_, s)| *s != 1.0) {
-            let mut new_shape: TVec<usize> = data.shape().into();
-            new_shape[axis] = output_shape[axis];
-            let input_len = data.shape()[axis];
-            data = match self.interpolator {
-                Interpolator::Cubic => {
-                    let a = self.cubic_coeff_a();
-                    let exclude = self.exclude_outside;
-                    tract_ndarray::ArrayD::from_shape_fn(&*new_shape, |co_o| -> f32 {
-                        let x_out = co_o[axis];
-                        let x_in = self.coord_transformer.transform(
-                            x_out,
-                            scale,
-                            input_len,
-                            new_shape[axis],
-                        );
-                        let x_floor = x_in.floor() as isize;
-                        let t = x_in - x_floor as f32;
-                        let mut co_i = co_o;
-                        let mut weights = [0.0f32; 4];
-                        let mut values = [0.0f32; 4];
-                        for (i, j) in (-1..=2isize).enumerate() {
-                            let raw_idx = x_floor + j;
-                            let w = cubic_kernel(t - j as f32, a);
-                            if exclude && (raw_idx < 0 || raw_idx >= input_len as isize) {
-                                weights[i] = 0.0;
-                            } else {
-                                weights[i] = w;
-                                let idx = raw_idx.clamp(0, input_len as isize - 1) as usize;
-                                co_i[axis] = idx;
-                                values[i] = data[&co_i];
-                            }
-                        }
-                        if exclude {
-                            let sum: f32 = weights.iter().sum();
-                            if sum != 0.0 {
-                                for w in &mut weights {
-                                    *w /= sum;
-                                }
-                            }
-                        }
-                        weights.iter().zip(values.iter()).map(|(w, v)| w * v).sum()
-                    })
-                }
-                _ => tract_ndarray::ArrayD::from_shape_fn(&*new_shape, |co_o| -> f32 {
-                    let x_out = co_o[axis];
-                    let x_in =
-                        self.coord_transformer.transform(x_out, scale, input_len, new_shape[axis]);
-                    let mut co_i = co_o;
-                    let x_floor = x_in.floor() as isize;
-                    let x_left = x_floor.clamp(0, input_len as isize - 1) as usize;
-                    co_i[axis] = x_left;
-                    let y_left = data[&co_i];
-                    let x_right = (x_floor + 1).clamp(0, input_len as isize - 1) as usize;
-                    co_i[axis] = x_right;
-                    let y_right = data[&co_i];
-                    let x_frac = x_in - x_floor as f32;
-                    match self.interpolator {
-                        Interpolator::Linear => y_left * (1.0 - x_frac) + y_right * x_frac,
-                        Interpolator::Nearest => {
-                            if self.nearest.prefers_right(x_frac) {
-                                y_right
-                            } else {
-                                y_left
-                            }
-                        }
-                        Interpolator::Cubic => unreachable!(),
-                    }
-                }),
+        let input = input.cast_to::<f32>()?;
+        let mut shape: TVec<usize> = input.shape().into();
+        let mut data: Vec<f32> = input.try_as_plain()?.as_slice::<f32>()?.to_vec();
+        for (axis, scale) in scales.into_iter().enumerate() {
+            let (len_in, len_out) = (shape[axis], output_shape[axis]);
+            if len_in == len_out && scale == 1.0 && !tf_crop {
+                continue;
             }
+            let plan = self.plan_axis(scale, len_in, len_out, roi[axis]);
+            let mut resampled = vec![0f32; data.len() / len_in * len_out];
+            resample_axis(&data, &shape, axis, &plan, self.extrapolation_value(), &mut resampled);
+            data = resampled;
+            shape[axis] = len_out;
         }
-        let out = data.into_tensor();
+        let out = tract_ndarray::ArrayD::from_shape_vec(&*shape, data)?.into_tensor();
         let out =
             if out.datum_type() == input_dt { out } else { out.cast_to_dt(input_dt)?.into_owned() };
         Ok(tvec!(out.into_tvalue()))
@@ -254,7 +406,6 @@ impl TypedOp for Resize {
     as_op!();
 
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
-        let _roi = self.optional_roi_input.and_then(|ix| inputs.get(ix));
         let scales = self.optional_scales_input.and_then(|ix| inputs.get(ix));
         let sizes = self.optional_sizes_input.and_then(|ix| inputs.get(ix));
         let output_shape = self.compute_output_shape(
@@ -270,29 +421,41 @@ impl TypedOp for Resize {
         model: &TypedModel,
         node: &TypedNode,
     ) -> TractResult<Option<TypedModelPatch>> {
+        let input_fact = model.outlet_fact(node.inputs[0])?;
+        let rank = input_fact.rank();
+        let axes = self.resized_axes(rank)?;
         if let Some(mut core_op) = self.as_core() {
-            let rank = model.outlet_fact(node.inputs[0])?.rank();
-            let is_active = |ix: usize| -> bool {
+            let konst = |ix: usize| -> Option<Arc<Tensor>> {
                 model
                     .outlet_fact(node.inputs[ix])
-                    .ok()
-                    .and_then(|f| f.konst.as_ref())
-                    .map(|k| k.len() == rank)
-                    .unwrap_or(false)
+                    .ok()?
+                    .konst
+                    .clone()
+                    .filter(|k| k.len() == axes.len())
             };
             let active = self
                 .optional_scales_input
-                .filter(|&ix| is_active(ix))
+                .filter(|&ix| konst(ix).is_some())
                 .map(|ix| (ix, false))
                 .or_else(|| {
-                    self.optional_sizes_input.filter(|&ix| is_active(ix)).map(|ix| (ix, true))
+                    self.optional_sizes_input.filter(|&ix| konst(ix).is_some()).map(|ix| (ix, true))
                 });
             if let Some((ix, use_sizes)) = active {
                 core_op.optional_scales_input = (!use_sizes).then_some(1);
                 core_op.optional_sizes_input = use_sizes.then_some(1);
                 let mut patch = TypedModelPatch::default();
                 let data = patch.tap_model(model, node.inputs[0])?;
-                let aux = patch.tap_model(model, node.inputs[ix])?;
+                let aux = if axes.len() == rank {
+                    patch.tap_model(model, node.inputs[ix])?
+                } else {
+                    let full = self.full_rank_aux(
+                        &input_fact.shape,
+                        &axes,
+                        &konst(ix).unwrap(),
+                        use_sizes,
+                    )?;
+                    patch.add_const(format!("{}.resize_aux", node.name), full)?
+                };
                 let wire = patch.wire_node(&node.name, core_op, &[data, aux])?;
                 patch.shunt_outside(model, node.id.into(), wire[0])?;
                 return Ok(Some(patch));
@@ -303,6 +466,7 @@ impl TypedOp for Resize {
         rule_if_some!(scales_input = self.optional_scales_input);
         let scales_fact = model.outlet_fact(node.inputs[scales_input])?;
         rule_if_some!(scales_tensor = &scales_fact.konst);
+        rule_if!(scales_tensor.len() == rank);
         let scales: Vec<f32> =
             scales_tensor.cast_to::<f32>()?.try_as_plain()?.as_slice::<f32>()?.to_vec();
         let int_scales: Vec<usize> = scales.iter().map(|&s| s.round() as usize).collect();
@@ -310,14 +474,17 @@ impl TypedOp for Resize {
             scales.iter().zip(&int_scales).all(|(&s, &i)| (s - i as f32).abs() <= 1e-5 && i != 0)
         );
         rule_if!(int_scales.iter().any(|&s| s != 1));
-        let input_shape = &model.outlet_fact(node.inputs[0])?.shape;
+        let CoordTransform::Plain(coord_transformer) = &self.coord_transformer else {
+            return Ok(None);
+        };
         for (axis, &scale) in int_scales.iter().enumerate().filter(|&(_, &s)| s > 1) {
-            let Some(len_in) = probe_length(&self.coord_transformer, &input_shape[axis]) else {
+            let Some(len_in) = probe_length(coord_transformer, &input_fact.shape[axis]) else {
                 return Ok(None);
             };
-            rule_if!(is_pixel_replication(&self.coord_transformer, len_in, scale, |frac| self
-                .nearest
-                .prefers_right(frac)));
+            rule_if!(is_pixel_replication(
+                &self.plan_axis(scale as f32, len_in, len_in * scale, (0.0, 1.0)),
+                scale
+            ));
         }
 
         lower_nearest_integer_upsample(model, node, &int_scales)
@@ -340,68 +507,102 @@ fn parameters() -> Vec<Parameter> {
     vec![
         TypeName::Scalar.tensor().named("input"),
         TypeName::Scalar.tensor().named("scales"),
+        TypeName::Scalar.tensor().named("roi").default(false),
         TypeName::String.named("coord_transformer").default("half_pixel"),
         TypeName::String.named("interpolator").default("nearest"),
         TypeName::String.named("nearest_mode").default("floor"),
         TypeName::Scalar.named("cubic_coeff_a").default(-0.75f32),
         TypeName::Logical.named("exclude_outside").default(false),
+        TypeName::Logical.named("antialias").default(false),
+        TypeName::Scalar.named("extrapolation_value").default(0.0f32),
     ]
 }
 
 fn dump(ast: &mut IntoAst, node: &TypedNode, op: &Resize) -> TractResult<Option<Arc<RValue>>> {
     let input = ast.mapping[&node.inputs[0]].clone();
-    let scales = if let Some(scales_ix) = op.optional_scales_input {
-        ast.mapping[&node.inputs[scales_ix]].clone()
-    } else if let Some(sizes_ix) = op.optional_sizes_input {
-        let input_shape = ast.model.outlet_fact(node.inputs[0])?.shape.to_tvec();
-        let sizes_fact = ast.model.outlet_fact(node.inputs[sizes_ix])?;
-        let sizes =
-            sizes_fact.konst.as_ref().context("sizes must be a constant for NNEF export")?;
-        let sizes = sizes.cast_to::<f32>()?;
-        let sizes = sizes.try_as_plain()?.as_slice::<f32>()?;
-        let scales: Vec<f32> = input_shape
-            .iter()
-            .zip(sizes.iter())
-            .map(|(i, s)| i.to_usize().map(|i| *s / i as f32).unwrap_or(1.0))
-            .collect();
-        let scales_tensor = tract_ndarray::arr1(&scales).into_arc_tensor();
-        ast.konst_variable(format!("{}.scales", node.name), &scales_tensor)?
+    let input_shape = ast.model.outlet_fact(node.inputs[0])?.shape.to_tvec();
+    let axes = op.resized_axes(input_shape.len())?;
+    let passthrough = op.optional_scales_input.filter(|&ix| {
+        axes.len() == input_shape.len()
+            && ast
+                .model
+                .outlet_fact(node.inputs[ix])
+                .map(|f| f.shape.volume() == axes.len().to_dim())
+                .unwrap_or(false)
+    });
+    let scales = if let Some(ix) = passthrough {
+        ast.mapping[&node.inputs[ix]].clone()
     } else {
-        bail!("Resize op has neither scales nor sizes input")
+        let output_shape = &node.outputs[0].fact.shape;
+        let mut scales = vec![1.0f32; input_shape.len()];
+        for &axis in &axes {
+            let (i, o) = (input_shape[axis].to_usize()?, output_shape[axis].to_usize()?);
+            scales[axis] = o as f32 / i as f32;
+        }
+        let scales = tract_ndarray::arr1(&scales).into_arc_tensor();
+        ast.konst_variable(format!("{}.scales", node.name), &scales)?
     };
-    Ok(Some(invocation(
-        "tract_onnx_resize",
-        &[input, scales],
-        &[
-            ("coord_transformer", string(op.coord_transformer.as_str())),
-            ("interpolator", string(op.interpolator.as_str())),
-            ("nearest_mode", string(op.nearest.as_str())),
-            ("cubic_coeff_a", numeric(op.cubic_coeff_a())),
-            ("exclude_outside", logical(op.exclude_outside)),
-        ],
-    )))
+    let mut args = vec![
+        ("coord_transformer", string(op.coord_transformer.as_str())),
+        ("interpolator", string(op.interpolator.as_str())),
+        ("nearest_mode", string(op.nearest.as_str())),
+        ("cubic_coeff_a", numeric(op.cubic_coeff_a())),
+        ("exclude_outside", logical(op.exclude_outside)),
+        ("antialias", logical(op.antialias)),
+        ("extrapolation_value", numeric(op.extrapolation_value())),
+    ];
+    if op.coord_transformer == CoordTransform::TfCropAndResize {
+        let ix = op.optional_roi_input.context("tf_crop_and_resize needs a roi input")?;
+        let roi = ast.model.outlet_fact(node.inputs[ix])?;
+        let roi = roi.konst.as_ref().context("roi must be a constant for NNEF export")?;
+        let roi = full_rank_roi(&axes, input_shape.len(), roi)?;
+        let roi = ast.konst_variable(format!("{}.roi", node.name), &roi)?;
+        args.push(("roi", (*roi).clone()));
+    }
+    Ok(Some(invocation("tract_onnx_resize", &[input, scales], &args)))
+}
+
+/// Spreads a per-`axes` ROI over the full rank, the layout the NNEF op expects.
+fn full_rank_roi(axes: &[usize], rank: usize, roi: &Tensor) -> TractResult<Arc<Tensor>> {
+    let roi = roi.cast_to::<f32>()?;
+    let roi = roi.try_as_plain()?.as_slice::<f32>()?;
+    let mut full = vec![0.0f32; rank];
+    full.extend(std::iter::repeat_n(1.0f32, rank));
+    for (i, &axis) in axes.iter().enumerate() {
+        full[axis] = roi[i];
+        full[rank + axis] = roi[i + axes.len()];
+    }
+    Ok(tract_ndarray::arr1(&full).into_arc_tensor())
 }
 
 fn load(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> TractResult<Value> {
     let input = invocation.named_arg_as(builder, "input")?;
     let scales = invocation.named_arg_as(builder, "scales")?;
+    let roi = invocation.optional_named_arg_as::<OutletId>(builder, "roi")?;
     let coord_transformer: String = invocation.named_arg_as(builder, "coord_transformer")?;
     let interpolator: String = invocation.named_arg_as(builder, "interpolator")?;
     let nearest_mode: String = invocation.named_arg_as(builder, "nearest_mode")?;
     let cubic_coeff_a: f32 = invocation.named_arg_as(builder, "cubic_coeff_a")?;
     let exclude_outside: bool = invocation.named_arg_as(builder, "exclude_outside")?;
+    let antialias: bool = invocation.named_arg_as(builder, "antialias")?;
+    let extrapolation_value: f32 = invocation.named_arg_as(builder, "extrapolation_value")?;
 
     let op = Resize {
         axes: None,
-        coord_transformer: CoordTransformer::parse(&coord_transformer)?,
+        coord_transformer: CoordTransform::parse(&coord_transformer)?,
         interpolator: Interpolator::parse(&interpolator)?,
         nearest: Nearest::parse(&nearest_mode)?,
+        antialias,
         cubic_coeff_a_bits: cubic_coeff_a.to_bits(),
         exclude_outside,
-        optional_roi_input: None,
+        extrapolation_value_bits: extrapolation_value.to_bits(),
+        keep_aspect_ratio_policy: AspectRatio::Stretch,
+        optional_roi_input: roi.map(|_| 2),
         optional_scales_input: Some(1),
         optional_sizes_input: None,
     };
 
-    builder.wire(op, &[input, scales])
+    let mut wires = tvec!(input, scales);
+    wires.extend(roi);
+    builder.wire(op, &wires)
 }

--- a/onnx/src/ops/resize.rs
+++ b/onnx/src/ops/resize.rs
@@ -1,9 +1,9 @@
 use crate::model::ParsingContext;
 use crate::pb::*;
 use tract_hir::internal::*;
-use tract_nnef::tract_core::ops::nn::resize::{CoordTransformer, Interpolator};
+use tract_nnef::tract_core::ops::nn::resize::Interpolator;
 use tract_nnef::tract_num_traits::Zero as _;
-use tract_onnx_opl::resize::{Nearest, Resize};
+use tract_onnx_opl::resize::{AspectRatio, CoordTransform, Nearest, Resize};
 
 pub fn resize(
     ctx: &ParsingContext,
@@ -21,45 +21,30 @@ pub fn resize(
 
 fn resize_10(node: &NodeProto) -> TractResult<Resize> {
     Ok(Resize {
-        axes: None,
         optional_roi_input: None,
         optional_scales_input: Some(1),
         optional_sizes_input: None,
-        coord_transformer: coord_transformer_from_node(node)?,
-        interpolator: interpolator_from_node(node)?,
-        nearest: nearest_from_node(node)?,
-        cubic_coeff_a_bits: cubic_coeff_a_from_node(node)?,
-        exclude_outside: exclude_outside_from_node(node)?,
+        ..common(node)?
     })
 }
 
 fn resize_11(node: &NodeProto) -> TractResult<Resize> {
     let mut options = crate::model::optional_inputs(node).skip(3);
     Ok(Resize {
-        axes: None,
         optional_roi_input: Some(1),
         optional_scales_input: Some(2),
         optional_sizes_input: options.next().unwrap(),
-        coord_transformer: coord_transformer_from_node(node)?,
-        interpolator: interpolator_from_node(node)?,
-        nearest: nearest_from_node(node)?,
-        cubic_coeff_a_bits: cubic_coeff_a_from_node(node)?,
-        exclude_outside: exclude_outside_from_node(node)?,
+        ..common(node)?
     })
 }
 
 fn resize_13(node: &NodeProto) -> TractResult<Resize> {
     let mut options = crate::model::optional_inputs(node).skip(1);
     Ok(Resize {
-        axes: None,
         optional_roi_input: options.next().unwrap(),
         optional_scales_input: options.next().unwrap(),
         optional_sizes_input: options.next().unwrap(),
-        coord_transformer: coord_transformer_from_node(node)?,
-        interpolator: interpolator_from_node(node)?,
-        nearest: nearest_from_node(node)?,
-        cubic_coeff_a_bits: cubic_coeff_a_from_node(node)?,
-        exclude_outside: exclude_outside_from_node(node)?,
+        ..common(node)?
     })
 }
 
@@ -67,19 +52,40 @@ fn resize_18(node: &NodeProto) -> TractResult<Resize> {
     let mut options = crate::model::optional_inputs(node).skip(1);
     Ok(Resize {
         axes: node.get_attr_opt_vec("axes")?,
+        antialias: node.get_attr_opt::<i64>("antialias")?.unwrap_or(0) != 0,
+        keep_aspect_ratio_policy: AspectRatio::parse(
+            node.get_attr_opt("keep_aspect_ratio_policy")?.unwrap_or("stretch"),
+        )?,
         optional_roi_input: options.next().unwrap(),
         optional_scales_input: options.next().unwrap(),
         optional_sizes_input: options.next().unwrap(),
+        ..common(node)?
+    })
+}
+
+/// The attributes every Resize opset shares. `axes`, `antialias` and
+/// `keep_aspect_ratio_policy` arrive with opset 18 and stay at their neutral
+/// value below it.
+fn common(node: &NodeProto) -> TractResult<Resize> {
+    let extrapolation_value: f32 = node.get_attr_opt("extrapolation_value")?.unwrap_or(0.0);
+    Ok(Resize {
+        axes: None,
+        antialias: false,
+        keep_aspect_ratio_policy: AspectRatio::Stretch,
         coord_transformer: coord_transformer_from_node(node)?,
         interpolator: interpolator_from_node(node)?,
         nearest: nearest_from_node(node)?,
         cubic_coeff_a_bits: cubic_coeff_a_from_node(node)?,
         exclude_outside: exclude_outside_from_node(node)?,
+        extrapolation_value_bits: extrapolation_value.to_bits(),
+        optional_roi_input: None,
+        optional_scales_input: None,
+        optional_sizes_input: None,
     })
 }
 
-fn coord_transformer_from_node(node: &NodeProto) -> TractResult<CoordTransformer> {
-    CoordTransformer::parse(
+fn coord_transformer_from_node(node: &NodeProto) -> TractResult<CoordTransform> {
+    CoordTransform::parse(
         node.get_attr_opt("coordinate_transformation_mode")?.unwrap_or("half_pixel"),
     )
 }
@@ -130,7 +136,7 @@ impl Expansion for ResizeInference {
         } else if op.optional_sizes_input.is_some() {
             rules_with_sizes(op, s, inputs, outputs)
         } else {
-            todo!()
+            bail!("Resize with neither scales nor sizes")
         }
     }
 
@@ -154,7 +160,9 @@ fn rules_with_scales<'r, 'p: 'r, 's: 'r>(
     let scales = &inputs[scales_input];
     s.equals(&scales.datum_type, f32::datum_type())?;
     s.equals(&scales.rank, 1)?;
-    s.equals(&scales.shape[0], inputs[0].rank.bex().to_dim())?;
+    s.given(&inputs[0].rank, move |s, rank| {
+        s.equals(&scales.shape[0], op.resized_axes(rank as usize)?.len().to_dim())
+    })?;
     s.given_2(&inputs[0].shape, &inputs[scales_input].value, move |s, input_shape, scales| {
         let output_size = op.compute_output_shape(&input_shape, Some(scales.as_ref()), None)?;
         let rank = input_shape.len();
@@ -173,10 +181,13 @@ fn rules_with_sizes<'r, 'p: 'r, 's: 'r>(
 ) -> InferenceResult {
     let sizes = &inputs[op.optional_sizes_input.unwrap()];
     s.equals(&sizes.rank, 1)?;
-    s.equals(&sizes.shape[0], inputs[0].rank.bex().to_dim())?;
     s.given(&inputs[0].rank, move |s, rank| {
-        for i in 0..(rank as usize) {
-            s.equals(&outputs[0].shape[i], sizes.value[i].bex().to_dim())?;
+        s.equals(&sizes.shape[0], op.resized_axes(rank as usize)?.len().to_dim())
+    })?;
+    s.given_2(&inputs[0].shape, &sizes.value, move |s, input_shape, sizes| {
+        let output_size = op.compute_output_shape(&input_shape, None, Some(sizes.as_ref()))?;
+        for (i, dim) in output_size.iter().enumerate() {
+            s.equals(&outputs[0].shape[i], dim.to_dim())?;
         }
         Ok(())
     })

--- a/test-rt/suite-onnx/node.txt
+++ b/test-rt/suite-onnx/node.txt
@@ -488,19 +488,7 @@ test_reshape_reordered_dims                                                     
 test_reshape_reordered_last_dims input:data
 test_reshape_zero_and_negative_dim input:data
 test_reshape_zero_dim input:data
-test_resize_downsample_scales_cubic                                                 input:X
-test_resize_downsample_scales_cubic_align_corners                                   input:X
-test_resize_downsample_scales_cubic_A_n0p5_exclude_outside                          input:X
-test_resize_downsample_scales_linear                                                input:X
-test_resize_downsample_sizes_cubic                                                  input:X
-test_resize_downsample_sizes_linear_pytorch_half_pixel                              input:X
-test_resize_upsample_scales_cubic                                                   input:X
-test_resize_upsample_scales_cubic_align_corners                                     input:X
-test_resize_upsample_scales_cubic_asymmetric                                        input:X
-test_resize_upsample_scales_cubic_A_n0p5_exclude_outside                            input:X
-test_resize_upsample_scales_linear_align_corners                                    input:X not-nnef
-test_resize_upsample_sizes_cubic                                                    input:X
-test_resize_upsample_sizes_nearest_ceil_half_pixel                                  input:X
+test_resize.*                                                                       input:X
 test_rnn_seq_length
 test_round
 test_scan9_sum


### PR DESCRIPTION
Implements the ONNX Resize attributes tract was missing — `antialias`, `axes`, `keep_aspect_ratio_policy`, `half_pixel_symmetric`, `tf_crop_and_resize` + `roi`/`extrapolation_value` — and replaces the per-element evaluator with a precomputed per-axis tap/weight plan, which is 2.7× faster on the op and 1.45× end-to-end on a Resize-heavy model.

**Stacked on #2554** — its commit is the first of the two here, so please merge that one first; this PR's own diff is the second commit.

### Conformance

Enabling the whole ONNX Resize node set gives the before/after (each counted across both opset checkouts and both runtimes):

| | before | after |
|---|---|---|
| Resize node tests | 84 passed / **64 failed** | **148 passed / 0 failed** |

The 18 distinct failures fell into five groups, and the failure modes were not equally visible:

- `antialias` — parsed nowhere, so it was **silently dropped**: downsampling models got aliased output with no error.
- `keep_aspect_ratio_policy` — same, not parsed at all.
- `axes` — parsed into a field nothing read, then failed shape inference.
- `half_pixel_symmetric` (opset 19) — rejected at parse.
- `tf_crop_and_resize` / `roi` / `extrapolation_value` — rejected at parse.

Semantics were taken from the ONNX reference implementation (`onnx/reference/ops/op_resize.py`), including the `ratio = 1` convention at integer source coordinates, edge-padded neighbour selection, `exclude_outside` renormalisation, and the antialias footprint widening to `1/scale`.

### Evaluator

`eval` used `ArrayD::from_shape_fn` with a dynamic-rank index per output element, recomputing the coordinate transform (and a division) per pixel. It now builds one `AxisPlan` per axis — clamped tap indices plus weights — and resamples over contiguous inner runs, which is also what makes the widened antialias windows affordable. Both the core and the ONNX op share the plan builder; each keeps its own kernel and tie-break set, so the core/ONNX split is unchanged.

`axes` is spread to full rank at declutter time when the aux input is constant, so the core op still takes over those nodes.

### Numbers

u2netp (rembg, 38 bilinear Resize nodes), 1×3×320×320, release, interleaved A/B, min of 5 rounds:

| | Resize op | whole network |
|---|---|---|
| main | 302.4 ms | 605.4 ms |
| this branch | 107.6 ms | **419.1 ms** |
| | **2.7×** | **1.45×** |

All seven model outputs are bit-identical to main (max abs diff 0.0), so this is overhead removal, not a numerics change. Resize was 49% of optimised runtime on this model before, 26% after.

### Testing

`onnx-tests.sh` on `1_13_0` and `1_19_1`, `test-unit-core`, `test-f16`, `test-metal`, and the crate unit tests all green. `cargo fmt --all` and `cargo clippy --workspace` clean. Note that `cargo check --all-targets` fails on aarch64 for an unrelated pre-existing reason (`linalg/benches/avx512_zombies.rs` is x86-only).

🍍