### PR TITLE
core: give add_const a name no node is using

### DIFF
--- a/core/src/model/typed.rs
+++ b/core/src/model/typed.rs
@@ -147,7 +147,7 @@ impl SpecialOps<TypedFact, Box<dyn TypedOp>> for TypedModel {
             }
         }
         let fact = TypedFact::try_from(v.clone())?;
-        let name = name.into();
+        let name = self.unique_name(name.into()).into_owned();
         let op = if let Some(exotic) = &fact.exotic_fact {
             crate::ops::konst::Const::new_with_exotic_fact(v, exotic.clone())?
         } else {
@@ -345,5 +345,22 @@ mod test {
     fn test() {
         fn is_sync<T: Sync>() {}
         is_sync::<TypedModel>();
+    }
+
+    #[test]
+    fn add_const_does_not_reuse_a_taken_name() {
+        let mut model = TypedModel::default();
+        let first = model.add_const("konst", tensor1(&[0.0f32])).unwrap();
+        let second = model.add_const("konst", tensor1(&[1.0f32])).unwrap();
+        assert_ne!(first.node, second.node);
+        assert_ne!(model.node(first.node).name, model.node(second.node).name);
+    }
+
+    #[test]
+    fn add_const_still_shares_an_identical_value() {
+        let mut model = TypedModel::default();
+        let first = model.add_const("a", tensor1(&[0.0f32])).unwrap();
+        let second = model.add_const("b", tensor1(&[0.0f32])).unwrap();
+        assert_eq!(first.node, second.node);
     }
 }


### PR DESCRIPTION
`add_const` deduplicates a constant by value, then adds the node under the caller's name without checking that name is free — two different questions, of which only the first was being asked. A constant that outlives the node it was named after then collides with a replacement arriving under the same name, and `check_compact` rejects the graph:

```
running pass codegen: after graph compaction: duplicate name /convt3/Conv.bias
```

Found loading plain (non-`ll`) DeepFilterNet 3 through `deep_filter`. In `erb_dec`, `/convt3/Conv` has an all-zero bias, so a const named `/convt3/Conv.bias` is created for it; being a zero tensor, the value-dedup hands that same node to the padding value of `/conv0_out/0/Conv`'s im2col; `/convt3/Conv` is later rewritten and its replacement bias arrives by patch under a name the shared node still holds.

Since `check_compact` is `#[cfg(debug_assertions)]`, the model loads in release and refuses to load in debug — invisible where it is harmless, fatal where it is being checked.

`add_const` now takes its name from `unique_name`. The two tests cover the name not being reused and an identical value still being shared, since the fix must not disturb that. `cargo test -p tract-core`: 272 passed, 0 failed, 3 ignored.

🍍
