### PR TITLE
data: let stack_tensors' block copy handle a non-trivial outer dimension

### DIFF
--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -263,7 +263,7 @@ impl Tensor {
         self.as_plain_mut().context("Tensor storage is not plain")
     }
 
-    /// Create an uninitialized tensor (dt as type parameter).
+    /// Create an uninitialized tensor (dt as type paramater).
     #[inline]
     pub unsafe fn uninitialized<T: Datum>(shape: &[usize]) -> TractResult<Tensor> {
         unsafe { Self::uninitialized_dt(T::datum_type(), shape) }
@@ -343,17 +343,25 @@ impl Tensor {
         shape[axis] = tensors.iter().map(|v| v.borrow().shape()[axis]).sum();
         unsafe {
             let mut result = Tensor::uninitialized_dt(dt, &shape)?;
-            if dt.is_copy() && shape[..axis].iter().all(|d| *d == 1) {
+            // Every input keeps the same trailing block, so one outer stride walks
+            // them alongside the result and each contribution stays contiguous.
+            let outer: usize = shape[..axis].iter().product();
+            let out_stride = shape[axis..].iter().product::<usize>() * dt.size_of();
+            if dt.is_copy() && tensors.iter().all(|t| t.borrow().storage.as_plain().is_some()) {
+                let out = result.plain_storage_mut().as_mut_ptr();
                 let mut offset = 0isize;
                 for v in tensors {
                     let v = v.borrow();
-                    let len = v.storage.byte_len();
-                    std::ptr::copy_nonoverlapping(
-                        v.plain_storage().as_ptr(),
-                        result.plain_storage_mut().as_mut_ptr().offset(offset),
-                        len,
-                    );
-                    offset += len as isize;
+                    let block = v.storage.byte_len() / outer;
+                    let src = v.plain_storage().as_ptr();
+                    for o in 0..outer {
+                        std::ptr::copy_nonoverlapping(
+                            src.add(o * block),
+                            out.offset(offset + (o * out_stride) as isize),
+                            block,
+                        );
+                    }
+                    offset += block as isize;
                 }
             } else {
                 let mut offset = 0;


### PR DESCRIPTION
# data: let stack_tensors' block copy handle a non-trivial outer dimension

`Tensor::stack_tensors` only took its `copy_nonoverlapping` path when every axis before
the concatenated one had extent 1; anything else fell through to
`assign_slice_from_resolved`. The inputs agree on the axes before the concatenated one, so
one outer loop carrying a stride covers those shapes too, and each contribution stays a
contiguous block.

DTLN's LSTM state is `[1, 2, 128, 2]` and its two stages stack it on the last axis, which
missed the old condition on the `2` and the `128`: 4.8 us to move 2 KB, about 0.4 GB/s.
`Concat` drops out of that model's top three ops, and end to end, single-threaded on an
i7-3770, median of 7 interleaved runs against the same build with only this file reverted:
DTLN stage 1 0.079 to 0.077 ms, stage 2 0.131 to 0.129, GTCRN 1.556 to 1.531, UL-UNAS
2.329 to 2.332. So a percent or two where it applies and nothing worse elsewhere — the op
is a small share of these models to begin with.

The condition also now checks the storage is plain before taking the fast path.
`plain_storage()` panics otherwise, and `dt.is_copy()` alone did not establish it.

🍍
