### PR TITLE
refactor: drop commented-out debug prints

### DIFF
--- a/core/src/ops/einsum/proptest.rs
+++ b/core/src/ops/einsum/proptest.rs
@@ -121,7 +121,6 @@ impl BinEinsumProblem {
         model = model.into_decluttered()?;
         let expected = model.clone().into_runnable()?.run(inputs.clone())?.remove(0);
         let optimised = model.clone().into_optimized()?;
-        //dbg!(&optimised);
         let found = optimised.into_runnable()?.run(inputs.clone())?.remove(0);
         found.close_enough(&expected, Approximation::Close)
     }

--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -744,15 +744,11 @@ where
     F: Fact + Clone + 'static,
     O: Debug + Display + AsRef<dyn Op> + AsMut<dyn Op> + Clone + 'static,
 {
-    // eprint!("{node} {input:?}");
-    #[allow(clippy::let_and_return)]
-    let r = match state {
+    match state {
         Some(ref mut state) => state.eval(session_state, node.op(), input),
         None => node.op().eval_with_session(node.id, session_state, input),
     }
-    .with_context(|| format!("Evaluating {node}"));
-    // eprintln!(" ==> {}", r.as_ref().unwrap()[0].dump(true)?);
-    r
+    .with_context(|| format!("Evaluating {node}"))
 }
 
 #[derive(Clone, Debug)]

--- a/harness/core-proptest-pulse/src/lib.rs
+++ b/harness/core-proptest-pulse/src/lib.rs
@@ -44,7 +44,6 @@ fn proptest_regular_against_pulse(
 
     let len = input_array.shape()[axis];
     let model = model.into_decluttered().unwrap();
-    // dbg!(&model);
     let s = model.symbols.sym("S");
     let subs =
         std::collections::HashMap::from([(s.clone(), tract_data::prelude::TDim::Val(len as i64))]);
@@ -55,13 +54,9 @@ fn proptest_regular_against_pulse(
     }
     let runnable = concrete.into_runnable().unwrap();
 
-    // dbg!(&runnable);
     let outputs = runnable.run(tvec!(input_array.clone().into_tvalue())).unwrap();
-    // dbg!(&outputs);
     debug!("Build pulsing model");
-    // dbg!(&model);
     let pulsed = PulsedModel::new(&model, s.clone(), &pulse.to_dim()).unwrap();
-    // dbg!(&pulsed);
     let output_fact = pulsed.output_fact(0).unwrap().clone();
 
     let stream_info = output_fact.stream.as_ref().unwrap();
@@ -81,7 +76,6 @@ fn proptest_regular_against_pulse(
     let mut output_len = None;
 
     debug!("Run pulsing model");
-    //dbg!(pulsed_plan.model());
     let mut written = 0;
     loop {
         let to_write_in_chunk = pulse.min(input_array.shape()[axis].saturating_sub(written));

--- a/linalg/src/hwbench/runner.rs
+++ b/linalg/src/hwbench/runner.rs
@@ -111,11 +111,6 @@ fn run_bench_inner<T, F: FnMut(usize) -> T + Copy>(
     let samples = ((bench_s / (inner_loops as f64 * evaled)) as usize).max(min_samples);
     let warmup = (warmup_s / evaled) as usize;
 
-    // println!(
-    //     "evaled: {:?} samples:{samples} inner_loops:{inner_loops} time:{}",
-    //     Duration::from_secs_f64(evaled),
-    //     (samples * inner_loops) as f64 * evaled
-    // );
     let mut measures = vec![0.0; samples];
 
     black_box(f(warmup));

--- a/metal/src/kernels/matmul/ggml_gemm/mod.rs
+++ b/metal/src/kernels/matmul/ggml_gemm/mod.rs
@@ -246,7 +246,6 @@ fn dispatch_metal_ggml_gemv(
     output_offset: usize,
 ) -> TractResult<()> {
     let (name, (nth0, nth1, nrows)) = mv_kernel_name_and_dispatch_params(&params)?;
-    //dbg!(&name);
     let pipeline = stream.load_pipeline(LibraryName::Ggml, &name)?;
 
     let ggml_params: GgmlGemvParams = params.clone().into();
@@ -308,7 +307,6 @@ fn dispatch_metal_ggml_gemm(
     let i2_tname = DeviceTensor::tname(dts[0])?;
 
     let name = format!("kernel_mul_mm_{i1_tname}_{i2_tname}");
-    //dbg!(&name);
     let pipeline = stream.load_pipeline(LibraryName::Ggml, &name)?;
 
     let ggml_params: GgmlGemmParams = params.clone().into();

--- a/metal/src/kernels/matmul/mlx_gemm/mod.rs
+++ b/metal/src/kernels/matmul/mlx_gemm/mod.rs
@@ -397,7 +397,6 @@ pub fn dispatch_metal_mlx_gemm(
     });
     if debug {
         stream.wait_until_completed()?;
-        //log::debug!("{:#?}", gemm_debug);
     }
 
     Ok(())

--- a/tensorflow/src/ops/nn/conv2d.rs
+++ b/tensorflow/src/ops/nn/conv2d.rs
@@ -147,8 +147,6 @@ mod tests {
         let filter = tensor4(&[[[[160.72833f32]], [[107.84076]]], [[[247.50552]], [[-38.738464]]]]);
         let exp = tensor4(&[[[[80142.31f32], [5067.5586]], [[32266.81], [-1812.2109]]]]);
         let got = &conv.eval(tvec![data.into(), filter.into()]).unwrap()[0];
-        //println!("{:?}", got);
-        //println!("{:?}", exp);
         exp.close_enough(got, true).unwrap()
     }
 

--- a/test-rt/suite-onnx/src/lib.rs
+++ b/test-rt/suite-onnx/src/lib.rs
@@ -167,8 +167,6 @@ pub fn ensure_onnx_git_checkout() {
         for (v, _) in versions() {
             let wanted = dir().join(format!("onnx-{}", v.replace('.', "_")));
             if !wanted.join("onnx/backend/test/data").exists() {
-                //let df = std::process::Command::new("df").arg("-h").output().unwrap();
-                //dbg!(df);
                 let tmp = wanted.with_extension("tmp");
                 let _ = std::fs::remove_dir_all(&wanted);
                 let _ = std::fs::remove_dir_all(&tmp);
@@ -302,8 +300,6 @@ fn run_model(
         );
     }
     for (ix, (a, b)) in computed.iter().zip(expected.iter()).enumerate() {
-        //                println!("computed: {:?}", computed[ix].dump(true));
-        //                println!("expected: {:?}", expected[ix].dump(true));
         if let Err(e) = a.close_enough(b, approx) {
             bail!(
                 "For {:?}, different ({approx:?}) result for output #{}:\ngot:\n{:?}\nexpected:\n{:?} \n{}",
@@ -311,7 +307,7 @@ fn run_model(
                 ix,
                 a.cast_to::<f32>().unwrap().to_plain_array_view::<f32>().unwrap(),
                 b.cast_to::<f32>().unwrap().to_plain_array_view::<f32>().unwrap(),
-                e //                e.display_chain()
+                e
             );
         }
     }

--- a/test-rt/suite-unit/src/bin_einsum.rs
+++ b/test-rt/suite-unit/src/bin_einsum.rs
@@ -127,7 +127,6 @@ impl Arbitrary for BinEinsumProblem {
                 let b: String = b.into_iter().collect();
                 let c: String = c.into_iter().collect();
                 let expr: AxesMapping = format!("{a},{b}->{c}").parse().unwrap();
-                //eprintln!("{expr}");
                 expr
             })
             .prop_flat_map(|expr| {
@@ -208,12 +207,7 @@ impl BinEinsumProblem {
         }
 
         model.select_output_outlets(&output)?;
-
-        //let test = model.node_by_name("einsum")?.op.as_op().downcast_ref::<EinSum>().unwrap();
-
         model = model.into_decluttered()?;
-        //let test1 = model.node_by_name("einsum")?.op.as_op().downcast_ref::<EinSum>().unwrap();
-        //dbg!(&test1.axes);
         Ok(model)
     }
 
@@ -300,7 +294,6 @@ impl Test for BinEinsumProblem {
         approx: Approximation,
     ) -> TestResult {
         let reference = self.reference::<f32>().into_tensor();
-        //dbg!(&reference);
         let mut model = self.tract()?;
 
         model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));

--- a/test-rt/suite-unit/src/conv_f32.rs
+++ b/test-rt/suite-unit/src/conv_f32.rs
@@ -35,7 +35,6 @@ impl ConvProblem {
     }
 
     pub fn reference(&self) -> ArrayD<f32> {
-        // dbg!(self);
         assert_eq!(self.data.shape(), &*self.shape_in.shape, "inconsistent shapes in test");
         let n = *self.shape_in.n().unwrap_or(&1);
         let ci_per_g = self.shape_in.c() / self.group;
@@ -110,7 +109,6 @@ impl ConvProblem {
             .fmt
             .from_n_c_hw(self.shape_in.n().cloned().unwrap_or(1), co_per_g * self.group, shape_out)
             .unwrap();
-        // dbg!(&shape_out);
         let mut out = ArrayD::zeros(&*shape_out.shape);
         for n in 0..n {
             for g in 0..self.group {
@@ -334,15 +332,11 @@ impl Test for ConvProblem {
         approx: Approximation,
     ) -> TestResult {
         let reference = self.reference().into_tensor();
-        // dbg!(&reference);
         let mut model = self.tract()?;
-        //       dbg!(&model);
         model.declutter()?;
-        //       dbg!(&model);
         model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));
         let mut output = runtime.prepare(model)?.run(tvec![self.data.clone().into_tvalue()])?;
         let output = output.remove(0).into_tensor();
-        // dbg!(&output);
         output.close_enough(&reference, approx)
     }
 }

--- a/test-rt/suite-unit/src/conv_q.rs
+++ b/test-rt/suite-unit/src/conv_q.rs
@@ -275,7 +275,6 @@ impl Test for QConvProblem {
         });
         let data = self.data.clone().into_tensor().cast_to_dt(idt)?.into_owned().into_tvalue();
         let output = model.run(tvec!(data))?.remove(0);
-        //eprintln!("reference: {reference:?}\noutput   : {output:?}");
         output.close_enough(&reference, approx)
     }
 }

--- a/test-rt/suite-unit/src/matmul_q40.rs
+++ b/test-rt/suite-unit/src/matmul_q40.rs
@@ -111,10 +111,6 @@ impl MatmulQ40Problem {
         )?;
 
         model.select_output_outlets(&output)?;
-        //let test = model.node_by_name("einsum")?.op.as_op().downcast_ref::<EinSum>().unwrap();
-
-        //let test1 = model.node_by_name("einsum")?.op.as_op().downcast_ref::<EinSum>().unwrap();
-        //dbg!(&test1.axes);
         Ok(model)
     }
 
@@ -156,7 +152,6 @@ impl Test for MatmulQ40Problem {
     ) -> TestResult {
         let uses_q81_activations = runtime.name().contains("cuda");
         let reference = self.reference(uses_q81_activations)?;
-        //dbg!(&reference);
         let mut model = self.tract()?;
 
         model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));

--- a/test-rt/suite-unit/src/q_flavours.rs
+++ b/test-rt/suite-unit/src/q_flavours.rs
@@ -53,7 +53,6 @@ impl Test for QFlavoursProblem {
             .run(tvec![self.input.clone().into_tvalue()])?
             .remove(0)
             .into_tensor();
-        //dbg!(&output);
         let reference = self.input.cast_to::<f32>()?;
         let comparison = output.cast_to::<f32>()?;
         comparison.close_enough(&reference, approx)

--- a/test-rt/suite-unit/src/rms_norm.rs
+++ b/test-rt/suite-unit/src/rms_norm.rs
@@ -108,7 +108,6 @@ where
         approx: Approximation,
     ) -> TestResult {
         let reference = self.reference().into_tensor();
-        //dbg!(&reference);
         let mut model = self.tract()?;
 
         model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));

--- a/test-rt/suite-unit/src/scaled_masked_softmax.rs
+++ b/test-rt/suite-unit/src/scaled_masked_softmax.rs
@@ -139,12 +139,10 @@ where
         let mut model = self.tract()?;
 
         model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));
-        //dbg!(&self.input, &self.mask);
         let mut output = runtime
             .prepare(model)?
             .run(tvec![self.input.clone().into_tvalue(), self.mask.clone().into_tvalue()])?;
         let output = output.remove(0).into_tensor();
-        // dbg!(&reference, &output);
         output.close_enough(&reference, approx)
     }
 }

--- a/test-rt/test-nnef-cycle/src/lib.rs
+++ b/test-rt/test-nnef-cycle/src/lib.rs
@@ -74,14 +74,9 @@ mod nnef_cycle {
         ) -> TractResult<Box<dyn Runnable>> {
             info!("Store to NNEF");
             let mut buffer = vec![];
-            // eprintln!("BEFORE NNEF:\n{model}");
-            // dbg!(&model);
             self.0.write_to_tar(&model, &mut buffer)?;
-            // self.0.write_to_dir(&model, "foo")?;
             info!("Reload from NNEF");
             let reloaded = self.0.model_for_read(&mut &*buffer)?;
-            // eprintln!("RELOADED:\n{}", reloaded.clone().into_decluttered().unwrap());
-            // dbg!(reloaded.clone().into_decluttered());
             Ok(Box::new(reloaded.into_optimized()?.into_runnable_with_options(&options)?))
         }
         fn check(&self) -> TractResult<()> {

--- a/transformers/src/ops/sdpa.rs
+++ b/transformers/src/ops/sdpa.rs
@@ -244,7 +244,6 @@ impl Sdpa {
 
         let body_outputs = patch.model.output_outlets()?;
         patch.shunt_outside(model, node.id.into(), body_outputs[0])?;
-        //println!("{}",&patch.model);
         Ok(Some(patch))
     }
 }


### PR DESCRIPTION
Stale dbg!/println! remnants from old debugging sessions; comments here are reserved for constraints and invariants, not narration. Two could no longer even be uncommented: one printed a gemm_debug binding that no longer exists, another indexed loop variables that had since been renamed. No behavior change.