### PR TITLE
cli: add /ci bench-mt-ladder thread-scaling run

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,6 +15,11 @@ on:
         description: "Optional PR number to bench (from fork ok). Leave empty to run on selected branch."
         required: false
         type: number
+      mt_ladder:
+        description: "Thread-count ladder (comma list, 0=physical cores) for a scaling run; empty = normal vs-main bench."
+        required: false
+        type: string
+        default: ''
   pull_request:
     paths-ignore:
       - '**/*.md'
@@ -38,6 +43,7 @@ jobs:
       pr_number: ${{ steps.gate.outputs.pr_number }}
       is_pr: ${{ steps.gate.outputs.is_pr }}
       same_repo: ${{ steps.gate.outputs.same_repo }}
+      mt_ladder: ${{ steps.gate.outputs.mt_ladder }}
     steps:
       # Resolves this run's target ref and whether it should behave like a PR run
       # (compare + comment) or a reference run (append to bench-data): a manual
@@ -57,6 +63,9 @@ jobs:
               core.setOutput('enabled', 'true');
             }
             core.setOutput('day', new Date().toISOString().slice(0, 10));
+            // Set on any event; a pull_request trigger has no inputs, so it stays empty
+            // (normal vs-main bench). Only a workflow_dispatch can request a scaling run.
+            core.setOutput('mt_ladder', context.payload.inputs?.mt_ladder || '');
 
             const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
             if (context.eventName === 'pull_request') {
@@ -177,6 +186,7 @@ jobs:
         env:
           TRIPLE: ${{ matrix.triple }}
           DEVICE: ${{ matrix.target }}
+          MT_LADDER: ${{ needs.prepare.outputs.mt_ladder }}
         run: |
           chmod +x tract-cli/tract
           tract-cli/tract bench-suite \
@@ -184,6 +194,7 @@ jobs:
             --bench-data bench-ref \
             --thresholds .travis/bench-thresholds.toml \
             --triple "$TRIPLE" --device "$DEVICE" \
+            ${MT_LADDER:+--threads-ladder "$MT_LADDER"} \
             ${{ needs.prepare.outputs.is_pr != 'true' && '--samples 5' || '' }} \
             ${{ matrix.bench_args }}        # produces ./metrics
 
@@ -320,6 +331,7 @@ jobs:
           DEVICE: ${{ matrix.device }}
           TRIPLE: ${{ matrix.triple }}
           SAMPLES: ${{ needs.prepare.outputs.is_pr != 'true' && '--samples 5' || '' }}
+          MT_LADDER: ${{ needs.prepare.outputs.mt_ladder }}
         run: |
           chmod +x tract-cli/tract
           mkdir -p result
@@ -334,6 +346,7 @@ jobs:
           if CARGO_PKG_NAME=tract cargo-dinghy --cleanup -d "$DINGHY_TARGET" runner \
                ./tract-cli/tract -- bench-suite \
                --manifest .travis/benches.toml --skip-runtimes --no-cache --output - $SAMPLES \
+               ${MT_LADDER:+--threads-ladder "$MT_LADDER"} \
                --base-url '${TRACT_BENCH_BASE_URL}' --cpu-governor '${TRACT_BENCH_CPU_GOVERNOR}' \
                >captured.out 2>captured.err
           then
@@ -443,14 +456,21 @@ jobs:
           path: bench-data
           fetch-depth: 1
           persist-credentials: false
+      # An mt-ladder run renders a self-contained thread-scaling table (speed + speedup
+      # vs serial, no bench-data reference); a normal run renders the vs-main comparison.
       - name: Render comparison
         env:
           PR_SHA: ${{ needs.prepare.outputs.ref }}
+          MT_LADDER: ${{ needs.prepare.outputs.mt_ladder }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           chmod +x tract-cli/tract
-          tract-cli/tract bench-report --results results --bench-data bench-data \
-            --thresholds .travis/bench-thresholds.toml --pr-sha "$PR_SHA" --out pr-comment.md
+          if [ -n "$MT_LADDER" ]; then
+            tract-cli/tract bench-mt-report --results results --pr-sha "$PR_SHA" --out pr-comment.md
+          else
+            tract-cli/tract bench-report --results results --bench-data bench-data \
+              --thresholds .travis/bench-thresholds.toml --pr-sha "$PR_SHA" --out pr-comment.md
+          fi
       # Only an automatic `pull_request` event on a fork gets a read-only token; every other
       # trigger (same-repo pull_request, or any workflow_dispatch — including /ci bench,
       # which always runs with a write token regardless of the target PR's fork status) can

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -12,6 +12,7 @@ name: CI slash command
 #   /ci ex             -> alias of examples
 #   /ci bench          -> Bench                    (bench.yml)
 #   /ci benches        -> alias of bench
+#   /ci bench-mt-ladder [ladder] -> thread-scaling run (bench.yml); ladder defaults to 2,4,0
 # Only commenters with write access can trigger (enforced by slash-command-dispatch).
 
 on:
@@ -62,13 +63,14 @@ jobs:
               'ex': 'examples.yml',
               'bench': 'bench.yml',
               'benches': 'bench.yml',
+              'bench-mt-ladder': 'bench.yml',
             };
             const workflow = map[target];
             if (!workflow) {
               const usage = [
                 `Unknown \`/ci\` target: \`${target || '(none)'}\`.`,
                 '',
-                'Usage: `/ci full`, `/ci large-models` (aliases: `large`, `llm`), `/ci wheels` (aliases: `python`, `py`), `/ci examples` (alias: `ex`), or `/ci bench` (alias: `benches`).',
+                'Usage: `/ci full`, `/ci large-models` (aliases: `large`, `llm`), `/ci wheels` (aliases: `python`, `py`), `/ci examples` (alias: `ex`), `/ci bench` (alias: `benches`), or `/ci bench-mt-ladder [ladder]` (default ladder `2,4,0`).',
               ].join('\n');
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -79,11 +81,17 @@ jobs:
               core.setFailed(usage);
               return;
             }
+            const inputs = { pr_number: String(pr) };
+            // `/ci bench-mt-ladder [ladder]`: pass the optional ladder (default 2,4,0) so
+            // bench.yml runs the thread scaling sweep + scaling report instead of vs-main.
+            if (target === 'bench-mt-ladder') {
+              inputs.mt_ladder = cp.slash_command.args.unnamed.arg2 || '2,4,0';
+            }
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: workflow,
               ref: context.payload.repository.default_branch,
-              inputs: { pr_number: String(pr) },
+              inputs,
             });
             core.info(`Dispatched ${workflow} for PR #${pr}`);

--- a/cli/src/bench_report.rs
+++ b/cli/src/bench_report.rs
@@ -146,6 +146,35 @@ fn describe(metric: &str) -> (String, String, String, &'static str) {
     }
 }
 
+/// Split a bench variant into its base config and thread-rung code: `_mt` → 0
+/// (physical cores), `_t{n}` → n, no suffix → 1 (the always-kept serial base).
+fn split_rung(variant: &str) -> (String, usize) {
+    if let Some(base) = variant.strip_suffix("_mt") {
+        (base.to_string(), 0)
+    } else if let Some(pos) = variant.rfind("_t") {
+        if let Ok(n) = variant[pos + 2..].parse::<usize>() {
+            return (variant[..pos].to_string(), n);
+        }
+        (variant.to_string(), 1)
+    } else {
+        (variant.to_string(), 1)
+    }
+}
+
+/// Column sort key: serial (1) and `t{n}` in ascending thread count, `_mt` (0 =
+/// all physical cores) always last.
+fn col_order(code: usize) -> usize {
+    if code == 0 { usize::MAX } else { code }
+}
+
+fn col_header(code: usize) -> String {
+    match code {
+        0 => "all cores".to_string(),
+        1 => "serial".to_string(),
+        n => format!("t{n}"),
+    }
+}
+
 /// Format like C `printf %g` with `p` significant figures (trailing zeros stripped).
 fn fmt_g(x: f64, p: usize) -> String {
     if x == 0.0 {
@@ -589,9 +618,109 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
     Ok(())
 }
 
+/// `tract bench-mt-report`: render the thread-scaling table for an mt-ladder run.
+/// Self-contained (no bench-data reference): for each device and each thread-tagged
+/// bench, list evaltime and speedup vs the serial base across the ladder's thread
+/// counts. Writes nothing when no rungs ran, so an empty run posts no vacuous comment.
+pub fn handle_mt(matches: &clap::ArgMatches) -> TractResult<()> {
+    let get = |k| matches.get_one::<String>(k).map(String::as_str);
+    let results = get("results").context("--results is required")?;
+    let out = get("out").context("--out is required")?;
+    let pr_sha = get("pr-sha").context("--pr-sha is required")?;
+    let run_url = std::env::var("RUN_URL").unwrap_or_else(|_| "#".to_string());
+
+    let mut result_dirs: Vec<std::path::PathBuf> = std::fs::read_dir(results)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.join("meta.json").exists())
+        .collect();
+    result_dirs.sort();
+
+    let mut sections = String::new();
+    for dir in &result_dirs {
+        let meta: Meta = serde_json::from_str(&std::fs::read_to_string(dir.join("meta.json"))?)?;
+        let pr = read_metrics(dir.join("metrics").to_str().unwrap_or_default());
+        // bench label -> (thread-rung code -> evaltime seconds)
+        let mut groups: BTreeMap<String, BTreeMap<usize, f64>> = BTreeMap::new();
+        for (metric, val) in &pr {
+            let p: Vec<&str> = metric.split('.').collect();
+            if p.first() != Some(&"net") || p.get(2) != Some(&"evaltime") {
+                continue;
+            }
+            let (model, _, variant, _) = describe(metric);
+            let (base, code) = split_rung(&variant);
+            groups.entry(format!("{model} · {base}")).or_default().insert(code, *val);
+        }
+        // A bench with no rung (not thread-tagged) has only the serial base; drop it.
+        groups.retain(|_, m| m.keys().any(|&c| c != 1));
+        if groups.is_empty() {
+            continue;
+        }
+        let mut cols: Vec<usize> = groups.values().flat_map(|m| m.keys().copied()).collect();
+        cols.sort_by_key(|&c| col_order(c));
+        cols.dedup();
+
+        sections.push_str(&format!("### `{}`\n\n| bench |", meta.device));
+        for &c in &cols {
+            sections.push_str(&format!(" {} |", col_header(c)));
+        }
+        sections.push_str("\n|---|");
+        for _ in &cols {
+            sections.push_str("---|");
+        }
+        sections.push('\n');
+        for (label, times) in &groups {
+            sections.push_str(&format!("| {label} |"));
+            let base = times.get(&1).copied();
+            for &c in &cols {
+                let cell = match times.get(&c) {
+                    None => "–".to_string(),
+                    Some(&t) if c == 1 => fmt_val(t, "s"),
+                    Some(&t) => match base {
+                        Some(b) if b > 0.0 && t > 0.0 => {
+                            format!("{}<br><sub>{:.2}×</sub>", fmt_val(t, "s"), b / t)
+                        }
+                        _ => fmt_val(t, "s"),
+                    },
+                };
+                sections.push_str(&format!(" {cell} |"));
+            }
+            sections.push('\n');
+        }
+        sections.push('\n');
+    }
+
+    if sections.is_empty() {
+        println!("no thread-scaling metrics; not writing a comment");
+        return Ok(());
+    }
+
+    let sha = &pr_sha[..pr_sha.len().min(9)];
+    let body = format!(
+        "<!-- bench-mt-ladder -->\n🧵 **Thread scaling — mt-ladder** · PR `{sha}`\n\n\
+         _evaltime per thread count; speedup vs serial · [run]({run_url})_\n\n{sections}"
+    );
+    std::fs::write(out, tidy(&body))?;
+    println!("wrote mt-ladder scaling table");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rung_split_and_column_order() {
+        assert_eq!(split_rung("400ms"), ("400ms".to_string(), 1));
+        assert_eq!(split_rung("400ms_t2"), ("400ms".to_string(), 2));
+        assert_eq!(split_rung("2sec_mt"), ("2sec".to_string(), 0));
+        // serial first, threads ascending, all-cores (0) last.
+        let mut cols = vec![0usize, 4, 1, 2];
+        cols.sort_by_key(|&c| col_order(c));
+        assert_eq!(cols, vec![1, 2, 4, 0]);
+        assert_eq!(col_header(1), "serial");
+        assert_eq!(col_header(4), "t4");
+        assert_eq!(col_header(0), "all cores");
+    }
 
     fn row(device: &str, metric: &str, refv: f64, prv: f64, worse: bool, mover: bool) -> Row {
         Row {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -289,6 +289,13 @@ fn main() -> TractResult<()> {
                 .arg(arg!(--templates [DIR] "Template dir (default: .travis)"))
                 .arg(arg!(--today [DATE] "Override today's date YYYY-MM-DD (for reproducible output)")),
         );
+        app = app.subcommand(
+            clap::Command::new("bench-mt-report")
+                .long_about("Render the thread-scaling (mt-ladder) table; no bench-data reference.")
+                .arg(arg!(--results <DIR> "Dir of per-device result subdirs (meta.json + metrics)"))
+                .arg(arg!(--"pr-sha" <SHA> "PR commit sha"))
+                .arg(arg!(--out <PATH> "PR comment markdown output path")),
+        );
     }
 
     app = app.subcommand(dump_subcommand());
@@ -820,6 +827,8 @@ fn handle(matches: clap::ArgMatches, probe: Option<&Probe>) -> TractResult<()> {
         Some(("bench-diff", m)) => return bench_suite::diff(m),
         #[cfg(feature = "bench-suite")]
         Some(("bench-report", m)) => return bench_report::handle(m),
+        #[cfg(feature = "bench-suite")]
+        Some(("bench-mt-report", m)) => return bench_report::handle_mt(m),
         Some(("kernels", _)) => {
             println!();
             fn colored_name(m: &dyn MatMatMul) -> String {


### PR DESCRIPTION
Dispatch bench.yml with --threads-ladder from a /ci bench-mt-ladder [ladder] comment (default 2,4,0) and render a self-contained bench-mt-report table (evaltime + speedup vs the serial base per thread count) instead of the vs-main comparison.