### PR TITLE
ci: single source of truth for LLM model/quant list

### DIFF
--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -88,49 +88,35 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     outputs:
-      models: ${{steps.set-matrix.outputs.models}}
-      q: ${{steps.set-matrix.outputs.q}}
+      combos: ${{steps.set-matrix.outputs.combos}}
 
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.prepare.outputs.test_ref }}
+          persist-credentials: false
       - id: set-matrix
         env:
           FULL: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
         run: |
           if [ "$FULL" = "true" ]
           then
-            echo 'models=[ "openelm-270M", "llama-3.2-1B-instruct", "llama-3.2-3B-instruct", "llama-3.1-8B-instruct", "qwen3-1.7B", "qwen3-8B" ]' >> $GITHUB_OUTPUT
-            echo 'q=[ "f16f16", "f32f32", "q40ef16" ]' >> $GITHUB_OUTPUT
+            combos=$(jq -c '[ .[] | .id as $m | .quants[] | {model:$m, q:.} ]' .travis/llm-models.json)
           else
             echo ::notice::Skipping most checks on PR and commit. Dispatch workflow manually if needed.
-            echo 'models=[ "llama-3.2-1B-instruct" ]' >> $GITHUB_OUTPUT
-            echo 'q=[ "f32f32", "q40ef16" ]' >> $GITHUB_OUTPUT
+            combos='[ {"model":"llama-3.2-1B-instruct","q":"f32f32"}, {"model":"llama-3.2-1B-instruct","q":"q40ef16"} ]'
           fi
+          echo "combos=$combos" >> $GITHUB_OUTPUT
 
   foundation-llm:
-    name: ${{ matrix.os }} / ${{matrix.rt}} / ${{ matrix.model }} / ${{ matrix.q }}
+    name: ${{ matrix.os }} / ${{matrix.rt}} / ${{ matrix.combo.model }} / ${{ matrix.combo.q }}
     needs: [ prepare, cli, foundation-llms ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ macOS, cuda-lovelace ]
-        model: ${{fromJson(needs.foundation-llms.outputs.models)}}
-        q: ${{fromJson(needs.foundation-llms.outputs.q)}}
         rt: [ cpu, gpu ]
-        exclude:
-          - model: openelm-270M
-            q: f32f32
-          - model: Llama-3.2-3B-Instruct
-            q: f32f32
-          - model: Llama-3.2-3B-Instruct
-            q: f32f32
-          - model: Llama-3.1-8B-Instruct
-            q: f32f32
-          - model: Qwen3-1.7B
-            q: f32f32
-          - model: Qwen3-8B
-            q: f32f32
-          - model: OpenELM-270M
-            q: f32f32
+        combo: ${{fromJson(needs.foundation-llms.outputs.combos)}}
       fail-fast: false
     permissions:
       id-token: write
@@ -152,8 +138,8 @@ jobs:
       env:
         UNAME: ${{ env.uname }}
         RT_MATRIX: ${{ matrix.rt }}
-        MODEL: ${{ matrix.model }}
-        Q: ${{ matrix.q }}
+        MODEL: ${{ matrix.combo.model }}
+        Q: ${{ matrix.combo.q }}
       run: |
         chmod +x "tract-cli-${UNAME}/tract"
         export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli-${UNAME}/tract"

--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           if [ "$FULL" = "true" ]
           then
-            combos=$(jq -c '[ .[] | .id as $m | .quants[] | {model:$m, q:.} ]' .travis/llm-models.json)
+            combos=$(awk -F'\t' 'BEGIN{printf "["} /^#/||NF<3{next} {n=split($3,qs,","); for(i=1;i<=n;i++){printf "%s{\"model\":\"%s\",\"q\":\"%s\"}", (c++?",":""), $1, qs[i]}} END{print "]"}' .travis/llm-models.tsv)
           else
             echo ::notice::Skipping most checks on PR and commit. Dispatch workflow manually if needed.
             combos='[ {"model":"llama-3.2-1B-instruct","q":"f32f32"}, {"model":"llama-3.2-1B-instruct","q":"q40ef16"} ]'

--- a/.travis/llm-models.json
+++ b/.travis/llm-models.json
@@ -1,0 +1,8 @@
+[
+  { "id": "openelm-270M",          "hf": "apple/OpenELM-270M",               "quants": ["f16f16", "q40ef16"] },
+  { "id": "llama-3.2-1B-instruct", "hf": "meta-llama/Llama-3.2-1B-Instruct", "quants": ["f32f32", "f16f16", "q40ef16"] },
+  { "id": "llama-3.2-3B-instruct", "hf": "meta-llama/Llama-3.2-3B-Instruct", "quants": ["f16f16", "q40ef16"] },
+  { "id": "llama-3.1-8B-instruct", "hf": "meta-llama/Llama-3.1-8B-Instruct", "quants": ["f16f16", "q40ef16"] },
+  { "id": "qwen3-1.7B",            "hf": "Qwen/Qwen3-1.7B",                   "quants": ["f16f16", "q40ef16"] },
+  { "id": "qwen3-8B",              "hf": "Qwen/Qwen3-8B",                     "quants": ["f16f16", "q40ef16"] }
+]

--- a/.travis/llm-models.json
+++ b/.travis/llm-models.json
@@ -1,8 +1,0 @@
-[
-  { "id": "openelm-270M",          "hf": "apple/OpenELM-270M",               "quants": ["f16f16", "q40ef16"] },
-  { "id": "llama-3.2-1B-instruct", "hf": "meta-llama/Llama-3.2-1B-Instruct", "quants": ["f32f32", "f16f16", "q40ef16"] },
-  { "id": "llama-3.2-3B-instruct", "hf": "meta-llama/Llama-3.2-3B-Instruct", "quants": ["f16f16", "q40ef16"] },
-  { "id": "llama-3.1-8B-instruct", "hf": "meta-llama/Llama-3.1-8B-Instruct", "quants": ["f16f16", "q40ef16"] },
-  { "id": "qwen3-1.7B",            "hf": "Qwen/Qwen3-1.7B",                   "quants": ["f16f16", "q40ef16"] },
-  { "id": "qwen3-8B",              "hf": "Qwen/Qwen3-8B",                     "quants": ["f16f16", "q40ef16"] }
-]

--- a/.travis/llm-models.tsv
+++ b/.travis/llm-models.tsv
@@ -1,0 +1,8 @@
+# Single source of truth for the LLM CI models. Columns, tab-separated:
+#   id (CI/matrix token)    hf (HuggingFace id)    quants (comma-separated)
+openelm-270M	apple/OpenELM-270M	f16f16,q40ef16
+llama-3.2-1B-instruct	meta-llama/Llama-3.2-1B-Instruct	f32f32,f16f16,q40ef16
+llama-3.2-3B-instruct	meta-llama/Llama-3.2-3B-Instruct	f16f16,q40ef16
+llama-3.1-8B-instruct	meta-llama/Llama-3.1-8B-Instruct	f16f16,q40ef16
+qwen3-1.7B	Qwen/Qwen3-1.7B	f16f16,q40ef16
+qwen3-8B	Qwen/Qwen3-8B	f16f16,q40ef16

--- a/.travis/test-llm.sh
+++ b/.travis/test-llm.sh
@@ -16,16 +16,11 @@ then
     device=cpu
 fi
 generation=541
+manifest=$ROOT/.travis/llm-models.json
 
 if [ "$model" = "all" ]
 then
-    for m in \
-        openelm-270M \
-	llama-3.2-1B-instruct \
-	llama-3.2-3B-instruct \
-	llama-3.1-8B-instruct \
-	qwen3-1.7B \
-	qwen3-8B
+    for m in $(jq -r '.[].id' $manifest)
     do
         $0 $m $2 $device
     done
@@ -34,29 +29,30 @@ fi
 
 model=$(echo $model | tr 'A-Z' 'a-z' | tr -d "_.-")
 
-for m in \
-    apple--OpenELM-270M \
-    meta-llama--Llama-3.2-1B-Instruct \
-    meta-llama--Llama-3.2-3B-Instruct \
-    meta-llama--Llama-3.1-8B-Instruct \
-    Qwen--Qwen3-1.7B \
-    Qwen--Qwen3-8B
+quants=
+while IFS=$'\t' read -r id hf qs
 do
-    norm=$(echo $m | tr "A-Z" "a-z" | tr -d "_.-")
-    if [[ "$norm" == *"$model"* ]];
-    then
-        model_id=$m
-    fi
-done
+    local_id=$(echo $hf | sed 's/\//--/g')
+    for cand in "$id" "$local_id"
+    do
+        norm=$(echo $cand | tr "A-Z" "a-z" | tr -d "_.-")
+        if [[ "$norm" == *"$model"* ]]
+        then
+            model_id=$local_id
+            quants=$qs
+        fi
+    done
+done < <(jq -r '.[] | "\(.id)\t\(.hf)\t\(.quants|join(","))"' $manifest)
 
 if [ -z "$model_id" ]
 then
     echo "No model matched"
+    exit 1
 fi
 
 if [ "$q" = "all" ]
 then
-    for q in q40ef16 f16f16 f32f32
+    for q in $(echo $quants | tr ',' ' ')
     do
         $0 $1 $q $device
     done

--- a/.travis/test-llm.sh
+++ b/.travis/test-llm.sh
@@ -16,11 +16,11 @@ then
     device=cpu
 fi
 generation=541
-manifest=$ROOT/.travis/llm-models.json
+manifest=$ROOT/.travis/llm-models.tsv
 
 if [ "$model" = "all" ]
 then
-    for m in $(jq -r '.[].id' $manifest)
+    for m in $(grep -v '^#' $manifest | cut -f1)
     do
         $0 $m $2 $device
     done
@@ -32,6 +32,7 @@ model=$(echo $model | tr 'A-Z' 'a-z' | tr -d "_.-")
 quants=
 while IFS=$'\t' read -r id hf qs
 do
+    case "$id" in ''|\#*) continue;; esac
     local_id=$(echo $hf | sed 's/\//--/g')
     for cand in "$id" "$local_id"
     do
@@ -42,7 +43,7 @@ do
             quants=$qs
         fi
     done
-done < <(jq -r '.[] | "\(.id)\t\(.hf)\t\(.quants|join(","))"' $manifest)
+done < $manifest
 
 if [ -z "$model_id" ]
 then

--- a/examples/causal_llm/scripts/generate_ci_llm_assets.sh
+++ b/examples/causal_llm/scripts/generate_ci_llm_assets.sh
@@ -14,29 +14,12 @@ else
     source $venv/bin/activate
 fi
 
-MODELS=
-MODELS="$MODELS apple/OpenELM-270M"
-MODELS="$MODELS meta-llama/Llama-3.2-1B-Instruct"
-MODELS="$MODELS meta-llama/Llama-3.2-3B-Instruct"
-MODELS="$MODELS meta-llama/Llama-3.1-8B-Instruct"
-MODELS="$MODELS Qwen/Qwen2.5-7B-Instruct"
-MODELS="$MODELS Qwen/Qwen3-1.7B"
-MODELS="$MODELS Qwen/Qwen3-8B"
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+MANIFEST=$ROOT/.travis/llm-models.json
 
-MODELS_F32_ALLOWED="meta-llama/Llama-3.2-1B-Instruct"
-
-VARIANTS="f32f32 f16f16 q40ef16 "
-
-for hf_id in $MODELS
+jq -r '.[] | .hf as $hf | .quants[] | "\($hf)\t\(.)"' "$MANIFEST" | while IFS=$'\t' read -r hf_id q
 do
     local_id=$(echo $hf_id | sed "s/\//--/g")
-
-    for q in $VARIANTS
-    do
-	 if [ "$q" = "f32f32" ] && ! echo "$MODELS_F32_ALLOWED" | grep -q -w "$hf_id"; then
-         echo "INFO: Skipping f32f32 for model $hf_id"
-            continue
-         fi
          model=$local_id-$q
          rm -rf $model
          case $q in
@@ -60,6 +43,4 @@ do
           then
             aws s3 cp $model/tests/prompt_with_past_io.npz s3://tract-ci-builds/tests/llm/current/$model/$model.p50s50.io.npz
           fi
-    done
-
 done

--- a/examples/causal_llm/scripts/generate_ci_llm_assets.sh
+++ b/examples/causal_llm/scripts/generate_ci_llm_assets.sh
@@ -15,10 +15,13 @@ else
 fi
 
 ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
-MANIFEST=$ROOT/.travis/llm-models.json
+MANIFEST=$ROOT/.travis/llm-models.tsv
 
-jq -r '.[] | .hf as $hf | .quants[] | "\($hf)\t\(.)"' "$MANIFEST" | while IFS=$'\t' read -r hf_id q
+while IFS=$'\t' read -r id hf_id quants
 do
+    case "$id" in ''|\#*) continue;; esac
+    for q in $(echo $quants | tr ',' ' ')
+    do
     local_id=$(echo $hf_id | sed "s/\//--/g")
          model=$local_id-$q
          rm -rf $model
@@ -43,4 +46,5 @@ do
           then
             aws s3 cp $model/tests/prompt_with_past_io.npz s3://tract-ci-builds/tests/llm/current/$model/$model.p50s50.io.npz
           fi
-done
+    done
+done < "$MANIFEST"


### PR DESCRIPTION
Model and quant lists were duplicated across the asset generator, test-llm.sh and the large_models matrix, and drifted: test-llm.sh looped f32f32 for every model though only Llama-3.2-1B has it, 404ing on 'all' runs. Read the list from .travis/llm-models.json everywhere and build the CI matrix from per-model quants instead of a models x quants product with a hand-kept exclude block.