### PR TITLE
fix(linalg): fix tanh and gelu output range

### DIFF
--- a/linalg/arm32/armv7neon/armv7neon_tanh_f32_4n.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_tanh_f32_4n.S.j2
@@ -128,6 +128,15 @@ armv7neon_tanh_f32_4n_{{suffix}}:
     vmul.f32    q11, q5, q8
     vmul.f32    q12, q6, q9
 
+    vdup.32     q13, d6[1]
+    vdup.32     q14, d6[0]
+    vmax.f32    q10, q13
+    vmax.f32    q11, q13
+    vmax.f32    q12, q13
+    vmin.f32    q10, q14
+    vmin.f32    q11, q14
+    vmin.f32    q12, q14
+
     vstmia      r0!, { q10, q11, q12 }
 
     subs        r1, #12
@@ -178,6 +187,11 @@ armv7neon_tanh_f32_4n_{{suffix}}:
 
     vmul.f32    q10, q4, q7
 
+    vdup.32     q13, d6[1]
+    vdup.32     q4, d6[0]
+    vmax.f32    q10, q13
+    vmin.f32    q10, q4
+
     vstmia      r0!, { q10 }
 
     subs        r1, #4;
@@ -204,6 +218,6 @@ armv7neon_tanh_f32_4n_{{suffix}}:
     .float 0.4641733162
 
     .float 1.0
-    .float 0                        // padding
+    .float -1.0                     // output clamp low
     .float 0                        // padding
     .float 0                        // padding

--- a/linalg/arm64/arm64simd/arm64simd_tanh_f32_4n.S.j2
+++ b/linalg/arm64/arm64simd/arm64simd_tanh_f32_4n.S.j2
@@ -16,6 +16,8 @@
     ld1         { v0.4s, v1.4s, v2.4s, v3.4s }, [x2]
     dup         v5.4s, v0.s[0]              // v5 <- low, broadcasted
     dup         v6.4s, v0.s[1]              // v6 <- high, broadcasted
+    dup         v4.4s, v3.s[0]              // v4 <- 1.0, broadcasted
+    dup         v7.4s, v3.s[1]              // v7 <- -1.0, broadcasted
 
     cmp         x1, #16
     blt         .loop
@@ -129,6 +131,16 @@
     fdiv        v18.4s, v18.4s, v26.4s
     fdiv        v19.4s, v19.4s, v27.4s
 
+    fmax        v16.4s, v16.4s, v7.4s
+    fmax        v17.4s, v17.4s, v7.4s
+    fmax        v18.4s, v18.4s, v7.4s
+    fmax        v19.4s, v19.4s, v7.4s
+
+    fmin        v16.4s, v16.4s, v4.4s
+    fmin        v17.4s, v17.4s, v4.4s
+    fmin        v18.4s, v18.4s, v4.4s
+    fmin        v19.4s, v19.4s, v4.4s
+
     st1         { v16.4s, v17.4s, v18.4s, v19.4s }, [x0], #64
 
     subs        x1, x1, #16
@@ -168,6 +180,9 @@
 
     fdiv        v16.4s, v16.4s, v24.4s
 
+    fmax        v16.4s, v16.4s, v7.4s
+    fmin        v16.4s, v16.4s, v4.4s
+
     st1         { v16.4s }, [x0], #16
 
     subs        x1, x1, #4
@@ -193,6 +208,6 @@
     .float 0.4641733162
 
     .float 1.0
-    .float 0                        // padding
+    .float -1.0                     // output clamp low
     .float 0                        // padding
     .float 0                        // padding

--- a/linalg/src/arm64/arm64simd/gelu_fused.rs
+++ b/linalg/src/arm64/arm64simd/gelu_fused.rs
@@ -56,7 +56,7 @@ ew_impl_wrap!(
             //   v7:    0.5 (broadcast of v3.s[1])
             //   v8-v11: 0.5 * original x (saved after load)
             //   v16-v19: working (load -> pre_tanh -> clamped -> numerator)
-            //   v20-v23: x² for tanh polynomial
+            //   v20-v23: x² for tanh polynomial (v20/v21 reused for the tanh clamp)
             //   v24-v27: polynomial intermediates (denominator at end)
             //   v28-v31: polynomial intermediates (also x³ temp before tanh)
             std::arch::asm!("
@@ -209,6 +209,20 @@ ew_impl_wrap!(
                     fdiv v18.4s, v18.4s, v26.4s
                     fdiv v19.4s, v19.4s, v27.4s
 
+                    // The quotient can reach ±(1 + 2^-23), which takes the 0.5*(1 + tanh)
+                    // factor out of (0, 1): below 0 it flips the result's sign, above 1 it
+                    // pushes the result past x. x² is dead here, so v20/v21 carry the bounds.
+                    fmov v20.4s, #-1.0
+                    fmov v21.4s, #1.0
+                    fmax v16.4s, v16.4s, v20.4s
+                    fmax v17.4s, v17.4s, v20.4s
+                    fmax v18.4s, v18.4s, v20.4s
+                    fmax v19.4s, v19.4s, v20.4s
+                    fmin v16.4s, v16.4s, v21.4s
+                    fmin v17.4s, v17.4s, v21.4s
+                    fmin v18.4s, v18.4s, v21.4s
+                    fmin v19.4s, v19.4s, v21.4s
+
                     // result = 0.5*x * (1 + tanh) = (0.5*x) + (0.5*x) * tanh
                     fmla v8.4s, v8.4s, v16.4s
                     fmla v9.4s, v9.4s, v17.4s
@@ -260,6 +274,11 @@ ew_impl_wrap!(
                     fmla v24.4s, v20.4s, v28.4s
 
                     fdiv v16.4s, v16.4s, v24.4s
+
+                    fmov v20.4s, #-1.0
+                    fmov v21.4s, #1.0
+                    fmax v16.4s, v16.4s, v20.4s
+                    fmin v16.4s, v16.4s, v21.4s
 
                     fmla v8.4s, v8.4s, v16.4s
 

--- a/linalg/src/frame/element_wise.rs
+++ b/linalg/src/frame/element_wise.rs
@@ -193,11 +193,16 @@ pub mod test {
     use proptest::test_runner::{TestCaseError, TestCaseResult};
     use tract_data::internal::*;
 
-    /// Every finite `f16`, or a 1/256 grid of `[-30, 30]` for wider types.
+    /// Every finite `f16`, or a 1/4096 grid of `[-30, 30]` for wider types.
     ///
-    /// The grid samples where the `f16` set is enumerated, but it reaches past the `±18.6`
-    /// input clamp the f32 kernels apply, so no input outside its bounds takes a path it
-    /// has not already exercised.
+    /// The grid samples where the `f16` set is enumerated, but it reaches past every input
+    /// clamp the f32 kernels apply, so no input outside its bounds takes a path it has not
+    /// already exercised.
+    ///
+    /// The step has to stay fine because these invariants break on value-specific
+    /// rounding, not over a contiguous region: the Tanh kernels leave `[-1, 1]` only
+    /// inside a band about 0.3 wide, and a 1/256 grid steps clean over
+    /// `arm64simd_tanh_f32_4n`'s share of it.
     fn invariant_sweep<T: LADatum>() -> Vec<T>
     where
         f32: AsPrimitive<T>,
@@ -208,7 +213,7 @@ pub mod test {
             let all = tensor1(&all).cast_to::<T>().unwrap().into_owned();
             return all.try_as_plain().unwrap().as_slice::<T>().unwrap().to_vec();
         }
-        (-30 * 256..=30 * 256).map(|i| (i as f32 / 256.).as_()).collect()
+        (-30 * 4096..=30 * 4096).map(|i| (i as f32 / 4096.).as_()).collect()
     }
 
     /// Assert `invariant` holds of every `(input, output)` pair a kernel produces over

--- a/linalg/src/frame/gelu.rs
+++ b/linalg/src/frame/gelu.rs
@@ -38,7 +38,48 @@ pub mod test {
                         .unwrap();
                 }
             }
+
+            #[test]
+            fn sign_on_tails() {
+                if $cond {
+                    $crate::frame::gelu::test::test_gelu_sign::<$ker, $t>().unwrap()
+                }
+            }
+
+            #[test]
+            fn magnitude_on_tails() {
+                if $cond {
+                    $crate::frame::gelu::test::test_gelu_magnitude::<$ker, $t>().unwrap()
+                }
+            }
         };
+    }
+
+    /// Assert every output of a GELU kernel carries the sign of its input: `gelu(x) =
+    /// 0.5 * x * (1 + tanh(..))` and the tanh-form factor is positive, so an internal tanh
+    /// that dips below -1 makes the factor negative and flips the sign of the result.
+    pub fn test_gelu_sign<K: ElementWiseKer<T>, T: LADatum + Float>() -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        crate::frame::element_wise::test::test_element_wise_invariant::<K, T>(
+            "the sign of the input",
+            |x, y| if x < T::zero() { y <= T::zero() } else { y >= T::zero() },
+        )
+    }
+
+    /// Assert no output of a GELU kernel exceeds its input in magnitude. The tanh-form
+    /// factor is below 1, so `gelu` contracts towards zero — negative inputs included,
+    /// where the output is negative but never more negative than the input. An internal
+    /// tanh above 1 pushes the factor past 1 and the result past its input.
+    pub fn test_gelu_magnitude<K: ElementWiseKer<T>, T: LADatum + Float>() -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        crate::frame::element_wise::test::test_element_wise_invariant::<K, T>(
+            "a magnitude not above the input's",
+            |x, y| y.abs() <= x.abs(),
+        )
     }
 
     pub fn test_gelu<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/frame/tanh.rs
+++ b/linalg/src/frame/tanh.rs
@@ -69,6 +69,13 @@ pub mod test {
             }
 
             #[test]
+            fn tanh_range_on_tails() {
+                if $cond {
+                    $crate::frame::tanh::test::test_tanh_range::<$ker, $t>().unwrap()
+                }
+            }
+
+            #[test]
             fn tanh_asymptots() {
                 use tract_data::internal::*;
                 use $crate::frame::element_wise::*;
@@ -88,6 +95,19 @@ pub mod test {
                 }
             }
         };
+    }
+
+    /// Assert every output of a tanh kernel lands in `[-1, 1]`, the range its consumers
+    /// rely on and which a `p / q` kernel can step outside near its input clamp, where the
+    /// true value is already within one ulp of `±1`.
+    pub fn test_tanh_range<K: ElementWiseKer<T>, T: LADatum + Float>() -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        crate::frame::element_wise::test::test_element_wise_invariant::<K, T>(
+            "a result in [-1, 1]",
+            |_, y| y >= -T::one() && y <= T::one(),
+        )
     }
 
     pub fn test_tanh<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/generic/tanh.rs
+++ b/linalg/src/generic/tanh.rs
@@ -2,6 +2,13 @@
 use crate::frame::element_wise::ElementWiseKer;
 use tract_data::internal::*;
 
+/// f32 tanh, as a rational minimax fit of `tanh` over `[LOW, HIGH]`.
+///
+/// The quotient is clamped to `[-1, 1]` to keep the range consumers rely on. Across the
+/// top of the input range the correctly rounded result is already within one ulp of `±1`
+/// — `1 - tanh(8.9)` is `3.7e-8`, under the `2^-24` f32 step just below 1 — while the two
+/// Horner chains and the division leave a few ulps of relative error, so an upward
+/// rounding lands on `±(1 + 2^-22)`. NaN still propagates.
 pub fn stanh(x: f32) -> f32 {
     const LOW: f32 = -8.9;
     const HIGH: f32 = 8.9;
@@ -37,9 +44,13 @@ pub fn stanh(x: f32) -> f32 {
     let q = x2 * q + BETA_2;
     let q = x2 * q + BETA_0;
 
-    p / q
+    (p / q).clamp(-1.0, 1.0)
 }
 
+/// f16 tanh, as a rational minimax fit of `tanh` over `[LOW, HIGH]`.
+///
+/// Needs no output clamp, unlike [`stanh`]: `1 - tanh(3.84)` is `9.3e-4`, about two f16
+/// steps below 1, so the quotient keeps its margin for every f16 input.
 pub fn htanh(x: f16) -> f16 {
     const LOW: f16 = f16::from_f32_const(-3.84);
     const HIGH: f16 = f16::from_f32_const(3.84);

--- a/linalg/src/wasm/act.rs
+++ b/linalg/src/wasm/act.rs
@@ -181,6 +181,9 @@ impl ElementWiseKer<f32> for WasmTanh4Relaxed {
             let b2 = f32x4_splat(BETA_2);
             let b0 = f32x4_splat(BETA_0);
 
+            let one = f32x4_splat(1.0);
+            let minus_one = f32x4_splat(-1.0);
+
             let mut p = buf.as_mut_ptr();
             let end = p.add(buf.len());
             while p < end {
@@ -202,7 +205,11 @@ impl ElementWiseKer<f32> for WasmTanh4Relaxed {
                 let qn = f32x4_relaxed_madd(x2, qn, b2);
                 let qn = f32x4_relaxed_madd(x2, qn, b0);
 
+                // tanh is (-1, 1): the quotient comes within one ulp of ±1 across the top
+                // of the input range, under the kernel's own rounding error, so it needs
+                // clamping to stay in range.
                 let r = f32x4_div(pn, qn);
+                let r = f32x4_min(one, f32x4_max(minus_one, r));
                 v128_store(p as *mut v128, r);
                 p = p.add(4);
             }

--- a/linalg/x86_64/avx512/tanh_f32.S.j2
+++ b/linalg/x86_64/avx512/tanh_f32.S.j2
@@ -184,6 +184,18 @@ avx512_tanh_f32_{{suffix}} proc
     vdivps          zmm6, zmm6, zmm14
     vdivps          zmm7, zmm7, zmm15
 
+    // This fit's beta_0 is not 1.0, so both bounds come from the table
+    vbroadcastss    zmm0, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
+    vbroadcastss    zmm1, dword ptr [{{offset}} {{L}}coeffs_num_one]
+    vmaxps          zmm4, zmm4, zmm0
+    vmaxps          zmm5, zmm5, zmm0
+    vmaxps          zmm6, zmm6, zmm0
+    vmaxps          zmm7, zmm7, zmm0
+    vminps          zmm4, zmm4, zmm1
+    vminps          zmm5, zmm5, zmm1
+    vminps          zmm6, zmm6, zmm1
+    vminps          zmm7, zmm7, zmm1
+
     vmovaps [rdi], zmm4
     vmovaps [rdi + 64], zmm5
     vmovaps [rdi + 128], zmm6
@@ -235,6 +247,11 @@ avx512_tanh_f32_{{suffix}} proc
     vfmadd132ps     zmm12, zmm0, zmm8
 
     vdivps          zmm4, zmm4, zmm12
+
+    vbroadcastss    zmm0, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
+    vbroadcastss    zmm1, dword ptr [{{offset}} {{L}}coeffs_num_one]
+    vmaxps          zmm4, zmm4, zmm0
+    vminps          zmm4, zmm4, zmm1
 
     vmovaps [rdi], zmm4
     add     rdi, 64
@@ -305,6 +322,11 @@ avx512_tanh_f32_{{suffix}} proc
     {{float}} 2.26843463243900e-03     // beta_2
 {{L}}coeffs_num_beta_0:
     {{float}} 4.89352518554385e-03     // beta_0
+
+{{L}}coeffs_num_one:
+    {{float}} 1.0
+{{L}}coeffs_num_minus_one:
+    {{float}} -1.0
 
 {% if msvc %}
 avx512_tanh_f32_{{suffix}} endp

--- a/linalg/x86_64/fma/avx_tanh_f32.S.j2
+++ b/linalg/x86_64/fma/avx_tanh_f32.S.j2
@@ -216,6 +216,17 @@ avx_tanh_f32_{{suffix}} proc
     vdivps          ymm6, ymm6, ymm14
     vdivps          ymm7, ymm7, ymm15
 
+    // ymm0 still holds beta_0, which this fit sets to 1.0; the denominator chain freed ymm1
+    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
+    vmaxps          ymm4, ymm4, ymm1
+    vmaxps          ymm5, ymm5, ymm1
+    vmaxps          ymm6, ymm6, ymm1
+    vmaxps          ymm7, ymm7, ymm1
+    vminps          ymm4, ymm4, ymm0
+    vminps          ymm5, ymm5, ymm0
+    vminps          ymm6, ymm6, ymm0
+    vminps          ymm7, ymm7, ymm0
+
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -276,6 +287,10 @@ avx_tanh_f32_{{suffix}} proc
     vaddps          ymm12, ymm12, ymm0
 
     vdivps          ymm4, ymm4, ymm12
+
+    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
+    vmaxps          ymm4, ymm4, ymm1
+    vminps          ymm4, ymm4, ymm0
 
     vmovaps [rdi], ymm4
     add     rdi, 32
@@ -346,6 +361,9 @@ avx_tanh_f32_{{suffix}} proc
     {{float}} 0.4641733162
 {{L}}coeffs_num_beta_0:
     {{float}} 1.0
+
+{{L}}coeffs_num_minus_one:
+    {{float}} -1.0
 
 
 

--- a/linalg/x86_64/fma/fma_tanh_f32.S.j2
+++ b/linalg/x86_64/fma/fma_tanh_f32.S.j2
@@ -180,6 +180,17 @@ fma_tanh_f32_{{suffix}} proc
     vdivps          ymm6, ymm6, ymm14
     vdivps          ymm7, ymm7, ymm15
 
+    // ymm0 still holds beta_0, which this fit sets to 1.0; the denominator chain freed ymm1
+    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
+    vmaxps          ymm4, ymm4, ymm1
+    vmaxps          ymm5, ymm5, ymm1
+    vmaxps          ymm6, ymm6, ymm1
+    vmaxps          ymm7, ymm7, ymm1
+    vminps          ymm4, ymm4, ymm0
+    vminps          ymm5, ymm5, ymm0
+    vminps          ymm6, ymm6, ymm0
+    vminps          ymm7, ymm7, ymm0
+
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -231,6 +242,10 @@ fma_tanh_f32_{{suffix}} proc
     vfmadd132ps     ymm12, ymm0, ymm8
 
     vdivps          ymm4, ymm4, ymm12
+
+    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
+    vmaxps          ymm4, ymm4, ymm1
+    vminps          ymm4, ymm4, ymm0
 
     vmovaps [rdi], ymm4
     add     rdi, 32
@@ -301,6 +316,9 @@ fma_tanh_f32_{{suffix}} proc
     {{float}} 0.4641733162
 {{L}}coeffs_num_beta_0:
     {{float}} 1.0
+
+{{L}}coeffs_num_minus_one:
+    {{float}} -1.0
 
 
 


### PR DESCRIPTION
## Summary

tract's f32 Tanh kernels could return values outside tanh's `(-1, 1)` range — up to `±(1 + 2^-22)` for `|x| ≈ 8.1–9.0` — and the fused arm64 GELU kernel, which clones the tanh polynomial, inherited it at both ends. This clamps every f32 Tanh kernel's output to `[-1, 1]`, and the internal tanh of the fused GELU kernel for the same reason. Follow-up to #2620, which fixed the same class of bug in Sigmoid/SiLU.

## Root cause

Near the input clamp (`±8.9`, `±9.0` on AVX-512) the correct answer is already within one f32 ulp of `1.0` — `1 - tanh(8.9) = 3.7e-8`, less than the `2^-24` step below 1 — and the rational fit's own few-ulp error is enough to round over the boundary. So the violations land strictly *inside* the input clamp, at ordinary activation magnitudes, and which values overshoot is rounding-specific rather than a contiguous region. Downstream this mirrors #2618: `sqrt(1 - tanh(x)²)` and `atanh(tanh(x))` become NaN.

## Fused GELU

`gelu(x) = x·Φ(x)` with `Φ = 0.5·(1 + tanh θ) ∈ (0, 1)`, so `gelu(x)` lies strictly between `0` and `x`. An out-of-range tanh breaks both bounds: `arm64simd_gelu_f32_4n_fused` returned `gelu(-5.1257324) = +3.05e-7` against a true `-9.6e-8` (sign flipped), and `gelu(5.0625) = 5.0625005`, further from zero than its own input. Clamping its internal tanh restores both.

## Why clamp the output rather than pull the input clamp in

A tighter input clamp would close the band, but it is a magic number per coefficient set *and* per rounding mode, undecidable for wasm (it depends on whether the host fuses `f32x4_relaxed_madd`), and it relocates the band instead of establishing the invariant. `[-1, 1]` is correct by construction for any coefficients, any host, and any kernel added later — and it can be tested as a property. `±1` is already an accepted output today, so no consumer sees anything new; accuracy inside the fit region is unchanged (bit-identical over `[0, 8]` on x86), at a cost of ~2 SIMD instructions per vector.

## Changes

Clamps in generic `stanh`, arm64 (Tanh + fused GELU), armv7neon, FMA, AVX-512 and the wasm relaxed kernel — one commit per architecture, shared tests last. f16 Tanh needs no clamp (real margin at its `±3.84` clamp; the new test sweeps every finite f16 through it), and the GELU kernels that *call* the Tanh kernel rather than inlining its polynomial are fixed transitively.

New frame tests: `tanh_range_on_tails`, plus GELU `sign_on_tails` and `magnitude_on_tails`. The shared invariant sweep grid goes from 1/256 to 1/4096, which is load-bearing: on the coarser grid the unfixed arm64 kernel passes outright. The existing accuracy tests cannot stand in — their `1e-4` tolerance is four orders of magnitude looser than the ~`2e-7` overshoot.

## Verification

Every kernel here was executed on its own hardware except wasm: arm64 (macOS), armv7 NEON (Cortex-A9), AVX-512 + FMA (i9-11900KB). Each new test was confirmed failing on the unfixed kernel at the predicted inputs and passing after, both loop bodies exercised, register liveness at each clamp site checked against the disassembly. An exhaustive x86 sweep of every f32 bit pattern with `|x| ≤ 12` gives `max(|y| - 1) = 0`. `cargo fmt --all` and `cargo clippy -p tract-linalg` clean.

`WasmTanh4Relaxed` was compiled and its emitted `f32x4.min`/`max` pair inspected against the already-fixed `WasmSigmoid4Relaxed`, but not executed — no relaxed-SIMD host available.