### PR TITLE
deny: skip syn duplicate during the 2->3 transition

### DIFF
--- a/api/rs/deny.toml
+++ b/api/rs/deny.toml
@@ -42,6 +42,7 @@ skip = [
     { name = "rand_distr", version="<0.6" },
     { name = "itertools", version="<0.15" },
     { name = "windows-sys", version="<0.61" },
+    { name = "syn", version="<3" },
 ]
 
 [sources]


### PR DESCRIPTION
clap_derive 4.6.4 pulls syn 3 while the rest of the proc-macro tree is still on syn 2; allow the duplicate in api/rs like the other transitional skips until the ecosystem catches up.