### PR TITLE
reduce: accumulate the generic f16 row sums in f32

### DIFF
--- a/linalg/src/generic/reduce.rs
+++ b/linalg/src/generic/reduce.rs
@@ -110,7 +110,10 @@ pub mod sum {
         fn run(x: &[f16], _: ()) -> f16 {
             debug_assert!(x.len() % Self::nr() == 0);
             debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
-            x.iter().sum::<f16>()
+            // f32 accumulator: a row long enough for the running sum to outgrow
+            // its own terms stalls in f16. The vector kernels are shielded by
+            // holding one partial per lane; this one is not.
+            f16::from_f32(x.iter().map(|v| v.to_f32()).sum::<f32>())
         },
         fn reduce_two(a: f16, b: f16) -> f16 {
             a + b
@@ -218,14 +221,24 @@ pub mod softmax_l2 {
 }
 
 #[cfg(test)]
-mod softmax_l2_f16_accumulator {
+mod f16_accumulators {
     use super::*;
-    use crate::frame::reduce::MapReduceKer;
+    use crate::frame::reduce::{MapReduceKer, ReduceKer};
     use tract_data::internal::f16;
 
     /// The returned row sum must stay close to the same sum taken in f32. A row
     /// long enough for the running total to outgrow its own terms is the case an
     /// f16 accumulator silently drops.
+    #[test]
+    fn plain_sum_keeps_long_rows() {
+        for len in [1024usize, 4096, 8192] {
+            let row: Vec<f16> = vec![f16::from_f32(1.0); len];
+            let got = sum::HSum8::red().run(&row).unwrap().to_f32();
+            let err = (got - len as f32).abs() / len as f32;
+            assert!(err < 0.01, "len {len}: summed to {got}, rel {err}");
+        }
+    }
+
     #[test]
     fn long_rows_keep_their_sum() {
         for len in [1024usize, 4096, 8192] {

--- a/linalg/src/generic/reduce.rs
+++ b/linalg/src/generic/reduce.rs
@@ -172,14 +172,17 @@ pub mod softmax_l2 {
         fn run(x: &mut [f16], max: f16) -> f16 {
             debug_assert!(x.len() % Self::nr() == 0);
             debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
-            let mut sum = f16::zero();
+            // f32 accumulator: a row long enough for the running sum to outgrow
+            // its own terms stalls in f16, matching what the AVX-512 f16 kernel
+            // already does.
+            let mut sum = 0f32;
             for v in x.iter_mut() {
                 let y = *v - max;
                 let y = f16::from_f32(fast_compact_exp_f32(y.to_f32()));
                 *v = y;
-                sum += y;
+                sum += y.to_f32();
             }
-            sum
+            f16::from_f32(sum)
         },
         fn reduce_two(a: f16, b: f16) -> f16 {
             a + b
@@ -211,5 +214,28 @@ pub mod softmax_l2 {
     pub mod h {
         use super::*;
         crate::softmax_l2_frame_tests!(true, f16, HSoftMaxL2);
+    }
+}
+
+#[cfg(test)]
+mod softmax_l2_f16_accumulator {
+    use super::*;
+    use crate::frame::reduce::MapReduceKer;
+    use tract_data::internal::f16;
+
+    /// The returned row sum must stay close to the same sum taken in f32. A row
+    /// long enough for the running total to outgrow its own terms is the case an
+    /// f16 accumulator silently drops.
+    #[test]
+    fn long_rows_keep_their_sum() {
+        for len in [1024usize, 4096, 8192] {
+            let max = f16::from_f32(0.0);
+            let mut row: Vec<f16> = vec![f16::from_f32(0.0); len];
+            let got = softmax_l2::HSoftMaxL2::red().run_with_params(&mut row, max).unwrap();
+
+            let want: f32 = row.iter().map(|v| v.to_f32()).sum();
+            let err = (got.to_f32() - want).abs() / want;
+            assert!(err < 0.01, "len {len}: kernel returned {got}, row sums to {want}, rel {err}");
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #2586, one level down, now covering both f16 accumulators in `linalg/src/generic/reduce.rs`.

`HSoftMaxL2` and `HSum8` both accumulate a row into an **f16** total, so once a row is long enough that the running sum outgrows its own terms the additions round away. The regression tests added here fail on main with:

- `HSoftMaxL2`: `len 4096: kernel returned 2048, row sums to 4082` — 49.8% low
- `HSum8`: 4096 ones sum to **2048**, 8192 ones also sum to **2048** — 50% and 75% low

f16 spacing at 2048 is 2.0, so from there `sum + 1.0 == sum` and the total simply stops moving.

### Not a new opinion about the right accumulator

The AVX-512 f16 softmax kernel already accumulates in f32, and its comment says why:

> The sum is accumulated in f32 across the loop (higher precision than the generic HSoftMaxL2 which accumulates in f16) and cast to f16 at return

So the gap was known and written down; this closes it rather than introducing a split.

### Who was actually affected

The vector kernels are shielded by accident rather than by design: `arm64fp16_sum_f16_32n` keeps one partial per lane, so each lane only accumulates `len / 32` terms and a `ReduceSum` over 8192 f16 comes out exact on aarch64 with FEAT_FP16. The generic kernels have no such protection, and they are what x86 (no f16 sum or softmax_l2 kernel outside AVX-512), wasm, arm32 and pre-ARMv8.2 aarch64 all run.

### Scope

Per-element values are untouched — the same `fast_compact_exp_f32` result is still stored as f16 — so only the accumulation changes and short rows are unaffected. `SSum4` and `SSoftMaxL2` are f32 already and left alone.

Two residuals are deliberate. The frame combines at most three partials via `reduce_two`, which stays f16 — negligible over three terms. And `run` must return the frame's element type, so a large sum is quantised to f16 at return: about 0.1% at 4096, against the 50% it replaces. Making that exact would mean giving the reduce frame a distinct accumulator type, which is a much larger change than the bug warrants.

### Tests

tract-linalg 4416, tract-core 270, test-f16 2378, test-unit-core 816 — green. `cargo fmt --all` and `cargo clippy` clean.

🍍