### PR TITLE
riscv64: 1 of 4: RVV 1.0 f32 matmul kernels

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -267,8 +267,9 @@ jobs:
           - triple: armv7-unknown-linux-gnueabihf-stretch
             rustc_triple: armv7-unknown-linux-gnueabihf
           # RISC-V boards run a fully-static musl CLI (built directly by cross.sh, no stretch
-          # container); one self-tuning build serves every rv64gc board. No RVV kernels yet, so
-          # this is the generic scalar path.
+          # container); one self-tuning build serves every rv64gc board. The RVV kernels are
+          # picked at runtime off the hart's VLEN, so this same binary runs them on an RVV 1.0
+          # board and the generic scalar path where the vector unit is absent or the 0.7.1 draft.
           - triple: riscv64gc-unknown-linux-musl
             rustc_triple: riscv64gc-unknown-linux-musl
     steps:

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -91,6 +91,8 @@ jobs:
           - aarch64-unknown-linux-musl
           - cortexa53-unknown-linux-musl
           - armv7-unknown-linux-musl
+          - riscv64gc-unknown-linux-gnu
+          - rvv128-unknown-linux-gnu
           - aarch64-linux-android
           - armv7-linux-androideabi
           - i686-linux-android

--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -211,9 +211,12 @@ case "$PLATFORM" in
                 export ARCH=riscv64
                 export QEMU_ARCH=riscv64
                 export RUSTC_TRIPLE=riscv64gc-unknown-linux-musl
-                export CUSTOM_TC=`pwd`/riscv64-linux-musl-cross
-                [ -d "$CUSTOM_TC" ] || curl -s https://tract-test-assets.tract.rs/toolchains/riscv64-linux-musl-cross.tgz | tar zx
-                export TARGET_CC=$CUSTOM_TC/bin/riscv64-linux-musl-gcc
+                # Bootlin rather than musl.cc: the linalg RVV kernels need an assembler that
+                # knows the ratified RVV 1.0 encodings, which arrived in binutils 2.38, and
+                # musl-cross-make has cut no release since 2021 and is stuck on 2.37.
+                export CUSTOM_TC=`pwd`/riscv64-lp64d--musl--stable-2025.08-1
+                [ -d "$CUSTOM_TC" ] || curl -s https://tract-test-assets.tract.rs/toolchains/riscv64-lp64d--musl--stable-2025.08-1.tar.xz | tar Jx
+                export TARGET_CC=$CUSTOM_TC/bin/riscv64-buildroot-linux-musl-gcc
                 # riscv64 musl defaults to dynamic linking (unlike the aarch64/armv7 musl
                 # targets here); force a static binary so it runs on the glibc boards, which
                 # have no musl loader.

--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -142,7 +142,8 @@ case "$PLATFORM" in
 
     "aarch64-unknown-linux-gnu" | "armv6vfp-unknown-linux-gnueabihf" | "armv7-unknown-linux-gnueabihf" | \
         "aarch64-unknown-linux-musl" | "armv7-unknown-linux-musl" | "cortexa53-unknown-linux-musl" | \
-        "riscv64gc-unknown-linux-musl" )
+        "riscv64gc-unknown-linux-musl" | \
+        "riscv64gc-unknown-linux-gnu" | "rvv128-unknown-linux-gnu" )
 
         ensure_cargo_dinghy
         case "$PLATFORM" in
@@ -217,6 +218,31 @@ case "$PLATFORM" in
                 # targets here); force a static binary so it runs on the glibc boards, which
                 # have no musl loader.
                 export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C target-feature=+crt-static"
+                ;;
+            # RVV is vector-length agnostic and the mmm kernels are gated on the
+            # hart's VLEN, so the two entries below differ only in vlen: 256 is
+            # the SpacemiT K1/X100 shape, 128 the Sophgo SG2044 one, and they
+            # select disjoint halves of the kernel set.
+            #
+            # -cpu max rather than a profile model: rva23u64 would describe real
+            # silicon more closely but predates neither the CI image's qemu nor
+            # its glibc safely, and the generic rv64 model cannot run Debian's
+            # riscv64 glibc at all (it SIGILLs on a trivial static binary).
+            "riscv64gc-unknown-linux-gnu")
+                export ARCH=riscv64
+                export QEMU_ARCH=riscv64
+                export LIBC_ARCH=riscv64
+                export QEMU_OPTS="-cpu max,vlen=256"
+                export RUSTC_TRIPLE=riscv64gc-unknown-linux-gnu
+                export DEBIAN_TRIPLE=riscv64-linux-gnu
+                ;;
+            "rvv128-unknown-linux-gnu")
+                export ARCH=riscv64
+                export QEMU_ARCH=riscv64
+                export LIBC_ARCH=riscv64
+                export QEMU_OPTS="-cpu max,vlen=128"
+                export RUSTC_TRIPLE=riscv64gc-unknown-linux-gnu
+                export DEBIAN_TRIPLE=riscv64-linux-gnu
                 ;;
             *)
                 echo "unsupported platform $PLATFORM"

--- a/linalg/Cargo.toml
+++ b/linalg/Cargo.toml
@@ -29,6 +29,10 @@ rayon = { workspace = true, optional = true }
 scan_fmt.workspace = true
 tract-data.workspace = true
 
+# RVV detection reads the V bit out of AT_HWCAP via getauxval(3).
+[target.'cfg(target_arch = "riscv64")'.dependencies]
+libc.workspace = true
+
 [build-dependencies]
 cc.workspace = true
 half.workspace = true

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -68,6 +68,21 @@ fn assembler_supports_dotprod() -> bool {
         .is_ok()
 }
 
+// Probe whether the target assembler can encode ratified RVV 1.0. `.option
+// arch` arrived in binutils 2.36 and the 1.0 encodings in 2.38; anything older
+// either rejects the directive outright or knows only the incompatible 0.7.1
+// draft. When the probe fails we skip the RVV kernels and the `tract_rvv` cfg,
+// and dispatch falls back to the generic Rust kernels.
+fn assembler_supports_rvv() -> bool {
+    cc::Build::new()
+        .file("riscv64/rvv/dummy_rvv.S")
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(false)
+        .try_compile("tract_rvv_probe")
+        .is_ok()
+}
+
 // Probe whether the target assembler can encode `vpdpbusd ymm` (AVX-512 VNNI
 // with AVX-512 VL, i.e. the 256-bit form). binutils gained this in ~2.30
 // (2018); the Debian stretch toolchain ships 2.28 and rejects the mnemonic.
@@ -271,6 +286,8 @@ fn main() {
     // Set below only when the assembler accepts the `{vex}` prefix on
     // VPDPBUSD (binutils >= 2.36) -- needed for the AVX-VNNI ymm kernel.
     println!("cargo:rustc-check-cfg=cfg(tract_avxvnni)");
+    // Set below only when the riscv64 assembler probe for RVV 1.0 passes.
+    println!("cargo:rustc-check-cfg=cfg(tract_rvv)");
 
     match arch.as_ref() {
         "x86_64" => {
@@ -512,8 +529,60 @@ fn main() {
                 config.cc().files(files).compile("arm64fp16")
             }
         }
+        "riscv64" if assembler_supports_rvv() => {
+            let files = render_rvv_kernels("f32", "4", "+v", RVV_F32_KERNELS, &suffix);
+            println!("cargo:rustc-cfg=tract_rvv");
+            cc::Build::new().files(files).compile("rvv");
+        }
         _ => {}
     }
+}
+
+/// `(geometry, MR, NR, LMUL)`. The geometry string ends up in the exported
+/// symbol, and the vector width each `(MR, LMUL)` pair needs is what the Rust
+/// side declares as the kernel's instruction set, so a hart with `VLMAX < MR`
+/// never sees it.
+///
+/// LMUL is the smallest that both reaches MR on the narrowest hart the kernel
+/// targets and leaves room for NR accumulator groups plus one for A.
+///
+///   8x8  m2   VLEN >= 128   universal GEMM tile
+///   16x8 m2   VLEN >= 256   SpacemiT K1 / X100, twice the tile for free
+///   32x1 m8   VLEN >= 128   universal GEMV
+///   64x1 m8   VLEN >= 256   wider GEMV where the registers allow it
+const RVV_F32_KERNELS: &[(&str, &str, &str, &str)] = &[
+    ("8x8", "8", "8", "2"),
+    ("16x8", "16", "8", "2"),
+    ("32x1", "32", "1", "8"),
+    ("64x1", "64", "1", "8"),
+];
+
+fn render_rvv_kernels(
+    dt: &'static str,
+    esize: &'static str,
+    arch: &'static str,
+    kernels: &[(&'static str, &'static str, &'static str, &'static str)],
+    suffix: &str,
+) -> Vec<path::PathBuf> {
+    let out_dir = path::PathBuf::from(var("OUT_DIR"));
+    kernels
+        .iter()
+        .map(|(geo, mr, nr, lmul)| {
+            let tmpl = path::Path::new("riscv64/rvv/rvv_mmm.S.j2");
+            let out = out_dir.join(format!("rvv_mmm_{dt}_{geo}_{suffix}.S"));
+            let globals = [
+                ("dt", dt),
+                ("esize", esize),
+                ("arch", arch),
+                ("geo", *geo),
+                ("mr", *mr),
+                ("nr", *nr),
+                ("lmul", *lmul),
+            ];
+            preprocess_file(tmpl, &out, &globals, suffix, false);
+            out
+        })
+        .collect()
 }
 
 type Variant = (&'static str, Vec<&'static str>);

--- a/linalg/riscv64/rvv/dispatcher.j2
+++ b/linalg/riscv64/rvv/dispatcher.j2
@@ -1,0 +1,42 @@
+// vim: ft=asm
+
+// Walks the FusedKerSpec array in a0 and vectors to the handler for each
+// entry's discriminant. Layout is #[repr(C, usize)]: an 8-byte discriminant at
+// +0 then the payload at +8/+16/+24/+32, 40 bytes per entry.
+//
+// The table is `j` instructions rather than addresses so it stays PC-relative
+// (the kernels are linked into PIE binaries, and a table of absolute addresses
+// in .text would need runtime relocations). `.option norvc` keeps the assembler
+// from compressing any of them to 2 bytes, which would break the fixed stride
+// the index arithmetic below assumes.
+
+.non_linear:
+    addi        a0, a0, -40
+
+.non_linear_loop:
+    addi        a0, a0, 40
+    ld          t0, 0(a0)
+
+    li          t1, {{ jump_table | length }}
+    bgeu        t0, t1, .unsupported
+
+    lla         t1, .jmp_table
+    slli        t0, t0, 2
+    add         t1, t1, t0
+    jr          t1
+
+.option push
+.option norvc
+.jmp_table:
+{% for j in jump_table %}
+    j           .{{j}}
+{% endfor %}
+.option pop
+
+.unsupported:
+    li          a0, 1
+    ret
+
+.done:
+    li          a0, 0
+    ret

--- a/linalg/riscv64/rvv/dummy_rvv.S
+++ b/linalg/riscv64/rvv/dummy_rvv.S
@@ -1,0 +1,24 @@
+// Build-time capability probe for the assembler, used by build.rs
+// (assembler_supports_rvv). `.option arch` landed in binutils 2.36 and the
+// ratified RVV 1.0 encodings in 2.38; toolchains older than that either reject
+// the directive or silently know only the incompatible 0.7.1 draft. If this
+// file fails to assemble, build.rs skips the RVV kernels and the `tract_rvv`
+// cfg, and the runtime falls back to the generic Rust kernels. Not linked into
+// anything.
+//
+// The instruction mix is deliberately the one the kernels actually need: the
+// vector-scalar FMA that carries the inner loop, and the strided load/store
+// pair the tile store and add_unicast are built on.
+.option arch, +v
+.text
+.globl tract_rvv_probe
+tract_rvv_probe:
+    vsetivli t0, 8, e32, m2, ta, ma
+    vle32.v v8, (a0)
+    vfmacc.vf v16, ft0, v8
+    vfrsub.vf v16, v16, ft0
+    vmfgt.vf v0, v16, ft0
+    vmerge.vvm v16, v18, v16, v0
+    vlse32.v v4, (a0), a1
+    vsse32.v v16, (a0), a1
+    ret

--- a/linalg/riscv64/rvv/rvv_mmm.S.j2
+++ b/linalg/riscv64/rvv/rvv_mmm.S.j2
@@ -1,0 +1,206 @@
+// vim: ft=asm
+{% set mr = mr | int %}{% set nr = nr | int %}{% set lmul = lmul | int %}{% set esize = esize | int %}
+{% set ew = esize * 8 %}
+{% set fl = "flw" if esize == 4 else "flh" %}
+{% set fzero = "fmv.w.x" if esize == 4 else "fmv.h.x" %}
+{% set va = 8 %}
+{% set vs = 24 if lmul == 8 else 4 %}
+
+// {{mr}}x{{nr}} {{dt}} matmul tile, RVV 1.0, SEW={{ew}}, LMUL={{lmul}}.
+//
+//   v{{va}}   packed A column, {{mr}} {{dt}}
+//   v{{vs}}   scratch: per-row operand, unicast, leaky relu
+//   v0    leaky relu mask
+{% for j in range(nr) %}
+//   v{{ 16 + j * lmul }}  accumulator, C tile column {{j}}
+{% endfor %}
+//
+// Accumulators start at v16 so the LMUL=8 case stays 8-aligned. Only
+// caller-saved registers are touched, so there is no frame.
+//
+// `vl` is pinned to {{mr}} for the whole call, which is what makes this kernel
+// VLEN-specific: vsetvli grants min(AVL, VLMAX), so a hart with VLMAX < {{mr}}
+// would compute a short tile rather than fail. Dispatch is gated on the vector
+// width that reaches vlmax_{{dt}}({{lmul}}) >= {{mr}}; the check below is the
+// backstop for the two disagreeing, and cannot fire on a hart with no vector
+// unit at all -- there the guard instruction is itself illegal.
+
+.option arch, {{arch}}
+.text
+.align 2
+
+.global {{G}}rvv_mmm_{{dt}}_{{geo}}_{{suffix}}
+{{G}}rvv_mmm_{{dt}}_{{geo}}_{{suffix}}:
+
+    li          t0, {{mr}}
+    vsetvli     t1, t0, e{{ew}}, m{{lmul}}, ta, ma
+    bne         t1, t0, .unsupported
+
+{% include "dispatcher.j2" %}
+
+// Packed A is column-major panels of {{mr}}, so a K step reads one contiguous
+// column; packed B is row-major panels of {{nr}}, so it reads {{nr}} scalars.
+// vfmacc.vf sources its scalar straight from an f register, so no broadcast is
+// needed.
+.add_mat_mul:
+    ld          t1, 8(a0)               // k
+    ld          a1, 16(a0)              // pa
+    ld          a2, 24(a0)              // pb
+
+    beqz        t1, .non_linear_loop
+
+.packed_packed_loop_1:
+    vle{{ew}}.v     v{{va}}, (a1)
+    addi        a1, a1, {{ mr * esize }}
+{% for j in range(nr) %}
+    {{fl}}         ft{{j}}, {{ j * esize }}(a2)
+{% endfor %}
+    addi        a2, a2, {{ nr * esize }}
+{% for j in range(nr) %}
+    vfmacc.vf   v{{ 16 + j * lmul }}, ft{{j}}, v{{va}}
+{% endfor %}
+    addi        t1, t1, -1
+    bnez        t1, .packed_packed_loop_1
+
+    j           .non_linear_loop
+
+.clear:
+{% for j in range(nr) %}
+    vmv.v.i     v{{ 16 + j * lmul }}, 0
+{% endfor %}
+    j           .non_linear_loop
+
+.load_tile:
+    ld          t1, 8(a0)
+{% for j in range(nr) %}
+    vle{{ew}}.v     v{{ 16 + j * lmul }}, (t1)
+{% if not loop.last %}
+    addi        t1, t1, {{ mr * esize }}
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+{# ScalarSub is `scalar - acc` and ScalarSubF is `acc - scalar`, so the plain
+   form maps to the reversed vector op. #}
+{% for label, op in [
+    ("scalar_min", "vfmin.vf"),
+    ("scalar_max", "vfmax.vf"),
+    ("scalar_mul", "vfmul.vf"),
+    ("scalar_add", "vfadd.vf"),
+    ("scalar_sub", "vfrsub.vf"),
+    ("scalar_sub_flipped", "vfsub.vf"),
+] %}
+.{{label}}:
+    {{fl}}         ft0, 8(a0)
+{% for j in range(nr) %}
+    {{op}}   v{{ 16 + j * lmul }}, v{{ 16 + j * lmul }}, ft0
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+.leaky_relu:
+    {{fl}}         ft0, 8(a0)
+    {{fzero}}     ft1, zero
+{% for j in range(nr) %}
+    vfmul.vf    v{{vs}}, v{{ 16 + j * lmul }}, ft0
+    vmfgt.vf    v0, v{{ 16 + j * lmul }}, ft1
+    vmerge.vvm  v{{ 16 + j * lmul }}, v{{vs}}, v{{ 16 + j * lmul }}, v0
+{% endfor %}
+    j           .non_linear_loop
+
+{# Per-row operand at +8: {{mr}} values, one per row, so one lane each and a
+   single unit-stride load serves every accumulator. #}
+{% for label, op, flipped in [
+    ("per_row_min", "vfmin.vv", false),
+    ("per_row_max", "vfmax.vv", false),
+    ("per_row_mul", "vfmul.vv", false),
+    ("per_row_add", "vfadd.vv", false),
+    ("per_row_sub", "vfsub.vv", false),
+    ("per_row_sub_flipped", "vfsub.vv", true),
+] %}
+.{{label}}:
+    ld          t1, 8(a0)
+    vle{{ew}}.v     v{{vs}}, (t1)
+{% for j in range(nr) %}
+{% if flipped %}
+    {{op}}   v{{ 16 + j * lmul }}, v{{ 16 + j * lmul }}, v{{vs}}
+{% else %}
+    {{op}}   v{{ 16 + j * lmul }}, v{{vs}}, v{{ 16 + j * lmul }}
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+{# Per-col operand at +8: {{nr}} values, one per accumulator. #}
+{% for label, op in [
+    ("per_col_min", "vfmin.vf"),
+    ("per_col_max", "vfmax.vf"),
+    ("per_col_mul", "vfmul.vf"),
+    ("per_col_add", "vfadd.vf"),
+    ("per_col_sub", "vfrsub.vf"),
+    ("per_col_sub_flipped", "vfsub.vf"),
+] %}
+.{{label}}:
+    ld          t1, 8(a0)
+{% for j in range(nr) %}
+    {{fl}}         ft0, {{ j * esize }}(t1)
+    {{op}}   v{{ 16 + j * lmul }}, v{{ 16 + j * lmul }}, ft0
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+.add_row_col_products:
+    ld          t1, 8(a0)               // rows, {{mr}} values
+    ld          t2, 16(a0)              // cols, {{nr}} values
+    vle{{ew}}.v     v{{vs}}, (t1)
+{% for j in range(nr) %}
+    {{fl}}         ft0, {{ j * esize }}(t2)
+    vfmacc.vf   v{{ 16 + j * lmul }}, ft0, v{{vs}}
+{% endfor %}
+    j           .non_linear_loop
+
+{# OutputStoreKer at +8: ptr, row_byte_stride, col_byte_stride, item_size.
+   C[i][j] lives at ptr + i*row + j*col, and accumulator j holds column j one
+   row per lane, so a column is exactly one strided access -- no lane-by-lane
+   peeling for the non-contiguous case, unlike the NEON and AVX ports. #}
+.add_unicast:
+    ld          t1, 8(a0)
+    ld          t2, 16(a0)
+    ld          t3, 24(a0)
+{% for j in range(nr) %}
+    vlse{{ew}}.v    v{{vs}}, (t1), t2
+    vfadd.vv    v{{ 16 + j * lmul }}, v{{ 16 + j * lmul }}, v{{vs}}
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+.store:
+    ld          t1, 8(a0)
+    ld          t2, 16(a0)
+    ld          t3, 24(a0)
+
+    li          t4, {{esize}}
+    bne         t2, t4, .store_strided
+{% for j in range(nr) %}
+    vse{{ew}}.v     v{{ 16 + j * lmul }}, (t1)
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+.store_strided:
+{% for j in range(nr) %}
+    vsse{{ew}}.v    v{{ 16 + j * lmul }}, (t1), t2
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+.q_scale:
+.q_shl:
+.q_shr:
+    j           .unsupported

--- a/linalg/src/isa.rs
+++ b/linalg/src/isa.rs
@@ -13,9 +13,9 @@ use std::sync::OnceLock;
 /// kernel tree and a dispatch tier are keyed on; [`Isa::of_arch`] is the same thing as a set
 /// member, and [`IsaSet::arch`] reads it back out of a machine's features.
 ///
-/// Naming one is not having kernels for it: [`RiscV64`](Arch::RiscV64) has no tree yet, so a
-/// riscv64 build is generic-only even though it knows what it is running on, and an
-/// architecture tract does not name at all has no variant here. Only the wasm tree hinges on a
+/// Naming one is not having kernels for it: an architecture tract does not name at all has no
+/// variant here, and a build whose assembler cannot encode a tree's instructions is
+/// generic-only even though it knows what it is running on. Only the wasm tree hinges on a
 /// build feature — hence the variant naming that feature; the others exist on their arch and
 /// gate individual kernels on runtime probes instead.
 #[allow(non_camel_case_types)]
@@ -87,12 +87,17 @@ pub enum Isa {
     X86_64AvxVnni,
     X86_64AmxInt8,
     X86_64AmxBf16,
+    /// The ratified Vector extension, RVV 1.0, which mandates `VLEN >= 128`.
+    RiscV64V,
+    /// A vector unit at least 256 bits wide, which is what the wide RVV tiles need. Not an
+    /// instruction set feature, but the hart property that decides which tile heights exist.
+    RiscV64Vlen256,
     Wasm32Simd128,
     Wasm32RelaxedSimd,
 }
 
 impl Isa {
-    pub const ALL: [Isa; 24] = [
+    pub const ALL: [Isa; 26] = [
         Isa::Arm,
         Isa::Aarch64,
         Isa::X86_64,
@@ -115,6 +120,8 @@ impl Isa {
         Isa::X86_64AvxVnni,
         Isa::X86_64AmxInt8,
         Isa::X86_64AmxBf16,
+        Isa::RiscV64V,
+        Isa::RiscV64Vlen256,
         Isa::Wasm32Simd128,
         Isa::Wasm32RelaxedSimd,
     ];
@@ -144,6 +151,8 @@ impl Isa {
             Isa::X86_64AvxVnni => "avxvnni",
             Isa::X86_64AmxInt8 => "amx-int8",
             Isa::X86_64AmxBf16 => "amx-bf16",
+            Isa::RiscV64V => "rvv",
+            Isa::RiscV64Vlen256 => "vlen256",
             Isa::Wasm32Simd128 => "simd128",
             Isa::Wasm32RelaxedSimd => "relaxed-simd",
         }
@@ -179,6 +188,9 @@ impl Isa {
             // so this sits a step above the set it extends.
             Isa::X86_64Avx512Fp16 => 4,
             Isa::X86_64AmxInt8 | Isa::X86_64AmxBf16 => 5,
+            // riscv: the vector unit, then the width the wide tiles need on top of it.
+            Isa::RiscV64V => 1,
+            Isa::RiscV64Vlen256 => 2,
             // arm: NEON is the armv7 step above bare VFP, and baseline on aarch64 where the
             // ladder continues through the matrix extensions.
             Isa::ArmNeon => 1,
@@ -222,7 +234,7 @@ impl Isa {
             | Isa::X86_64AvxVnni
             | Isa::X86_64AmxInt8
             | Isa::X86_64AmxBf16 => Arch::X86_64,
-            Isa::RiscV64 => Arch::RiscV64,
+            Isa::RiscV64 | Isa::RiscV64V | Isa::RiscV64Vlen256 => Arch::RiscV64,
             Isa::Wasm32 | Isa::Wasm32Simd128 | Isa::Wasm32RelaxedSimd => Arch::Wasm32Simd128,
         }
     }
@@ -315,7 +327,9 @@ impl IsaSet {
             (Arch::X86_64, 3) => "avx512",
             (Arch::X86_64, 4) => "fp16",
             (Arch::X86_64, _) => "amx",
-            (Arch::RiscV64, _) => "rv64",
+            (Arch::RiscV64, 0) => "rv64",
+            (Arch::RiscV64, 1) => "rvv",
+            (Arch::RiscV64, _) => "vlen256",
             (Arch::Wasm32Simd128, 0) => "simd",
             (Arch::Wasm32Simd128, _) => "relaxed",
         }
@@ -440,6 +454,8 @@ fn probe() -> IsaSet {
     return crate::arm64::isa_set();
     #[cfg(target_arch = "x86_64")]
     return crate::x86_64::isa_set();
+    #[cfg(target_arch = "riscv64")]
+    return crate::riscv64::isa_set();
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
     return crate::wasm::isa_set();
     // An architecture with no kernel tree, or wasm without simd128: nothing to declare, and no
@@ -448,6 +464,7 @@ fn probe() -> IsaSet {
         target_arch = "arm",
         target_arch = "aarch64",
         target_arch = "x86_64",
+        target_arch = "riscv64",
         all(target_arch = "wasm32", target_feature = "simd128")
     )))]
     IsaSet::empty()

--- a/linalg/src/lib.rs
+++ b/linalg/src/lib.rs
@@ -82,6 +82,9 @@ pub fn has_fp16() -> bool {
 #[cfg(any(target_arch = "arm", feature = "foreign-inventory"))]
 pub mod arm32;
 
+#[cfg(any(target_arch = "riscv64", feature = "foreign-inventory"))]
+pub mod riscv64;
+
 #[cfg(any(all(target_arch = "wasm32", target_feature = "simd128"), feature = "foreign-inventory"))]
 pub mod wasm;
 

--- a/linalg/src/riscv64.rs
+++ b/linalg/src/riscv64.rs
@@ -1,0 +1,144 @@
+//! RISC-V (rv64) backend for the ratified Vector extension, RVV 1.0.
+//!
+//! Kernels are assembly rendered from jinja, as on x86_64 and arm64, because
+//! Rust exposes no stable RVV intrinsics and `-C target-feature=+v` is itself
+//! unstable.
+//!
+//! RVV is vector-length agnostic -- `VLEN` is a runtime property of the hart --
+//! while `MR` and `NR` must be const generics, since they select the packing
+//! format. Kernels reconcile the two by fixing `(MR, NR, LMUL)` and pinning
+//! `vl` to `MR`. `vsetvli` clamps to `VLMAX`, so such a kernel is correct
+//! wherever `VLMAX >= MR`, merely leaves lanes idle when `VLMAX > MR`, and
+//! computes a short tile when `VLMAX < MR`. Each kernel therefore declares the
+//! narrowest vector unit that reaches its `MR`: [`Isa::RiscV64V`] for the
+//! `VLEN >= 128` every RVV 1.0 hart mandates, [`Isa::RiscV64Vlen256`] above it.
+
+use crate::isa::{Arch, Isa, IsaSet};
+
+// `tract_rvv` is set by build.rs only when the assembler could encode RVV 1.0;
+// without it the kernel symbols do not exist and dispatch stays generic.
+#[cfg(tract_rvv)]
+mod rvv;
+#[cfg(tract_rvv)]
+pub use rvv::*;
+
+/// `AT_HWCAP` -- see `getauxval(3)`.
+#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+const AT_HWCAP: libc::c_ulong = 16;
+
+/// Bit `'V' - 'A'` of the single-letter extension bitmap Linux puts in
+/// `AT_HWCAP` (`COMPAT_HWCAP_ISA_V`).
+///
+/// This bit alone is a sufficient RVV 1.0 gate: Linux sets it only for the
+/// ratified extension, never for the incompatible 0.7.1 draft implemented by
+/// the Allwinner D1 and Sophgo SG2042.
+#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+const HWCAP_ISA_V: libc::c_ulong = 1 << (b'V' - b'A');
+
+#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+fn probe_rvv() -> bool {
+    // SAFETY: getauxval is thread-safe and takes a scalar; it returns 0 for an
+    // unknown type, which reads here as "no vector unit".
+    unsafe { libc::getauxval(AT_HWCAP) & HWCAP_ISA_V != 0 }
+}
+
+#[cfg(not(all(target_arch = "riscv64", target_os = "linux")))]
+fn probe_rvv() -> bool {
+    false
+}
+
+/// Reads `vlenb`, the read-only CSR holding `VLEN / 8`.
+///
+/// Callers must establish [`has_rvv`] first: without vector state the CSR read
+/// raises an illegal instruction, which arrives as SIGILL and cannot be
+/// recovered from.
+#[cfg(target_arch = "riscv64")]
+fn read_vlenb() -> usize {
+    let vlenb: usize;
+    // SAFETY: guarded by has_rvv(). `csrr` on a read-only CSR has no side
+    // effects. The CSR is named numerically so the assembler does not need to
+    // know about vector extensions to encode it.
+    unsafe {
+        std::arch::asm!("csrr {out}, 0xC22", out = out(reg) vlenb, options(nomem, nostack, preserves_flags));
+    }
+    vlenb
+}
+
+#[cfg(not(target_arch = "riscv64"))]
+fn read_vlenb() -> usize {
+    0
+}
+
+lazy_static::lazy_static! {
+    static ref HAS_RVV: bool = probe_rvv();
+
+    static ref VLENB: usize = if *HAS_RVV { read_vlenb() } else { 0 };
+}
+
+/// Whether the hart implements the ratified RVV 1.0 vector extension.
+pub fn has_rvv() -> bool {
+    *HAS_RVV
+}
+
+/// Vector register width in bytes (`VLEN / 8`); 0 without RVV.
+pub fn vlenb() -> usize {
+    *VLENB
+}
+
+/// `VLMAX = LMUL * VLEN / SEW` for 32-bit elements: the largest `vl` this hart
+/// can grant. A kernel of tile height `MR` is dispatchable only where this
+/// reaches `MR`.
+pub fn vlmax_f32(lmul: usize) -> usize {
+    vlenb() * lmul / std::mem::size_of::<f32>()
+}
+
+/// What this hart has, in the shared vocabulary. `VLEN` is not an instruction
+/// set feature, but it decides which tile heights are reachable, so the width
+/// the wide kernels need is carried as a step of its own.
+pub fn isa_set() -> IsaSet {
+    let mut set = IsaSet::of_arch(Arch::RiscV64);
+    if has_rvv() {
+        set = set.with(Isa::RiscV64V);
+        if vlenb() >= 32 {
+            set = set.with(Isa::RiscV64Vlen256);
+        }
+        log::info!("RVV 1.0 available, VLEN = {} bits", vlenb() * 8);
+    }
+    set
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Detection must be internally consistent and must not trap. Written to
+    /// pass on a hart without V as well, so it stays meaningful under
+    /// qemu-riscv64 with and without `v=true`.
+    #[test]
+    fn detection_is_coherent() {
+        eprintln!(
+            "rvv={} VLEN={} vlmax_f32(lmul=1,2,4)={:?}",
+            has_rvv(),
+            vlenb() * 8,
+            [vlmax_f32(1), vlmax_f32(2), vlmax_f32(4)],
+        );
+        if has_rvv() {
+            let vlenb = vlenb();
+            assert!(vlenb >= 16, "RVV 1.0 mandates VLEN >= 128, got VLEN={}", vlenb * 8);
+            assert!(vlenb.is_power_of_two(), "VLEN must be a power of two, got {}", vlenb * 8);
+            assert_eq!(vlmax_f32(1), vlenb / 4);
+            assert_eq!(vlmax_f32(4), vlenb);
+        } else {
+            assert_eq!(vlenb(), 0);
+        }
+    }
+
+    /// The vector width the wide kernels declare must be the one they actually
+    /// need: `VLMAX >= MR` for the `(MR, LMUL)` build.rs rendered them from.
+    #[test]
+    fn vlen256_is_what_the_wide_tiles_need() {
+        let set = isa_set();
+        assert_eq!(set.has(Isa::RiscV64Vlen256), has_rvv() && vlmax_f32(2) >= 16);
+        assert_eq!(set.has(Isa::RiscV64Vlen256), has_rvv() && vlmax_f32(8) >= 64);
+    }
+}

--- a/linalg/src/riscv64.rs
+++ b/linalg/src/riscv64.rs
@@ -12,6 +12,10 @@
 //! computes a short tile when `VLMAX < MR`. Each kernel therefore declares the
 //! narrowest vector unit that reaches its `MR`: [`Isa::RiscV64V`] for the
 //! `VLEN >= 128` every RVV 1.0 hart mandates, [`Isa::RiscV64Vlen256`] above it.
+//!
+//! Everything here rests on [`has_rvv`] being true only for the *ratified*
+//! extension: the 0.7.1 draft parts share neither encodings nor CSRs, and the
+//! kernels are not merely slow there but wrong.
 
 use crate::isa::{Arch, Isa, IsaSet};
 
@@ -22,24 +26,55 @@ mod rvv;
 #[cfg(tract_rvv)]
 pub use rvv::*;
 
-/// `AT_HWCAP` -- see `getauxval(3)`.
+/// `__NR_riscv_hwprobe`, Linux 6.4 and later.
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
-const AT_HWCAP: libc::c_ulong = 16;
+const NR_RISCV_HWPROBE: libc::c_long = 258;
 
-/// Bit `'V' - 'A'` of the single-letter extension bitmap Linux puts in
-/// `AT_HWCAP` (`COMPAT_HWCAP_ISA_V`).
+/// `RISCV_HWPROBE_KEY_IMA_EXT_0`, the extension bitmap.
+#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+const HWPROBE_KEY_IMA_EXT_0: i64 = 4;
+
+/// `RISCV_HWPROBE_IMA_V`, which the kernel sets only for the ratified vector
+/// extension.
+#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+const HWPROBE_IMA_V: u64 = 1 << 2;
+
+/// `struct riscv_hwprobe`.
+#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+#[repr(C)]
+struct HwprobePair {
+    key: i64,
+    value: u64,
+}
+
+/// Whether the hart offers ratified RVV 1.0, asked through `riscv_hwprobe(2)`.
 ///
-/// This bit alone is a sufficient RVV 1.0 gate: Linux sets it only for the
-/// ratified extension, never for the incompatible 0.7.1 draft implemented by
-/// the Allwinner D1 and Sophgo SG2042.
-#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
-const HWCAP_ISA_V: libc::c_ulong = 1 << (b'V' - b'A');
-
+/// The `AT_HWCAP` 'V' bit cannot answer this. Linux derives that bitmap from
+/// the ISA string the firmware reports, and a T-Head C910 — BeagleV-Ahead,
+/// Sipeed LicheePi 4A — advertises a bare `v` while implementing the
+/// incompatible 0.7.1 draft, so the bit is set on a hart that faults on, or
+/// silently misdecodes, every 1.0 encoding. `hwprobe` is the interface that
+/// distinguishes them, and a kernel too old to have it is treated as having no
+/// vector unit: the draft parts are the old-kernel population, and losing the
+/// kernels on a 1.0 hart running an old kernel costs speed, not correctness.
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
 fn probe_rvv() -> bool {
-    // SAFETY: getauxval is thread-safe and takes a scalar; it returns 0 for an
-    // unknown type, which reads here as "no vector unit".
-    unsafe { libc::getauxval(AT_HWCAP) & HWCAP_ISA_V != 0 }
+    let mut pair = HwprobePair { key: HWPROBE_KEY_IMA_EXT_0, value: 0 };
+    // SAFETY: the syscall writes only through the pointer we hand it, to one
+    // pair of the layout it expects. A kernel without it fails with ENOSYS and
+    // writes nothing, leaving `pair` as initialised here.
+    let rc = unsafe {
+        libc::syscall(
+            NR_RISCV_HWPROBE,
+            &mut pair as *mut HwprobePair,
+            1 as libc::c_ulong,
+            0 as libc::c_ulong,
+            std::ptr::null_mut::<libc::c_ulong>(),
+            0 as libc::c_uint,
+        )
+    };
+    // An unrecognised key comes back as -1 with the value left at 0.
+    rc == 0 && pair.key == HWPROBE_KEY_IMA_EXT_0 && pair.value & HWPROBE_IMA_V != 0
 }
 
 #[cfg(not(all(target_arch = "riscv64", target_os = "linux")))]

--- a/linalg/src/riscv64/rvv.rs
+++ b/linalg/src/riscv64/rvv.rs
@@ -1,0 +1,110 @@
+//! RVV 1.0 matmul kernels.
+//!
+//! Each kernel pins `vl` to its own `MR`, so it is correct only where
+//! `VLMAX >= MR`. The declared instruction set is that constraint: the
+//! `(MR, LMUL)` pairs build.rs renders the assembly from split into tiles every
+//! RVV 1.0 hart can reach and tiles needing `VLEN >= 256`, and each kernel
+//! re-checks the granted `vl` on entry, so a predicate the hart disagrees with
+//! is a clean refusal rather than a short tile.
+
+use crate::DatumType;
+use crate::isa::{Isa, IsaSet};
+use crate::mmm::{Query, Suitable};
+
+MMMExternKernel!(riscv64; rvv_mmm_f32_8x8  <f32>( 8, 8)@(16, 16) isa(RiscV64V));
+MMMExternKernel!(riscv64; rvv_mmm_f32_16x8 <f32>(16, 8)@(16, 16) isa(RiscV64Vlen256));
+MMMExternKernel!(riscv64; rvv_mmm_f32_32x1 <f32>(32, 1)@(16, 16) isa(RiscV64V));
+MMMExternKernel!(riscv64; rvv_mmm_f32_64x1 <f32>(64, 1)@(16, 16) isa(RiscV64Vlen256));
+
+/// The widest tile the hart can reach, for each of the two shapes. A vector
+/// unit is the only thing these kernels are ranked on -- there is one RVV
+/// kernel set, not a per-chip family -- so the choice is `n == 1` or not, and
+/// then the width.
+fn preferred(
+    isa: &IsaSet,
+    dt: DatumType,
+    query: &Query,
+    _suitable: &[Suitable],
+) -> Option<&'static str> {
+    if dt != DatumType::F32 {
+        return None;
+    }
+    let wide = isa.has(Isa::RiscV64Vlen256);
+    Some(match query.n {
+        Some(1) if wide => rvv_mmm_f32_64x1.name.as_str(),
+        Some(1) => rvv_mmm_f32_32x1.name.as_str(),
+        _ if wide => rvv_mmm_f32_16x8.name.as_str(),
+        _ => rvv_mmm_f32_8x8.name.as_str(),
+    })
+}
+
+inventory::submit! {
+    crate::mmm_tiers::MmmTier {
+        arch: Some(crate::isa::Arch::RiscV64),
+        precedence: 1,
+        name: "rvv",
+        applies: |isa| isa.has(Isa::RiscV64V),
+        preferred,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::frame::mmm::{FusedKerSpec, MatMatMulKer};
+
+    /// `(name, MR, LMUL)` mirroring the build.rs kernel table.
+    const GEOMETRIES: &[(&str, usize, usize)] =
+        &[("8x8", 8, 2), ("16x8", 16, 2), ("32x1", 32, 8), ("64x1", 64, 8)];
+
+    fn runnable() -> [bool; 4] {
+        [
+            rvv_mmm_f32_8x8.runnable(),
+            rvv_mmm_f32_16x8.runnable(),
+            rvv_mmm_f32_32x1.runnable(),
+            rvv_mmm_f32_64x1.runnable(),
+        ]
+    }
+
+    /// The generated kernel suites early-return on an unrunnable kernel and
+    /// count as passes, so a green run says nothing about whether the declared
+    /// instruction sets are right. This asserts the dispatch set directly.
+    ///
+    /// The permissive direction is the dangerous one: a kernel whose MR exceeds
+    /// VLMAX computes a short tile, and short is not the same as failing.
+    #[test]
+    fn dispatch_matches_vlen() {
+        let vlenb = super::super::vlenb();
+        for ((name, mr, lmul), got) in GEOMETRIES.iter().zip(runnable()) {
+            let want = vlenb * lmul / std::mem::size_of::<f32>() >= *mr;
+            eprintln!("VLEN={} {name}: {got} (want {want})", vlenb * 8);
+            assert_eq!(got, want, "{name} dispatch disagrees with VLEN={}", vlenb * 8);
+        }
+    }
+
+    /// The `vsetvli` guard heading every kernel backstops the predicates above.
+    /// Vacuous on a hart wide enough for all of them, hence no assertion on
+    /// finding a candidate.
+    ///
+    /// Meaningful only where V is present: the guard is itself a vector
+    /// instruction, so it covers "unit too narrow for this tile" but not "no
+    /// unit", where calling at all is a SIGILL rather than a return code.
+    #[test]
+    fn oversized_tile_refuses_to_run() {
+        if !super::super::has_rvv() {
+            return;
+        }
+        let runners: [&dyn Fn() -> isize; 4] = [
+            &|| rvv_mmm_f32_8x8.kernel(&[FusedKerSpec::Done]),
+            &|| rvv_mmm_f32_16x8.kernel(&[FusedKerSpec::Done]),
+            &|| rvv_mmm_f32_32x1.kernel(&[FusedKerSpec::Done]),
+            &|| rvv_mmm_f32_64x1.kernel(&[FusedKerSpec::Done]),
+        ];
+        for (((name, ..), ok), run) in GEOMETRIES.iter().zip(runnable()).zip(runners) {
+            if !ok {
+                assert_eq!(run(), 1, "{name} ran on a hart whose VLMAX is below its MR");
+                eprintln!("{name}: correctly refused");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a RISC-V backend for the ratified Vector extension. rv64gc already built,
but ran the generic Rust kernels for every matmul; this plugs an RVV 1.0 f32
mmm tier in behind runtime detection.

## What's here

- Detection: V from the `AT_HWCAP` bit, VLEN from the `vlenb` CSR. That bit is
  a sufficient RVV-1.0 gate on its own — Linux never sets it for the
  incompatible 0.7.1 draft on the Allwinner D1 and Sophgo SG2042.
- Four f32 kernels rendered from one template: 8x8 and 16x8 GEMM tiles, 32x1
  and 64x1 GEMV.
- `.travis/cross.sh` and CI matrix entries at VLEN 128 and 256.

## The part worth reviewing carefully

RVV is vector-length agnostic, so VLEN is a runtime property of the hart, while
`MR` and `NR` have to be const generics because they select the packing format.
Each kernel reconciles that by fixing `(MR, NR, LMUL)` and pinning `vl` to `MR`.
`vsetvli` clamps to `VLMAX`, so such a kernel is correct wherever
`VLMAX >= MR`, merely leaves lanes idle when `VLMAX > MR`, and computes a
**short tile** when `VLMAX < MR` — wrong, not failed.

So dispatch is gated on `vlmax_f32(LMUL) >= MR`, and each kernel re-checks the
granted `vl` on entry, turning a predicate/assembly disagreement into a clean
fallback rather than a quiet wrong answer.

That guard cannot fire on a hart with no vector unit at all, where the guard
instruction is itself illegal; there the predicate is the whole protection.

One consequence for reviewers: tract's generated kernel suites early-return as
passes on an unsupported kernel, so a green run says nothing about whether the
predicates are right — all four VLENs report identical counts either way.
`dispatch_matches_vlen` asserts the dispatch set directly instead.

## Assembly, not intrinsics

Rust exposes no stable RVV intrinsics and `-C target-feature=+v` is itself
unstable, so this follows the x86_64/arm64 pattern rather than the wasm one. An
assembler probe keeps toolchains predating RVV 1.0 on the generic fallback, as
the SME and dotprod probes already do.

## Testing

tract-linalg and tract-core pass under qemu-riscv64 at VLEN 128, 256, 512 and
1024, and with V absent. The two CI entries cover 128 and 256, which select
disjoint halves of the kernel set.

End to end, InceptionV3 (NNEF, 5.7 GFLOP) loads, optimises and executes on
riscv64 under emulation, returning a well-formed softmax over 1001 classes.
`tract kernels` lists the RVV kernels as registered and dispatchable.

No hardware numbers yet: QEMU proves correctness and nothing whatsoever about
speed. Happy to hold this until I can benchmark on a K1 board if you would
rather not take it on emulation alone — and equally happy to hear that a
RISC-V backend is not something you want to carry, before I spend more on it.

🍍