### PR TITLE
metal: fast path for contiguous softmax_nd3

### DIFF
--- a/metal/src/kernels/nn/nn_ops.metal
+++ b/metal/src/kernels/nn/nn_ops.metal
@@ -460,6 +460,57 @@ template [[host_name(
 template [[host_name(
     "nn_ops::softmax_nd3_f16")]] [[kernel]] softmax_nd3_t softmax_nd3<half>;
 
+// Fast path for softmax_nd3 restricted to a contiguous softmax axis
+// (strides[1]==1) whose length is a multiple of 4; the caller guarantees both
+// so the F4 loads stay in bounds and 16-byte aligned. F4 is F's 4-wide vector.
+template <typename F, typename F4>
+[[kernel]] void softmax_nd3_contig(device const void *input_b, device void *output_b,
+                                   constant const size_t shape[3],
+                                   constant const size_t strides[3],
+                                   uint3 tgpig [[threadgroup_position_in_grid]],
+                                   uint tiisg  [[thread_index_in_simdgroup]],
+                                   uint tpsg   [[threads_per_simdgroup]]) {
+    device const F *input = (device const F *)input_b;
+    device F *output = (device F *)output_b;
+    size_t dim = shape[1];
+    size_t base = tgpig.x * strides[2] + tgpig.z * strides[0];
+    device const F4 *in4 = (device const F4 *)(input + base);
+    device F4 *out4 = (device F4 *)(output + base);
+    uint vec_dim = (uint)dim >> 2;
+
+    float pmax = -INFINITY;
+    float psum = 0.0f;
+    for (uint v = tiisg; v < vec_dim; v += tpsg) {
+        float4 x = float4(in4[v]);
+        float vmax = max(max(x[0], x[1]), max(x[2], x[3]));
+        if (vmax > pmax) { psum *= fast::exp(pmax - vmax); pmax = vmax; }
+        psum += dot(fast::exp(x - pmax), float4(1.0f));
+    }
+    for (uint i = vec_dim * 4 + tiisg; i < (uint)dim; i += tpsg) {
+        float x = float(input[base + i]);
+        if (x > pmax) { psum *= fast::exp(pmax - x); pmax = x; }
+        psum += fast::exp(x - pmax);
+    }
+
+    float amax = simd_max(pmax);
+    float inv = 1.0f / simd_sum(psum * fast::exp(pmax - amax));
+
+    for (uint v = tiisg; v < vec_dim; v += tpsg) {
+        float4 x = float4(in4[v]);
+        out4[v] = F4(fast::exp(x - amax) * inv);
+    }
+    for (uint i = vec_dim * 4 + tiisg; i < (uint)dim; i += tpsg) {
+        output[base + i] = F(fast::exp(float(input[base + i]) - amax) * inv);
+    }
+}
+
+typedef decltype(softmax_nd3_contig<float, float4>) softmax_nd3_contig_f32_t;
+template [[host_name("nn_ops::softmax_nd3_contig_f32")]] [[kernel]]
+softmax_nd3_contig_f32_t softmax_nd3_contig<float, float4>;
+typedef decltype(softmax_nd3_contig<half, half4>) softmax_nd3_contig_f16_t;
+template [[host_name("nn_ops::softmax_nd3_contig_f16")]] [[kernel]]
+softmax_nd3_contig_f16_t softmax_nd3_contig<half, half4>;
+
 template <typename F>
 [[kernel]] void scaled_masked_softmax_nd5(
     device const void *input_b, device const void *mask_b,

--- a/metal/src/kernels/nn/softmax.rs
+++ b/metal/src/kernels/nn/softmax.rs
@@ -47,8 +47,19 @@ impl Softmax {
         let shape_nd3 = utils::reshape_to_rank_3(input.shape(), axis);
         let strides_nd3 = Tensor::natural_strides(&shape_nd3);
 
-        let pipeline =
-            stream.load_pipeline(LibraryName::NNOps, &self.kernel_name(input.datum_type())?)?;
+        // Fast path for contiguous last-axis softmax (strides[1]==1) whose dim is
+        // a multiple of 4 (so every row start stays 16-byte aligned for the
+        // float4/half4 loads). Falls back to the general strided kernel otherwise.
+        let dt = input.datum_type();
+        let tname = DeviceTensor::tname(dt)?;
+        let use_contig = strides_nd3[1] == 1 && shape_nd3[1].is_multiple_of(4);
+        let kernel_name = if use_contig {
+            ensure!(Self::is_supported_dt(dt), "Unsupported dt {:?} for metal softmaxop", dt);
+            format!("nn_ops::softmax_nd3_contig_{tname}")
+        } else {
+            self.kernel_name(dt)?
+        };
+        let pipeline = stream.load_pipeline(LibraryName::NNOps, &kernel_name)?;
 
         let command_buffer = stream.command_buffer();
         command_buffer.encode(|encoder| {


### PR DESCRIPTION
Adds a `softmax_nd3_contig` kernel (f32 + f16) dispatched when the softmax axis is contiguous (`strides[1] == 1`) and its length is a multiple of 4, falling back to the existing general kernel otherwise. It fuses the max and sum reductions into a single online pass (running max + rescaled running sum) and uses `float4`/`half4` vectorized loads and stores, which the strided general kernel can't.

Measured with `cargo bench -p tract-metal --bench metal_softmax` against the current
`softmax_nd3`, on a 67 MB working set so the figures are DRAM-bound rather than cache-resident,
20 dispatches per iteration, criterion median. Outputs match the CPU reference to ~1e-8.

| shape | M1 Pro `softmax_nd3` | M1 Pro contig | | M4 `softmax_nd3` | M4 contig | |
| --- | --- | --- | --- | --- | --- | --- |
| 32768x512 | 88 GB/s | 168 GB/s | 1.91x | 92 GB/s | 97 GB/s | 1.06x |
| 16384x1024 | 87 GB/s | 164 GB/s | 1.89x | 89 GB/s | 97 GB/s | 1.10x |
| 8192x2048 | 84 GB/s | 161 GB/s | 1.93x | 62 GB/s | 97 GB/s | 1.57x |
| 2048x8192 | 54 GB/s | 115 GB/s | 2.14x | 40 GB/s | 74 GB/s | 1.82x |

The contiguous kernel reaches 161-168 GB/s on the M1 Pro, about 90% of the 183 GB/s a pure
streaming kernel gets there, and ~97 GB/s on the M4 against a ~105 GB/s ceiling.

How much that is worth depends on how much headroom the general kernel was leaving. On the M1 Pro
it sits at roughly half the machine's streaming rate at every shape, so the fast path is ~1.9x
throughout. On the M4 the general kernel is already near the ceiling for short rows, leaving almost
nothing to gain (1.06x at dim 512); the gap only opens as rows lengthen and the strided kernel falls
off, reaching 1.82x at dim 8192.

`cargo test -p tract-metal` passes (110 passed, 0 failed, 8 ignored); the softmax proptests cover both the fast path and the general fallback.

Draft: the large_models RBO nightly hasn't been run yet (no access to the arm64 model box right now). It reuses the same `fast::exp` and only changes the reduction structure, but softmax numerics on quantised LLMs warrant the nightly before merge. 🍍

