### PR TITLE
rms_norm: stop copying the tensor twice on the f32 slow path

### DIFF
--- a/core/src/ops/nn/rms_norm.rs
+++ b/core/src/ops/nn/rms_norm.rs
@@ -58,7 +58,9 @@ impl EvalOp for RmsNorm {
         }
 
         // Slow path: original 4-call composition (kept for non-contiguous axes).
-        let input_f32 = input.cast_to::<f32>()?.into_owned();
+        let already_f32 = in_dt == DatumType::F32;
+        let input_f32 =
+            if already_f32 { input.into_tensor() } else { input.cast_to::<f32>()?.into_owned() };
         // eps inherits the input dtype from the declutter pattern (F16 when the
         // surrounding LayerNorm chain is F16). The MeanOfSquares + Add + Rsqrt
         // + Mul chain below all runs at F32, so eps must be cast to match —
@@ -70,6 +72,9 @@ impl EvalOp for RmsNorm {
         let mut a2 = Add.eval(a1.into_tvalue(), eps.into_tvalue(), DatumType::F32)?;
         Rsqrt {}.eval_in_place(&mut a2, None)?;
         let a3 = Mul.eval(a2.into_tvalue(), input_f32.into_tvalue(), DatumType::F32)?;
+        if already_f32 {
+            return Ok(tvec![a3.into_tvalue()]);
+        }
         Ok(tvec![a3.cast_to_dt(in_dt)?.into_owned().into()])
     }
 }


### PR DESCRIPTION
Same copy elision as #2576, on the other branch of `RmsNorm::eval`. The composition path used for a non-trailing axis calls `cast_to::<f32>()` on the input and `cast_to_dt()` on the result; both return `Cow::Borrowed` when the tensor is already f32, so each `into_owned()` cloned it in full.

Independent of #2576 — different region of the function, so the two apply in either order. The f16 path is untouched: both of its conversions are real work.

### Effect

Output is bit-identical: same reduce, same eps handling, same `Mul`, only the two copies removed. `into_tensor()` clones when the value is shared, so this is never worse than what it replaces.

f32 `RmsNorm` on a non-trailing axis, through a real plan, criterion against a saved baseline on the merge-base:

| shape | change | 95% CI |
|---|---|---|
| 8x512x1024 | -8.1% | -10.7% .. -5.3% |
| 32x1024x512 | -6.4% | -8.4% .. -3.2% |

p = 0.00 on both. Smaller than the fast path's -15..-25% because the composition itself allocates several intermediates, so the two saved copies are a smaller share of the total. The harness also clones the input once per iteration in both arms, which dilutes it further.

Worth noting for anyone re-measuring: hand-rolled `Instant` timing is not usable here — repeated runs of one unchanged binary spanned a 50% range on the larger shape. These are criterion with `--save-baseline` / `--baseline`.

If #2576 lands first there will be two separate `already_f32` bindings in the two scopes; happy to fold them into one in whichever merges second.

### Tests

tract-core 269, test-f16 2378, test-unit-core 816 — green. `cargo fmt --all` and `cargo clippy` clean.

🍍