### PR TITLE
onnx: fix GatherNd output shape inference

### DIFF
--- a/hir/src/ops/array/gather_nd.rs
+++ b/hir/src/ops/array/gather_nd.rs
@@ -18,11 +18,23 @@ impl InferenceRulesOp for GatherNd {
             }
             s.given_2(
                 &inputs[1].shape[indices_rank - 1],
-                &inputs[1].rank,
-                move |s, n, input_rank| {
+                &inputs[0].rank,
+                move |s, n, data_rank| {
                     if let Ok(n) = n.to_i64() {
-                        for i in 0..(input_rank - n) as usize {
-                            s.equals(&outputs[0].shape[indices_rank - 1 + i], &inputs[1].shape[i])?;
+                        let n = n as usize + self.batch_dims;
+                        ensure!(
+                            n <= data_rank as usize,
+                            "GatherNd indices index {n} axes (last indices dimension plus batch_dims) but data has rank {data_rank}"
+                        );
+                        s.equals(
+                            &outputs[0].rank,
+                            (indices_rank - 1 + data_rank as usize - n) as i64,
+                        )?;
+                        for i in 0..(data_rank as usize - n) {
+                            s.equals(
+                                &outputs[0].shape[indices_rank - 1 + i],
+                                &inputs[0].shape[n + i],
+                            )?;
                         }
                     }
                     Ok(())
@@ -33,4 +45,42 @@ impl InferenceRulesOp for GatherNd {
 
     as_op!();
     to_typed!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn infer(
+        batch_dims: usize,
+        data: InferenceFact,
+        indices: InferenceFact,
+    ) -> TractResult<TVec<InferenceFact>> {
+        let mut op = GatherNd::new(batch_dims);
+        let output = InferenceFact::default();
+        Ok(op.infer_facts(tvec!(&data, &indices), tvec!(&output), tvec!())?.1)
+    }
+
+    #[test]
+    fn trailing_dims_come_from_data() {
+        let facts = infer(0, f32::fact([8, 128, 256]).into(), i64::fact([32, 1]).into()).unwrap();
+        assert_eq!(facts, tvec!(f32::fact([32, 128, 256]).into()));
+    }
+
+    #[test]
+    fn batch_dims_shift_the_data_axes() {
+        let facts = infer(1, f32::fact([4, 15, 18]).into(), i64::fact([4, 15, 1]).into()).unwrap();
+        assert_eq!(facts, tvec!(f32::fact([4, 15, 18]).into()));
+    }
+
+    #[test]
+    fn indexing_every_data_axis_leaves_the_index_prefix() {
+        let facts = infer(0, f32::fact([4, 5, 6]).into(), i64::fact([7, 3]).into()).unwrap();
+        assert_eq!(facts, tvec!(f32::fact([7]).into()));
+    }
+
+    #[test]
+    fn indices_deeper_than_data_rank_is_rejected() {
+        infer(0, f32::fact([4, 5, 6]).into(), i64::fact([7, 4]).into()).unwrap_err();
+    }
 }


### PR DESCRIPTION
The `GatherNd` inference rule derived the trailing output dimensions from the indices rank and shape rather than the data tensor, so any ONNX model whose data tensor outranks its indices failed at the analyse stage. Core's `compute_shape` was already spec-correct — only HIR inference was wrong.

Found while loading an NVIDIA Nemotron 3.5 Lightning (`nemotron_h`) export, where MoE expert routing emits `GatherND(data: [8,128,256], indices: [32,1])` and tract rejected it with `Impossible to unify Val(128) with Val(32)`. This also covers #1353, whose `batch_dims=1` TF export fails through the same rule.

Indices addressing more axes than the data has previously spun forever (`data_rank - n` underflowed into a ~1.8e19 loop bound); it now reports an error.

Verified: new inference tests in `hir`, the ONNX backend suite (4528 pass), and NNEF round-trips with numeric assertions for `batch_dims` 0 and 1.

Note: I could not run `cargo clippy --workspace` on Linux — it fails compiling the Apple-only `core-graphics-types`. Clippy is clean on `tract-hir`, `tract-onnx`, `tract-core` and `tract-cli`.

🍍