### PR TITLE
gelu: fuse the erf-form chain into a single op

### DIFF
--- a/core/src/ops/math/mod.rs
+++ b/core/src/ops/math/mod.rs
@@ -702,8 +702,13 @@ element_wise!(erf, Erf,
      xs.iter_mut().zip(f32s.into_iter()).for_each(|(x, f)| *x = f16::from_f32(f));
      Ok(())
 };
- cost: |dt| {tvec!((Cost::FMA(dt), 11), (Cost::Div(dt), 1))}
+ cost: |dt| {tvec!((Cost::FMA(dt), 11), (Cost::Div(dt), 1))};
+ declutter: declutter_erf
 );
+
+fn declutter_erf(model: &TypedModel, node: &TypedNode) -> TractResult<Option<TypedModelPatch>> {
+    crate::ops::nn::gelu_exact::detect_gelu_exact(model, node)
+}
 
 element_wise!(acosh, Acosh, [f16, f32, f64] => |_, xs| {
     xs.iter_mut().for_each(|x| *x = x.acosh());

--- a/core/src/ops/nn/gelu_exact.rs
+++ b/core/src/ops/nn/gelu_exact.rs
@@ -1,0 +1,149 @@
+use crate::internal::*;
+use crate::ops::binary::TypedBinOp;
+use crate::ops::math::{Add, Mul};
+
+const CHUNK: usize = 1024;
+
+fn inv_sqrt2() -> f32 {
+    (2.0f32).sqrt().recip()
+}
+
+crate::element_wise!(gelu_exact, GeluExact,
+    [f16] => |_, xs| {
+        let erf = (tract_linalg::ops().erf_f32)();
+        let c = f16::from_f32(inv_sqrt2());
+        let half = f16::from_f32(0.5);
+        let one = f16::from_f32(1.0);
+        let mut scratch = vec![0f32; xs.len().min(CHUNK)];
+        for chunk in xs.chunks_mut(CHUNK) {
+            let scaled = &mut scratch[..chunk.len()];
+            scaled.iter_mut().zip(chunk.iter()).for_each(|(s, x)| *s = (*x * c).to_f32());
+            erf.run(scaled)?;
+            chunk.iter_mut().zip(scaled.iter()).for_each(|(x, e)| {
+                *x = (*x * half) * (f16::from_f32(*e) + one);
+            });
+        }
+        Ok(())
+    },
+    [f32] => |_, xs| {
+        let erf = (tract_linalg::ops().erf_f32)();
+        let c = inv_sqrt2();
+        let mut scratch = vec![0f32; xs.len().min(CHUNK)];
+        for chunk in xs.chunks_mut(CHUNK) {
+            let scaled = &mut scratch[..chunk.len()];
+            scaled.iter_mut().zip(chunk.iter()).for_each(|(s, x)| *s = *x * c);
+            erf.run(scaled)?;
+            chunk.iter_mut().zip(scaled.iter()).for_each(|(x, e)| *x = (*x * 0.5) * (*e + 1.0));
+        }
+        Ok(())
+    };
+    cost: |dt| {tvec!((Cost::FMA(dt), 14), (Cost::Div(dt), 1))}
+);
+
+/// Search pattern => GELU(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+///
+/// Anchored on the `Erf`, which the ONNX `Gelu` (without `approximate="tanh"`)
+/// and `BiasGelu` expansions both emit as the middle of a five node chain.
+pub fn detect_gelu_exact(
+    model: &TypedModel,
+    node: &TypedNode,
+) -> TractResult<Option<TypedModelPatch>> {
+    let erf_node = node;
+    let dt = model.node_input_facts(erf_node.id)?[0].datum_type;
+    rule_if!(matches!(dt, DatumType::F32 | DatumType::F16));
+
+    // x / sqrt(2)
+    let scale = &model.nodes()[erf_node.inputs[0].node];
+    rule_if_some!(scale_op = scale.op_as::<TypedBinOp>());
+    rule_if!(scale_op.0.is::<Mul>());
+    rule_if!(model.matches_single_input_const(scale, inv_sqrt2()));
+    rule_if_some!(
+        x = scale
+            .inputs
+            .iter()
+            .find(|o| model.outlet_fact(**o).map(|f| f.konst.is_none()).unwrap_or(false))
+            .copied()
+    );
+
+    // 1 + erf(x / sqrt(2))
+    rule_if_some!(one_plus_erf = model.find_succ_bin_with_const::<Add>(erf_node, 1.0));
+
+    // (0.5 * x) * (1 + erf(x / sqrt(2)))
+    rule_if_some!(out = model.single_succ(one_plus_erf.id)?);
+    rule_if_some!(out_op = out.op_as::<TypedBinOp>());
+    rule_if!(out_op.0.is::<Mul>());
+    rule_if_some!(
+        half_x = out
+            .inputs
+            .iter()
+            .filter_map(|i| {
+                let n = &model.nodes()[i.node];
+                n.op_as::<TypedBinOp>()?.0.is::<Mul>().then_some(n)
+            })
+            .next()
+    );
+    rule_if!(model.matches_single_input_const(half_x, 0.5));
+    rule_if!(half_x.inputs.contains(&x));
+
+    let mut patch = TypedModelPatch::default();
+    let tap = patch.taps(model, &[x])?;
+    let wired =
+        patch.wire_node(format!("{}.gelu_exact", erf_node.name), gelu_exact(), &[tap[0]])?;
+    patch.shunt_outside(model, out.id.into(), wired[0])?;
+    Ok(Some(patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::element_wise::ElementWiseOp;
+    use crate::ops::math::{Erf, add, erf, mul};
+
+    fn chain(dt: DatumType, len: usize) -> TractResult<TypedModel> {
+        let mut m = TypedModel::default();
+        let x = m.add_source("x", dt.fact([len]))?;
+        let c = m.add_const("c", tensor1(&[inv_sqrt2()]).cast_to_dt(dt)?.into_owned())?;
+        let scaled = m.wire_node("scale", mul(), &[x, c])?[0];
+        let e = m.wire_node("erf", erf(), &[scaled])?[0];
+        let one = m.add_const("one", tensor1(&[1f32]).cast_to_dt(dt)?.into_owned())?;
+        let ope = m.wire_node("add_one", add(), &[e, one])?[0];
+        let half = m.add_const("half", tensor1(&[0.5f32]).cast_to_dt(dt)?.into_owned())?;
+        let hx = m.wire_node("half_x", mul(), &[x, half])?[0];
+        let out = m.wire_node("out", mul(), &[hx, ope])?;
+        m.select_output_outlets(&out)?;
+        Ok(m)
+    }
+
+    fn is_mini<T: crate::ops::element_wise::ElementWiseMiniOp>(n: &TypedNode) -> bool {
+        n.op_as::<ElementWiseOp>().map(|e| e.0.is::<T>()).unwrap_or(false)
+    }
+
+    fn input(dt: DatumType, len: usize) -> TractResult<TValue> {
+        let values: Vec<f32> = (0..len).map(|i| (i as f32 * 0.37).sin() * 4.0).collect();
+        Ok(tensor1(&values).cast_to_dt(dt)?.into_owned().into_tvalue())
+    }
+
+    #[test]
+    fn fuses_the_chain_and_keeps_the_values() -> TractResult<()> {
+        for dt in [DatumType::F32, DatumType::F16] {
+            let len = 2050;
+            let raw = chain(dt, len)?;
+            let reference = raw.clone().into_runnable()?.run(tvec!(input(dt, len)?))?;
+
+            let fused = raw.into_decluttered()?;
+            assert!(
+                fused.nodes().iter().any(is_mini::<GeluExact>),
+                "{dt:?}: no GeluExact after declutter"
+            );
+            assert!(!fused.nodes().iter().any(is_mini::<Erf>), "{dt:?}: Erf survived");
+
+            let got = fused.into_runnable()?.run(tvec!(input(dt, len)?))?;
+            assert_eq!(
+                got[0].as_bytes(),
+                reference[0].as_bytes(),
+                "{dt:?}: fused output differs from the chain"
+            );
+        }
+        Ok(())
+    }
+}

--- a/core/src/ops/nn/mod.rs
+++ b/core/src/ops/nn/mod.rs
@@ -1,5 +1,6 @@
 mod data_formats;
 pub mod gelu_approximate;
+pub mod gelu_exact;
 pub mod grid_sample;
 mod reduce;
 pub mod resize;
@@ -9,6 +10,7 @@ mod softmax;
 
 pub use self::data_formats::{BaseDataShape, DataFormat, DataShape, SymDataShape};
 pub use self::gelu_approximate::GeluApproximate;
+pub use self::gelu_exact::GeluExact;
 pub use self::grid_sample::{GridSample, InterpolationMode, PaddingMode};
 pub use self::reduce::{Reduce, Reducer, expand_mean_of_squares};
 pub use self::resize::{CoordTransformer, Interpolator, Nearest, Resize};


### PR DESCRIPTION
ONNX `Gelu` without `approximate="tanh"`, and `BiasGelu`, expand to five unfused nodes — `Mul -> Erf -> Add -> Mul -> Mul`. The tensor makes five round trips through memory and four intermediates are allocated, for what is one element-wise function. This adds a `GeluExact` op and a declutter rule on `Erf` that collapses the chain onto it, mirroring `detect_gelu_approx`.

### Shape of it

The rule anchors on the `Erf` because that is the one node in the chain with no ambiguity, then walks out to the `Mul` by `1/sqrt(2)` feeding it, the `Add` of 1, the `Mul` by 0.5 sharing the same source outlet, and the final `Mul`.

The op evaluates the same operations in the same order over a bounded scratch, so it is bit-identical to the chain rather than a re-derivation — including f16, where each step still rounds to f16 exactly as the separate binary ops did. `fuses_the_chain_and_keeps_the_values` builds the chain, checks a `GeluExact` appears and the `Erf` is gone, and compares the output bytes against the undecluttered model, for f32 and f16.

### Numbers

Chain through an optimized plan, criterion against a saved baseline with the rule disabled:

| dtype | shape | before | after | |
|---|---|---|---|---|
| f32 | 128x3072 | 468 us | 321 us | -31.6% |
| f32 | 512x3072 | 1.912 ms | 1.292 ms | -32.3% |
| f16 | 128x3072 | 605 us | 544 us | -7.7% |
| f16 | 512x3072 | 2.521 ms | 2.175 ms | -13.7% |

p = 0.00 throughout. f16 gains less because the fused op still widens to f32 around the erf kernel; #2579 replaces that with a table lookup and the two should compound.

### Note

This is the payoff I was looking for after measuring that a hand-written NEON `erf` kernel is **not** worth writing: the generic `SErf4` is branch-free arithmetic with no libm call, so LLVM already auto-vectorises it to within 8% of a hand-written NEON kernel of comparable op count (594 ns vs 551 ns per 1024 elements, against 1739 ns for a genuinely scalar loop). The cost on this path was never the erf itself — it was the five memory round trips.

### Tests

tract-core 271, test-f16 2378, test-unit-core 816, tract-onnx 14 — green. `cargo fmt --all` clean; `cargo clippy` clean (the two remaining warnings are pre-existing on main, in `softmax/mod.rs` and `optim/propagate_roi.rs`).

🍍