### PR TITLE
suite-unit: drop core::f32 import shadowing the primitive

### DIFF
--- a/test-rt/suite-unit/src/scaled_masked_softmax.rs
+++ b/test-rt/suite-unit/src/scaled_masked_softmax.rs
@@ -1,5 +1,3 @@
-use core::f32;
-
 use infra::Test;
 use infra::TestResult;
 use infra::TestSuite;


### PR DESCRIPTION
The import made f32::NEG_INFINITY resolve to the deprecated core::f32 module constant instead of the f32 associated const, breaking nightly clippy under -D warnings.