### PR TITLE
rms_norm: stop copying the tensor twice on the f32 fast path

### DIFF
--- a/core/src/ops/nn/rms_norm.rs
+++ b/core/src/ops/nn/rms_norm.rs
@@ -41,7 +41,12 @@ impl EvalOp for RmsNorm {
             && self.axis == input.rank() - 1
         {
             let eps_f32: f32 = self.eps.cast_to_scalar::<f32>()?;
-            let mut buf = input.cast_to::<f32>()?.into_owned();
+            let already_f32 = in_dt == DatumType::F32;
+            let mut buf = if already_f32 {
+                input.into_tensor()
+            } else {
+                input.cast_to::<f32>()?.into_owned()
+            };
             let row_len = buf.shape()[self.axis];
             if row_len > 0 {
                 let data = unsafe { buf.as_slice_mut_unchecked::<f32>() };
@@ -53,6 +58,9 @@ impl EvalOp for RmsNorm {
                     }
                     Ok(())
                 })?;
+            }
+            if already_f32 {
+                return Ok(tvec![buf.into_tvalue()]);
             }
             return Ok(tvec![buf.cast_to_dt(in_dt)?.into_owned().into()]);
         }


### PR DESCRIPTION
`RmsNorm`'s fast path calls `cast_to::<f32>()` on the way in and `cast_to_dt()` on the way out. Both return `Cow::Borrowed` when the input is already f32, so each `into_owned()` clones the entire tensor — two full copies bracketing an op that is otherwise memory-bandwidth bound.

When the input is already f32 this takes it by value and returns it directly. The f16 path is untouched: there both conversions are real work, and the outbound `cast_to_dt` already yields `Cow::Owned`, so its `into_owned()` was never a copy.

### Effect

Same kernel, same traversal order, same eps handling — only the two copies go away, so output is bit-identical. `into_tensor()` clones when the value is shared, so this is never worse than what it replaces, and it is the idiom `element_wise` and `binary` already use for in-place evaluation.

f32 `RmsNorm` on the trailing axis, through a real plan, criterion against a saved baseline on this branch's merge-base:

| shape | change | 95% CI |
|---|---|---|
| 128x768 | -24.9% | -28.0% .. -22.1% |
| 512x4096 | -14.3% | -18.0% .. -8.8% |
| 2048x4096 | -19.8% | -22.8% .. -15.5% |

p = 0.00 on all three. Those understate the op-level effect: the harness clones the input tensor once per iteration in both arms, which dilutes the difference.

A caution if anyone re-measures this — hand-rolled `Instant` timing was useless here. Repeated runs of one unchanged binary spanned 2.00-3.01 ms on the 2048x4096 case, enough noise to show this change as a 14% regression on the first attempt. The numbers above are criterion with `--save-baseline` / `--baseline`.

### Tests

tract-core 269, test-f16 2378, test-unit-core 816, tract-transformers 40 — green. `cargo fmt --all` and `cargo clippy` clean.

🍍