### PR TITLE
docs: correct what CONST_FOLD_MEM_BUDGET actually bounds

### DIFF
--- a/core/src/optim/mod.rs
+++ b/core/src/optim/mod.rs
@@ -22,13 +22,16 @@ use self::slice::PushSliceUp;
 use self::uniform_mask::FoldUniformMask;
 use op_optim::OpOptim;
 
-/// Memory a single constant fold may materialize.
+/// Byte allowance for the growth an eager constant fold may cause.
 ///
-/// Bounds every eager evaluation of a constant subgraph, both during inference
-/// and in `prop_const`: a fold under the budget is cheap enough to pay for at
-/// load time, and one over it is left in the graph rather than risk turning a
-/// large weight into several copies. Shape and index arithmetic sits far below
-/// it, decoded weight tensors far above.
+/// A fold is admissible when its output is no larger than
+/// `input_mem.max(BUDGET)`: under the allowance it is cheap enough to pay for
+/// at load time, above it only a fold that does not grow its inputs is worth
+/// the copy. A caller that can see a constant's consumers also weighs the
+/// allowance against turning one shared buffer into one buffer per consumer.
+///
+/// Shape and index arithmetic sits far below it, decoded weight tensors far
+/// above.
 pub const CONST_FOLD_MEM_BUDGET: u64 = 4 << 20;
 
 pub trait TypedPass: Debug + Send + Sync + dyn_clone::DynClone {

--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -9,8 +9,13 @@ use crate::optim::{CONST_FOLD_MEM_BUDGET, OptimizerSession};
 
 /// Replaces stateless nodes whose inputs are all constant with the constant they
 /// evaluate to, walking forward through single-successor chains so one patch can
-/// collapse a whole run. Folds are bounded by [`CONST_FOLD_MEM_BUDGET`] so a large
-/// weight is not duplicated once per consumer.
+/// collapse a whole run.
+///
+/// [`CONST_FOLD_MEM_BUDGET`] is weighed only against an input that has several
+/// successors, so a large weight is not duplicated once per consumer; a
+/// sole-consumer input, or any input of a `Slice`, is exempt whatever its size.
+/// Every fold, including each step of the walk, must additionally keep its output
+/// within the allowance.
 #[derive(Clone, Debug, Default)]
 pub struct PropConst(usize);
 

--- a/hir/src/infer/ops.rs
+++ b/hir/src/infer/ops.rs
@@ -22,6 +22,11 @@ pub trait InferenceOp: Op {
     /// also try to eval() the op if its a EvalOp and if the inputs are
     /// fully determined.
     ///
+    /// Facts carry no graph, so that eager eval cannot count a constant's
+    /// consumers: on top of holding the output within
+    /// [`CONST_FOLD_MEM_BUDGET`], it requires every input to be plain and
+    /// itself under the allowance.
+    ///
     /// Returns Err in case of an unrecoverable error during the inference,
     /// and the refined properties about the inputs and outputs otherwise.
     fn infer(


### PR DESCRIPTION
The budget's doc described a flat ceiling on every eager constant fold, which neither consult site implements: a fold is admissible when its output stays within `input_mem.max(BUDGET)`, so the value is an allowance for growth rather than a cap on fold size. Anyone tuning it was being told the wrong contract.

The constant now states that allowance alone, leaving each site to document its own policy where a reader changing it will see it: the multi-successor test and its `Slice` and sole-consumer exemptions on `PropConst`, the per-input gate on `InferenceOp::infer`, which cannot count consumers from facts.