### PR TITLE
linalg: give hwbench a bandwidth probe on architectures without a hand-written one

### DIFF
--- a/linalg/src/hwbench/bandwidth.rs
+++ b/linalg/src/hwbench/bandwidth.rs
@@ -102,6 +102,25 @@ fn load_a_slice(slice: &[u8], loops: usize) {
     }
 }
 
+/// Streams the slice with volatile word loads, for targets with no hand-written
+/// loop above. Volatile is what stops the reads being optimised away, and it
+/// also blocks the vectorisation the intrinsic paths get by hand, so this
+/// reports a lower figure than they would on comparable hardware.
+#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "arm")))]
+#[inline(never)]
+fn load_a_slice(slice: &[u8], loops: usize) {
+    type Chunk = [usize; 8];
+    let chunks = slice.len() / std::mem::size_of::<Chunk>();
+    unsafe {
+        let base = slice.as_ptr() as *const Chunk;
+        for _ in 0..loops {
+            for i in 0..chunks {
+                std::ptr::read_volatile(base.add(i));
+            }
+        }
+    }
+}
+
 fn bandwidth_seq(slice_len: usize, threads: usize) -> f64 {
     #[cfg(target_arch = "x86_64")]
     unsafe {


### PR DESCRIPTION
Fixes #2561. `load_a_slice` in `hwbench/bandwidth.rs` had definitions for x86_64, aarch64 and arm and no fallback, so `tract-linalg` with the `hwbench` feature — which `cli/Cargo.toml` always enables — did not compile on any other target.

This adds a portable volatile-load definition for the remaining architectures. The three existing paths are untouched, so nothing changes on x86_64, aarch64 or arm.

## Verified

| | before | after |
|---|---|---|
| `cargo check -p tract-linalg --features hwbench --target wasm32-wasip1` | E0425 | clean |
| `cargo check -p tract-linalg --features hwbench --target riscv64gc-unknown-linux-gnu` | E0425 | clean |
| `cargo test -p tract-linalg --features hwbench --lib` (aarch64) | 4407 pass | 4407 pass |
| `cargo clippy -p tract-linalg --features hwbench` | clean | clean |

## One thing worth your call

The fallback reads about 2x low. Forcing it on an M1 Pro in place of the `ld1` path measures 68 GiB/s at L1 where the real path gives 137 GiB/s — a plain `usize`-at-a-time volatile loop managed only 20 GiB/s, hence the 64-byte chunk. `read_volatile` is what keeps the loads from being optimised away, and it also blocks the vectorisation the asm paths get by hand.

So `tract hwbench` on those targets would print a number in the same field as a native measurement, but not comparable to one. I have left it as a doc comment on the function; if you would rather the subcommand flag it, or not report bandwidth at all where there is no hand-written loop, say which and I will change it.

Note this does not on its own make `tract-cli` build for wasm32 — `reqwest` → `rustls` → `ring` does not support the target either, which looks deliberate given the CLI fetches models over HTTP. `bandwidth_seq` also uses `std::thread::scope`, so `tract hwbench` would still fail at spawn on wasip1. Only the build is addressed here.

🍍
