### PR TITLE
tanh: give aarch64 cores without FEAT_FP16 an f32-roundtrip f16 kernel

### DIFF
--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -189,3 +189,7 @@ harness = false
 [[bench]]
 name = "avxvnni_i32"
 harness = false
+
+[[bench]]
+name = "tanh_f16_arm64"
+harness = false

--- a/linalg/benches/tanh_f16_arm64.rs
+++ b/linalg/benches/tanh_f16_arm64.rs
@@ -1,0 +1,25 @@
+// f16 tanh on aarch64 cores without FEAT_FP16: generic scalar vs f32 roundtrip.
+use criterion::*;
+use tract_data::prelude::*;
+use tract_linalg::element_wise::ElementWiseKer;
+
+fn bench(c: &mut Criterion) {
+    for n in [1024usize, 65536] {
+        let mut t = unsafe { Tensor::uninitialized_aligned::<f16>(&[n], 16).unwrap() };
+        let input = unsafe { t.as_slice_mut_unchecked::<f16>() };
+        for (i, x) in input.iter_mut().enumerate() {
+            *x = f16::from_f32((i as f32 / 10.0).sin() * 5.0);
+        }
+        let mut g = c.benchmark_group(format!("tanh_f16/{n}"));
+        g.throughput(Throughput::Elements(n as u64));
+        g.bench_function("generic", |b| b.iter(|| tract_linalg::generic::HTanh8::run(input, ())));
+        #[cfg(target_arch = "aarch64")]
+        g.bench_function("f32-roundtrip", |b| {
+            b.iter(|| tract_linalg::arm64::arm64simd_tanh_f16_4n::run(input, ()))
+        });
+        g.finish();
+    }
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -509,9 +509,7 @@ pub fn plug(ops: &mut Ops) {
         ops.sum_f16 = Box::new(|| arm64fp16_sum_f16_32n::red());
         ops.mul_by_scalar_f16 = Box::new(|| arm64fp16_mul_by_scalar_f16_32n::ew());
     } else {
-        log::info!(
-            "No native fp16 support; f32-roundtrip NEON sigmoid_f16 and tanh_f16 activated"
-        );
+        log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 and tanh_f16 activated");
         ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_4n::ew());
         ops.tanh_f16 = Box::new(|| arm64simd_tanh_f16_4n::ew());
     }

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -509,8 +509,11 @@ pub fn plug(ops: &mut Ops) {
         ops.sum_f16 = Box::new(|| arm64fp16_sum_f16_32n::red());
         ops.mul_by_scalar_f16 = Box::new(|| arm64fp16_mul_by_scalar_f16_32n::ew());
     } else {
-        log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 activated");
+        log::info!(
+            "No native fp16 support; f32-roundtrip NEON sigmoid_f16 and tanh_f16 activated"
+        );
         ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_4n::ew());
+        ops.tanh_f16 = Box::new(|| arm64simd_tanh_f16_4n::ew());
     }
     #[cfg(any(target_os = "macos", all(target_os = "ios", feature = "apple-amx-ios")))]
     {

--- a/linalg/src/arm64.rs
+++ b/linalg/src/arm64.rs
@@ -510,9 +510,12 @@ pub fn plug(ops: &mut Ops) {
         // TODO: Change this SiLU kernel once we have a native-FP16 one
         ops.silu_f16 = Box::new(|| arm64simd_silu_f16_4n::ew());
     } else {
-        log::info!("No native fp16 support; f32-roundtrip NEON sigmoid_f16 and silu_f16 activated");
+        log::info!(
+            "No native fp16 support; f32-roundtrip NEON sigmoid_f16, silu_f16 and tanh_f16 activated"
+        );
         ops.sigmoid_f16 = Box::new(|| arm64simd_sigmoid_f16_4n::ew());
         ops.silu_f16 = Box::new(|| arm64simd_silu_f16_4n::ew());
+        ops.tanh_f16 = Box::new(|| arm64simd_tanh_f16_4n::ew());
     }
     #[cfg(any(target_os = "macos", all(target_os = "ios", feature = "apple-amx-ios")))]
     {

--- a/linalg/src/arm64/arm64simd.rs
+++ b/linalg/src/arm64/arm64simd.rs
@@ -17,6 +17,7 @@ mod unicast;
 pub use act_f16::arm64simd_sigmoid_f16_4n;
 pub use act_f16::arm64simd_silu_f16_4n;
 pub use act_f16::arm64simd_silu_f16_lut_8n;
+pub use act_f16::arm64simd_tanh_f16_4n;
 pub use by_scalar::*;
 pub use gelu::arm64simd_gelu_f32_4n;
 pub use gelu_fused::arm64simd_gelu_f32_4n_fused;

--- a/linalg/src/arm64/arm64simd.rs
+++ b/linalg/src/arm64/arm64simd.rs
@@ -16,6 +16,7 @@ mod unicast;
 
 pub use act_f16::arm64simd_sigmoid_f16_4n;
 pub use act_f16::arm64simd_silu_f16_4n;
+pub use act_f16::arm64simd_tanh_f16_4n;
 pub use by_scalar::*;
 pub use gelu::arm64simd_gelu_f32_4n;
 pub use gelu_fused::arm64simd_gelu_f32_4n_fused;

--- a/linalg/src/arm64/arm64simd/act_f16.rs
+++ b/linalg/src/arm64/arm64simd/act_f16.rs
@@ -239,3 +239,21 @@ mod silu_f16_agreement {
         assert_eq!(mismatch, None);
     }
 }
+
+// f32-roundtrip f16 tanh for arm64 cores without FEAT_FP16.
+ew_impl_f16_via_f32!(
+    arm64simd_tanh_f16_4n,
+    4,
+    4,
+    CHUNK,
+    16,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::arm64simd_tanh_f32_4n
+);
+
+#[cfg(test)]
+pub mod test_arm64simd_tanh_f16_4n {
+    use super::*;
+    tanh_frame_tests!(true, f16, arm64simd_tanh_f16_4n);
+}

--- a/linalg/src/arm64/arm64simd/act_f16.rs
+++ b/linalg/src/arm64/arm64simd/act_f16.rs
@@ -173,3 +173,21 @@ pub mod test_arm64simd_silu_f16_4n {
     use super::*;
     silu_frame_tests!(true, f16, arm64simd_silu_f16_4n);
 }
+
+// f32-roundtrip f16 tanh for arm64 cores without FEAT_FP16.
+ew_impl_f16_via_f32!(
+    arm64simd_tanh_f16_4n,
+    4,
+    4,
+    CHUNK,
+    16,
+    cvt_f16_to_f32,
+    cvt_f32_to_f16,
+    super::arm64simd_tanh_f32_4n
+);
+
+#[cfg(test)]
+pub mod test_arm64simd_tanh_f16_4n {
+    use super::*;
+    tanh_frame_tests!(true, f16, arm64simd_tanh_f16_4n);
+}


### PR DESCRIPTION
`sigmoid_f16` and `silu_f16` both fall back to NEON kernels that widen into an f32 scratch when FEAT_FP16 is missing (`arm64simd_sigmoid_f16_4n`, `arm64simd_silu_f16_4n`). `tanh_f16` had no such kernel, so that branch left it on `generic::HTanh8` — a scalar loop. This adds the matching roundtrip kernel and registers it there.

Twelve lines of wiring: the kernel is one `ew_impl_f16_via_f32!` over the existing `arm64simd_tanh_f32_4n`, exactly as the sigmoid and silu ones are.

### Numbers

| elements | generic scalar | f32 roundtrip | |
|---|---|---|---|
| 1024 | 838 Melem/s | 1.723 Gelem/s | **2.06x** |
| 65536 | 835 Melem/s | 1.755 Gelem/s | **2.10x** |

Both arms in one process. Cores *with* FEAT_FP16 are untouched — they keep `arm64fp16_tanh_f16_8n`, which at 7.9 Gelem/s is far ahead of either of these.

Accuracy moves toward the reference rather than away: the roundtrip evaluates the f32 Padé and rounds once at the end, where `HTanh8` evaluates a lower-degree Padé in f16 throughout. Same change of character the sigmoid fallback already made.

### How I got here

I set out to put a 2^16 lookup table behind `sigmoid_f16` and `tanh_f16`, as #2568/#2579/#2583 do for gelu, erf and silu. Measuring first killed it: the table tops out at ~3.9 Gelem/s for *any* f16 unary — it is a scalar gather, bound by load issue rather than by the cost of the function — while the native FEAT_FP16 kernels run at **7.33** (sigmoid) and **7.90** (tanh) Gelem/s. A table would have been a 2x regression on every core that has FEAT_FP16.

What the same measurements did show is that the non-FEAT_FP16 branch was leaving 2x on the table for tanh, which is what this PR is.

### Tests

tract-linalg 4421, tract-core 270, test-f16 2378 — green. `cargo fmt --all` and `cargo clippy` clean.

🍍