### PR TITLE
riscv64: 3 of 4: 8 and i32 RVV matmul kernels

### DIFF
--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -546,10 +546,20 @@ fn main() {
             }
         }
         "riscv64" if assembler_supports_rvv() => {
-            let mut files = render_rvv_kernels("f32", "4", "+v", RVV_F32_KERNELS, &suffix);
+            const F32: &str = "riscv64/rvv/rvv_mmm.S.j2";
+            let mut files = render_rvv_kernels(F32, "f32", "4", "+v", RVV_F32_KERNELS, &suffix);
+            files.extend(render_rvv_kernels(
+                "riscv64/rvv/rvv_mmm_i32.S.j2",
+                "i32",
+                "4",
+                "+v",
+                RVV_I32_KERNELS,
+                &suffix,
+            ));
             println!("cargo:rustc-cfg=tract_rvv");
             if assembler_supports_zvfh() {
                 files.extend(render_rvv_kernels(
+                    F32,
                     "f16",
                     "2",
                     "+v, +zvfh, +zfhmin",
@@ -583,6 +593,21 @@ const RVV_F32_KERNELS: &[(&str, &str, &str, &str)] = &[
     ("64x1", "64", "1", "8"),
 ];
 
+/// As [`RVV_F32_KERNELS`], for the i32 accumulator tier. LMUL here is the one
+/// the i8 inner loop runs at; the accumulators, and therefore the vector width
+/// the kernel declares, sit at twice it.
+///
+///   8x8  m1   VLEN >= 128
+///   16x8 m1   VLEN >= 256
+///   16x1 m2   VLEN >= 128
+///   32x1 m2   VLEN >= 256
+const RVV_I32_KERNELS: &[(&str, &str, &str, &str)] = &[
+    ("8x8", "8", "8", "1"),
+    ("16x8", "16", "8", "1"),
+    ("16x1", "16", "1", "2"),
+    ("32x1", "32", "1", "2"),
+];
+
 /// As [`RVV_F32_KERNELS`]; SEW=16 doubles VLMAX, so every tile is twice as
 /// tall for the same LMUL and VLEN.
 const RVV_F16_KERNELS: &[(&str, &str, &str, &str)] = &[
@@ -593,6 +618,7 @@ const RVV_F16_KERNELS: &[(&str, &str, &str, &str)] = &[
 ];
 
 fn render_rvv_kernels(
+    tmpl: &str,
     dt: &'static str,
     esize: &'static str,
     arch: &'static str,
@@ -603,7 +629,7 @@ fn render_rvv_kernels(
     kernels
         .iter()
         .map(|(geo, mr, nr, lmul)| {
-            let tmpl = path::Path::new("riscv64/rvv/rvv_mmm.S.j2");
+            let tmpl = path::Path::new(tmpl);
             let out = out_dir.join(format!("rvv_mmm_{dt}_{geo}_{suffix}.S"));
             let globals = [
                 ("dt", dt),

--- a/linalg/riscv64/rvv/rvv_mmm_i32.S.j2
+++ b/linalg/riscv64/rvv/rvv_mmm_i32.S.j2
@@ -1,0 +1,255 @@
+// vim: ft=asm
+{% set mr = mr | int %}{% set nr = nr | int %}{% set lmul = lmul | int %}
+{% set al = lmul * 2 %}
+{% set vs = 4 %}
+{% set va = 8 %}
+{% set q0 = 8 %}
+{% set q1 = 12 if al == 2 else 24 %}
+
+// {{mr}}x{{nr}} i32 matmul tile, RVV 1.0.
+//
+//   v{{vs}}   scratch: A for the i32 packing, per-row operand, unicast
+//   v{{va}}   packed A column widened to i16, i8 packing only
+//   v{{q0}}/v{{q1}}  i64 scratch for the quantised ops
+//   v0    mask
+{% for j in range(nr) %}
+//   v{{ 16 + j * al }}  accumulator, C tile column {{j}}
+{% endfor %}
+//
+// vtype is e32/m{{al}} everywhere except inside the i8 inner loop and the
+// quantised ops, which set and restore it themselves. The i8 loop runs at
+// e16/m{{lmul}} so that `vle8.v` picks up EEW=8 from the instruction and
+// `vwmacc.vx` widens straight into the e32 accumulators; that also makes
+// VLMAX identical to the e32 one, so a single `vl` of {{mr}} serves both.
+//
+// The tile is correct only where VLMAX >= {{mr}}, which is vlmax_f32({{al}});
+// the check below backstops a disagreement with the dispatch predicate.
+
+.option arch, +v
+.text
+.align 2
+
+.global {{G}}rvv_mmm_i32_{{geo}}_{{suffix}}
+{{G}}rvv_mmm_i32_{{geo}}_{{suffix}}:
+
+    li          t0, {{mr}}
+    vsetvli     t1, t0, e32, m{{al}}, ta, ma
+    bne         t1, t0, .unsupported
+
+{% include "dispatcher.j2" %}
+
+// AddMatMul { k: +8, pa: +16, pb: +24, packing: +32 }. Packing 0 is i32 x i32,
+// packing 1 is i8 x i8 accumulating into i32.
+.add_mat_mul:
+    ld          t1, 8(a0)
+    ld          a1, 16(a0)
+    ld          a2, 24(a0)
+    ld          t2, 32(a0)
+
+    beqz        t1, .non_linear_loop
+
+    li          t3, 1
+    beq         t2, t3, .packed_packed_loop_1_i8i8
+
+.packed_packed_loop_1:
+    vle32.v     v{{vs}}, (a1)
+    addi        a1, a1, {{ mr * 4 }}
+{% for j in range(nr) %}
+    lw          t3, {{ j * 4 }}(a2)
+    vmacc.vx    v{{ 16 + j * al }}, t3, v{{vs}}
+{% endfor %}
+    addi        a2, a2, {{ nr * 4 }}
+    addi        t1, t1, -1
+    bnez        t1, .packed_packed_loop_1
+
+    j           .non_linear_loop
+
+.packed_packed_loop_1_i8i8:
+    li          t0, {{mr}}
+    vsetvli     t0, t0, e16, m{{lmul}}, ta, ma
+
+.packed_packed_loop_1_i8i8_inner:
+    vle8.v      v{{vs}}, (a1)
+    addi        a1, a1, {{mr}}
+    vsext.vf2   v{{va}}, v{{vs}}
+{% for j in range(nr) %}
+    lb          t3, {{j}}(a2)
+    vwmacc.vx   v{{ 16 + j * al }}, t3, v{{va}}
+{% endfor %}
+    addi        a2, a2, {{nr}}
+    addi        t1, t1, -1
+    bnez        t1, .packed_packed_loop_1_i8i8_inner
+
+    li          t0, {{mr}}
+    vsetvli     t0, t0, e32, m{{al}}, ta, ma
+    j           .non_linear_loop
+
+.clear:
+{% for j in range(nr) %}
+    vmv.v.i     v{{ 16 + j * al }}, 0
+{% endfor %}
+    j           .non_linear_loop
+
+.load_tile:
+    ld          t1, 8(a0)
+{% for j in range(nr) %}
+    vle32.v     v{{ 16 + j * al }}, (t1)
+{% if not loop.last %}
+    addi        t1, t1, {{ mr * 4 }}
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+{# ScalarSub is `scalar - acc` and ScalarSubF is `acc - scalar`, so the plain
+   form maps to the reversed vector op. #}
+{% for label, op in [
+    ("scalar_min", "vmin.vx"),
+    ("scalar_max", "vmax.vx"),
+    ("scalar_mul", "vmul.vx"),
+    ("scalar_add", "vadd.vx"),
+    ("scalar_sub", "vrsub.vx"),
+    ("scalar_sub_flipped", "vsub.vx"),
+] %}
+.{{label}}:
+    lw          t1, 8(a0)
+{% for j in range(nr) %}
+    {{op}}    v{{ 16 + j * al }}, v{{ 16 + j * al }}, t1
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+.leaky_relu:
+    lw          t1, 8(a0)
+{% for j in range(nr) %}
+    vmul.vx     v{{vs}}, v{{ 16 + j * al }}, t1
+    vmsgt.vx    v0, v{{ 16 + j * al }}, x0
+    vmerge.vvm  v{{ 16 + j * al }}, v{{vs}}, v{{ 16 + j * al }}, v0
+{% endfor %}
+    j           .non_linear_loop
+
+{# Per-row operand at +8: {{mr}} values, one per row, so one lane each. #}
+{% for label, op, flipped in [
+    ("per_row_min", "vmin.vv", false),
+    ("per_row_max", "vmax.vv", false),
+    ("per_row_mul", "vmul.vv", false),
+    ("per_row_add", "vadd.vv", false),
+    ("per_row_sub", "vsub.vv", false),
+    ("per_row_sub_flipped", "vsub.vv", true),
+] %}
+.{{label}}:
+    ld          t1, 8(a0)
+    vle32.v     v{{vs}}, (t1)
+{% for j in range(nr) %}
+{% if flipped %}
+    {{op}}    v{{ 16 + j * al }}, v{{ 16 + j * al }}, v{{vs}}
+{% else %}
+    {{op}}    v{{ 16 + j * al }}, v{{vs}}, v{{ 16 + j * al }}
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+{# Per-col operand at +8: {{nr}} values, one per accumulator. #}
+{% for label, op in [
+    ("per_col_min", "vmin.vx"),
+    ("per_col_max", "vmax.vx"),
+    ("per_col_mul", "vmul.vx"),
+    ("per_col_add", "vadd.vx"),
+    ("per_col_sub", "vrsub.vx"),
+    ("per_col_sub_flipped", "vsub.vx"),
+] %}
+.{{label}}:
+    ld          t1, 8(a0)
+{% for j in range(nr) %}
+    lw          t2, {{ j * 4 }}(t1)
+    {{op}}    v{{ 16 + j * al }}, v{{ 16 + j * al }}, t2
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+.add_row_col_products:
+    ld          t1, 8(a0)
+    ld          t2, 16(a0)
+    vle32.v     v{{vs}}, (t1)
+{% for j in range(nr) %}
+    lw          t3, {{ j * 4 }}(t2)
+    vmacc.vx    v{{ 16 + j * al }}, t3, v{{vs}}
+{% endfor %}
+    j           .non_linear_loop
+
+{# OutputStoreKer at +8: ptr, row_byte_stride, col_byte_stride, item_size.
+   Accumulator j holds column j one row per lane, so a column is exactly one
+   strided access whatever the strides. The i8 store narrows twice, e32 to e16
+   to e8, since RVV narrows by one power of two at a time. #}
+.add_unicast:
+    ld          t1, 8(a0)
+    ld          t2, 16(a0)
+    ld          t3, 24(a0)
+    ld          t5, 32(a0)
+
+    li          t4, 4
+    bne         t5, t4, .add_unicast_i8
+{% for j in range(nr) %}
+    vlse32.v    v{{vs}}, (t1), t2
+    vadd.vv     v{{ 16 + j * al }}, v{{ 16 + j * al }}, v{{vs}}
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+.add_unicast_i8:
+{% for j in range(nr) %}
+    vlse8.v     v{{vs}}, (t1), t2
+    vsext.vf4   v{{va}}, v{{vs}}
+    vadd.vv     v{{ 16 + j * al }}, v{{ 16 + j * al }}, v{{va}}
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+.store:
+    ld          t1, 8(a0)
+    ld          t2, 16(a0)
+    ld          t3, 24(a0)
+    ld          t5, 32(a0)
+
+    li          t4, 4
+    bne         t5, t4, .store_i8
+
+    bne         t2, t4, .store_strided
+{% for j in range(nr) %}
+    vse32.v     v{{ 16 + j * al }}, (t1)
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+.store_strided:
+{% for j in range(nr) %}
+    vsse32.v    v{{ 16 + j * al }}, (t1), t2
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    j           .non_linear_loop
+
+.store_i8:
+    li          t0, {{mr}}
+{% for j in range(nr) %}
+    vsetvli     t4, t0, e16, m{{lmul}}, ta, ma
+    vnsra.wi    v{{vs}}, v{{ 16 + j * al }}, 0
+    vsetvli     t4, t0, e8, {{ "mf2" if lmul == 1 else "m1" }}, ta, ma
+    vnsra.wi    v{{va}}, v{{vs}}, 0
+    vsse8.v     v{{va}}, (t1), t2
+{% if not loop.last %}
+    add         t1, t1, t3
+{% endif %}
+{% endfor %}
+    li          t0, {{mr}}
+    vsetvli     t4, t0, e32, m{{al}}, ta, ma
+    j           .non_linear_loop
+
+{% include "rvv_mmm_i32_q.j2" %}

--- a/linalg/riscv64/rvv/rvv_mmm_i32_q.j2
+++ b/linalg/riscv64/rvv/rvv_mmm_i32_q.j2
@@ -1,0 +1,145 @@
+// vim: ft=asm
+{#
+   Quantised fused ops for the i32 tier, shared by every geometry.
+
+   All three follow the reference in generic/rounding.rs, which rounds in
+   sign-magnitude rather than by arithmetic shift:
+
+       half = 1 << (shift - 1)
+       r    = (|v| + half + nudge) >> shift
+       out  = signum(v) * r
+
+   with nudge selecting the tie behaviour. signum needs no special case at
+   v == 0: half + nudge never exceeds 1 << (shift - 1), which shifts to zero
+   for every shift >= 1, so all six policies already yield 0 there.
+
+   MinusInf and PlusInf nudge on the sign of the *original* value, which is
+   gone once |v| overwrites it -- but the negative mask in v0 was taken before
+   that, and PlusInf's v <= 0 differs from v < 0 only at v == 0, where the
+   result is 0 whatever the nudge. So v0 alone serves both.
+
+   Callers set t1 = MR, t2 = shift, t3 = half, and leave vtype at the width
+   the arithmetic runs in.
+#}
+
+{% macro nudge(policy, acc, q) %}
+{% if policy == "zero" %}
+    vadd.vi     v{{acc}}, v{{acc}}, -1
+{% elif policy == "away" %}
+{% elif policy == "minus_inf" %}
+    vmv.v.i     v{{q}}, -1
+    vmerge.vxm  v{{q}}, v{{q}}, x0, v0
+    vadd.vv     v{{acc}}, v{{acc}}, v{{q}}
+{% elif policy == "plus_inf" %}
+    li          t4, -1
+    vmv.v.i     v{{q}}, 0
+    vmerge.vxm  v{{q}}, v{{q}}, t4, v0
+    vadd.vv     v{{acc}}, v{{acc}}, v{{q}}
+{% elif policy == "even" %}
+    vsra.vx     v{{q}}, v{{acc}}, t2
+    vand.vi     v{{q}}, v{{q}}, 1
+    vadd.vi     v{{q}}, v{{q}}, -1
+    vadd.vv     v{{acc}}, v{{acc}}, v{{q}}
+{% elif policy == "odd" %}
+    vsra.vx     v{{q}}, v{{acc}}, t2
+    vand.vi     v{{q}}, v{{q}}, 1
+    vsub.vv     v{{acc}}, v{{acc}}, v{{q}}
+{% endif %}
+{% endmacro %}
+
+{# Rounds one register group in place at the current vtype width, using a
+   single scratch group. The mask is taken before |v| overwrites the sign. #}
+{% macro round_in_place(acc, policy, q) %}
+    vmslt.vx    v0, v{{acc}}, x0
+    vneg.v      v{{q}}, v{{acc}}
+    vmerge.vvm  v{{acc}}, v{{acc}}, v{{q}}, v0
+    {{ nudge(policy, acc, q) }}
+    vadd.vx     v{{acc}}, v{{acc}}, t3
+    vsra.vx     v{{acc}}, v{{acc}}, t2
+    vneg.v      v{{q}}, v{{acc}}
+    vmerge.vvm  v{{acc}}, v{{acc}}, v{{q}}, v0
+{% endmacro %}
+
+{# RoundingPolicy has Native=0 first, and Native is the one value no kernel
+   implements, so it falls through to .unsupported. #}
+{% macro dispatch(prefix) %}
+    li          t4, 1
+    beq         t5, t4, .{{prefix}}_zero
+    li          t4, 2
+    beq         t5, t4, .{{prefix}}_away
+    li          t4, 3
+    beq         t5, t4, .{{prefix}}_minus_inf
+    li          t4, 4
+    beq         t5, t4, .{{prefix}}_plus_inf
+    li          t4, 5
+    beq         t5, t4, .{{prefix}}_even
+    li          t4, 6
+    beq         t5, t4, .{{prefix}}_odd
+    j           .unsupported
+{% endmacro %}
+
+// RoundingShiftRight(shift: +8, policy: +16). i32 throughout, so the
+// accumulators are rounded where they sit.
+.q_shr:
+    ld          t2, 8(a0)
+    ld          t5, 16(a0)
+    addi        t4, t2, -1
+    li          t3, 1
+    sll         t3, t3, t4
+    {{ dispatch("q_shr") }}
+
+{% for policy in ["zero", "away", "minus_inf", "plus_inf", "even", "odd"] %}
+.q_shr_{{policy}}:
+{% for j in range(nr) %}
+    {{ round_in_place(16 + j * al, policy, q1) }}
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+.q_shl:
+    ld          t2, 8(a0)
+{% for j in range(nr) %}
+    vsll.vx     v{{ 16 + j * al }}, v{{ 16 + j * al }}, t2
+{% endfor %}
+    j           .non_linear_loop
+
+// QScale(shift: +8, policy: +16, mult: +24). The product is i64, so this
+// widens to e64, rounds by shift + 31 there and truncates back, matching the
+// reference which computes in i64 and casts. A non-positive effective shift
+// means a plain left shift instead.
+.q_scale:
+    li          t1, {{mr}}
+    ld          t2, 8(a0)
+    ld          t5, 16(a0)
+    lw          t6, 24(a0)
+    addi        t2, t2, 31
+    blez        t2, .q_scale_shl
+    addi        t4, t2, -1
+    li          t3, 1
+    sll         t3, t3, t4
+    {{ dispatch("q_scale") }}
+
+{% for policy in ["zero", "away", "minus_inf", "plus_inf", "even", "odd"] %}
+.q_scale_{{policy}}:
+{% for j in range(nr) %}
+    vsetvli     t0, t1, e64, m{{ al * 2 }}, ta, ma
+    vsext.vf2   v{{q0}}, v{{ 16 + j * al }}
+    vmul.vx     v{{q0}}, v{{q0}}, t6
+    {{ round_in_place(q0, policy, q1) }}
+    vsetvli     t0, t1, e32, m{{al}}, ta, ma
+    vnsra.wi    v{{ 16 + j * al }}, v{{q0}}, 0
+{% endfor %}
+    j           .non_linear_loop
+{% endfor %}
+
+.q_scale_shl:
+    neg         t2, t2
+{% for j in range(nr) %}
+    vsetvli     t0, t1, e64, m{{ al * 2 }}, ta, ma
+    vsext.vf2   v{{q0}}, v{{ 16 + j * al }}
+    vmul.vx     v{{q0}}, v{{q0}}, t6
+    vsll.vx     v{{q0}}, v{{q0}}, t2
+    vsetvli     t0, t1, e32, m{{al}}, ta, ma
+    vnsra.wi    v{{ 16 + j * al }}, v{{q0}}, 0
+{% endfor %}
+    j           .non_linear_loop

--- a/linalg/src/riscv64/rvv.rs
+++ b/linalg/src/riscv64/rvv.rs
@@ -12,15 +12,52 @@
 //! declare the same pair of widths for tiles twice as tall. They need Zvfh on
 //! top, and the assembler needs to know it: `tract_rvv_zvfh` is the build-time
 //! half of that, and without it f16 stays on the generic kernels.
+//!
+//! The i32 set runs its i8 inner loop at half the accumulator `LMUL`, so the
+//! `(MR, LMUL)` in its build.rs table is not the pair its width follows from --
+//! the accumulators are, and they sit one `LMUL` step above. That lands the four
+//! tiles on the same two widths again.
 
 use crate::DatumType;
 use crate::isa::{Isa, IsaSet};
 use crate::mmm::{Query, Suitable};
+use crate::pack::PackedFormat;
 
 MMMExternKernel!(riscv64; rvv_mmm_f32_8x8  <f32>( 8, 8)@(16, 16) isa(RiscV64V));
 MMMExternKernel!(riscv64; rvv_mmm_f32_16x8 <f32>(16, 8)@(16, 16) isa(RiscV64Vlen256));
 MMMExternKernel!(riscv64; rvv_mmm_f32_32x1 <f32>(32, 1)@(16, 16) isa(RiscV64V));
 MMMExternKernel!(riscv64; rvv_mmm_f32_64x1 <f32>(64, 1)@(16, 16) isa(RiscV64Vlen256));
+
+MMMExternKernel!(riscv64; rvv_mmm_i32_8x8 <i32>( 8, 8)@(16, 16) isa(RiscV64V)
+    packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 8, 16), PackedFormat::new(DatumType::I8, 8, 16));
+    store(i8)
+);
+MMMExternKernel!(riscv64; rvv_mmm_i32_16x8<i32>(16, 8)@(16, 16) isa(RiscV64Vlen256)
+    packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 16, 16), PackedFormat::new(DatumType::I8, 8, 16));
+    store(i8)
+);
+/// The wide step's matvec is `32x1`, a packing group away from its `16x8`, so on a wide hart
+/// this kernel is the only GEMV sharing the `MR = 16` packing and dropping it leaves that group
+/// usable for one role out of two. There it is a peer of the step above. On a narrower hart it
+/// already sits beside `8x8` on its own rung, and lifting it there would drop that matrix kernel
+/// instead — the same hole, at the other end of the ladder.
+const I32_16X1_PEER: fn() -> isize = || {
+    if crate::isa::native().has(Isa::RiscV64Vlen256) {
+        crate::isa::peer_of(Isa::RiscV64V, Isa::RiscV64Vlen256)
+    } else {
+        0
+    }
+};
+
+MMMExternKernel!(riscv64; rvv_mmm_i32_16x1<i32>(16, 1)@(16, 1) isa(RiscV64V)
+    packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 16, 16), PackedFormat::new(DatumType::I8, 1, 1));
+    boost(I32_16X1_PEER)
+    store(i8)
+);
+MMMExternKernel!(riscv64; rvv_mmm_i32_32x1<i32>(32, 1)@(16, 1) isa(RiscV64Vlen256)
+    packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 32, 16), PackedFormat::new(DatumType::I8, 1, 1));
+    store(i8)
+);
 
 #[cfg(tract_rvv_zvfh)]
 mod zvfh {
@@ -62,6 +99,12 @@ fn preferred(
             (false, true) => zvfh::rvv_mmm_f16_32x8.name.as_str(),
             (false, false) => zvfh::rvv_mmm_f16_16x8.name.as_str(),
         }),
+        DatumType::I32 => Some(match (gemv, wide) {
+            (true, true) => rvv_mmm_i32_32x1.name.as_str(),
+            (true, false) => rvv_mmm_i32_16x1.name.as_str(),
+            (false, true) => rvv_mmm_i32_16x8.name.as_str(),
+            (false, false) => rvv_mmm_i32_8x8.name.as_str(),
+        }),
         _ => None,
     }
 }
@@ -81,12 +124,18 @@ mod test {
     use super::*;
     use crate::frame::mmm::{FusedKerSpec, MatMatMulKer};
 
-    /// `(name, MR, LMUL, SEW in bytes)` mirroring the build.rs kernel tables.
+    /// `(name, MR, LMUL, SEW in bytes)` mirroring the build.rs kernel tables. The
+    /// i32 entries carry the accumulator `LMUL`, twice the one their table lists,
+    /// since that is the state whose `VLMAX` has to reach `MR`.
     const GEOMETRIES: &[(&str, usize, usize, usize)] = &[
         ("f32 8x8", 8, 2, 4),
         ("f32 16x8", 16, 2, 4),
         ("f32 32x1", 32, 8, 4),
         ("f32 64x1", 64, 8, 4),
+        ("i32 8x8", 8, 2, 4),
+        ("i32 16x8", 16, 2, 4),
+        ("i32 16x1", 16, 4, 4),
+        ("i32 32x1", 32, 4, 4),
         #[cfg(tract_rvv_zvfh)]
         ("f16 16x8", 16, 2, 2),
         #[cfg(tract_rvv_zvfh)]
@@ -104,6 +153,10 @@ mod test {
             rvv_mmm_f32_16x8.runnable(),
             rvv_mmm_f32_32x1.runnable(),
             rvv_mmm_f32_64x1.runnable(),
+            rvv_mmm_i32_8x8.runnable(),
+            rvv_mmm_i32_16x8.runnable(),
+            rvv_mmm_i32_16x1.runnable(),
+            rvv_mmm_i32_32x1.runnable(),
         ];
         #[cfg(tract_rvv_zvfh)]
         runnable.extend([
@@ -151,6 +204,10 @@ mod test {
             Box::new(|| rvv_mmm_f32_16x8.kernel(&[FusedKerSpec::Done])),
             Box::new(|| rvv_mmm_f32_32x1.kernel(&[FusedKerSpec::Done])),
             Box::new(|| rvv_mmm_f32_64x1.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| rvv_mmm_i32_8x8.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| rvv_mmm_i32_16x8.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| rvv_mmm_i32_16x1.kernel(&[FusedKerSpec::Done])),
+            Box::new(|| rvv_mmm_i32_32x1.kernel(&[FusedKerSpec::Done])),
         ];
         #[cfg(tract_rvv_zvfh)]
         runners.extend::<Vec<Box<dyn Fn() -> isize>>>(vec![


### PR DESCRIPTION
> **Stacked on #2599 and #2600.** GitHub cannot base a pull request on a fork branch,
> so this targets `main` and its diff carries those PRs' commits too. The only new
> commit here is `0b3bce0f` — the rest are reviewed in #2599 and #2600.

Stacked on the f32 and f16 tiers. Adds four i32-accumulator kernels — 8x8 and
16x8 GEMM, 16x1 and 32x1 GEMV — covering both packings the frame offers:
i32 x i32, and i8 x i8 accumulating into i32.

## The i8 inner loop

vtype sits at e16 for that loop, which buys two things at once. `vle8.v` takes
EEW=8 from the instruction rather than from vtype, so the packed A column loads
as bytes with no separate widening step beyond one `vsext.vf2`; and
`vwmacc.vx` widens on the way in, landing straight in the e32 accumulators.
Because VLMAX at e16/mN equals VLMAX at e32/m2N, a single `vl` of MR is valid
in both states, so the loop needs one `vsetvli` on entry and one on exit rather
than a pair per K step.

`Zvqdotq` would collapse this further, but it is unratified and no hardware
implements it yet.

## Quantised ops

`QScale`, `RoundingShiftRight` and `ShiftLeft` follow the sign-magnitude
reference in `generic/rounding.rs` rather than an arithmetic shift, so the six
rounding policies differ only in the nudge term. Two things make that cheaper
than it looks:

- The negative mask is taken before the magnitude overwrites the sign, and it
  serves the MinusInf and PlusInf nudges as well. PlusInf wants `v <= 0` rather
  than `v < 0`, but those differ only at `v == 0`, where `half + nudge` never
  survives the shift and the result is 0 under every policy.
- For the same reason `signum` needs no zero case.

`QScale` widens to e64 for the i64 product, rounds there, and truncates back,
matching the reference which computes in i64 and casts.

## Testing

`test_mmm_kernel_i32!` pulls in `mmm_q_scale_tests!`, so every policy is
proptested against the reference — that is what these were developed against.
2683 tract-linalg tests and tract-core's 270 pass at VLEN 128, 256, 512 and
1024, on stock RVA23, and with V absent, under both qemu 10.2.1 and 11.0.3.

No CI change needed; the entries the f32 PR added cover this tier.

Same caveat as the earlier two: correctness under emulation, no hardware
numbers.

🍍