### PR TITLE
core: support tf_half_pixel_for_nn resize coordinate mode

### DIFF
--- a/core/src/ops/nn/resize.rs
+++ b/core/src/ops/nn/resize.rs
@@ -10,6 +10,7 @@ pub enum CoordTransformer {
     Asymmetric,
     PytorchHalfPixel,
     HalfPixelSymmetric,
+    TfHalfPixelForNn,
 }
 
 impl CoordTransformer {
@@ -37,6 +38,7 @@ impl CoordTransformer {
                 let offset = len_in as f32 / 2.0 * (1.0 - adjustment);
                 offset + (x_out as f32 + 0.5) / scale - 0.5
             }
+            CoordTransformer::TfHalfPixelForNn => (x_out as f32 + 0.5) / scale,
         }
     }
 
@@ -47,6 +49,7 @@ impl CoordTransformer {
             CoordTransformer::Asymmetric => "asymmetric",
             CoordTransformer::PytorchHalfPixel => "pytorch_half_pixel",
             CoordTransformer::HalfPixelSymmetric => "half_pixel_symmetric",
+            CoordTransformer::TfHalfPixelForNn => "tf_half_pixel_for_nn",
         }
     }
 
@@ -57,6 +60,7 @@ impl CoordTransformer {
             "asymmetric" => CoordTransformer::Asymmetric,
             "pytorch_half_pixel" => CoordTransformer::PytorchHalfPixel,
             "half_pixel_symmetric" => CoordTransformer::HalfPixelSymmetric,
+            "tf_half_pixel_for_nn" => CoordTransformer::TfHalfPixelForNn,
             s => bail!("coordinate_transformation_mode: {s}"),
         })
     }
@@ -466,12 +470,14 @@ impl TypedOp for Resize {
     }
 }
 
-/// An axis length to build a probe plan on. `HalfPixel` and `Asymmetric` map
-/// coordinates without consulting the axis lengths, so a symbolic axis can
-/// still be probed on a stand-in; the others cannot.
+/// An axis length to build a probe plan on. `HalfPixel`, `Asymmetric` and
+/// `TfHalfPixelForNn` map coordinates without consulting the axis lengths, so a
+/// symbolic axis can still be probed on a stand-in; the others cannot.
 pub fn probe_length(coord_transformer: &CoordTransformer, len: &TDim) -> Option<usize> {
     len.to_usize().ok().or(match coord_transformer {
-        CoordTransformer::HalfPixel | CoordTransformer::Asymmetric => Some(4),
+        CoordTransformer::HalfPixel
+        | CoordTransformer::Asymmetric
+        | CoordTransformer::TfHalfPixelForNn => Some(4),
         _ => None,
     })
 }

--- a/onnx/src/ops/resize.rs
+++ b/onnx/src/ops/resize.rs
@@ -1,7 +1,7 @@
 use crate::model::ParsingContext;
 use crate::pb::*;
 use tract_hir::internal::*;
-use tract_nnef::tract_core::ops::nn::resize::Interpolator;
+use tract_nnef::tract_core::ops::nn::resize::{CoordTransformer, Interpolator};
 use tract_nnef::tract_num_traits::Zero as _;
 use tract_onnx_opl::resize::{AspectRatio, CoordTransform, Nearest, Resize};
 
@@ -21,6 +21,7 @@ pub fn resize(
 
 fn resize_10(node: &NodeProto) -> TractResult<Resize> {
     Ok(Resize {
+        coord_transformer: CoordTransform::Plain(CoordTransformer::Asymmetric),
         optional_roi_input: None,
         optional_scales_input: Some(1),
         optional_sizes_input: None,

--- a/test-rt/suite-onnx/node.txt
+++ b/test-rt/suite-onnx/node.txt
@@ -488,6 +488,10 @@ test_reshape_reordered_dims                                                     
 test_reshape_reordered_last_dims input:data
 test_reshape_zero_and_negative_dim input:data
 test_reshape_zero_dim input:data
+test_resize_upsample_nearest                                                        input:X since:11
+test_resize_upsample_sizes_nearest_ceil_half_pixel                                  input:X since:12
+test_resize_upsample_sizes_nearest_floor_align_corners                              input:X since:12
+test_resize_upsample_sizes_nearest_round_prefer_ceil_asymmetric                     input:X since:12
 test_resize.*                                                                       input:X
 test_rnn_seq_length
 test_round


### PR DESCRIPTION
Resize rejected the legacy tf_half_pixel_for_nn coordinate transformation mode, so ONNX models using it failed to build. Add it to CoordTransformer as a length-independent, ROI-free coordinate map ((x + 0.5) / scale).