### PR TITLE
fix(linalg): fix sigmoid and silu output range

### DIFF
--- a/linalg/arm32/armv7neon/armv7neon_sigmoid_f32_4n.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_sigmoid_f32_4n.S.j2
@@ -132,6 +132,17 @@ armv7neon_sigmoid_f32_4n_{{suffix}}:
     vmla.f32    q11, q5, q8
     vmla.f32    q12, q6, q9
 
+    // sigmoid is (0, 1): the vmla above cancels down to ~1e-8 on either tail, below the
+    // rounding error of the reciprocal, so the sum needs clamping to stay in range.
+    vmov.i32    q13, #0
+    vdup.32     q14, d6[0]
+    vmax.f32    q10, q13
+    vmax.f32    q11, q13
+    vmax.f32    q12, q13
+    vmin.f32    q10, q14
+    vmin.f32    q11, q14
+    vmin.f32    q12, q14
+
     vstmia      r0!, { q10, q11, q12 }
 
     subs        r1, #12
@@ -182,6 +193,11 @@ armv7neon_sigmoid_f32_4n_{{suffix}}:
 
     vdup.32     q10, d6[1]
     vmla.f32    q10, q4, q7
+
+    vmov.i32    q13, #0
+    vdup.32     q14, d6[0]
+    vmax.f32    q10, q13
+    vmin.f32    q10, q14
 
     vstmia      r0!, { q10 }
 

--- a/linalg/arm32/armv7neon/armv7neon_silu_f32_4n.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_silu_f32_4n.S.j2
@@ -9,7 +9,7 @@
     Fused SiLU kernel.
 
     Per element (z = clamp(x, -18.6, 18.6), w = z^2):
-        SiLU(x) = f * (0.5 + z * P(w) / Q(w))
+        SiLU(x) = f * max(0.5 + z * P(w) / Q(w), 0)
     where P is the degree-6 Horner polynomial over the numerator coeffs, Q the
     degree-3 Horner polynomial over the denominator coeffs, and f = max(x, -18.6)
     the factor the sigmoid multiplies. Reuses the sigmoid coefficients and
@@ -22,7 +22,9 @@
     the true SiLU approaches from below as x -> -inf.
 
     ARMv7 has only 16 q registers, so f (q4/q5) is kept across a 2-group
-    (8-element) main loop.
+    (8-element) main loop. That leaves q14/q15 as the only registers free across
+    the whole body: they hold the zero floor and the low clamp, so the high clamp
+    is the one constant still re-duped per iteration.
 
     s16-s31 (d8-d15, q4-q7) must be preserved
     s0-s15 (d0-d7, q0-q3) and d16-d31 (q8-q15) do not need to be preserved
@@ -37,18 +39,20 @@ armv7neon_silu_f32_4n_{{suffix}}:
     adr         r2, .coeffs_num
     vldmia      r2!, { s0-s13 }
 
+    vmov.i32    q14, #0                    // q14 <- 0
+    vdup.32     q15, d0[0]                 // q15 <- low = -18.6
+
     cmp         r1, #8
     blt         .loop
 
 .loop_2:
     vldmia      r0, { q6, q7 }             // q6,q7 <- x
 
-    vdup.32     q15, d0[0]
     vmax.f32    q4, q6, q15
     vmax.f32    q5, q7, q15                // q4,q5 <- f = max(x, -18.6)
-    vdup.32     q15, d0[1]
-    vmin.f32    q6, q4, q15
-    vmin.f32    q7, q5, q15                // q6,q7 <- z = min(f, 18.6)
+    vdup.32     q10, d0[1]
+    vmin.f32    q6, q4, q10
+    vmin.f32    q7, q5, q10                // q6,q7 <- z = min(f, 18.6)
 
     vmul.f32    q8, q6, q6                 // q8,q9 <- w = z^2
     vmul.f32    q9, q7, q7
@@ -113,6 +117,11 @@ armv7neon_silu_f32_4n_{{suffix}}:
     vmla.f32    q10, q6, q8                // q10,q11 <- sigmoid = 0.5 + num/denum
     vmla.f32    q11, q7, q9
 
+    // The vmla above cancels down to ~1e-8 on the negative tail, below the rounding error
+    // of the reciprocal; a sigmoid that came out negative would flip the sign of the SiLU.
+    vmax.f32    q10, q10, q14              // q10,q11 <- sigmoid, floored at 0
+    vmax.f32    q11, q11, q14
+
     vmul.f32    q10, q10, q4               // q10,q11 <- SiLU = sigmoid * f
     vmul.f32    q11, q11, q5
 
@@ -128,10 +137,9 @@ armv7neon_silu_f32_4n_{{suffix}}:
 .loop:
     vldmia      r0, { q6 }                 // q6 <- x
 
-    vdup.32     q15, d0[0]
     vmax.f32    q4, q6, q15                // q4 <- f = max(x, -18.6)
-    vdup.32     q15, d0[1]
-    vmin.f32    q6, q4, q15                // q6 <- z = min(f, 18.6)
+    vdup.32     q10, d0[1]
+    vmin.f32    q6, q4, q10                // q6 <- z = min(f, 18.6)
 
     vmul.f32    q8, q6, q6                 // q8 <- w = z^2
 
@@ -166,6 +174,8 @@ armv7neon_silu_f32_4n_{{suffix}}:
 
     vdup.32     q10, d6[1]
     vmla.f32    q10, q6, q8                // q10 <- sigmoid = 0.5 + num/denum
+
+    vmax.f32    q10, q10, q14              // q10 <- sigmoid, floored at 0
 
     vmul.f32    q10, q10, q4               // q10 <- SiLU = sigmoid * f
 

--- a/linalg/arm64/arm64simd/arm64simd_sigmoid_f32_4n.S.j2
+++ b/linalg/arm64/arm64simd/arm64simd_sigmoid_f32_4n.S.j2
@@ -17,6 +17,7 @@
     dup         v5.4s, v0.s[0]              // v5 <- low, broadcasted
     dup         v6.4s, v0.s[1]              // v6 <- high, broadcasted
     dup         v7.4s, v3.s[1]              // v7 <- 0.5, broadcasted
+    movi        v4.4s, #0                   // v4 <- 0, the output floor
 
     cmp         x1, #16
     blt         .loop
@@ -135,6 +136,19 @@
     fadd        v18.4s, v18.4s, v7.4s
     fadd        v19.4s, v19.4s, v7.4s
 
+    // sigmoid is (0, 1): the fadd above cancels down to ~1e-8 on either tail, below the
+    // rounding error of the division, so the sum needs clamping to stay in range. The loop
+    // has no register free to hold the 1.0 ceiling, so it lands over the dead x^2 in v20.
+    dup         v20.4s, v3.s[0]
+    fmax        v16.4s, v16.4s, v4.4s
+    fmax        v17.4s, v17.4s, v4.4s
+    fmax        v18.4s, v18.4s, v4.4s
+    fmax        v19.4s, v19.4s, v4.4s
+    fmin        v16.4s, v16.4s, v20.4s
+    fmin        v17.4s, v17.4s, v20.4s
+    fmin        v18.4s, v18.4s, v20.4s
+    fmin        v19.4s, v19.4s, v20.4s
+
     st1         { v16.4s, v17.4s, v18.4s, v19.4s }, [x0], #64
 
     subs        x1, x1, #16
@@ -174,6 +188,10 @@
 
     fdiv        v16.4s, v16.4s, v24.4s
     fadd        v16.4s, v16.4s, v7.4s
+
+    dup         v20.4s, v3.s[0]             // v20 <- 1.0
+    fmax        v16.4s, v16.4s, v4.4s
+    fmin        v16.4s, v16.4s, v20.4s
 
     st1         { v16.4s }, [x0], #16
 

--- a/linalg/src/arm64/arm64simd/silu_fused.rs
+++ b/linalg/src/arm64/arm64simd/silu_fused.rs
@@ -1,7 +1,7 @@
 // Fused SiLU kernel
 //
 // Exact formula computed per element (z = clamp(x, -18.6, 18.6), w = z²):
-//   SiLU(x) = f * (0.5 + z * P(w) / Q(w))
+//   SiLU(x) = f * max(0.5 + z * P(w) / Q(w), 0)
 // where P is the degree-6 Horner polynomial over coeffs COEFFS[2..=8], Q the
 // degree-3 Horner polynomial over coeffs COEFFS[9..=12], and f = max(x, -18.6)
 // the factor the sigmoid multiplies.
@@ -15,6 +15,12 @@
 // negative tail would return x * sigmoid(-18.6), whose magnitude grows toward -inf instead of
 // decaying to 0. With it, x < -18.6 saturates at the constant -18.6 * sigmoid(-18.6) ~= -1.55e-7,
 // which the true SiLU approaches from below as x -> -inf, so the error is bounded and tiny.
+//
+// The sigmoid factor is floored at 0 before it multiplies f: `0.5 + z * P(w) / Q(w)` cancels
+// down to ~1e-8 on the negative tail, below the rounding error of the division, and a sigmoid
+// that came out negative there would flip the sign of the whole result. It needs no matching
+// ceiling — the sigmoid kernel clamps at 1 to keep its own range, but here an overshoot of one
+// ulp only scales f by 1 + 2^-23, and SiLU has no upper bound to violate.
 
 ew_impl_wrap!(
     f32,
@@ -58,6 +64,7 @@ ew_impl_wrap!(
                 dup v5.4s, v0.s[0]             // v5 <- low, broadcasted
                 dup v6.4s, v0.s[1]             // v6 <- high, broadcasted
                 dup v7.4s, v3.s[1]             // v7 <- 0.5, broadcasted
+                movi v4.4s, #0                 // v4 <- 0, the sigmoid floor
 
                 cmp {len}, #16
                 blt 9f
@@ -176,6 +183,11 @@ ew_impl_wrap!(
                     fadd v18.4s, v18.4s, v7.4s
                     fadd v19.4s, v19.4s, v7.4s     // v16 <- sigmoid
 
+                    fmax v16.4s, v16.4s, v4.4s
+                    fmax v17.4s, v17.4s, v4.4s
+                    fmax v18.4s, v18.4s, v4.4s
+                    fmax v19.4s, v19.4s, v4.4s     // v16 <- sigmoid, floored at 0
+
                     fmul v16.4s, v16.4s, v8.4s
                     fmul v17.4s, v17.4s, v9.4s
                     fmul v18.4s, v18.4s, v10.4s
@@ -218,7 +230,8 @@ ew_impl_wrap!(
                     fmla v24.4s, v20.4s, v28.4s    // v24 <- denum
 
                     fdiv v16.4s, v16.4s, v24.4s
-                    fadd v16.4s, v16.4s, v7.4s     // v16 <- sigmoid
+                    fadd v16.4s, v16.4s, v7.4s
+                    fmax v16.4s, v16.4s, v4.4s     // v16 <- sigmoid, floored at 0
 
                     fmul v16.4s, v16.4s, v8.4s     // v16 <- SiLU (sigmoid * clamped-below x)
 
@@ -232,7 +245,7 @@ ew_impl_wrap!(
             ptr = inout(reg) ptr => _,
             len = inout(reg) len => _,
             out("v0") _, out("v1") _, out("v2") _, out("v3") _,
-            out("v5") _, out("v6") _, out("v7") _,
+            out("v4") _, out("v5") _, out("v6") _, out("v7") _,
             out("v8") _, out("v9") _, out("v10") _, out("v11") _,
             out("v16") _, out("v17") _, out("v18") _, out("v19") _,
             out("v20") _, out("v21") _, out("v22") _, out("v23") _,

--- a/linalg/src/frame/element_wise.rs
+++ b/linalg/src/frame/element_wise.rs
@@ -189,8 +189,54 @@ where
 #[cfg(test)]
 pub mod test {
     use crate::{LADatum, frame::element_wise::*};
+    use num_traits::AsPrimitive;
     use proptest::test_runner::{TestCaseError, TestCaseResult};
     use tract_data::internal::*;
+
+    /// Every finite `f16`, or a 1/256 grid of `[-30, 30]` for wider types.
+    ///
+    /// The grid samples where the `f16` set is enumerated, but it reaches past the `±18.6`
+    /// input clamp the f32 kernels apply, so no input outside its bounds takes a path it
+    /// has not already exercised.
+    fn invariant_sweep<T: LADatum>() -> Vec<T>
+    where
+        f32: AsPrimitive<T>,
+    {
+        if T::datum_type() == f16::datum_type() {
+            let all: Vec<f16> =
+                (0..=u16::MAX).map(f16::from_bits).filter(|x| x.is_finite()).collect();
+            let all = tensor1(&all).cast_to::<T>().unwrap().into_owned();
+            return all.try_as_plain().unwrap().as_slice::<T>().unwrap().to_vec();
+        }
+        (-30 * 256..=30 * 256).map(|i| (i as f32 / 256.).as_()).collect()
+    }
+
+    /// Assert `invariant` holds of every `(input, output)` pair a kernel produces over
+    /// [`invariant_sweep`], reporting `expected` on the first pair that breaks it.
+    ///
+    /// The accuracy tests cannot stand in for this on the saturating tails: there the true
+    /// value is smaller than the rounding error of the kernels' own arithmetic, so an
+    /// output that violates the range or the sign still compares close to the reference.
+    pub fn test_element_wise_invariant<K: ElementWiseKer<T>, T: LADatum>(
+        expected: &str,
+        invariant: impl Fn(T, T) -> bool,
+    ) -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        crate::setup_test_logger();
+        let values = invariant_sweep::<T>();
+        let mut found = values.clone();
+        K::ew().run(&mut found).unwrap();
+        for (x, y) in values.iter().zip(found.iter()) {
+            proptest::prop_assert!(
+                invariant(*x, *y),
+                "{}({x:?}) returned {y:?}, expected {expected}",
+                K::name()
+            );
+        }
+        Ok(())
+    }
 
     pub fn test_element_wise<K: ElementWiseKer<T, ()>, T: LADatum, F: Fn(T) -> T>(
         values: &[T],

--- a/linalg/src/frame/sigmoid.rs
+++ b/linalg/src/frame/sigmoid.rs
@@ -62,6 +62,13 @@ pub mod test {
             }
 
             #[test]
+            fn sigmoid_range_on_tails() {
+                if $cond {
+                    $crate::frame::sigmoid::test::test_sigmoid_range::<$ker, $t>().unwrap()
+                }
+            }
+
+            #[test]
             fn sigmoid_asymptots() {
                 use tract_data::internal::*;
                 use $crate::frame::element_wise::*;
@@ -81,6 +88,18 @@ pub mod test {
                 }
             }
         };
+    }
+
+    /// Assert every output of a sigmoid kernel lands in `[0, 1]`, the range its consumers
+    /// rely on and which the tail cancellation of a `p / q + 0.5` kernel can step outside.
+    pub fn test_sigmoid_range<K: ElementWiseKer<T>, T: LADatum + Float>() -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        crate::frame::element_wise::test::test_element_wise_invariant::<K, T>(
+            "a result in [0, 1]",
+            |_, y| y >= T::zero() && y <= T::one(),
+        )
     }
 
     pub fn test_sigmoid<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/frame/silu.rs
+++ b/linalg/src/frame/silu.rs
@@ -39,6 +39,13 @@ pub mod test {
                 }
             }
             #[test]
+            fn sign_on_tails() {
+                if $cond {
+                    $crate::frame::silu::test::test_silu_sign::<$ker, $t>().unwrap()
+                }
+            }
+
+            #[test]
             fn tails() {
                 if $cond {
                     $crate::frame::silu::test::test_silu::<$ker, $t>(&[
@@ -48,6 +55,19 @@ pub mod test {
                 }
             }
         };
+    }
+
+    /// Assert every output of a SiLU kernel carries the sign of its input: `SiLU(x) =
+    /// x * sigmoid(x)` and sigmoid is positive, so a sigmoid factor that dips below zero
+    /// flips the sign of the whole result.
+    pub fn test_silu_sign<K: ElementWiseKer<T>, T: LADatum + Float>() -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        crate::frame::element_wise::test::test_element_wise_invariant::<K, T>(
+            "the sign of the input",
+            |x, y| if x < T::zero() { y <= T::zero() } else { y >= T::zero() },
+        )
     }
 
     pub fn test_silu<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/generic/sigmoid.rs
+++ b/linalg/src/generic/sigmoid.rs
@@ -2,6 +2,12 @@
 use crate::frame::element_wise::ElementWiseKer;
 use tract_data::internal::*;
 
+/// f32 sigmoid, as a rational minimax fit of `sigmoid(x) - 0.5` over `[LOW, HIGH]`.
+///
+/// The sum is clamped to `[0, 1]` to keep the range consumers rely on: on either tail
+/// `p / q` approaches ±0.5 and the final `+ 0.5` cancels down to ~1e-8, below the ~6e-8
+/// f32 rounding error of `p / q` itself, so the sum can land just outside the interval.
+/// NaN still propagates.
 pub fn ssigmoid(x: f32) -> f32 {
     const LOW: f32 = -18.6;
     const HIGH: f32 = -LOW;
@@ -36,9 +42,13 @@ pub fn ssigmoid(x: f32) -> f32 {
     let q = x2 * q + BETA_2;
     let q = x2 * q + BETA_0;
 
-    p / q + 0.5
+    (p / q + 0.5).clamp(0.0, 1.0)
 }
 
+/// f16 sigmoid, as a rational minimax fit of `sigmoid(x) - 0.5` over `[LOW, HIGH]`.
+///
+/// Needs no output clamp, unlike [`ssigmoid`]: the `+ 0.5` cancellation stays inside
+/// (0, 1) for every non-NaN f16 input.
 pub fn hsigmoid(x: f16) -> f16 {
     /*
      * (x (0.249895 + x^2 (0.00400222 - 0.0000124702 x^2)))

--- a/linalg/src/wasm/act.rs
+++ b/linalg/src/wasm/act.rs
@@ -82,6 +82,8 @@ impl ElementWiseKer<f32> for WasmSigmoid4Relaxed {
             let b0 = f32x4_splat(BETA_0);
 
             let half = f32x4_splat(0.5);
+            let zero = f32x4_splat(0.0);
+            let one = f32x4_splat(1.0);
 
             let mut p = buf.as_mut_ptr();
             let end = p.add(buf.len());
@@ -106,7 +108,11 @@ impl ElementWiseKer<f32> for WasmSigmoid4Relaxed {
                 let qn = f32x4_relaxed_madd(x2, qn, b2);
                 let qn = f32x4_relaxed_madd(x2, qn, b0);
 
+                // sigmoid is (0, 1): the add below cancels down to ~1e-8 on either tail,
+                // below the rounding error of the division, so the sum needs clamping to
+                // stay in range.
                 let r = f32x4_add(f32x4_div(pn, qn), half);
+                let r = f32x4_min(one, f32x4_max(zero, r));
                 v128_store(p as *mut v128, r);
                 p = p.add(4);
             }

--- a/linalg/x86_64/avx512/sigmoid_f32.S.j2
+++ b/linalg/x86_64/avx512/sigmoid_f32.S.j2
@@ -189,6 +189,20 @@ avx512_sigmoid_f32_{{suffix}} proc
     vaddps          zmm6, zmm6, zmm1
     vaddps          zmm7, zmm7, zmm1
 
+    // sigmoid is (0, 1): the vaddps above cancels down to ~1e-8 on either tail, below the
+    // rounding error of the division, so the sum needs clamping to stay in range. vpxord
+    // rather than vxorps: the latter needs AVX512DQ, this kernel only requires AVX512F.
+    vpxord          zmm0, zmm0, zmm0
+    vbroadcastss    zmm2, dword ptr [{{offset}} {{L}}coeffs_num_one]
+    vmaxps          zmm4, zmm4, zmm0
+    vmaxps          zmm5, zmm5, zmm0
+    vmaxps          zmm6, zmm6, zmm0
+    vmaxps          zmm7, zmm7, zmm0
+    vminps          zmm4, zmm4, zmm2
+    vminps          zmm5, zmm5, zmm2
+    vminps          zmm6, zmm6, zmm2
+    vminps          zmm7, zmm7, zmm2
+
     vmovaps [rdi], zmm4
     vmovaps [rdi + 64], zmm5
     vmovaps [rdi + 128], zmm6
@@ -242,6 +256,11 @@ avx512_sigmoid_f32_{{suffix}} proc
 
     vdivps          zmm4, zmm4, zmm12
     vaddps          zmm4, zmm4, zmm1
+
+    vpxord          zmm0, zmm0, zmm0
+    vbroadcastss    zmm2, dword ptr [{{offset}} {{L}}coeffs_num_one]
+    vmaxps          zmm4, zmm4, zmm0
+    vminps          zmm4, zmm4, zmm2
 
     vmovaps [rdi], zmm4
     add     rdi, 64
@@ -315,6 +334,9 @@ avx512_sigmoid_f32_{{suffix}} proc
 
 {{L}}coeffs_num_half:
     {{float}} 0.5
+
+{{L}}coeffs_num_one:
+    {{float}} 1.0
 
 {% if msvc %}
 avx512_sigmoid_f32_{{suffix}} endp

--- a/linalg/x86_64/fma/fma_sigmoid_f32.S.j2
+++ b/linalg/x86_64/fma/fma_sigmoid_f32.S.j2
@@ -184,6 +184,18 @@ fma_sigmoid_f32_{{suffix}} proc
     vaddps          ymm6, ymm6, ymm1
     vaddps          ymm7, ymm7, ymm1
 
+    // sigmoid is (0, 1): the vaddps above cancels down to ~1e-8 on either tail, below the
+    // rounding error of the division, so the sum needs clamping to stay in range.
+    vxorps          ymm2, ymm2, ymm2
+    vmaxps          ymm4, ymm4, ymm2
+    vmaxps          ymm5, ymm5, ymm2
+    vmaxps          ymm6, ymm6, ymm2
+    vmaxps          ymm7, ymm7, ymm2
+    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
+    vminps          ymm5, ymm5, ymm0
+    vminps          ymm6, ymm6, ymm0
+    vminps          ymm7, ymm7, ymm0
+
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -237,6 +249,10 @@ fma_sigmoid_f32_{{suffix}} proc
 
     vdivps          ymm4, ymm4, ymm12
     vaddps          ymm4, ymm4, ymm1
+
+    vxorps          ymm2, ymm2, ymm2
+    vmaxps          ymm4, ymm4, ymm2
+    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
 
     vmovaps [rdi], ymm4
     add     rdi, 32

--- a/linalg/x86_64/fma/fma_silu_f32.S.j2
+++ b/linalg/x86_64/fma/fma_silu_f32.S.j2
@@ -4,7 +4,7 @@
 Fused SiLU kernel.
 
 Per element (z = clamp(x, -18.6, 18.6), w = z^2):
-    SiLU(x) = f * (0.5 + z * P(w) / Q(w))
+    SiLU(x) = f * max(0.5 + z * P(w) / Q(w), 0)
 where P is the degree-6 Horner polynomial over the numerator coeffs, Q the
 degree-3 Horner polynomial over the denominator coeffs, and f = max(x, -18.6)
 the factor the sigmoid multiplies. Reuses the coefficients and the rational
@@ -15,6 +15,12 @@ keeps the sigmoid polynomial argument z in range, whereas SiLU(x) ~ x as
 x -> +inf so the factor must stay unbounded above. The lower clamp keeps the
 negative tail bounded: x < -18.6 saturates at -18.6 * sigmoid(-18.6), which
 the true SiLU approaches from below as x -> -inf.
+
+The sigmoid factor is floored at 0 before it multiplies f, since the final
+`+ 0.5` cancels down to ~1e-8 on the negative tail and a sigmoid that came out
+negative there would flip the sign of the whole result. It needs no matching
+ceiling: an overshoot of one ulp only scales f by 1 + 2^-23, and SiLU has no
+upper bound to violate.
 
 x86-64 has only 16 ymm registers and the sigmoid kernel already fills them with
 a 4-group loop, so holding f costs half the unrolling: the main loop here runs
@@ -167,6 +173,12 @@ fma_silu_f32_{{suffix}} proc
     vaddps          ymm4, ymm4, ymm1
     vaddps          ymm5, ymm5, ymm1        // ymm4..5 <- sigmoid
 
+    // The vaddps above cancels down to ~1e-8 on the negative tail, below the rounding error
+    // of the division; a sigmoid that came out negative would flip the sign of the SiLU.
+    vxorps          ymm0, ymm0, ymm0
+    vmaxps          ymm4, ymm4, ymm0
+    vmaxps          ymm5, ymm5, ymm0        // ymm4..5 <- sigmoid, floored at 0
+
     vmulps          ymm4, ymm4, ymm10
     vmulps          ymm5, ymm5, ymm11       // ymm4..5 <- SiLU
 
@@ -221,6 +233,9 @@ fma_silu_f32_{{suffix}} proc
 
     vdivps          ymm4, ymm4, ymm8
     vaddps          ymm4, ymm4, ymm1        // ymm4 <- sigmoid
+
+    vxorps          ymm0, ymm0, ymm0
+    vmaxps          ymm4, ymm4, ymm0        // ymm4 <- sigmoid, floored at 0
 
     vmulps          ymm4, ymm4, ymm10       // ymm4 <- SiLU
 


### PR DESCRIPTION
## Summary

tract's f32 Sigmoid kernels could return values outside sigmoid's `(0, 1)` range — `-2^-24` for inputs like `-18.25`, and `1 + 2^-23` at `17.851563` — because they compute `p / q + 0.5` and that closing addition catastrophically cancels on the tails. This clamps the sum to `[0, 1]` in every f32 Sigmoid kernel, and floors the internal sigmoid in every fused SiLU kernel, which inherited the same defect as a sign flip. Fixes #2618.

## Root cause

The kernels don't approximate sigmoid directly. They fit `sigmoid(x) - 0.5` with a rational minimax approximation — symmetric about zero, so cheaper and more accurate — and add the `0.5` back at the end:

```
sigmoid(x) = P(x)/Q(x) + 0.5
```

At `x = -18.25` the true result is `1.19e-8`, so `P/Q` must land on `-0.5 + 1.19e-8`. Two independent things make that impossible in f32:

- **The inputs to the addition are too big.** `P` and `Q` are O(10²) here (`-176.863` and `353.727`), so rounding through the Horner chain and the division leaves about `0.5 * 2^-23 ≈ 6e-8` of error in `P/Q` — five times the value being extracted.
- **The output can't be represented.** The spacing between representable f32 values just below `0.5` is `2^-25 ≈ 2.98e-8`. The residual `1.19e-8` is smaller than that gap, so there is no float between `-0.5` and its neighbour to hold it. Every result in the band is a small multiple of `2^-25` whose sign is decided by rounding luck: the four observed outputs in #2618 's own output block are exactly `-2^-24`, `0`, `+2^-25`, `+2^-24`.

The approximation itself is sound. Evaluated in exact rational arithmetic the same coefficients give `+1.127e-8` at `-18.25` (true `1.186e-8`) and never go negative anywhere in the region. All the damage is f32 evaluation error in the final two operations.

Violation spans, measured on a 1/1024 grid over `[-31, 31]`:

| kernel group | below 0 | above 1 |
| --- | --- | --- |
| generic, wasm without hardware FMA | `[-18.598, -16.504]` | `17.873` |
| arm64, x86-64 FMA, wasm with hardware FMA | `[-18.595, -17.343]` | `17.852` |
| AVX-512 (its own fit, clamp ±18.0) | everything below `-18.0`, up to `-16.825` | none |

AVX-512 is the worst case: its clamp point `-18.0` itself evaluates to `-2^-24`, so *every* input below `-18.0` came back negative rather than a scattered few.

Fused SiLU inherits it as a sign error, since `SiLU(x) = x * sigmoid(x)` must carry the sign of `x`: `silu(-18.25)` returned `+1.0877848e-6` where the true value is `-2.1646544e-7`.

## Why clamp the output rather than retune the input clamp

The obvious alternative is to pull the existing input clamp inward — `LOW` from `-18.6` to somewhere the cancellation can no longer cross zero — so the tail saturates on a value that happens to be positive. We rejected it.

**Retuning the input clamp**

- *Pro:* costs nothing in the inner loop; it reuses the `fmax`/`fmin` already there.
- *Con:* the threshold is knowable only by brute-forcing one specific coefficient set against one specific rounding pattern. This PR's own measurements need three different values — `-16.50`, `-17.34`, `-16.83` — and the wasm kernel's value depends on whether the host fuses `f32x4_relaxed_madd`, which isn't decidable at build time.
- *Con:* it doesn't establish the invariant, it relocates the band. Any coefficient retune, any new FMA-capable host, or any new kernel silently reintroduces the bug, and the number carries no derivation explaining what it protects.
- *Con:* it doesn't address the upper violation at all unless `HIGH` also comes in to ~`17.87`, giving a second, independent magic constant.
- *Con:* it discards accuracy where the fit is good. Freezing the output for `|x| > 16.5` throws away the correct values the approximation produces across `[16.5, 18.6]`, and pins the whole tail to a constant that is itself up to ~`7e-8` from the truth.

**Clamping the output to `[0, 1]` (this PR)**

- *Pro:* states the invariant directly. Sigmoid's range is `(0, 1)`, so the kernel enforces `[0, 1]` — correct by construction for any coefficients, any rounding mode, any host, and any kernel added later. No magic numbers.
- *Pro:* it is a property, so it can be tested as one; see the new frame test. A threshold can only be spot-checked.
- *Pro:* matches onnxruntime, which returns `0.0` for these inputs.
- *Pro:* leaves the fit's good values untouched everywhere it is accurate.
- *Con:* two extra SIMD instructions per vector in Sigmoid (`fmax` + `fmin`), one in SiLU. Small next to the `fdiv` in the same loop, but not free. In the armv7 SiLU the floor's zero and the low clamp live in the two registers the kernel has spare, so the floor really is one instruction per vector; the armv7 Sigmoid has no spare register in its 3-group loop and re-duplicates both bounds.
- *Con:* it fixes the range violation, not the accuracy. In the saturating band the values are still well off the true tail (`0.0` versus `1.19e-8` at `-18.25`). Fixing *that* means not forming `-0.5 + tiny` at all — an `exp`-based branch for the far tail — which is a much larger change and out of scope here.
- Con: the ceiling needs a 1.0. It is free on x86-64 FMA, where beta_0 = 1.0 is still live in a register at the clamp; arm64 and armv7 are register-starved and rematerialise it in the loop from a dead register (x² on arm64, the denominator on armv7); AVX-512 needs a new 1.0 in its coefficient table because its beta_0 is 0.993, not 1.0.

## Changes

<details>
<summary>One commit per architecture, plus the shared test last so every commit is green</summary>

- `linalg/src/generic/sigmoid.rs` — `ssigmoid` clamps its sum via `.clamp(0.0, 1.0)`.
- `linalg/arm64/…/arm64simd_sigmoid_f32_4n.S.j2` and `linalg/src/arm64/…/silu_fused.rs`.
- `linalg/arm32/armv7neon/armv7neon_{sigmoid,silu}_f32_4n.S.j2`.
- `linalg/x86_64/fma/fma_{sigmoid,silu}_f32.S.j2` and `linalg/x86_64/avx512/sigmoid_f32.S.j2`.
- `linalg/src/wasm/act.rs` — `WasmSigmoid4Relaxed`.
- `linalg/src/frame/{element_wise,sigmoid,silu}.rs` — a shared test_element_wise_invariant that sweeps a kernel's input domain and checks a per-element invariant, plus the sigmoid_range_on_tails and sign_on_tails cases wired into the frame test macros, so every kernel they instantiate is covered.

</details>

NaN propagation is unchanged in every kernel: `clamp` preserves NaN, ARM `fmax`/`fmin` propagate it, and the x86 kernels already destroyed it at the input clamp.

## Deliberately not changed

- **f16 Sigmoid** (`hsigmoid`, `arm64fp16_sigmoid_f16_8n`) has the same structure but needs no clamp: the new frame test sweeps every finite f16 through them — the whole domain, minus NaN and `±inf` — and nothing lands outside `[0, 1]`. Since the f16 domain is finite that is a proof rather than a sample, and it reruns on every cargo test, so a coefficient retune cannot quietly invalidate it.
- The f16 kernels that round-trip through f32 (`arm64simd_sigmoid_f16_4n`, `arm64simd_silu_f16_4n`, the AVX-512 f16 pair) and the AVX-512 f32 SiLU wrapper are fixed transitively — they call the f32 kernels. This inheritance is airtight, not incidental: rounding a value in `[0, 1]` to f16 stays in `[0, 1]`, since 0 and 1 are exactly representable and the rounding is monotone.
- **Fused SiLU gets a floor but no ceiling.** The invariant SiLU needs is sign preservation, which only the floor provides; a sigmoid one ulp above 1 merely scales the factor by `1 + 2^-23`, well inside the kernel's normal error, and SiLU has no upper bound to violate.
- **Metal and CUDA** compute sigmoid and SiLU from a real `exp` and cannot go out of range.
- **Generic SiLU** (`SSiLU4`, `HSiLU8`) also uses a real `exp`; only the fused kernels share the polynomial.
- **Tanh** shares the `p / q + const` shape and may deserve the same look, but its range invariant is different and it is outside this issue. @kali I'll take a look at it after we confirm this PR is the right thing to do.

## Verification

- `cargo test -p tract-linalg` on aarch64-apple-darwin passes correctly. The new tests were confirmed to fail on each unfixed kernel first.
- `cargo test -p tract-core -p test-unit-core`: green, including the SiLU op proptests.
- Sweeping every f32 on a 1/1024 grid over `[-40, 40]` through the arm64 kernels: 0 results below 0, 0 above 1, 0 SiLU sign contradictions. The issue's reported inputs now return `0.0`, matching onnxruntime.
- `cargo fmt --all` clean; `cargo clippy --workspace` clean.

<details>
<summary>Both the x86-64 kernels and the armv7 templates have been executed on real hardware</summary>

x86-64 ran natively on an AVX-512 host with fma and avx512f/vl/bw/dq present, so none of the feature-gated tests short-circuit: `cargo test -p tract-linalg --release` is green. Reverting only linalg/x86_64/ to its pre-fix state makes the new tests fail as expected, which confirms they exercise the kernels rather than passing vacuously: `fma_sigmoid_f32` gives `sigmoid(-18.566406) = -5.96e-8`, `avx512_sigmoid_f32` and `x86_64_avx512_sigmoid_f16_16n` give `sigmoid(-30.0) = -5.96e-8`, `fma_silu_f32` gives `silu(-18.566406) = +1.11e-6`, and `x86_64_avx512_silu_f32_16n` / `x86_64_avx512_silu_f16_16n` give `silu(-30.0) = +1.07e-6`. The two distinct first-failure inputs track the kernels' differing internal clamps (`-18.6` for FMA, `-18.0` for AVX-512); the f16 kernels are affected because they wrap the f32 AVX-512 sigmoid.

armv7 ran on a physical armv7l Cortex-A9 board with NEON, so `has_neon()` resolves from /proc/cpuinfo with no forcing: the full tract-linalg lib suite passes. Reverting only linalg/arm32/ makes `armv7neon_sigmoid_f32_4n::sigmoid_range_on_tails` fail at `sigmoid(-18.582031) = -5.96e-8` and `armv7neon_silu_f32_4n::sign_on_tails` at `silu(-18.582031) = +1.11e-6`.

</details>