### PR TITLE
docs: fix typos in pool error messages, doc comments, and guides

### DIFF
--- a/api/ffi/src/lib.rs
+++ b/api/ffi/src/lib.rs
@@ -824,7 +824,7 @@ pub struct TractRunnable(tract::Runnable);
 /// This function does not take ownership of the `runnable` object, it can be used again to spawn
 /// other state instances. The runnable object is internally reference counted, it will be
 /// kept alive as long as any associated `State` exists (or as long as the `runnable` is not
-/// explicitely release with `tract_runnable_release`).
+/// explicitly release with `tract_runnable_release`).
 ///
 /// `state` is a newly-created object. It should ultimately be detroyed with `tract_state_destroy`.
 #[unsafe(no_mangle)]

--- a/core/src/optim/slice.rs
+++ b/core/src/optim/slice.rs
@@ -155,7 +155,7 @@ fn should_slice_output(
         })
         .map(|inlet| inlet.node)
         .collect();
-    /* aggressive: 1 slice as succesor => we propagate it */
+    /* aggressive: 1 slice as successor => we propagate it */
     /*
     let Some(slice) = node.outputs[0].successors.iter().find_map(|inlet| {
         model.node(inlet.node).op_as::<Slice>().filter(|slice| slice.axis == axis).map(|_| inlet.node)

--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -252,7 +252,7 @@ impl Tensor {
         self.as_plain_mut().context("Tensor storage is not plain")
     }
 
-    /// Create an uninitialized tensor (dt as type paramater).
+    /// Create an uninitialized tensor (dt as type parameter).
     #[inline]
     pub unsafe fn uninitialized<T: Datum>(shape: &[usize]) -> TractResult<Tensor> {
         unsafe { Self::uninitialized_dt(T::datum_type(), shape) }

--- a/doc/cli-recipe.md
+++ b/doc/cli-recipe.md
@@ -63,7 +63,7 @@ The displayed form is `tract-opl` intermediate representation. It is *decluttere
 training artefacts, in a form meant to be simple to reason about and as stripped down as
 possible.
 
-This is not the "optimised" form: `tract-opl` form is meant to be platform independant, can
+This is not the "optimised" form: `tract-opl` form is meant to be platform independent, can
 be serialized to nnef. The optimised form is just meant to be as fast as possible on a given
 CPU.
 

--- a/doc/graph.md
+++ b/doc/graph.md
@@ -124,7 +124,7 @@ TypedFact has also a optional constant value: if a tensor in the graph has a
 constant value regardless of the network inputs, this is information the
 optimiser may be able to use to simplify the network.
 
-As we implied beforehand, this type is not suitable to reprensent network where
+As we implied beforehand, this type is not suitable to represent network where
 some wires have an unknown datum type, or partial shape information. In order
 to reason about these networks, we need a more flexible Fact:
 

--- a/doc/op.md
+++ b/doc/op.md
@@ -242,9 +242,9 @@ rank determined or not and individual dimensions known or not.
 The framework will try to propagate type information accross the graph,
 refining incrementally its knowledge of all the inference facts. It will do
 so by calling the `infer()` method on operators which interfaces are not fully
-determined. The operator receives as paramaters the current information on its
+determined. The operator receives as parameters the current information on its
 inputs and outputs, try to improve them and returns the refined versions. The
-third paramaters and result (`observed`) is out of scope here.
+third parameters and result (`observed`) is out of scope here.
 
 Once a network has been entirely typed, it can be translated to a TypedOp. The
 framework will visit the entire network and call the `to_typed()` method on

--- a/examples/tensorflow-mobilenet-v2/README.md
+++ b/examples/tensorflow-mobilenet-v2/README.md
@@ -116,7 +116,7 @@ model.
 
 ### Specifying input size and optimizing.
 
-TensorFlow models typically do not specify explicitely the input dimensions,
+TensorFlow models typically do not specify explicitly the input dimensions,
 but a lot of optimization in `tract` depends on the knownledge of all tensors
 types and shapes in the network.
 

--- a/hir/src/infer/ops.rs
+++ b/hir/src/infer/ops.rs
@@ -92,7 +92,7 @@ pub trait InferenceOp: Op {
     /// manifest with temporaries nodes that can run some form of inference but
     /// require refactoring the network before it can be evaluated.
     ///
-    /// Called after succesful analyse, but before translating to typed model.
+    /// Called after successful analyse, but before translating to typed model.
     #[allow(unused_variables)]
     fn incorporate(
         &self,

--- a/linalg/README.md
+++ b/linalg/README.md
@@ -1,7 +1,7 @@
 # tract-linalg
 
 linalg stands for "linear algebra". This is a misnamer. This crates contains
-low-level, architecture dependant optimisations used by tract-core.
+low-level, architecture dependent optimisations used by tract-core.
 
 # Functions
 

--- a/nnef/src/ops/nnef/deser.rs
+++ b/nnef/src/ops/nnef/deser.rs
@@ -642,7 +642,7 @@ pub fn max_pool_with_index(
     let input_fact = builder.model.outlet_fact(input)?;
     if input_fact.rank() != size.len() {
         bail!(
-            "Max pool input expected as NCHW, and \"size\" paramater must be [ 1, 1, x, y ]. Got {:?}, and {:?}",
+            "Max pool input expected as NCHW, and \"size\" parameter must be [ 1, 1, x, y ]. Got {:?}, and {:?}",
             input_fact,
             size
         );
@@ -672,7 +672,7 @@ pub fn sum_pool(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> 
     let input_fact = builder.model.outlet_fact(input)?;
     if input_fact.rank() != size.len() {
         bail!(
-            "Sum pool input expected as NCHW, and \"size\" paramater must be [ 1, 1, x, y ]. Got {:?}, and {:?}",
+            "Sum pool input expected as NCHW, and \"size\" parameter must be [ 1, 1, x, y ]. Got {:?}, and {:?}",
             input_fact,
             size
         );


### PR DESCRIPTION
The NNEF max_pool and sum_pool rank-mismatch errors misspelled "parameter" as "paramater" in text users see on a bad model. The same misspelling, plus "succesful", "succesor", "explicitely", "reprensent", "independant", and "dependant", appeared in doc comments and in the prose under doc/, linalg/README.md, and the mobilenet-v2 example.