### PR TITLE
Fix dropping of uninitialised memory in tensor0

### DIFF
--- a/core/src/ops/array/range.rs
+++ b/core/src/ops/array/range.rs
@@ -40,8 +40,9 @@ impl Range {
             let step = step.try_as_plain()?.to_scalar::<T>()?;
             {
                 let mut result_plain = result.try_as_plain_mut()?;
+                let slots = result_plain.as_slice_mut_unchecked::<T>().as_mut_ptr();
                 for i in 0..len {
-                    result_plain.as_slice_mut_unchecked::<T>()[i] = v.clone();
+                    std::ptr::write(slots.add(i), v.clone());
                     v = v + step;
                 }
             }

--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -9,7 +9,7 @@ use itertools::{Itertools, izip};
 use ndarray::prelude::*;
 #[cfg(feature = "complex")]
 use num_complex::Complex;
-use num_traits::{Float, Zero};
+use num_traits::Float;
 use std::borrow::Cow;
 use std::fmt;
 use std::hash::Hash;
@@ -328,16 +328,21 @@ impl Tensor {
             tensor.update_strides_and_len();
         }
         if !tensor.storage.is_empty() {
-            if dt == String::datum_type() || dt == Blob::datum_type() {
-                // assumes zero-initialized string and blob are valid
-                tensor.plain_storage_mut().as_bytes_mut().fill(0);
-            } else if dt == TDim::datum_type() {
+            unsafe fn write_defaults<T: Datum + Default>(tensor: &mut Tensor) {
                 unsafe {
-                    tensor
-                        .as_slice_mut_unchecked::<TDim>()
-                        .iter_mut()
-                        .for_each(|dim| std::ptr::write(dim, TDim::zero()))
+                    let len = tensor.len;
+                    let dst = tensor.as_slice_mut_unchecked::<T>().as_mut_ptr();
+                    for i in 0..len {
+                        std::ptr::write(dst.add(i), T::default());
+                    }
                 }
+            }
+            if dt == String::datum_type() {
+                unsafe { write_defaults::<String>(&mut tensor) }
+            } else if dt == Blob::datum_type() {
+                unsafe { write_defaults::<Blob>(&mut tensor) }
+            } else if dt == TDim::datum_type() {
+                unsafe { write_defaults::<TDim>(&mut tensor) }
             } else if cfg!(debug_assertions) {
                 assert!(dt.is_copy());
                 if dt == DatumType::F32 {
@@ -1600,7 +1605,7 @@ impl Tensor {
         unsafe fn nth_t<T: Datum>(me: &Tensor, nth: usize, output: &mut Tensor) {
             unsafe {
                 let value = me.as_slice_unchecked::<T>()[nth].clone();
-                output.as_slice_mut_unchecked::<T>()[0] = value;
+                std::ptr::write(output.as_slice_mut_unchecked::<T>().as_mut_ptr(), value);
             }
         }
         unsafe {

--- a/data/src/tensor/litteral.rs
+++ b/data/src/tensor/litteral.rs
@@ -30,7 +30,7 @@ where
 pub fn tensor0<A: Datum>(x: A) -> Tensor {
     unsafe {
         let mut tensor = Tensor::uninitialized::<A>(&[]).unwrap();
-        tensor.as_slice_mut_unchecked::<A>()[0] = x;
+        std::ptr::write(tensor.as_slice_mut_unchecked::<A>().as_mut_ptr(), x);
         tensor
     }
 }


### PR DESCRIPTION
`tensor0` builds an uninitialised buffer and then writes to that value with an assignment operator. [Assignment drops the uninitialised `tensor` before overwriting it with `x`.](https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.assign.drop-target)

```rust
let mut tensor = Tensor::uninitialized::<A>(&[]).unwrap();
tensor.as_slice_mut_unchecked::<A>()[0] = x;
```
## Reproduction:

### Test case:
```rust
#[test]
fn drop_of_uninit() {
    let _t: Tensor = tensor0(1.0f32);
}
```

### Verifying with Miri:
```
cargo +nightly-2025-08-20 miri test -p tract-data --test repro
```

Miri output:
```
error: Undefined Behavior: constructing invalid value at .pointer: encountered 0, but expected something greater or equal to 1
    |
512 |         self.ptr.cast().as_non_null_ptr()
    |         ^^^^^^^^ Undefined Behavior occurred here
    |
```

## Fix: 

Replace the assignment operator with the [`std::ptr::write` function which directly writes to `x`](https://doc.rust-lang.org/std/ptr/fn.write.html), fixing the drop of uninitialised memory.