### PR TITLE
riscv64: 2 of 4: 16 RVV matmul kernels behind Zvfh

### DIFF
--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -83,6 +83,20 @@ fn assembler_supports_rvv() -> bool {
         .is_ok()
 }
 
+// Probe whether the target assembler can encode Zvfh (f16 vector arithmetic).
+// Zvfh reached binutils later than base RVV 1.0, so a toolchain can assemble
+// the f32 kernels and still reject these. When the probe fails we skip the f16
+// kernels and the `tract_rvv_zvfh` cfg, and f16 matmul stays generic.
+fn assembler_supports_zvfh() -> bool {
+    cc::Build::new()
+        .file("riscv64/rvv/dummy_rvv_zvfh.S")
+        .cargo_metadata(false)
+        .cargo_warnings(false)
+        .warnings(false)
+        .try_compile("tract_rvv_zvfh_probe")
+        .is_ok()
+}
+
 // Probe whether the target assembler can encode `vpdpbusd ymm` (AVX-512 VNNI
 // with AVX-512 VL, i.e. the 256-bit form). binutils gained this in ~2.30
 // (2018); the Debian stretch toolchain ships 2.28 and rejects the mnemonic.
@@ -288,6 +302,8 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(tract_avxvnni)");
     // Set below only when the riscv64 assembler probe for RVV 1.0 passes.
     println!("cargo:rustc-check-cfg=cfg(tract_rvv)");
+    // Set below only when the riscv64 assembler probe for Zvfh also passes.
+    println!("cargo:rustc-check-cfg=cfg(tract_rvv_zvfh)");
 
     match arch.as_ref() {
         "x86_64" => {
@@ -530,8 +546,18 @@ fn main() {
             }
         }
         "riscv64" if assembler_supports_rvv() => {
-            let files = render_rvv_kernels("f32", "4", "+v", RVV_F32_KERNELS, &suffix);
+            let mut files = render_rvv_kernels("f32", "4", "+v", RVV_F32_KERNELS, &suffix);
             println!("cargo:rustc-cfg=tract_rvv");
+            if assembler_supports_zvfh() {
+                files.extend(render_rvv_kernels(
+                    "f16",
+                    "2",
+                    "+v, +zvfh, +zfhmin",
+                    RVV_F16_KERNELS,
+                    &suffix,
+                ));
+                println!("cargo:rustc-cfg=tract_rvv_zvfh");
+            }
             cc::Build::new().files(files).compile("rvv");
         }
         _ => {}
@@ -555,6 +581,15 @@ const RVV_F32_KERNELS: &[(&str, &str, &str, &str)] = &[
     ("16x8", "16", "8", "2"),
     ("32x1", "32", "1", "8"),
     ("64x1", "64", "1", "8"),
+];
+
+/// As [`RVV_F32_KERNELS`]; SEW=16 doubles VLMAX, so every tile is twice as
+/// tall for the same LMUL and VLEN.
+const RVV_F16_KERNELS: &[(&str, &str, &str, &str)] = &[
+    ("16x8", "16", "8", "2"),
+    ("32x8", "32", "8", "2"),
+    ("64x1", "64", "1", "8"),
+    ("128x1", "128", "1", "8"),
 ];
 
 fn render_rvv_kernels(

--- a/linalg/riscv64/rvv/dummy_rvv_zvfh.S
+++ b/linalg/riscv64/rvv/dummy_rvv_zvfh.S
@@ -1,0 +1,17 @@
+// Build-time capability probe for the assembler, used by build.rs
+// (assembler_supports_zvfh). Zvfh reached binutils later than base RVV 1.0, so
+// a toolchain can assemble the f32 kernels and still reject these. When the
+// probe fails we skip the f16 kernels and the `tract_rvv_zvfh` cfg, and f16
+// matmul falls back to the generic Rust kernels. Not linked into anything.
+.option arch, +v, +zvfh, +zfhmin
+.text
+.globl tract_rvv_zvfh_probe
+tract_rvv_zvfh_probe:
+    vsetivli t0, 16, e16, m2, ta, ma
+    flh ft0, 0(a0)
+    fmv.h.x ft1, zero
+    vle16.v v8, (a0)
+    vfmacc.vf v16, ft0, v8
+    vmfgt.vf v0, v16, ft1
+    vsse16.v v16, (a0), a1
+    ret

--- a/linalg/src/isa.rs
+++ b/linalg/src/isa.rs
@@ -92,12 +92,15 @@ pub enum Isa {
     /// A vector unit at least 256 bits wide, which is what the wide RVV tiles need. Not an
     /// instruction set feature, but the hart property that decides which tile heights exist.
     RiscV64Vlen256,
+    /// Zvfh, f16 arithmetic in the vector unit. Zvfhmin, which RVA23 mandates instead, converts
+    /// to f32 and back and so cannot hold an f16 accumulator.
+    RiscV64Zvfh,
     Wasm32Simd128,
     Wasm32RelaxedSimd,
 }
 
 impl Isa {
-    pub const ALL: [Isa; 26] = [
+    pub const ALL: [Isa; 27] = [
         Isa::Arm,
         Isa::Aarch64,
         Isa::X86_64,
@@ -122,6 +125,7 @@ impl Isa {
         Isa::X86_64AmxBf16,
         Isa::RiscV64V,
         Isa::RiscV64Vlen256,
+        Isa::RiscV64Zvfh,
         Isa::Wasm32Simd128,
         Isa::Wasm32RelaxedSimd,
     ];
@@ -153,6 +157,7 @@ impl Isa {
             Isa::X86_64AmxBf16 => "amx-bf16",
             Isa::RiscV64V => "rvv",
             Isa::RiscV64Vlen256 => "vlen256",
+            Isa::RiscV64Zvfh => "zvfh",
             Isa::Wasm32Simd128 => "simd128",
             Isa::Wasm32RelaxedSimd => "relaxed-simd",
         }
@@ -188,9 +193,11 @@ impl Isa {
             // so this sits a step above the set it extends.
             Isa::X86_64Avx512Fp16 => 4,
             Isa::X86_64AmxInt8 | Isa::X86_64AmxBf16 => 5,
-            // riscv: the vector unit, then the width the wide tiles need on top of it.
+            // riscv: the vector unit, then the width the wide tiles need on top of it, then
+            // native f16, which the parts wide enough to want it are the ones that ship.
             Isa::RiscV64V => 1,
             Isa::RiscV64Vlen256 => 2,
+            Isa::RiscV64Zvfh => 3,
             // arm: NEON is the armv7 step above bare VFP, and baseline on aarch64 where the
             // ladder continues through the matrix extensions.
             Isa::ArmNeon => 1,
@@ -207,7 +214,7 @@ impl Isa {
     /// Whether the feature brings f16 arithmetic, rather than the f16 conversions an f32 round
     /// trip needs. Only on such a machine is a round trip second best.
     pub const fn fp16_arithmetic(&self) -> bool {
-        matches!(self, Isa::Aarch64Fp16 | Isa::X86_64Avx512Fp16)
+        matches!(self, Isa::Aarch64Fp16 | Isa::X86_64Avx512Fp16 | Isa::RiscV64Zvfh)
     }
 
     /// Whose instruction set this belongs to. Every feature belongs to exactly one architecture —
@@ -234,7 +241,7 @@ impl Isa {
             | Isa::X86_64AvxVnni
             | Isa::X86_64AmxInt8
             | Isa::X86_64AmxBf16 => Arch::X86_64,
-            Isa::RiscV64 | Isa::RiscV64V | Isa::RiscV64Vlen256 => Arch::RiscV64,
+            Isa::RiscV64 | Isa::RiscV64V | Isa::RiscV64Vlen256 | Isa::RiscV64Zvfh => Arch::RiscV64,
             Isa::Wasm32 | Isa::Wasm32Simd128 | Isa::Wasm32RelaxedSimd => Arch::Wasm32Simd128,
         }
     }
@@ -329,7 +336,8 @@ impl IsaSet {
             (Arch::X86_64, _) => "amx",
             (Arch::RiscV64, 0) => "rv64",
             (Arch::RiscV64, 1) => "rvv",
-            (Arch::RiscV64, _) => "vlen256",
+            (Arch::RiscV64, 2) => "vlen256",
+            (Arch::RiscV64, _) => "zvfh",
             (Arch::Wasm32Simd128, 0) => "simd",
             (Arch::Wasm32Simd128, _) => "relaxed",
         }

--- a/linalg/src/riscv64.rs
+++ b/linalg/src/riscv64.rs
@@ -12,6 +12,9 @@
 //! computes a short tile when `VLMAX < MR`. Each kernel therefore declares the
 //! narrowest vector unit that reaches its `MR`: [`Isa::RiscV64V`] for the
 //! `VLEN >= 128` every RVV 1.0 hart mandates, [`Isa::RiscV64Vlen256`] above it.
+//! `SEW` is the other half of `VLMAX`, so the f16 tiles are twice as tall as
+//! the f32 ones at the same `LMUL` and reuse those same two widths, with
+//! [`Isa::RiscV64Zvfh`] on top for the arithmetic itself.
 //!
 //! Everything here rests on [`has_rvv`] being true only for the *ratified*
 //! extension: the 0.7.1 draft parts share neither encodings nor CSRs, and the
@@ -36,8 +39,12 @@ const HWPROBE_KEY_IMA_EXT_0: i64 = 4;
 
 /// `RISCV_HWPROBE_IMA_V`, which the kernel sets only for the ratified vector
 /// extension.
-#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
 const HWPROBE_IMA_V: u64 = 1 << 2;
+
+/// `RISCV_HWPROBE_EXT_ZVFH`. Zvfh, not Zvfhmin: the latter offers only
+/// f16<->f32 conversion and so cannot carry an f16 accumulator. RVA23 mandates
+/// Zvfhmin and leaves Zvfh optional, so the profile is not enough to infer it.
+const HWPROBE_EXT_ZVFH: u64 = 1 << 30;
 
 /// `struct riscv_hwprobe`.
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
@@ -47,7 +54,8 @@ struct HwprobePair {
     value: u64,
 }
 
-/// Whether the hart offers ratified RVV 1.0, asked through `riscv_hwprobe(2)`.
+/// The extension bitmap, asked through `riscv_hwprobe(2)`; 0 where it cannot
+/// be asked.
 ///
 /// The `AT_HWCAP` 'V' bit cannot answer this. Linux derives that bitmap from
 /// the ISA string the firmware reports, and a T-Head C910 — BeagleV-Ahead,
@@ -57,8 +65,11 @@ struct HwprobePair {
 /// distinguishes them, and a kernel too old to have it is treated as having no
 /// vector unit: the draft parts are the old-kernel population, and losing the
 /// kernels on a 1.0 hart running an old kernel costs speed, not correctness.
+/// It is also the only interface carrying the multi-letter extensions —
+/// `AT_HWCAP` has bits for the single-letter ones alone, so Zvfh has no answer
+/// there at all.
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
-fn probe_rvv() -> bool {
+fn probe_ima_ext_0() -> u64 {
     let mut pair = HwprobePair { key: HWPROBE_KEY_IMA_EXT_0, value: 0 };
     // SAFETY: the syscall writes only through the pointer we hand it, to one
     // pair of the layout it expects. A kernel without it fails with ENOSYS and
@@ -74,12 +85,12 @@ fn probe_rvv() -> bool {
         )
     };
     // An unrecognised key comes back as -1 with the value left at 0.
-    rc == 0 && pair.key == HWPROBE_KEY_IMA_EXT_0 && pair.value & HWPROBE_IMA_V != 0
+    if rc == 0 && pair.key == HWPROBE_KEY_IMA_EXT_0 { pair.value } else { 0 }
 }
 
 #[cfg(not(all(target_arch = "riscv64", target_os = "linux")))]
-fn probe_rvv() -> bool {
-    false
+fn probe_ima_ext_0() -> u64 {
+    0
 }
 
 /// Reads `vlenb`, the read-only CSR holding `VLEN / 8`.
@@ -105,7 +116,11 @@ fn read_vlenb() -> usize {
 }
 
 lazy_static::lazy_static! {
-    static ref HAS_RVV: bool = probe_rvv();
+    static ref IMA_EXT_0: u64 = probe_ima_ext_0();
+
+    static ref HAS_RVV: bool = *IMA_EXT_0 & HWPROBE_IMA_V != 0;
+
+    static ref HAS_ZVFH: bool = *HAS_RVV && *IMA_EXT_0 & HWPROBE_EXT_ZVFH != 0;
 
     static ref VLENB: usize = if *HAS_RVV { read_vlenb() } else { 0 };
 }
@@ -113,6 +128,11 @@ lazy_static::lazy_static! {
 /// Whether the hart implements the ratified RVV 1.0 vector extension.
 pub fn has_rvv() -> bool {
     *HAS_RVV
+}
+
+/// Whether the hart implements Zvfh, f16 arithmetic in the vector unit.
+pub fn has_zvfh() -> bool {
+    *HAS_ZVFH
 }
 
 /// Vector register width in bytes (`VLEN / 8`); 0 without RVV.
@@ -127,6 +147,11 @@ pub fn vlmax_f32(lmul: usize) -> usize {
     vlenb() * lmul / std::mem::size_of::<f32>()
 }
 
+/// As [`vlmax_f32`], for 16-bit elements: half the `SEW`, so twice the lanes.
+pub fn vlmax_f16(lmul: usize) -> usize {
+    vlenb() * lmul / std::mem::size_of::<crate::f16>()
+}
+
 /// What this hart has, in the shared vocabulary. `VLEN` is not an instruction
 /// set feature, but it decides which tile heights are reachable, so the width
 /// the wide kernels need is carried as a step of its own.
@@ -137,7 +162,10 @@ pub fn isa_set() -> IsaSet {
         if vlenb() >= 32 {
             set = set.with(Isa::RiscV64Vlen256);
         }
-        log::info!("RVV 1.0 available, VLEN = {} bits", vlenb() * 8);
+        if has_zvfh() {
+            set = set.with(Isa::RiscV64Zvfh);
+        }
+        log::info!("RVV 1.0 available, VLEN = {} bits, zvfh = {}", vlenb() * 8, has_zvfh());
     }
     set
 }
@@ -152,9 +180,10 @@ mod test {
     #[test]
     fn detection_is_coherent() {
         eprintln!(
-            "rvv={} VLEN={} vlmax_f32(lmul=1,2,4)={:?}",
+            "rvv={} VLEN={} zvfh={} vlmax_f32(lmul=1,2,4)={:?}",
             has_rvv(),
             vlenb() * 8,
+            has_zvfh(),
             [vlmax_f32(1), vlmax_f32(2), vlmax_f32(4)],
         );
         if has_rvv() {
@@ -163,8 +192,10 @@ mod test {
             assert!(vlenb.is_power_of_two(), "VLEN must be a power of two, got {}", vlenb * 8);
             assert_eq!(vlmax_f32(1), vlenb / 4);
             assert_eq!(vlmax_f32(4), vlenb);
+            assert_eq!(vlmax_f16(1), 2 * vlmax_f32(1));
         } else {
             assert_eq!(vlenb(), 0);
+            assert!(!has_zvfh(), "Zvfh is a vector extension and cannot be present without V");
         }
     }
 
@@ -175,5 +206,7 @@ mod test {
         let set = isa_set();
         assert_eq!(set.has(Isa::RiscV64Vlen256), has_rvv() && vlmax_f32(2) >= 16);
         assert_eq!(set.has(Isa::RiscV64Vlen256), has_rvv() && vlmax_f32(8) >= 64);
+        assert_eq!(set.has(Isa::RiscV64Vlen256), has_rvv() && vlmax_f16(2) >= 32);
+        assert_eq!(set.has(Isa::RiscV64Vlen256), has_rvv() && vlmax_f16(8) >= 128);
     }
 }

--- a/linalg/src/riscv64/rvv.rs
+++ b/linalg/src/riscv64/rvv.rs
@@ -6,6 +6,12 @@
 //! RVV 1.0 hart can reach and tiles needing `VLEN >= 256`, and each kernel
 //! re-checks the granted `vl` on entry, so a predicate the hart disagrees with
 //! is a clean refusal rather than a short tile.
+//!
+//! The f16 set is the same four shapes at `SEW=16`, where `VLMAX` doubles and
+//! so does every tile height for a given `LMUL` -- which is why the two tables
+//! declare the same pair of widths for tiles twice as tall. They need Zvfh on
+//! top, and the assembler needs to know it: `tract_rvv_zvfh` is the build-time
+//! half of that, and without it f16 stays on the generic kernels.
 
 use crate::DatumType;
 use crate::isa::{Isa, IsaSet};
@@ -16,26 +22,48 @@ MMMExternKernel!(riscv64; rvv_mmm_f32_16x8 <f32>(16, 8)@(16, 16) isa(RiscV64Vlen
 MMMExternKernel!(riscv64; rvv_mmm_f32_32x1 <f32>(32, 1)@(16, 16) isa(RiscV64V));
 MMMExternKernel!(riscv64; rvv_mmm_f32_64x1 <f32>(64, 1)@(16, 16) isa(RiscV64Vlen256));
 
+#[cfg(tract_rvv_zvfh)]
+mod zvfh {
+    use crate::f16;
+
+    MMMExternKernel!(riscv64; rvv_mmm_f16_16x8 <f16>( 16, 8)@(16, 16) isa(RiscV64V, RiscV64Zvfh));
+    MMMExternKernel!(riscv64; rvv_mmm_f16_32x8 <f16>( 32, 8)@(16, 16) isa(RiscV64Vlen256, RiscV64Zvfh));
+    MMMExternKernel!(riscv64; rvv_mmm_f16_64x1 <f16>( 64, 1)@(16, 16) isa(RiscV64V, RiscV64Zvfh));
+    MMMExternKernel!(riscv64; rvv_mmm_f16_128x1<f16>(128, 1)@(16, 16) isa(RiscV64Vlen256, RiscV64Zvfh));
+}
+
 /// The widest tile the hart can reach, for each of the two shapes. A vector
 /// unit is the only thing these kernels are ranked on -- there is one RVV
 /// kernel set, not a per-chip family -- so the choice is `n == 1` or not, and
 /// then the width.
+///
+/// f16 without Zvfh is left to the tier below, which reaches the f32 kernels
+/// through a round trip: an f16 accumulator needs arithmetic Zvfhmin does not
+/// have.
 fn preferred(
     isa: &IsaSet,
     dt: DatumType,
     query: &Query,
     _suitable: &[Suitable],
 ) -> Option<&'static str> {
-    if dt != DatumType::F32 {
-        return None;
-    }
     let wide = isa.has(Isa::RiscV64Vlen256);
-    Some(match query.n {
-        Some(1) if wide => rvv_mmm_f32_64x1.name.as_str(),
-        Some(1) => rvv_mmm_f32_32x1.name.as_str(),
-        _ if wide => rvv_mmm_f32_16x8.name.as_str(),
-        _ => rvv_mmm_f32_8x8.name.as_str(),
-    })
+    let gemv = query.n == Some(1);
+    match dt {
+        DatumType::F32 => Some(match (gemv, wide) {
+            (true, true) => rvv_mmm_f32_64x1.name.as_str(),
+            (true, false) => rvv_mmm_f32_32x1.name.as_str(),
+            (false, true) => rvv_mmm_f32_16x8.name.as_str(),
+            (false, false) => rvv_mmm_f32_8x8.name.as_str(),
+        }),
+        #[cfg(tract_rvv_zvfh)]
+        DatumType::F16 if isa.has(Isa::RiscV64Zvfh) => Some(match (gemv, wide) {
+            (true, true) => zvfh::rvv_mmm_f16_128x1.name.as_str(),
+            (true, false) => zvfh::rvv_mmm_f16_64x1.name.as_str(),
+            (false, true) => zvfh::rvv_mmm_f16_32x8.name.as_str(),
+            (false, false) => zvfh::rvv_mmm_f16_16x8.name.as_str(),
+        }),
+        _ => None,
+    }
 }
 
 inventory::submit! {
@@ -53,17 +81,38 @@ mod test {
     use super::*;
     use crate::frame::mmm::{FusedKerSpec, MatMatMulKer};
 
-    /// `(name, MR, LMUL)` mirroring the build.rs kernel table.
-    const GEOMETRIES: &[(&str, usize, usize)] =
-        &[("8x8", 8, 2), ("16x8", 16, 2), ("32x1", 32, 8), ("64x1", 64, 8)];
+    /// `(name, MR, LMUL, SEW in bytes)` mirroring the build.rs kernel tables.
+    const GEOMETRIES: &[(&str, usize, usize, usize)] = &[
+        ("f32 8x8", 8, 2, 4),
+        ("f32 16x8", 16, 2, 4),
+        ("f32 32x1", 32, 8, 4),
+        ("f32 64x1", 64, 8, 4),
+        #[cfg(tract_rvv_zvfh)]
+        ("f16 16x8", 16, 2, 2),
+        #[cfg(tract_rvv_zvfh)]
+        ("f16 32x8", 32, 2, 2),
+        #[cfg(tract_rvv_zvfh)]
+        ("f16 64x1", 64, 8, 2),
+        #[cfg(tract_rvv_zvfh)]
+        ("f16 128x1", 128, 8, 2),
+    ];
 
-    fn runnable() -> [bool; 4] {
-        [
+    fn runnable() -> Vec<bool> {
+        #[allow(unused_mut)]
+        let mut runnable = vec![
             rvv_mmm_f32_8x8.runnable(),
             rvv_mmm_f32_16x8.runnable(),
             rvv_mmm_f32_32x1.runnable(),
             rvv_mmm_f32_64x1.runnable(),
-        ]
+        ];
+        #[cfg(tract_rvv_zvfh)]
+        runnable.extend([
+            zvfh::rvv_mmm_f16_16x8.runnable(),
+            zvfh::rvv_mmm_f16_32x8.runnable(),
+            zvfh::rvv_mmm_f16_64x1.runnable(),
+            zvfh::rvv_mmm_f16_128x1.runnable(),
+        ]);
+        runnable
     }
 
     /// The generated kernel suites early-return on an unrunnable kernel and
@@ -75,10 +124,11 @@ mod test {
     #[test]
     fn dispatch_matches_vlen() {
         let vlenb = super::super::vlenb();
-        for ((name, mr, lmul), got) in GEOMETRIES.iter().zip(runnable()) {
-            let want = vlenb * lmul / std::mem::size_of::<f32>() >= *mr;
-            eprintln!("VLEN={} {name}: {got} (want {want})", vlenb * 8);
-            assert_eq!(got, want, "{name} dispatch disagrees with VLEN={}", vlenb * 8);
+        let zvfh = super::super::has_zvfh();
+        for ((name, mr, lmul, sew), got) in GEOMETRIES.iter().zip(runnable()) {
+            let want = vlenb * lmul / sew >= *mr && (*sew == 4 || zvfh);
+            eprintln!("VLEN={} zvfh={zvfh} {name}: {got} (want {want})", vlenb * 8);
+            assert_eq!(got, want, "{name} dispatch disagrees with this hart");
         }
     }
 
@@ -86,21 +136,33 @@ mod test {
     /// Vacuous on a hart wide enough for all of them, hence no assertion on
     /// finding a candidate.
     ///
-    /// Meaningful only where V is present: the guard is itself a vector
-    /// instruction, so it covers "unit too narrow for this tile" but not "no
-    /// unit", where calling at all is a SIGILL rather than a return code.
+    /// Meaningful only where V is present, and for the f16 tiles only where
+    /// Zvfh is: the guard is itself an instruction of the extension it stands
+    /// for, so it covers "unit too narrow for this tile" but not "no unit",
+    /// where calling at all is a SIGILL rather than a return code.
     #[test]
     fn oversized_tile_refuses_to_run() {
         if !super::super::has_rvv() {
             return;
         }
-        let runners: [&dyn Fn() -> isize; 4] = [
-            &|| rvv_mmm_f32_8x8.kernel(&[FusedKerSpec::Done]),
-            &|| rvv_mmm_f32_16x8.kernel(&[FusedKerSpec::Done]),
-            &|| rvv_mmm_f32_32x1.kernel(&[FusedKerSpec::Done]),
-            &|| rvv_mmm_f32_64x1.kernel(&[FusedKerSpec::Done]),
+        #[allow(unused_mut)]
+        let mut runners: Vec<Box<dyn Fn() -> isize>> = vec![
+            Box::new(|| rvv_mmm_f32_8x8.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| rvv_mmm_f32_16x8.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| rvv_mmm_f32_32x1.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| rvv_mmm_f32_64x1.kernel(&[FusedKerSpec::Done])),
         ];
-        for (((name, ..), ok), run) in GEOMETRIES.iter().zip(runnable()).zip(runners) {
+        #[cfg(tract_rvv_zvfh)]
+        runners.extend::<Vec<Box<dyn Fn() -> isize>>>(vec![
+            Box::new(|| zvfh::rvv_mmm_f16_16x8.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| zvfh::rvv_mmm_f16_32x8.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| zvfh::rvv_mmm_f16_64x1.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| zvfh::rvv_mmm_f16_128x1.kernel(&[FusedKerSpec::Done])),
+        ]);
+        for (((name, .., sew), ok), run) in GEOMETRIES.iter().zip(runnable()).zip(runners) {
+            if *sew == 2 && !super::super::has_zvfh() {
+                continue;
+            }
             if !ok {
                 assert_eq!(run(), 1, "{name} ran on a hart whose VLMAX is below its MR");
                 eprintln!("{name}: correctly refused");


### PR DESCRIPTION
> **Stacked on #2599.** GitHub cannot base a pull request on a fork branch, so this
> targets `main` and its diff carries that PR's commits too. The only new commit here
> is `80a800f5` — everything else belongs to #2599 and is reviewed there.

Stacked on the f32 tier. Adds four f16 mmm kernels — 16x8 and 32x8 GEMM, 64x1
and 128x1 GEMV — from the same template at SEW=16, where VLMAX doubles and so
does every tile height for a given LMUL and VLEN.

No template change was needed: the f32 PR already parameterised element size,
so this is a kernel table, a probe, and a predicate.

## Why this is not speculative

Zvfh is optional in RVA23, so it has to be detected rather than assumed — but
it is not hypothetical hardware. The SpacemiT X60 in the K1 reports `zvfh` and
`zvfhmin` in its `/proc/cpuinfo` isa string, which covers the Banana Pi BPI-F3,
Orange Pi RV2 and Milk-V Jupiter. llama.cpp's RISC-V build enables `zvfh`
alongside `v` for exactly this hardware.

The C920v2 in the SG2044 has scalar `zfh` only, so this is a VLEN=256-class
feature in practice, and the predicates fall back cleanly on parts without it.

Zvfhmin is *not* sufficient: it provides only f16<->f32 conversion and so cannot
carry an f16 accumulator, which is why the detection looks for Zvfh
specifically.

## Testing

No CI change needed — the `-cpu max` models the f32 PR added already enable
Zvfh, so both existing riscv64 entries exercise this tier. Locally, tract-linalg
passes at VLEN 128 and 256 with Zvfh on and off, and `dispatch_matches_vlen`
covers the f16 predicates alongside the f32 ones.

Same caveat as the f32 PR: correctness under emulation, no hardware numbers.

🍍