### PR TITLE
data: add an integer ULP bound to tensor comparison

### DIFF
--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -46,6 +46,7 @@ pub mod internal {
     pub use crate::tensor::Approximation;
     pub use crate::tensor::view::TensorView;
     pub use crate::tensor::{clip_range_bounds, vector_size};
+    pub use crate::ulp::{UlpFloat, ulp_distance};
     pub use anyhow::{Context as TractErrorContext, anyhow, bail, ensure, format_err};
     pub use ndarray as tract_ndarray;
     pub use num_integer;
@@ -65,3 +66,4 @@ mod dim;
 mod exotic;
 mod scatter;
 mod tensor;
+pub mod ulp;

--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -34,15 +34,23 @@ pub enum Approximation {
     SuperApproximate,
     UltraApproximate,
     Custom(f32, f32, f32),
+    /// Compare by integer ULP distance in the reference tensor's own float type,
+    /// accepting a distance up to the given bound.
+    ///
+    /// Unlike the tolerance-based variants this does not go through an f32 cast,
+    /// so an f16 comparison stays an f16 comparison. Use it to assert that two
+    /// implementations of a kernel agree to within a known number of rounding
+    /// steps.
+    Ulp(u64),
 }
 
 impl PartialEq for Approximation {
     fn eq(&self, other: &Self) -> bool {
-        use Approximation::Custom;
-        if let (Custom(aa, ar, ao), Custom(ba, br, bo)) = (self, other) {
-            aa == ba && ar == br && bo == ao
-        } else {
-            std::mem::discriminant(self) == std::mem::discriminant(other)
+        use Approximation::*;
+        match (self, other) {
+            (Custom(aa, ar, ao), Custom(ba, br, bo)) => aa == ba && ar == br && bo == ao,
+            (Ulp(a), Ulp(b)) => a == b,
+            _ => std::mem::discriminant(self) == std::mem::discriminant(other),
         }
     }
 }
@@ -69,6 +77,9 @@ impl Approximation {
             (SuperApproximate, _) => (0.1, 0.05, 0.0001),
             (UltraApproximate, _) => (0.2, 0.1, 0.0005),
             (Custom(atol, rtol, out), _) => (*atol as _, *rtol as _, *out as _),
+            // Handled by a dedicated path in `Tensor::close_enough`; these values
+            // are never consulted.
+            (Ulp(_), _) => (0.0, 0.0, 0.0),
         }
     }
 }
@@ -927,6 +938,9 @@ impl Tensor {
         if self.shape() != other.shape() {
             bail!("Shape mismatch {:?} != {:?}", self.shape(), other.shape())
         }
+        if let Approximation::Ulp(max_ulp) = approx {
+            return self.ulp_close_enough(other, max_ulp);
+        }
         let (atol, rtol, outliers) = approx.atol_rtol_outliers(&self.datum_type());
         let ma = self.cast_to::<f32>()?;
         let ma = ma.to_plain_array_view::<f32>()?;
@@ -951,8 +965,12 @@ impl Tensor {
             let indices = first_outlier.unwrap();
             let a = ma[&*indices];
             let b = mb[&*indices];
+            let ulp = self
+                .max_ulp_distance(other)
+                .map(|(d, _)| format!("{d}"))
+                .unwrap_or_else(|_| "n/a".to_string());
             bail!(
-                "Mismatch. First outlier: {:?} for {:?}) at {:?} {} != {}. Outliers: {} / {} = {:0.5} > {:0.5}.",
+                "Mismatch. First outlier: {:?} for {:?}) at {:?} {} != {}. Outliers: {} / {} = {:0.5} > {:0.5}. Max ULP ({:?}): {}.",
                 approx,
                 self.datum_type(),
                 indices,
@@ -961,10 +979,85 @@ impl Tensor {
                 outliers_count,
                 self.volume(),
                 outliers_count as f64 / self.volume() as f64,
-                outliers
+                outliers,
+                self.ulp_comparison_dt(),
+                ulp,
             );
         }
         Ok(())
+    }
+
+    /// The float type ULP distances against this tensor are measured in.
+    ///
+    /// Float tensors are compared in their own type, so an f16 comparison stays an
+    /// f16 comparison. Anything else falls back to f32, matching what
+    /// `close_enough` does for its tolerance check.
+    pub fn ulp_comparison_dt(&self) -> DatumType {
+        match self.datum_type() {
+            dt @ (DatumType::F16 | DatumType::F32 | DatumType::F64) => dt,
+            _ => DatumType::F32,
+        }
+    }
+
+    /// Largest integer ULP distance between `self` and `other`, and the flat index
+    /// where it occurs.
+    ///
+    /// Comparison happens in [`Self::ulp_comparison_dt`]. See [`crate::ulp`] for
+    /// the exact convention around signed zeros, infinities and NaN.
+    pub fn max_ulp_distance(&self, other: &Self) -> TractResult<(u64, Option<usize>)> {
+        if self.shape() != other.shape() {
+            bail!("Shape mismatch {:?} != {:?}", self.shape(), other.shape())
+        }
+        let dt = self.ulp_comparison_dt();
+        let a = self.cast_to_dt(dt)?;
+        let b = other.cast_to_dt(dt)?;
+        fn worst<D: Datum + crate::ulp::UlpFloat>(
+            a: &Tensor,
+            b: &Tensor,
+        ) -> TractResult<(u64, Option<usize>)> {
+            let a = a.to_plain_array_view::<D>()?;
+            let b = b.to_plain_array_view::<D>()?;
+            Ok(crate::ulp::max_ulp_distance(a.iter().copied(), b.iter().copied()))
+        }
+        match dt {
+            DatumType::F16 => worst::<f16>(&a, &b),
+            DatumType::F32 => worst::<f32>(&a, &b),
+            DatumType::F64 => worst::<f64>(&a, &b),
+            dt => bail!("No ULP comparison for {dt:?}"),
+        }
+    }
+
+    /// Compare two tensors by integer ULP distance, accepting a distance up to
+    /// `max_ulp`.
+    fn ulp_close_enough(&self, other: &Self, max_ulp: u64) -> TractResult<()> {
+        let (worst, at) = self.max_ulp_distance(other)?;
+        if worst <= max_ulp {
+            return Ok(());
+        }
+        let dt = self.ulp_comparison_dt();
+        let indices = at
+            .map(|flat| {
+                let mut rest = flat;
+                let mut indices = vec![0; self.rank()];
+                for (ix, dim) in self.shape().iter().enumerate().rev() {
+                    indices[ix] = rest % dim;
+                    rest /= dim;
+                }
+                format!("{indices:?}")
+            })
+            .unwrap_or_else(|| "?".to_string());
+        let a = self.cast_to::<f64>()?;
+        let b = other.cast_to::<f64>()?;
+        let (a, b) = (a.to_plain_array_view::<f64>()?, b.to_plain_array_view::<f64>()?);
+        let flat = at.unwrap_or(0);
+        bail!(
+            "Mismatch. Max ULP distance ({dt:?}): {} > {}, at {} ({} != {}).",
+            worst,
+            max_ulp,
+            indices,
+            a.iter().nth(flat).copied().unwrap_or(f64::NAN),
+            b.iter().nth(flat).copied().unwrap_or(f64::NAN),
+        );
     }
 
     /// Transform the tensor into a `ndarray::Array`.
@@ -2021,5 +2114,58 @@ mod tests {
         let a = symbols.sym("a");
         let t = tensor0(TDim::from(a));
         let _ = t.clone();
+    }
+
+    #[test]
+    fn ulp_approximation_accepts_within_bound() -> TractResult<()> {
+        let a = tensor1(&[1.0f32, 2.0, 3.0]);
+        let b = tensor1(&[
+            f32::from_bits(1.0f32.to_bits() + 1),
+            2.0,
+            f32::from_bits(3.0f32.to_bits() + 2),
+        ]);
+        a.close_enough(&b, Approximation::Ulp(2))?;
+        assert!(a.close_enough(&b, Approximation::Ulp(1)).is_err());
+        assert_eq!(a.max_ulp_distance(&b)?, (2, Some(2)));
+        Ok(())
+    }
+
+    #[test]
+    fn ulp_approximation_uses_the_tensor_own_float_type() -> TractResult<()> {
+        // One f16 rounding step is ~8192 f32 steps. Measuring in f32 would make an
+        // adjacent-f16 pair look wildly off, so the comparison must stay in f16.
+        let one = f16::from_f32(1.0);
+        let a = tensor1(&[one]);
+        let b = tensor1(&[f16::from_bits(one.to_bits() + 1)]);
+        assert_eq!(a.ulp_comparison_dt(), DatumType::F16);
+        assert_eq!(a.max_ulp_distance(&b)?, (1, Some(0)));
+        a.close_enough(&b, Approximation::Ulp(1))?;
+        Ok(())
+    }
+
+    #[test]
+    fn ulp_approximation_is_scale_free() -> TractResult<()> {
+        // The same relative error at wildly different magnitudes reads the same,
+        // which a shared atol cannot do.
+        let a = tensor1(&[1e-30f32, 1e30]);
+        let b = tensor1(&[
+            f32::from_bits(1e-30f32.to_bits() + 1),
+            f32::from_bits(1e30f32.to_bits() + 1),
+        ]);
+        a.close_enough(&b, Approximation::Ulp(1))?;
+        Ok(())
+    }
+
+    #[test]
+    fn ulp_approximation_rejects_shape_mismatch() {
+        let a = tensor1(&[1.0f32, 2.0]);
+        let b = tensor1(&[1.0f32]);
+        assert!(a.close_enough(&b, Approximation::Ulp(1000)).is_err());
+    }
+
+    #[test]
+    fn ulp_bounds_are_distinguished_by_equality() {
+        assert_eq!(Approximation::Ulp(1), Approximation::Ulp(1));
+        assert_ne!(Approximation::Ulp(1), Approximation::Ulp(2));
     }
 }

--- a/data/src/ulp.rs
+++ b/data/src/ulp.rs
@@ -1,0 +1,170 @@
+//! Integer ULP (unit in the last place) distance between floating point values.
+//!
+//! Absolute and relative tolerances answer "is the result roughly right?". ULP
+//! distance answers a sharper question: "how many representable floats apart are
+//! these two results?". That is the useful metric when two implementations of the
+//! same kernel are supposed to be equivalent, because it stays meaningful across
+//! the whole dynamic range and cleanly separates a one-off rounding difference
+//! from a genuinely different computation.
+//!
+//! The distance follows the usual total-ordering convention: adjacent floats are
+//! 1 apart, `+0.0` and `-0.0` are 1 apart (they are distinct representations),
+//! two NaNs are 0 apart, and a NaN against anything else is [`UlpFloat::MAX_ULP`].
+
+use half::f16;
+
+/// Floating point types for which an integer ULP distance is defined.
+pub trait UlpFloat: Copy {
+    /// Largest distance representable for this type. Also the distance reported
+    /// between a NaN and a non-NaN value.
+    const MAX_ULP: u64;
+
+    /// Bit pattern of the sign bit, widened to `u64`.
+    const SIGN_MASK: u64;
+
+    /// Raw bit pattern, widened to `u64`.
+    ///
+    /// Within a single sign, the bit patterns of finite floats are monotonic in
+    /// magnitude, which is what makes the subtraction below meaningful.
+    fn ulp_bits(self) -> u64;
+
+    fn ulp_is_nan(self) -> bool;
+
+    /// Bit pattern with the sign bit cleared, i.e. the bits of `|self|`.
+    #[inline]
+    fn ulp_magnitude_bits(self) -> u64 {
+        self.ulp_bits() & !Self::SIGN_MASK
+    }
+
+    #[inline]
+    fn ulp_is_sign_negative(self) -> bool {
+        self.ulp_bits() & Self::SIGN_MASK != 0
+    }
+}
+
+macro_rules! impl_ulp_float {
+    ($t:ty, $bits:ty) => {
+        impl UlpFloat for $t {
+            const MAX_ULP: u64 = <$bits>::MAX as u64;
+            const SIGN_MASK: u64 = 1 << (<$bits>::BITS - 1);
+
+            #[inline]
+            fn ulp_bits(self) -> u64 {
+                self.to_bits() as u64
+            }
+
+            #[inline]
+            fn ulp_is_nan(self) -> bool {
+                <$t>::is_nan(self)
+            }
+        }
+    };
+}
+
+impl_ulp_float!(f16, u16);
+impl_ulp_float!(f32, u32);
+impl_ulp_float!(f64, u64);
+
+/// Integer ULP distance between two floats of the same type.
+pub fn ulp_distance<T: UlpFloat>(a: T, b: T) -> u64 {
+    let (a_nan, b_nan) = (a.ulp_is_nan(), b.ulp_is_nan());
+    if a_nan && b_nan {
+        return 0;
+    }
+    if a_nan || b_nan {
+        return T::MAX_ULP;
+    }
+    if a.ulp_is_sign_negative() != b.ulp_is_sign_negative() {
+        // The two values sit on opposite sides of zero, so their bit patterns are
+        // not comparable directly. Measure each against its own zero, then add one
+        // to bridge the gap between -0.0 and +0.0.
+        return a
+            .ulp_magnitude_bits()
+            .saturating_add(b.ulp_magnitude_bits())
+            .saturating_add(1)
+            .min(T::MAX_ULP);
+    }
+    a.ulp_bits().abs_diff(b.ulp_bits())
+}
+
+/// Largest ULP distance over two sequences, with the index where it occurs.
+///
+/// Iteration stops at the shorter of the two; callers are expected to have
+/// checked the shapes already. Returns `(0, None)` when nothing was compared.
+pub fn max_ulp_distance<T: UlpFloat>(
+    a: impl IntoIterator<Item = T>,
+    b: impl IntoIterator<Item = T>,
+) -> (u64, Option<usize>) {
+    let mut worst = 0;
+    let mut at = None;
+    for (ix, (x, y)) in a.into_iter().zip(b).enumerate() {
+        let d = ulp_distance(x, y);
+        if d > worst || at.is_none() {
+            worst = d;
+            at = Some(ix);
+        }
+    }
+    (worst, at)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adjacent_floats_are_one_ulp_apart() {
+        assert_eq!(ulp_distance(1.0f32, f32::from_bits(1.0f32.to_bits() + 1)), 1);
+        assert_eq!(ulp_distance(1.0f64, f64::from_bits(1.0f64.to_bits() + 1)), 1);
+        assert_eq!(
+            ulp_distance(f16::from_f32(1.0), f16::from_bits(f16::from_f32(1.0).to_bits() + 1)),
+            1
+        );
+    }
+
+    #[test]
+    fn identical_values_are_zero_ulp_apart() {
+        assert_eq!(ulp_distance(0.0f32, 0.0f32), 0);
+        assert_eq!(ulp_distance(-3.25f32, -3.25f32), 0);
+        assert_eq!(ulp_distance(f32::INFINITY, f32::INFINITY), 0);
+    }
+
+    #[test]
+    fn distance_is_symmetric_and_sign_aware() {
+        assert_eq!(ulp_distance(1.0f32, -1.0f32), ulp_distance(-1.0f32, 1.0f32));
+        // Signed zeros are distinct representations, hence 1 apart.
+        assert_eq!(ulp_distance(0.0f32, -0.0f32), 1);
+        // Straddling zero costs the two magnitudes plus the zero crossing.
+        let tiny = f32::from_bits(1);
+        assert_eq!(ulp_distance(tiny, -tiny), 3);
+    }
+
+    #[test]
+    fn nan_handling() {
+        assert_eq!(ulp_distance(f32::NAN, f32::NAN), 0);
+        assert_eq!(ulp_distance(f32::NAN, 1.0f32), f32::MAX_ULP);
+        assert_eq!(ulp_distance(1.0f32, f32::NAN), f32::MAX_ULP);
+    }
+
+    #[test]
+    fn infinity_is_adjacent_to_max_finite() {
+        assert_eq!(ulp_distance(f32::MAX, f32::INFINITY), 1);
+        assert_eq!(ulp_distance(-f32::MAX, f32::NEG_INFINITY), 1);
+    }
+
+    #[test]
+    fn magnitude_independence() {
+        // The same "one rounding step" error reads as 1 ULP at any scale, which is
+        // the whole point of the metric.
+        for scale in [1e-30f32, 1.0, 1e30] {
+            assert_eq!(ulp_distance(scale, f32::from_bits(scale.to_bits() + 1)), 1);
+        }
+    }
+
+    #[test]
+    fn max_over_slice_reports_position() {
+        let a = [1.0f32, 2.0, 3.0];
+        let b = [1.0f32, 2.0, f32::from_bits(3.0f32.to_bits() + 5)];
+        assert_eq!(max_ulp_distance(a, b), (5, Some(2)));
+        assert_eq!(max_ulp_distance::<f32>([], []), (0, None));
+    }
+}

--- a/test-rt/suite-onnx/src/lib.rs
+++ b/test-rt/suite-onnx/src/lib.rs
@@ -21,6 +21,23 @@ const MANIFEST_SIMPLE: &str = include_str!("../simple.txt");
 const MANIFEST_PYTORCH_CONVERTED: &str = include_str!("../pytorch-converted.txt");
 const MANIFEST_PYTORCH_OPERATOR: &str = include_str!("../pytorch-operator.txt");
 
+/// `TRACT_ULP=<n>` swaps the suite's tolerance-based comparison for an integer ULP
+/// bound of `n`, measured in each output's own float type.
+///
+/// The tolerance the suite ships with is deliberately loose, because it has to
+/// cover every op and every runtime at once. When the question is "did this kernel
+/// change alter the numbers at all?", running the same suite under `TRACT_ULP=0`
+/// gives a bit-exactness check, and a small bound gives a sharp regression signal
+/// that a shared atol cannot express.
+fn ulp_override() -> Option<Approximation> {
+    let raw = std::env::var("TRACT_ULP").ok()?;
+    let bound = raw
+        .trim()
+        .parse::<u64>()
+        .unwrap_or_else(|e| panic!("TRACT_ULP must be a non-negative integer, got {raw:?}: {e}"));
+    Some(Approximation::Ulp(bound))
+}
+
 #[derive(Clone, Debug)]
 struct OnnxTestCase {
     path: PathBuf,
@@ -37,6 +54,7 @@ impl Test for OnnxTestCase {
         approx: Approximation,
     ) -> TractResult<()> {
         setup_test_logger();
+        let approx = ulp_override().unwrap_or(approx);
         let model_file = self.path.join("model.onnx");
         info!("Loading {model_file:?}");
         let mut onnx = tract_onnx::onnx();


### PR DESCRIPTION
Adds an integer ULP bound to tensor comparison, so a test can assert "these agree to within N rounding steps" rather than only "within some atol/rtol". The motivation is kernel work: when changing a SIMD path there is currently no way to ask whether the numbers moved at all, because `Approximation::Approximate` is loose enough to hide it.

`Approximation::Ulp(n)` compares in the tensor's own float type instead of casting to f32 — measuring an f16 pair in f32 space turns one rounding step into ~8192. Every tolerance mismatch now also reports the max ULP distance, which separates "one rounding step off" from "different algorithm" far more clearly than an absolute delta. `TRACT_ULP=<n>` switches the ONNX suite over, so `TRACT_ULP=0` is a bit-exactness check across the whole node suite.

Distance follows the usual total ordering: adjacent floats 1 apart, ±0.0 1 apart, two NaNs 0 apart, NaN against anything else the type's max.

As a worked example, `TRACT_ULP=0` over the node suite shows `test_add` is bit-exact while `test_softmax` reports `Max ULP distance (F32): 3 > 0` at a named index — a divergence from the ONNX reference that the current tolerance hides.

No behaviour change for existing tests; only the failure message gains a field. ONNX node suite 4528 passed / 0 failed, `tract-data` 152, `tract-linalg` 3798, `tract-core` 272, clippy clean.

🍍
