### PR TITLE
onnx/gru: keep the cell shape on the output update

### DIFF
--- a/onnx/src/ops/rec/gru.rs
+++ b/onnx/src/ops/rec/gru.rs
@@ -135,13 +135,12 @@ impl WireBody for GRU {
         }
         wire!(ht = self.g.clone(), ht0);
 
-        // Ht = (1 - zt) (.) ht + zt (.) Ht-1
-        let one: OutletId =
-            body.add_const("one", tensor2(&[[1f32]]).cast_to_dt(dt)?.into_owned())?;
-        wire!(one_sub_zt = math::sub(), one, zt);
-        wire!(one_sub_zt_ht = math::mul(), one_sub_zt, ht);
-        wire!(zt_Ht_1 = math::mul(), zt, Ht_1);
-        wire!(Ht = math::add(), one_sub_zt_ht, zt_Ht_1);
+        // Ht = (1 - zt) (.) ht + zt (.) Ht-1, rearranged so every operand keeps the
+        // cell shape: a literal 1 is rank-1 and would broadcast on each element-wise
+        // step.
+        wire!(Ht_1_sub_ht = math::sub(), Ht_1, ht);
+        wire!(zt_Ht_1_sub_ht = math::mul(), zt, Ht_1_sub_ht);
+        wire!(Ht = math::add(), ht, zt_Ht_1_sub_ht);
 
         wire!(y_h = AxisOp::Add(1), Ht);
         body.select_output_outlets(&[y_h])?;


### PR DESCRIPTION
# onnx/gru: keep the cell shape on the output update

The GRU output update was wired as `(1 - zt) (.) ht + zt (.) Ht-1` against a rank-1
constant `1`, so the subtraction broadcast a `[1, 1]` operand against the cell shape
on every iteration, and the update cost four element-wise nodes.

`(1 - z) (.) h + z (.) H` is `h + z (.) (H - h)`, which is three nodes with every
operand already at the cell shape, and drops the constant. On UL-UNAS — 28 GRUs of
hidden 4, scanned over subbands, 524 body iterations per frame — the broadcasting
subtraction alone measured 1.67 us per dispatch against 0.48 us for a same-shape add,
and the frame goes from 6.39 ms to 5.71 ms single-threaded on an i7-3770.

The rearrangement is exact in real arithmetic but reassociates in floating point, so
results move by a few ulp: checked against onnxruntime on DeepFilterNet3's three
graphs, GTCRN and UL-UNAS, the worst relative difference over all outputs goes from
5.94e-07 to 1.00e-06, inside `Approximation::Close`.

🍍
