### PR TITLE
scan: pass tensors through OptScan when a single iteration covers the whole axis

### DIFF
--- a/core/src/ops/scan/optimized.rs
+++ b/core/src/ops/scan/optimized.rs
@@ -211,8 +211,14 @@ impl OpState for State {
             }
         }
 
+        // One full-coverage iteration yields each scan output as-is, so the body
+        // tensor is handed through instead of copied into a preallocation. Warm-up
+        // calls (position <= skip) leave outputs unassigned and need the general path.
+        let runs_now = *position + 1 > op.skip;
+        let mut single_shot: TVec<bool> = tvec!();
         let mut outputs = tvec!();
         for (ix, output) in op.output_mapping.iter().enumerate() {
+            let mut one_shot = false;
             if let Some((slot, info)) = output.scan {
                 let fact = op.plan.model().output_fact(ix)?;
                 let mut shape: TVec<usize> =
@@ -222,10 +228,16 @@ impl OpState for State {
                     .as_ref()
                     .and_then(|d| d.as_usize())
                     .unwrap_or(shape[info.axis] * iters);
+                one_shot = iters == 1 && runs_now && scanning_dim == shape[info.axis];
                 shape[info.axis] = scanning_dim;
-                let t = unsafe { Tensor::uninitialized_dt(fact.datum_type, &shape)? };
+                let t = if one_shot {
+                    Tensor::default()
+                } else {
+                    unsafe { Tensor::uninitialized_dt(fact.datum_type, &shape)? }
+                };
                 outputs.push((slot, t));
             }
+            single_shot.push(one_shot);
             if let Some(slot) = output.last_value_slot {
                 outputs.push((slot, Tensor::default()));
             }
@@ -254,7 +266,14 @@ impl OpState for State {
                 iter_inputs.push(match m {
                     InputMapping::State => hidden_state.pop().unwrap(),
                     InputMapping::Scan(info) => {
-                        Self::slice_input(&inputs[slot], info.axis, i, info.chunk)?.into_tvalue()
+                        let input = &inputs[slot];
+                        // A chunk covering the whole axis slices to the input
+                        // itself, forward or backward.
+                        if i == 0 && input.shape()[info.axis] == info.chunk.unsigned_abs() {
+                            input.clone()
+                        } else {
+                            Self::slice_input(input, info.axis, i, info.chunk)?.into_tvalue()
+                        }
                     }
                     InputMapping::Full => inputs[slot].clone(),
                 });
@@ -274,9 +293,16 @@ impl OpState for State {
             model_state.reset_turn_keep_symbols();
             trace!("iter_outputs #{i}: {iter_outputs:?}");
 
-            for (v, mapping) in iter_outputs.into_iter().zip(&op.output_mapping) {
+            for (ix, (v, mapping)) in iter_outputs.into_iter().zip(&op.output_mapping).enumerate() {
                 if let Some((slot, info)) = mapping.scan {
-                    Self::assign_output(&mut outputs[slot], info.axis, &v, i, info.chunk < 0);
+                    if single_shot[ix] && !mapping.state && mapping.last_value_slot.is_none() {
+                        outputs[slot] = v.into_tensor();
+                        continue;
+                    } else if single_shot[ix] {
+                        outputs[slot] = v.clone().into_tensor();
+                    } else {
+                        Self::assign_output(&mut outputs[slot], info.axis, &v, i, info.chunk < 0);
+                    }
                 }
                 if i == iters - 1
                     && let Some(slot) = mapping.last_value_slot


### PR DESCRIPTION
At a single full-coverage iteration, `OptScan` still sliced the scan input into a
fresh chunk tensor and copied the body output into a preallocated full-sequence
tensor. This passes the input handle through and hands the body output out directly
when one iteration covers the whole scan axis and the body runs on this call;
warm-up (`skip`) calls, partial chunks and multi-iteration scans keep the general
path unchanged.

Complementary to #2605: that transform removes the Scan wrapper entirely where the
caller opts in to thread state; this makes the wrapper cheaper by default for every
Scan that remains — including models where #2605 declines or regresses.

Bit-exact: verified call-for-call against caller-managed-state references on the
pulsed DeepFilterNet3 graphs and TRU-Net. The gain scales with scan tensor size —
small on DFN3 (~1%; its 1–2 KB tensors mean the copies were never the dominant
cost), proportionally more where chunks are large. It is never worse than the
sliced path: read-only body consumers see strictly fewer copies and allocations,
and a body op that wants in-place mutation pays the same single copy it forced
before.

🍍
