### PR TITLE
softmax: accumulate the f16 row sum in f32

### DIFF
--- a/core/src/ops/nn/softmax/mod.rs
+++ b/core/src/ops/nn/softmax/mod.rs
@@ -275,28 +275,32 @@ impl Softmax {
         let max = (tract_linalg::ops().max_f16)().run(slice)?;
         match kind {
             SoftmaxKind::Softmax(exp_impl) => {
-                let sum = match exp_impl {
+                // Accumulated in f32: a row long enough for the running sum to
+                // outgrow its own terms stalls in f16, which costs double digits
+                // of relative error by a few thousand elements.
+                let sum: f32 = match exp_impl {
                     SoftmaxExp::Libc => {
-                        let mut s = f16::zero();
+                        let mut s = 0f32;
                         slice.iter_mut().for_each(|x| {
                             *x = (*x - max).exp();
-                            s += *x;
+                            s += x.to_f32();
                         });
                         s
                     }
                     SoftmaxExp::FastCompact => (tract_linalg::ops().softmax2_fastcompact_f16)()
-                        .run_with_params(slice, max)?,
+                        .run_with_params(slice, max)?
+                        .to_f32(),
                 };
-                let rsum = sum.recip();
+                let rsum = f16::from_f32(sum.recip());
                 (tract_linalg::ops().mul_by_scalar_f16)().run_with_params(slice, rsum)?;
             }
             SoftmaxKind::LogSoftmax => {
-                let mut exp_sum = f16::zero();
+                let mut exp_sum = 0f32;
                 slice.iter_mut().for_each(|x| {
                     *x -= max;
-                    exp_sum += x.exp();
+                    exp_sum += x.exp().to_f32();
                 });
-                let log_sum = exp_sum.ln();
+                let log_sum = f16::from_f32(exp_sum.ln());
                 slice.iter_mut().for_each(|x| *x -= log_sum);
             }
         }
@@ -784,6 +788,38 @@ mod test {
 
         let prob = InnerSoftmaxProblem { in_qp, out_qp, data };
         prob.check()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod f16_accumulator {
+    use super::*;
+
+    /// The f16 row must stay close to the same softmax evaluated in f32. A row
+    /// long enough for the running sum to outgrow its own terms is the case an
+    /// f16 accumulator silently drops.
+    #[test]
+    fn long_rows_keep_their_normalisation() -> TractResult<()> {
+        for len in [1024usize, 4096, 8192] {
+            let logits: Vec<f32> = (0..len).map(|i| ((i as f32) * 0.7).sin() * 0.5).collect();
+
+            let mut half: Vec<f16> = logits.iter().map(|v| f16::from_f32(*v)).collect();
+            Softmax::new(tvec![0], None, SoftmaxKind::Softmax(SoftmaxExp::Libc))
+                .softmax_inner_slice_f16(&mut half, SoftmaxKind::Softmax(SoftmaxExp::Libc))?;
+
+            let max = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+            let exps: Vec<f32> = logits.iter().map(|v| (v - max).exp()).collect();
+            let total: f32 = exps.iter().sum();
+
+            let got: f32 = half.iter().map(|v| v.to_f32()).sum();
+            assert!((got - 1.0).abs() < 0.02, "len {len}: row sums to {got}, expected 1.0");
+            for (i, (h, e)) in half.iter().zip(&exps).enumerate() {
+                let want = e / total;
+                let err = (h.to_f32() - want).abs() / want.max(f32::MIN_POSITIVE);
+                assert!(err < 0.05, "len {len} lane {i}: got {h}, want {want}, rel {err}");
+            }
+        }
         Ok(())
     }
 }

--- a/core/src/ops/nn/softmax/mod.rs
+++ b/core/src/ops/nn/softmax/mod.rs
@@ -275,28 +275,32 @@ impl Softmax {
         let max = (tract_linalg::ops().max_f16)().run(slice)?;
         match kind {
             SoftmaxKind::Softmax(exp_impl) => {
-                let sum = match exp_impl {
+                // Accumulated in f32: a row long enough for the running sum to
+                // outgrow its own terms stalls in f16, which costs double digits
+                // of relative error by a few thousand elements.
+                let sum: f32 = match exp_impl {
                     SoftmaxExp::Libc => {
-                        let mut s = f16::zero();
+                        let mut s = 0f32;
                         slice.iter_mut().for_each(|x| {
                             *x = (*x - max).exp();
-                            s += *x;
+                            s += x.to_f32();
                         });
                         s
                     }
                     SoftmaxExp::FastCompact => (tract_linalg::ops().softmax2_fastcompact_f16)()
-                        .run_with_params(slice, max)?,
+                        .run_with_params(slice, max)?
+                        .to_f32(),
                 };
-                let rsum = sum.recip();
+                let rsum = f16::from_f32(sum.recip());
                 (tract_linalg::ops().mul_by_scalar_f16)().run_with_params(slice, rsum)?;
             }
             SoftmaxKind::LogSoftmax => {
-                let mut exp_sum = f16::zero();
+                let mut exp_sum = 0f32;
                 slice.iter_mut().for_each(|x| {
                     *x -= max;
-                    exp_sum += x.exp();
+                    exp_sum += x.exp().to_f32();
                 });
-                let log_sum = exp_sum.ln();
+                let log_sum = f16::from_f32(exp_sum.ln());
                 slice.iter_mut().for_each(|x| *x -= log_sum);
             }
         }
@@ -785,6 +789,38 @@ mod test {
 
         let prob = InnerSoftmaxProblem { in_qp, out_qp, data };
         prob.check()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod f16_accumulator {
+    use super::*;
+
+    /// The f16 row must stay close to the same softmax evaluated in f32. A row
+    /// long enough for the running sum to outgrow its own terms is the case an
+    /// f16 accumulator silently drops.
+    #[test]
+    fn long_rows_keep_their_normalisation() -> TractResult<()> {
+        for len in [1024usize, 4096, 8192] {
+            let logits: Vec<f32> = (0..len).map(|i| ((i as f32) * 0.7).sin() * 0.5).collect();
+
+            let mut half: Vec<f16> = logits.iter().map(|v| f16::from_f32(*v)).collect();
+            Softmax::new(tvec![0], None, SoftmaxKind::Softmax(SoftmaxExp::Libc))
+                .softmax_inner_slice_f16(&mut half, SoftmaxKind::Softmax(SoftmaxExp::Libc))?;
+
+            let max = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+            let exps: Vec<f32> = logits.iter().map(|v| (v - max).exp()).collect();
+            let total: f32 = exps.iter().sum();
+
+            let got: f32 = half.iter().map(|v| v.to_f32()).sum();
+            assert!((got - 1.0).abs() < 0.02, "len {len}: row sums to {got}, expected 1.0");
+            for (i, (h, e)) in half.iter().zip(&exps).enumerate() {
+                let want = e / total;
+                let err = (h.to_f32() - want).abs() / want.max(f32::MIN_POSITIVE);
+                assert!(err < 0.05, "len {len} lane {i}: got {h}, want {want}, rel {err}");
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
`softmax_inner_slice_f16` summed the exponentials into an **f16** accumulator. Once a row is long enough that the running sum outgrows its own terms, the additions round away entirely and the row gets normalised by too small a divisor — so the output does not sum to 1.

The regression test added here fails on main with `row sums to 1.2903354, expected 1.0` at row length 4096: attention weights inflated by 29%.

### How bad, and where

Relative error of the f16 accumulator against the same sum in f32, over normally-distributed logits:

| row length | sd 0.5 | sd 1.0 | sd 2.0 |
|---|---|---|---|
| 1024 | 0.2% | 1.2% | 2.0% |
| 2048 | 2.1% | 3.8% | 4.6% |
| 4096 | **15.4%** | **10.1%** | **9.0%** |
| 8192 | **38.2%** | **28.3%** | **14.2%** |

The mechanism is easiest to see in the flat case: with all logits equal, every term after the max subtraction is 1.0, so the sum should be `row_len`. f16 spacing at 2048 is 2.0, so from there on `sum + 1.0 == sum` and the total sticks at 2048 — 50% low for a 4096-long row.

This is the **default** path rather than an opt-in one. `SoftmaxExp::default()` is `Libc`, and `ScaledMaskedSoftmax::eval` constructs `SoftmaxExp::Libc` directly, so every f16 attention softmax reaches it. Error grows with sequence length, which is the direction long-context inference is going.

### The fix

Accumulate in f32 and narrow once at the end, for both the softmax and log-softmax branches. Per-element values are untouched — the exponentials are still computed exactly as before and still stored as f16 — so the only thing that changes is the summation, and short rows are unaffected.

It should also be marginally *cheaper*: `f16 + f16` widens to f32 internally in the `half` crate anyway, so this drops a narrowing per element.

### Known, not fixed here

`FastCompact` has the same flaw one level down: `HSoftMaxL2` in `linalg/src/generic/reduce.rs` accumulates with `let mut sum = f16::zero()` and reduces with `reduce_two(a: f16, b: f16)`. Fixing that means changing the map-reduce accumulator type for f16, which touches the frame and the AVX-512 kernel alongside the generic one — a bigger change than this, and `FastCompact` is opt-in. Happy to follow up if you want it in the same series. This PR routes the `FastCompact` result through f32 for the reciprocal, but cannot repair a sum that was already lost inside the kernel.

### Tests

tract-core 271, test-f16 2378, test-unit-core 816, tract-linalg 4414 — green. `cargo fmt --all` clean; `cargo clippy` clean (the two remaining warnings are pre-existing on main).

🍍