### PR TITLE
core: size LstmEpilogue's row loop from the state, not the pre-activations

### DIFF
--- a/core/src/ops/lstm_cell.rs
+++ b/core/src/ops/lstm_cell.rs
@@ -69,7 +69,14 @@ impl LstmEpilogue {
         let h = self.hidden;
         let c_prev = &inputs[1]; // [.., h]
         let cp = unsafe { c_prev.as_slice_unchecked::<T>() };
-        let rows = inputs[0].len() / (4 * h); // any leading-dim layout, row-major
+        // Rows come from the state, which also sizes the outputs: a preact left
+        // broadcast on the batch axis would otherwise under-fill them.
+        let rows = cp.len() / h;
+        ensure!(
+            inputs[0].len() == rows * 4 * h,
+            "LstmEpilogue expects preact shaped [{rows}, 4*{h}], got {:?}",
+            inputs[0].shape()
+        );
         // Mutable copy of preact so the activation kernels run in place.
         let mut pre_t = inputs[0].clone().into_tensor();
         let pre = unsafe { pre_t.as_slice_mut_unchecked::<T>() };


### PR DESCRIPTION
# core: size LstmEpilogue's row loop from the state, not the pre-activations

`LstmEpilogue::eval_t` derives its row count from the pre-activation operand,
`inputs[0].len() / (4 * hidden)`, but allocates `Ht` and `Ct` from `c_prev`'s shape. The
two agree for every graph the importer builds today, since both operands come from
matmuls against the same inputs. They stop agreeing the moment a pre-activation reaches
the op broadcast on the batch axis — `[1, 4*hidden]` against a `[batch, hidden]` state —
and then the loop writes one row while the outputs hold `batch` of them, leaving the
rest of two `uninitialized_dt` tensors unwritten. That is silent wrong data rather than a
panic.

Taking the row count from the state makes the loop cover exactly what it allocates, and
an explicit check on the gate operand turns any future mismatch into an error at the
boundary.

Found while writing the equivalent op for GRU; not reachable from the current importer,
so this is a guard rather than a bug fix for anything in the wild.

🍍
