### PR TITLE
gelu: dispatch f16 through linalg and back it with a lookup table

### DIFF
--- a/core/src/ops/nn/gelu_approximate.rs
+++ b/core/src/ops/nn/gelu_approximate.rs
@@ -12,11 +12,15 @@ fn gelu_approx_f32(x: f32, pow: i32) -> f32 {
 
 element_wise!(gelu_approximate, GeluApproximate { fast_impl: bool },
     [f16] => |op, xs| {
-        let pow = if op.fast_impl { 2 } else { 3 };
-        xs.iter_mut().for_each(|x| {
-            *x = f16::from_f32(gelu_approx_f32(x.to_f32(), pow));
-        });
-        Ok(())
+        if op.fast_impl {
+            // pow=2 fast path: no linalg kernel yet, scalar fallback.
+            xs.iter_mut().for_each(|x| {
+                *x = f16::from_f32(gelu_approx_f32(x.to_f32(), 2));
+            });
+            Ok(())
+        } else {
+            (tract_linalg::ops().gelu_f16)().run(xs)
+        }
     },
     [f32] => |op, xs| {
         if op.fast_impl {

--- a/linalg/benches/gelu.rs
+++ b/linalg/benches/gelu.rs
@@ -26,6 +26,24 @@ fn gelu_f32(c: &mut Criterion) {
     });
 }
 
+fn gelu_f16(c: &mut Criterion) {
+    for n in [1024usize, 65536, 1 << 20] {
+        let mut group = c.benchmark_group(format!("gelu_f16/{n}"));
+        group.throughput(Throughput::Elements(n as u64));
+        let mut input = unsafe { Tensor::uninitialized_aligned::<f16>(&[n], 16).unwrap() };
+        let input = unsafe { input.as_slice_mut_unchecked::<f16>() };
+        for (i, x) in input.iter_mut().enumerate() {
+            *x = f16::from_f32((i as f32 / 10.0).sin() * 5.0);
+        }
+        group.bench_function("generic", |b| {
+            b.iter(|| tract_linalg::generic::HGelu8::run(input, ()))
+        });
+        group
+            .bench_function("lut", |b| b.iter(|| tract_linalg::generic::HGeluLut8::run(input, ())));
+        group.finish();
+    }
+}
+
 #[inline(never)]
 fn rust_scalar(input: &mut [f32]) {
     // Match tract's GeluApproximate scalar formula (pow=3).
@@ -43,5 +61,5 @@ fn linalg(input: &mut [f32]) {
     (tract_linalg::ops().gelu_f32)().run(input).unwrap();
 }
 
-criterion_group!(benches, gelu_f32);
+criterion_group!(benches, gelu_f32, gelu_f16);
 criterion_main!(benches);

--- a/linalg/benches/gelu.rs
+++ b/linalg/benches/gelu.rs
@@ -23,6 +23,24 @@ fn gelu_f32(c: &mut Criterion) {
     });
 }
 
+fn gelu_f16(c: &mut Criterion) {
+    for n in [1024usize, 65536, 1 << 20] {
+        let mut group = c.benchmark_group(format!("gelu_f16/{n}"));
+        group.throughput(Throughput::Elements(n as u64));
+        let mut input = unsafe { Tensor::uninitialized_aligned::<f16>(&[n], 16).unwrap() };
+        let input = unsafe { input.as_slice_mut_unchecked::<f16>() };
+        for (i, x) in input.iter_mut().enumerate() {
+            *x = f16::from_f32((i as f32 / 10.0).sin() * 5.0);
+        }
+        group.bench_function("generic", |b| {
+            b.iter(|| tract_linalg::generic::HGelu8::run(input, ()))
+        });
+        group
+            .bench_function("lut", |b| b.iter(|| tract_linalg::generic::HGeluLut8::run(input, ())));
+        group.finish();
+    }
+}
+
 #[inline(never)]
 fn rust_scalar(input: &mut [f32]) {
     // Match tract's GeluApproximate scalar formula (pow=3).
@@ -40,5 +58,5 @@ fn linalg(input: &mut [f32]) {
     (tract_linalg::ops().gelu_f32)().run(input).unwrap();
 }
 
-criterion_group!(benches, gelu_f32);
+criterion_group!(benches, gelu_f32, gelu_f16);
 criterion_main!(benches);

--- a/linalg/benches/gelu.rs
+++ b/linalg/benches/gelu.rs
@@ -3,7 +3,6 @@
 use criterion::*;
 use tract_data::prelude::*;
 
-#[cfg(target_arch = "aarch64")]
 use tract_linalg::element_wise::ElementWiseKer;
 
 fn gelu_f32(c: &mut Criterion) {

--- a/linalg/src/generic.rs
+++ b/linalg/src/generic.rs
@@ -21,7 +21,7 @@ use crate::{BinOp, LinalgRegistry};
 
 pub use self::by_scalar::{HMulByScalar8, SMulByScalar4};
 pub use self::erf::SErf4;
-pub use self::gelu::{HGelu8, SGelu4};
+pub use self::gelu::{HGelu8, HGeluLut8, SGelu4};
 pub use self::hardswish::{HHardSwish8, SHardSwish4};
 pub use self::leaky_relu::{HLeakyRelu8, SLeakyRelu4};
 pub use self::lut::GenericLut8;

--- a/linalg/src/generic/gelu.rs
+++ b/linalg/src/generic/gelu.rs
@@ -13,6 +13,15 @@ use tract_data::internal::*;
 const SQRT_2_OVER_PI: f32 = 0.7978845608028654;
 const COEF: f32 = 0.044715;
 
+/// The scalar reference every GELU kernel in this module is defined against.
+/// `HGeluLut8`'s table is built from this function, so the table is bit-identical
+/// to `HGelu8` by construction rather than by approximation.
+#[inline]
+fn gelu(v: f32) -> f32 {
+    let inner = SQRT_2_OVER_PI * (v + COEF * v * v * v);
+    0.5 * v * (1.0 + inner.tanh())
+}
+
 #[derive(Clone, Debug)]
 pub struct SGelu4;
 
@@ -36,11 +45,7 @@ impl ElementWiseKer<f32> for SGelu4 {
     fn run(x: &mut [f32], _: ()) {
         debug_assert!(x.len() % Self::nr() == 0);
         debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
-        x.iter_mut().for_each(|px| {
-            let v = *px;
-            let inner = SQRT_2_OVER_PI * (v + COEF * v * v * v);
-            *px = 0.5 * v * (1.0 + inner.tanh());
-        });
+        x.iter_mut().for_each(|px| *px = gelu(*px));
     }
 }
 
@@ -67,11 +72,49 @@ impl ElementWiseKer<f16> for HGelu8 {
     fn run(x: &mut [f16], _: ()) {
         debug_assert!(x.len() % Self::nr() == 0);
         debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
-        x.iter_mut().for_each(|px| {
-            let v = px.to_f32();
-            let inner = SQRT_2_OVER_PI * (v + COEF * v * v * v);
-            *px = f16::from_f32(0.5 * v * (1.0 + inner.tanh()));
-        });
+        x.iter_mut().for_each(|px| *px = f16::from_f32(gelu(px.to_f32())));
+    }
+}
+
+/// Every f16 bit pattern mapped through `gelu`, so the whole activation is one
+/// load per element. 128 KiB, built on first use: a model with no f16 GELU never
+/// pays for it, and the build costs 65536 scalar evaluations.
+fn gelu_lut() -> &'static [u16; 1 << 16] {
+    static LUT: std::sync::OnceLock<Box<[u16; 1 << 16]>> = std::sync::OnceLock::new();
+    LUT.get_or_init(|| {
+        let mut lut = Box::new([0u16; 1 << 16]);
+        for (bits, slot) in lut.iter_mut().enumerate() {
+            *slot = f16::from_f32(gelu(f16::from_bits(bits as u16).to_f32())).to_bits();
+        }
+        lut
+    })
+}
+
+#[derive(Clone, Debug)]
+pub struct HGeluLut8;
+
+impl ElementWiseKer<f16> for HGeluLut8 {
+    fn name() -> &'static str {
+        "lut"
+    }
+
+    fn alignment_bytes() -> usize {
+        16
+    }
+
+    fn alignment_items() -> usize {
+        4
+    }
+
+    fn nr() -> usize {
+        8
+    }
+
+    fn run(x: &mut [f16], _: ()) {
+        debug_assert!(x.len() % Self::nr() == 0);
+        debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
+        let lut = gelu_lut();
+        x.iter_mut().for_each(|px| *px = f16::from_bits(lut[px.to_bits() as usize]));
     }
 }
 
@@ -85,4 +128,46 @@ pub mod s {
 #[macro_use]
 pub mod h {
     gelu_frame_tests!(true, tract_data::internal::f16, crate::generic::gelu::HGelu8);
+}
+
+#[cfg(test)]
+mod lut {
+    use super::*;
+
+    #[test]
+    fn lut_matches_scalar_kernel_on_every_f16() {
+        let all: Vec<f16> = (0..=u16::MAX).map(f16::from_bits).collect();
+        let mut reference = all.clone();
+        let mut lut = all;
+        HGelu8::ew().run(&mut reference).unwrap();
+        HGeluLut8::ew().run(&mut lut).unwrap();
+        let mismatch = reference
+            .iter()
+            .zip(&lut)
+            .position(|(a, b)| a.to_bits() != b.to_bits())
+            .map(|i| (f16::from_bits(i as u16), reference[i], lut[i]));
+        assert_eq!(mismatch, None);
+    }
+
+    fn ordered(x: f16) -> i32 {
+        let b = x.to_bits();
+        if b & 0x8000 != 0 { !b as i32 } else { (b | 0x8000) as i32 }
+    }
+
+    #[test]
+    fn registered_kernel_tracks_the_scalar_kernel_on_every_f16() {
+        let all: Vec<f16> = (0..=u16::MAX).map(f16::from_bits).collect();
+        let mut reference = all.clone();
+        let mut registered = all;
+        HGelu8::ew().run(&mut reference).unwrap();
+        (crate::ops().gelu_f16)().run(&mut registered).unwrap();
+        let worst = reference
+            .iter()
+            .zip(&registered)
+            .filter(|(a, b)| !(a.is_nan() && b.is_nan()))
+            .map(|(a, b)| (ordered(*a) - ordered(*b)).abs())
+            .max()
+            .unwrap();
+        assert!(worst <= 1, "registered gelu_f16 drifts {worst} ulp from the scalar kernel");
+    }
 }

--- a/linalg/src/lib.rs
+++ b/linalg/src/lib.rs
@@ -240,7 +240,7 @@ pub fn generic() -> Ops {
         hardswish_f32: Box::new(|| generic::SHardSwish4::ew()),
         silu_f16: Box::new(|| generic::HSiLU8::ew()),
         silu_f32: Box::new(|| generic::SSiLU4::ew()),
-        gelu_f16: Box::new(|| generic::HGelu8::ew()),
+        gelu_f16: Box::new(|| generic::HGeluLut8::ew()),
         gelu_f32: Box::new(|| generic::SGelu4::ew()),
         lut_u8: Box::new(|table: &[u8]| Box::new(lut::LutImpl::<generic::GenericLut8>::new(table))),
         max_f16: Box::new(|| generic::reduce::max::HMax8::red()),


### PR DESCRIPTION
`GeluApproximate`'s f16 arm ran an inline scalar loop instead of calling `ops().gelu_f16`, so the f16 GELU dispatch slot was dead on every architecture — x86 has had `x86_64_avx512_gelu_f16_16n` registered but unreachable. This routes the canonical pow=3 f16 path through the dispatcher and backs it with a 2^16-entry lookup table.

### Why a table, and why it is safe

Every f16 bit pattern is a valid index, so the whole activation becomes one load per element. The table is built from the same extracted `gelu()` scalar that `HGelu8` evaluates, so it is bit-identical to the kernel it replaces by construction rather than by approximation — `lut_matches_scalar_kernel_on_every_f16` checks that over all 65536 patterns.

It is built lazily behind a `OnceLock`: a model with no f16 GELU never allocates the 128 KiB.

A second test, `registered_kernel_tracks_the_scalar_kernel_on_every_f16`, holds whatever kernel is registered on the current arch to within 1 ULP of the scalar reference, so a per-arch override is checked on its own hardware rather than assumed.

### Numbers

Kernel, `cargo bench -p tract-linalg --bench gelu -- gelu_f16` (M-series):

| buffer | scalar | lut |
|---|---|---|
| 2 KiB | 332 Melem/s | 3.68 Gelem/s (11.1x) |
| 128 KiB | 329 Melem/s | 3.56 Gelem/s (10.8x) |
| 2 MiB | 329 Melem/s | 3.13 Gelem/s (9.5x) |

It does not fall off a cliff when the 128 KiB table stops fitting alongside the data, so I also measured a transformer FFN block (matmul -> gelu -> matmul, f16) through a real plan, where the GEMMs compete for cache:

| shape | scalar | lut |
|---|---|---|
| seq=128 d=768 ff=3072 | 3.12 ms | 1.95 ms (1.60x) |
| seq=384 d=1024 ff=4096 | 17.89 ms | 14.14 ms (1.25x) |

First run is faster too (5.09 ms -> 2.47 ms), so the one-time table build repays inside the first inference. That FFN-only graph overstates GELU's share of a whole network — treat it as an upper bound.

### Behaviour change, stated plainly

Two deltas, both from the rewire rather than the table:

- The old core scalar computed `(2.0 / f32::consts::PI).sqrt()` at runtime (`0x3f4c4229`); linalg uses the correctly-rounded literal (`0x3f4c422a`), 1 ULP apart. Across all 63488 finite f16 inputs this changes exactly one output, by one f16 ULP, and toward the true function.
- On x86 with AVX-512, `x86_64_avx512_gelu_f16_16n` now actually runs. It was already written and frame-tested, just never reached. I have no AVX-512 hardware, so the 1-ULP test above is what covers it — please look at that CI result specifically.

**I have not run the large_models RBO nightly.** Given #2318 was reverted for exactly this class of shift, that is the check I would want before this merges, and I could not run it here. Happy for it to sit until that is green.

### Tests

tract-linalg 4410, tract-core 269, test-f16 2378, test-unit-core 816, plus nnef / hir / onnx / onnx-opl / transformers / extra / pulse — all green. `cargo fmt --all` clean; `cargo clippy` clean for the touched crates (the 3 `--all-targets` failures are pre-existing x86-only benches that do not build on aarch64).

### Unrelated find

While benchmarking an alternative I measured `arm64simd_gelu_f32_4n_fused` returning `0.5 * x * 2^-23` instead of 0 for x below about -9 — its Pade tanh saturates one ULP short of -1, so `1 + tanh` never cancels and the error grows linearly with |x| (-5.96e-5 at x=-1000, -3.90e-3 at x=-65504). That is pre-existing and affects f32, so it is not in this PR; I will open a separate issue with the clamp fix.

🍍