### PR TITLE
build: let the x86 avx-512 benches build on non-x86 hosts

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -148,7 +148,7 @@ jobs:
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
-    - run: rustup component add clippy && cargo clippy
+    - run: rustup component add clippy && cargo clippy --all-targets
     - name: clippy (bench-suite feature)
       run: cargo clippy -p tract-cli --features bench-suite
     - name: test (bench-suite feature)

--- a/linalg/benches/activations_avx512.rs
+++ b/linalg/benches/activations_avx512.rs
@@ -10,6 +10,7 @@
 // All buffers are 64-byte aligned (AVX-512 alignment_bytes) and a multiple of
 // 64 elements so every kernel's nr() divides the length. Criterion reports the
 // distribution; the min of the samples is the relevant "min-of-N" number.
+#![cfg_attr(not(target_arch = "x86_64"), allow(dead_code, unused_imports, unused_macros))]
 
 use criterion::*;
 use tract_data::prelude::*;
@@ -66,43 +67,50 @@ macro_rules! bench_pair {
 
 fn benches(c: &mut Criterion) {
     #[cfg(target_arch = "x86_64")]
-    enable_ftz_daz();
-    use tract_linalg::x86_64_fma::act::*;
-    use tract_linalg::x86_64_fma::{
-        avx512_sigmoid_f32, avx512_tanh_f32, fma_sigmoid_f32, fma_tanh_f32,
-    };
+    {
+        enable_ftz_daz();
+        use tract_linalg::x86_64_fma::act::*;
+        use tract_linalg::x86_64_fma::{
+            avx512_sigmoid_f32, avx512_tanh_f32, fma_sigmoid_f32, fma_tanh_f32,
+        };
 
-    bench_pair!(c, "sigmoid_f32", "fma", fma_sigmoid_f32, avx512_sigmoid_f32);
-    bench_pair!(c, "tanh_f32", "fma", fma_tanh_f32, avx512_tanh_f32);
-    bench_pair!(
-        c,
-        "hardswish_f32",
-        "generic",
-        tract_linalg::generic::SHardSwish4,
-        x86_64_avx512_hardswish_f32_64n
-    );
-    bench_pair!(
-        c,
-        "leaky_relu_f32",
-        "generic",
-        tract_linalg::generic::SLeakyRelu4,
-        x86_64_avx512_leaky_relu_f32_64n,
-        0.1f32
-    );
-    bench_pair!(
-        c,
-        "silu_f32",
-        "generic",
-        tract_linalg::generic::SSiLU4,
-        x86_64_avx512_silu_f32_16n
-    );
-    bench_pair!(
-        c,
-        "gelu_f32",
-        "generic",
-        tract_linalg::generic::SGelu4,
-        x86_64_avx512_gelu_f32_16n
-    );
+        bench_pair!(c, "sigmoid_f32", "fma", fma_sigmoid_f32, avx512_sigmoid_f32);
+        bench_pair!(c, "tanh_f32", "fma", fma_tanh_f32, avx512_tanh_f32);
+        bench_pair!(
+            c,
+            "hardswish_f32",
+            "generic",
+            tract_linalg::generic::SHardSwish4,
+            x86_64_avx512_hardswish_f32_64n
+        );
+        bench_pair!(
+            c,
+            "leaky_relu_f32",
+            "generic",
+            tract_linalg::generic::SLeakyRelu4,
+            x86_64_avx512_leaky_relu_f32_64n,
+            0.1f32
+        );
+        bench_pair!(
+            c,
+            "silu_f32",
+            "generic",
+            tract_linalg::generic::SSiLU4,
+            x86_64_avx512_silu_f32_16n
+        );
+        bench_pair!(
+            c,
+            "gelu_f32",
+            "generic",
+            tract_linalg::generic::SGelu4,
+            x86_64_avx512_gelu_f32_16n
+        );
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        eprintln!("this bench only runs on x86_64 targets — skipping on host");
+        let _ = c;
+    }
 }
 
 criterion_group!(g, benches);

--- a/linalg/benches/activations_avx512_f16.rs
+++ b/linalg/benches/activations_avx512_f16.rs
@@ -3,6 +3,7 @@
 // already runs `(*v - max).to_f32()`-style per-element conversions). Buffers
 // are 64-byte aligned (alignment that the AVX-512 path uses internally) and
 // a multiple of 64 elements.
+#![cfg_attr(not(target_arch = "x86_64"), allow(dead_code, unused_imports, unused_macros))]
 
 use criterion::*;
 use tract_data::prelude::*;
@@ -40,43 +41,51 @@ macro_rules! bench_pair {
 }
 
 fn benches(c: &mut Criterion) {
-    bench_pair!(
-        c,
-        "sigmoid_f16",
-        tract_linalg::generic::sigmoid::HSigmoid8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_sigmoid_f16_16n
-    );
-    bench_pair!(
-        c,
-        "tanh_f16",
-        tract_linalg::generic::tanh::HTanh8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_tanh_f16_16n
-    );
-    bench_pair!(
-        c,
-        "hardswish_f16",
-        tract_linalg::generic::hardswish::HHardSwish8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_hardswish_f16_64n
-    );
-    bench_pair!(
-        c,
-        "leaky_relu_f16",
-        tract_linalg::generic::leaky_relu::HLeakyRelu8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_leaky_relu_f16_64n,
-        f16::from_f32(0.1)
-    );
-    bench_pair!(
-        c,
-        "silu_f16",
-        tract_linalg::generic::silu::HSiLU8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_silu_f16_16n
-    );
-    bench_pair!(
-        c,
-        "gelu_f16",
-        tract_linalg::generic::gelu::HGelu8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_gelu_f16_16n
-    );
+    #[cfg(target_arch = "x86_64")]
+    {
+        bench_pair!(
+            c,
+            "sigmoid_f16",
+            tract_linalg::generic::sigmoid::HSigmoid8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_sigmoid_f16_16n
+        );
+        bench_pair!(
+            c,
+            "tanh_f16",
+            tract_linalg::generic::tanh::HTanh8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_tanh_f16_16n
+        );
+        bench_pair!(
+            c,
+            "hardswish_f16",
+            tract_linalg::generic::hardswish::HHardSwish8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_hardswish_f16_64n
+        );
+        bench_pair!(
+            c,
+            "leaky_relu_f16",
+            tract_linalg::generic::leaky_relu::HLeakyRelu8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_leaky_relu_f16_64n,
+            f16::from_f32(0.1)
+        );
+        bench_pair!(
+            c,
+            "silu_f16",
+            tract_linalg::generic::silu::HSiLU8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_silu_f16_16n
+        );
+        bench_pair!(
+            c,
+            "gelu_f16",
+            tract_linalg::generic::gelu::HGelu8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_gelu_f16_16n
+        );
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        eprintln!("this bench only runs on x86_64 targets — skipping on host");
+        let _ = c;
+    }
 }
 
 criterion_group!(g, benches);

--- a/linalg/benches/activations_avx512_fp16.rs
+++ b/linalg/benches/activations_avx512_fp16.rs
@@ -3,6 +3,7 @@
 // before native f16 ISA was available). Both run on 64-byte-aligned, 1024-
 // element buffers — same workload as the existing activations_avx512_f16
 // bench, just adding the native-fp16 column.
+#![cfg_attr(not(target_arch = "x86_64"), allow(dead_code, unused_imports, unused_macros))]
 
 use criterion::*;
 use tract_data::prelude::*;
@@ -47,21 +48,29 @@ macro_rules! bench_triple {
 }
 
 fn benches(c: &mut Criterion) {
-    bench_triple!(
-        c,
-        "hardswish_f16",
-        tract_linalg::generic::hardswish::HHardSwish8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_hardswish_f16_64n,
-        tract_linalg::x86_64_fma::act_f16_fp16::x86_64_avx512fp16_hardswish_f16_128n
-    );
-    bench_triple!(
-        c,
-        "leaky_relu_f16",
-        tract_linalg::generic::leaky_relu::HLeakyRelu8,
-        tract_linalg::x86_64_fma::act_f16::x86_64_avx512_leaky_relu_f16_64n,
-        tract_linalg::x86_64_fma::act_f16_fp16::x86_64_avx512fp16_leaky_relu_f16_128n,
-        f16::from_f32(0.1)
-    );
+    #[cfg(target_arch = "x86_64")]
+    {
+        bench_triple!(
+            c,
+            "hardswish_f16",
+            tract_linalg::generic::hardswish::HHardSwish8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_hardswish_f16_64n,
+            tract_linalg::x86_64_fma::act_f16_fp16::x86_64_avx512fp16_hardswish_f16_128n
+        );
+        bench_triple!(
+            c,
+            "leaky_relu_f16",
+            tract_linalg::generic::leaky_relu::HLeakyRelu8,
+            tract_linalg::x86_64_fma::act_f16::x86_64_avx512_leaky_relu_f16_64n,
+            tract_linalg::x86_64_fma::act_f16_fp16::x86_64_avx512fp16_leaky_relu_f16_128n,
+            f16::from_f32(0.1)
+        );
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        eprintln!("this bench only runs on x86_64 targets — skipping on host");
+        let _ = c;
+    }
 }
 
 criterion_group!(g, benches);

--- a/linalg/benches/avx512_zombies.rs
+++ b/linalg/benches/avx512_zombies.rs
@@ -23,44 +23,52 @@ fn run(c: &mut Criterion, name: &str, mmm: &dyn MatMatMul, m: usize, k: usize, n
 }
 
 fn benches(c: &mut Criterion) {
-    if !std::is_x86_feature_detected!("avx512f") {
-        eprintln!("avx512f not available, skipping");
-        return;
+    #[cfg(target_arch = "x86_64")]
+    {
+        if !std::is_x86_feature_detected!("avx512f") {
+            eprintln!("avx512f not available, skipping");
+            return;
+        }
+
+        use tract_data::prelude::DatumType::F32;
+        use tract_linalg::x86_64_fma::mmm::*;
+
+        // Representative large-K, square-ish M case.
+        let (m, k) = (64usize, 256usize);
+
+        // N = 5 : zombie was 32x5 vs old 64x3.
+        run(c, "N5_64x3_explicit", &*avx512_mmm_f32_64x3.mmm(), m, k, 5);
+        run(c, "N5_32x5_explicit", &*avx512_mmm_f32_32x5.mmm(), m, k, 5);
+
+        // N = 6 : zombie was 32x6 vs old 64x3.
+        run(c, "N6_64x3_explicit", &*avx512_mmm_f32_64x3.mmm(), m, k, 6);
+        run(c, "N6_32x6_explicit", &*avx512_mmm_f32_32x6.mmm(), m, k, 6);
+
+        // N = 8 : zombie was 16x8 vs old 48x4.
+        run(c, "N8_48x4_explicit", &*avx512_mmm_f32_48x4.mmm(), m, k, 8);
+        run(c, "N8_16x8_explicit", &*avx512_mmm_f32_16x8.mmm(), m, k, 8);
+
+        // What does the live dispatcher pick for these shapes? If the picker
+        // is healthy these match the zombie numbers above, kernel name printed
+        // to stderr at startup.
+        for n in [5usize, 6, 8] {
+            let mmm = tract_linalg::ops().mmm(F32, Some(m), Some(k), Some(n)).unwrap();
+            eprintln!("dispatcher@m={m},k={k},n={n} picked {}", mmm.name());
+            run(c, &format!("N{n}_dispatch"), &*mmm, m, k, n);
+        }
+
+        // Trace-only: a few shapes where M-padding overhead with the old
+        // picker was high. We expect the M-aware picker to pick smaller-mr
+        // kernels here.
+        for (m, n) in [(20usize, 2), (33, 3), (50, 4), (17, 5), (1000, 64)] {
+            let mmm = tract_linalg::ops().mmm(F32, Some(m), Some(k), Some(n)).unwrap();
+            eprintln!("dispatcher@m={m},k={k},n={n} picked {}", mmm.name());
+        }
     }
-
-    use tract_data::prelude::DatumType::F32;
-    use tract_linalg::x86_64_fma::mmm::*;
-
-    // Representative large-K, square-ish M case.
-    let (m, k) = (64usize, 256usize);
-
-    // N = 5 : zombie was 32x5 vs old 64x3.
-    run(c, "N5_64x3_explicit", &*avx512_mmm_f32_64x3.mmm(), m, k, 5);
-    run(c, "N5_32x5_explicit", &*avx512_mmm_f32_32x5.mmm(), m, k, 5);
-
-    // N = 6 : zombie was 32x6 vs old 64x3.
-    run(c, "N6_64x3_explicit", &*avx512_mmm_f32_64x3.mmm(), m, k, 6);
-    run(c, "N6_32x6_explicit", &*avx512_mmm_f32_32x6.mmm(), m, k, 6);
-
-    // N = 8 : zombie was 16x8 vs old 48x4.
-    run(c, "N8_48x4_explicit", &*avx512_mmm_f32_48x4.mmm(), m, k, 8);
-    run(c, "N8_16x8_explicit", &*avx512_mmm_f32_16x8.mmm(), m, k, 8);
-
-    // What does the live dispatcher pick for these shapes? If the picker
-    // is healthy these match the zombie numbers above, kernel name printed
-    // to stderr at startup.
-    for n in [5usize, 6, 8] {
-        let mmm = tract_linalg::ops().mmm(F32, Some(m), Some(k), Some(n)).unwrap();
-        eprintln!("dispatcher@m={m},k={k},n={n} picked {}", mmm.name());
-        run(c, &format!("N{n}_dispatch"), &*mmm, m, k, n);
-    }
-
-    // Trace-only: a few shapes where M-padding overhead with the old
-    // picker was high. We expect the M-aware picker to pick smaller-mr
-    // kernels here.
-    for (m, n) in [(20usize, 2), (33, 3), (50, 4), (17, 5), (1000, 64)] {
-        let mmm = tract_linalg::ops().mmm(F32, Some(m), Some(k), Some(n)).unwrap();
-        eprintln!("dispatcher@m={m},k={k},n={n} picked {}", mmm.name());
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        eprintln!("this bench only runs on x86_64 targets — skipping on host");
+        let _ = c;
     }
 }
 

--- a/linalg/benches/erf.rs
+++ b/linalg/benches/erf.rs
@@ -2,6 +2,7 @@
 // SErf4 (no FMA predecessor exists on x86). All buffers are 64-byte aligned
 // (AVX-512 alignment_bytes) and a multiple of 64 elements so the kernel's
 // nr() = 64 divides the length.
+#![cfg_attr(not(target_arch = "x86_64"), allow(dead_code, unused_imports))]
 
 use criterion::*;
 use tract_data::prelude::*;
@@ -19,19 +20,27 @@ fn aligned_input() -> Tensor {
 }
 
 fn erf_f32(c: &mut Criterion) {
-    let mut g = c.benchmark_group("erf_f32");
-    g.throughput(Throughput::Elements(N as u64));
-    let mut tp = aligned_input();
-    let sp = unsafe { tp.as_slice_mut_unchecked::<f32>() };
-    g.bench_function("generic", |b| b.iter(|| tract_linalg::generic::SErf4::run(sp, ())));
-    if std::is_x86_feature_detected!("avx512f") {
-        let mut ta = aligned_input();
-        let sa = unsafe { ta.as_slice_mut_unchecked::<f32>() };
-        g.bench_function("avx512", |b| {
-            b.iter(|| tract_linalg::x86_64_fma::erf::x86_64_avx512_erf_f32_64n::run(sa, ()))
-        });
+    #[cfg(target_arch = "x86_64")]
+    {
+        let mut g = c.benchmark_group("erf_f32");
+        g.throughput(Throughput::Elements(N as u64));
+        let mut tp = aligned_input();
+        let sp = unsafe { tp.as_slice_mut_unchecked::<f32>() };
+        g.bench_function("generic", |b| b.iter(|| tract_linalg::generic::SErf4::run(sp, ())));
+        if std::is_x86_feature_detected!("avx512f") {
+            let mut ta = aligned_input();
+            let sa = unsafe { ta.as_slice_mut_unchecked::<f32>() };
+            g.bench_function("avx512", |b| {
+                b.iter(|| tract_linalg::x86_64_fma::erf::x86_64_avx512_erf_f32_64n::run(sa, ()))
+            });
+        }
+        g.finish();
     }
-    g.finish();
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        eprintln!("this bench only runs on x86_64 targets — skipping on host");
+        let _ = c;
+    }
 }
 
 criterion_group!(g, erf_f32);

--- a/linalg/benches/vnni_i32.rs
+++ b/linalg/benches/vnni_i32.rs
@@ -40,29 +40,37 @@ fn run_kernel(be: &mut Bencher, mmm: &dyn MatMatMul, m: usize, k: usize, n: usiz
 }
 
 fn benches(c: &mut Criterion) {
-    if !std::is_x86_feature_detected!("avx512vnni") {
-        eprintln!("avx512vnni not available, skipping");
-        return;
-    }
-    use tract_linalg::x86_64_fma::mmm::*;
-    for &(m, k, n) in
-        &[(64usize, 256usize, 64usize), (256, 256, 256), (512, 512, 512), (1024, 1024, 64)]
+    #[cfg(target_arch = "x86_64")]
     {
-        let id = format!("{m}x{k}x{n}");
-        let mut g = c.benchmark_group("vnni_i32/packed_packed");
-        g.throughput(Throughput::Elements((m * k * n) as u64));
-        g.bench_with_input(BenchmarkId::new("avx2", &id), &(m, k, n), |b, &(m, k, n)| {
-            run_kernel(b, &*avx2_mmm_i32_8x8.mmm(), m, k, n)
-        });
-        g.bench_with_input(BenchmarkId::new("avx512vnni", &id), &(m, k, n), |b, &(m, k, n)| {
-            run_kernel(b, &*avx512vnni_mmm_i32_8x8.mmm(), m, k, n)
-        });
-        g.bench_with_input(
-            BenchmarkId::new("avx512vnni_16x16", &id),
-            &(m, k, n),
-            |b, &(m, k, n)| run_kernel(b, &*avx512vnni_mmm_i32_16x16.mmm(), m, k, n),
-        );
-        g.finish();
+        if !std::is_x86_feature_detected!("avx512vnni") {
+            eprintln!("avx512vnni not available, skipping");
+            return;
+        }
+        use tract_linalg::x86_64_fma::mmm::*;
+        for &(m, k, n) in
+            &[(64usize, 256usize, 64usize), (256, 256, 256), (512, 512, 512), (1024, 1024, 64)]
+        {
+            let id = format!("{m}x{k}x{n}");
+            let mut g = c.benchmark_group("vnni_i32/packed_packed");
+            g.throughput(Throughput::Elements((m * k * n) as u64));
+            g.bench_with_input(BenchmarkId::new("avx2", &id), &(m, k, n), |b, &(m, k, n)| {
+                run_kernel(b, &*avx2_mmm_i32_8x8.mmm(), m, k, n)
+            });
+            g.bench_with_input(BenchmarkId::new("avx512vnni", &id), &(m, k, n), |b, &(m, k, n)| {
+                run_kernel(b, &*avx512vnni_mmm_i32_8x8.mmm(), m, k, n)
+            });
+            g.bench_with_input(
+                BenchmarkId::new("avx512vnni_16x16", &id),
+                &(m, k, n),
+                |b, &(m, k, n)| run_kernel(b, &*avx512vnni_mmm_i32_16x16.mmm(), m, k, n),
+            );
+            g.finish();
+        }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        eprintln!("this bench only runs on x86_64 targets — skipping on host");
+        let _ = c;
     }
 }
 


### PR DESCRIPTION
`cargo check --benches -p tract-linalg` failed on aarch64 hosts, because six x86-only benches referenced x86-only kernels unconditionally: anyone developing on Apple Silicon hit six broken bench targets on a plain `--all-targets` check. They now build on every architecture and report being skipped when run off x86_64.

Nothing in CI caught this: the only job covering `--all-targets` runs on x86_64. The workspace clippy step now passes `--all-targets` too, so the scheduled macOS (aarch64) leg compiles the bench targets.

Work in #2613 will clear clippy warnings in test and bench code, guarded by CI.