### PR TITLE
gelu: saturate the fused f32 kernel's tanh to exactly -1

### DIFF
--- a/linalg/src/arm64/arm64simd/gelu_fused.rs
+++ b/linalg/src/arm64/arm64simd/gelu_fused.rs
@@ -55,6 +55,7 @@ ew_impl_wrap!(
             //   v6:    tanh clamp high (8.9, dup v0.s[1])
             //   v7:    0.5 (broadcast of v3.s[1])
             //   v8-v11: 0.5 * original x (saved after load)
+            //   v12-v15: low-clamp masks, then the corrected tanh
             //   v16-v19: working (load -> pre_tanh -> clamped -> numerator)
             //   v20-v23: x² for tanh polynomial
             //   v24-v27: polynomial intermediates (denominator at end)
@@ -110,6 +111,13 @@ ew_impl_wrap!(
                     fmin v17.4s, v17.4s, v6.4s
                     fmin v18.4s, v18.4s, v6.4s
                     fmin v19.4s, v19.4s, v6.4s
+
+                    // Lanes pinned to the low clamp: tanh is -1 there to f32
+                    // precision, and the polynomial lands one ulp short.
+                    fcmeq v12.4s, v16.4s, v5.4s
+                    fcmeq v13.4s, v17.4s, v5.4s
+                    fcmeq v14.4s, v18.4s, v5.4s
+                    fcmeq v15.4s, v19.4s, v5.4s
 
                     // Tanh Padé polynomial (cloned from arm64simd_tanh_f32_4n.S.j2)
                     fmul v20.4s, v16.4s, v16.4s
@@ -209,11 +217,17 @@ ew_impl_wrap!(
                     fdiv v18.4s, v18.4s, v26.4s
                     fdiv v19.4s, v19.4s, v27.4s
 
+                    fmov v20.4s, #-1.0
+                    bsl v12.16b, v20.16b, v16.16b
+                    bsl v13.16b, v20.16b, v17.16b
+                    bsl v14.16b, v20.16b, v18.16b
+                    bsl v15.16b, v20.16b, v19.16b
+
                     // result = 0.5*x * (1 + tanh) = (0.5*x) + (0.5*x) * tanh
-                    fmla v8.4s, v8.4s, v16.4s
-                    fmla v9.4s, v9.4s, v17.4s
-                    fmla v10.4s, v10.4s, v18.4s
-                    fmla v11.4s, v11.4s, v19.4s
+                    fmla v8.4s, v8.4s, v12.4s
+                    fmla v9.4s, v9.4s, v13.4s
+                    fmla v10.4s, v10.4s, v14.4s
+                    fmla v11.4s, v11.4s, v15.4s
 
                     st1 {{ v8.4s, v9.4s, v10.4s, v11.4s }}, [{ptr}], #64
                     sub {len}, {len}, #16
@@ -235,6 +249,7 @@ ew_impl_wrap!(
 
                     fmax v16.4s, v16.4s, v5.4s
                     fmin v16.4s, v16.4s, v6.4s
+                    fcmeq v12.4s, v16.4s, v5.4s
 
                     fmul v20.4s, v16.4s, v16.4s
 
@@ -261,7 +276,10 @@ ew_impl_wrap!(
 
                     fdiv v16.4s, v16.4s, v24.4s
 
-                    fmla v8.4s, v8.4s, v16.4s
+                    fmov v20.4s, #-1.0
+                    bsl v12.16b, v20.16b, v16.16b
+
+                    fmla v8.4s, v8.4s, v12.4s
 
                     st1 {{ v8.4s }}, [{ptr}], #16
                     subs {len}, {len}, 4
@@ -275,6 +293,7 @@ ew_impl_wrap!(
             out("v0") _, out("v1") _, out("v2") _, out("v3") _,
             out("v4") _, out("v5") _, out("v6") _, out("v7") _,
             out("v8") _, out("v9") _, out("v10") _, out("v11") _,
+            out("v12") _, out("v13") _, out("v14") _, out("v15") _,
             out("v16") _, out("v17") _, out("v18") _, out("v19") _,
             out("v20") _, out("v21") _, out("v22") _, out("v23") _,
             out("v24") _, out("v25") _, out("v26") _, out("v27") _,
@@ -289,4 +308,20 @@ ew_impl_wrap!(
 pub mod test_arm64simd_gelu_f32_4n_fused {
     use super::*;
     gelu_frame_tests!(true, f32, arm64simd_gelu_f32_4n_fused);
+
+    use crate::frame::element_wise::ElementWiseKer;
+
+    #[test]
+    fn decays_to_zero_on_large_negatives() {
+        // 16 exercises the unrolled body, 4 the tail.
+        for len in [4usize, 16, 20] {
+            for x in [-6.0f32, -9.0, -10.0, -100.0, -1000.0, -65504.0] {
+                let mut got = vec![x; len];
+                arm64simd_gelu_f32_4n_fused::ew().run(&mut got).unwrap();
+                for (i, g) in got.iter().enumerate() {
+                    assert_eq!(*g, 0.0, "len {len} lane {i} x={x}: got {g:e}");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2569. `arm64simd_gelu_f32_4n_fused` clamps the pre-tanh argument to `[-8.9, 8.9]`, but at the low bound the Padé polynomial evaluates to `-(1 - 2^-23)` rather than `-1`. `1 + tanh` therefore never cancels, and `gelu(x)` comes out as `0.5 * x * 2^-23` instead of 0 — an error that grows linearly with |x| and is unbounded.

Measured before: `-5.36e-7` at x=-9, `-5.96e-5` at x=-1000, `-3.90e-3` at x=-65504, against `-0` from the scalar kernel and from libm.

### The fix

The lanes that need correcting are exactly the ones the low clamp pinned, so `fcmeq` against the clamp constant identifies them and `bsl` substitutes an exact `-1.0` before the final combine. `v12`-`v15` were unused, so the masks need no spill. Nine instructions in the unrolled body, three in the tail; nothing else in the polynomial changes.

`decays_to_zero_on_large_negatives` covers both the unrolled body and the tail at six magnitudes.

### Cost

This is not free, and the microbenchmark number looks worse than the real one:

| | before | after | |
|---|---|---|---|
| kernel, 1024 elems | 630 ns | 682 ns | +8.2% |
| f32 FFN block (matmul -> gelu -> matmul) | 2.244 ms | 2.263 ms | +0.85% |

Both interleaved within one session rather than compared across runs — on this box a cross-run criterion baseline drifts far enough to invert the sign of a result this size, so I re-ran the two arms alternately and both rounds agreed. Sub-1% on a block where GEMMs dominate seemed a fair price for removing an unbounded error, but if you would rather not pay even that in the hot path I am happy to gate it.

### Two things I did not do

- **Moving the clamp instead.** Zero added instructions, and `-9.30` does land on exactly `-1` — but the neighbourhood is noisy under fma rounding (`-9.28` and `-9.32` do not), so it would be luck rather than a property.
- **Matching the sign of zero.** Corrected lanes return `+0` where the scalar kernel returns `-0`, because the combine is `fma(0.5x, tanh, 0.5x)` and `a - a` is `+0`, whereas the reference multiplies by zero. Making that exact costs another nine instructions per iteration. The two compare equal and behave identically downstream, so I left it — say the word if you want it exact. Note the fused kernel was never bit-identical to the scalar one anyway: the `fmla` rounds once where the reference rounds twice.

### Tests

tract-linalg 4415 — green. `cargo fmt --all` and `cargo clippy` clean.

🍍