### PR TITLE
metal: size reduce_nd3 threadgroups from the reduced axis

### DIFF
--- a/metal/Cargo.toml
+++ b/metal/Cargo.toml
@@ -43,3 +43,7 @@ rand.workspace = true
 name = "metal_gemm"
 harness = false
 
+
+[[bench]]
+name = "metal_reduce"
+harness = false

--- a/metal/benches/metal_reduce.rs
+++ b/metal/benches/metal_reduce.rs
@@ -1,0 +1,55 @@
+use criterion::*;
+use tract_core::internal::*;
+use tract_gpu::tensor::{DeviceTensor, IntoDevice};
+use tract_metal::kernels::nn::reduce::{Reducer, metal_reduce_launch};
+use tract_metal::with_metal_stream;
+
+const DISPATCHES: usize = 20;
+
+fn bench_shape(
+    g: &mut BenchmarkGroup<measurement::WallTime>,
+    shape: &[usize],
+    axis: usize,
+    name: &str,
+) {
+    with_metal_stream(|stream| {
+        let len = shape.iter().product::<usize>();
+        let a = Tensor::from_shape(shape, &vec![1.0f32; len])?.into_device()?;
+        let mut o_shape = shape.to_vec();
+        o_shape[axis] = 1;
+        let output = unsafe { DeviceTensor::uninitialized_dt(a.datum_type(), &o_shape)? };
+        metal_reduce_launch(&Reducer::Sum, &a, axis, &output)?;
+        stream.wait_until_completed()?;
+
+        g.bench_function(name, |b| {
+            b.iter(|| {
+                for _ in 0..DISPATCHES {
+                    metal_reduce_launch(&Reducer::Sum, &a, axis, &output).unwrap();
+                }
+                stream.wait_until_completed().unwrap();
+            })
+        });
+        Ok(())
+    })
+    .unwrap()
+}
+
+fn reduce(c: &mut Criterion) {
+    let mut g = c.benchmark_group("reduce_sum_f32");
+    g.sample_size(20);
+    for (shape, axis, name) in [
+        (tvec![64usize, 262144usize], 1, "64x262144"),
+        (tvec![256, 65536], 1, "256x65536"),
+        (tvec![1024, 16384], 1, "1024x16384"),
+        (tvec![16384, 1024], 1, "16384x1024"),
+        (tvec![32768, 333], 1, "32768x333"),
+        (tvec![65536, 64], 1, "65536x64"),
+        (tvec![64, 1024, 512], 1, "64x1024x512_strided"),
+    ] {
+        bench_shape(&mut g, &shape, axis, name);
+    }
+    g.finish();
+}
+
+criterion_group!(benches, reduce);
+criterion_main!(benches);

--- a/metal/src/kernels/nn/mod.rs
+++ b/metal/src/kernels/nn/mod.rs
@@ -33,7 +33,11 @@ pub fn all_functions() -> Vec<String> {
             .flat_map(|op| {
                 tract_gpu::tensor::DeviceTensor::SUPPORTED_DT.into_iter().map(move |dt| (op, dt))
             })
-            .flat_map(|(op, dt)| reduce::kernel_name(&op, dt).into_iter()),
+            .flat_map(|(op, dt)| {
+                [false, true]
+                    .into_iter()
+                    .flat_map(move |large| reduce::kernel_name(&op, dt, large).into_iter())
+            }),
     );
     functions.extend(
         tract_gpu::tensor::DeviceTensor::SUPPORTED_DT

--- a/metal/src/kernels/nn/nn_ops.metal
+++ b/metal/src/kernels/nn/nn_ops.metal
@@ -25,10 +25,19 @@ METAL_FUNC uint indices_to_idx_4(uint3 indices, constant const size_t shape[4],
     return idx;
 }
 
+// simd_reduce applies any normalization and must run exactly once, on the final accumulator.
+// A multi-simdgroup reduction folds its per-simdgroup accumulators with simd_accumulate and
+// combine, which merge already-accumulated values and never normalize.
 template <typename U> struct MeanOfSquares {
+    typedef float acc_t;
+
     float simd_reduce(float val, size_t reduce_dim) {
         return simd_sum(val) / static_cast<float>(reduce_dim);
     }
+
+    float simd_accumulate(float val) { return simd_sum(val); }
+
+    float combine(float a, float b) { return a + b; }
 
     static constexpr constant float init = 0.0;
 
@@ -40,7 +49,13 @@ template <typename U> struct MeanOfSquares {
 };
 
 template <typename U> struct Sum {
+    typedef U acc_t;
+
     U simd_reduce(U val, size_t reduce_dim) { return simd_sum(val); }
+
+    U simd_accumulate(U val) { return simd_sum(val); }
+
+    U combine(U a, U b) { return a + b; }
 
     static constexpr constant U init = U(0);
 
@@ -49,9 +64,15 @@ template <typename U> struct Sum {
 };
 
 template <typename U> struct Min {
+    typedef U acc_t;
+
     template <typename T> T simd_reduce(T val, size_t reduce_dim) {
         return simd_min(val);
     }
+
+    U simd_accumulate(U val) { return simd_min(val); }
+
+    U combine(U a, U b) { return a < b ? a : b; }
 
     static constexpr constant U init = metal::numeric_limits<U>::infinity();
 
@@ -60,9 +81,15 @@ template <typename U> struct Min {
 };
 
 template <typename U> struct Max {
+    typedef U acc_t;
+
     template <typename T> T simd_reduce(T val, size_t reduce_dim) {
         return simd_max(val);
     }
+
+    U simd_accumulate(U val) { return simd_max(val); }
+
+    U combine(U a, U b) { return a > b ? a : b; }
 
     static constexpr constant U init = -metal::numeric_limits<U>::infinity();
 
@@ -71,7 +98,13 @@ template <typename U> struct Max {
 };
 
 template <typename U> struct Prod {
+    typedef U acc_t;
+
     U simd_reduce(U val, size_t reduce_dim) { return simd_product(val); }
+
+    U simd_accumulate(U val) { return simd_product(val); }
+
+    U combine(U a, U b) { return a * b; }
 
     static constexpr constant U init = U(1);
 
@@ -80,7 +113,13 @@ template <typename U> struct Prod {
 };
 
 template <typename U> struct All {
+    typedef U acc_t;
+
     U simd_reduce(U val, size_t reduce_dim) { return simd_all(val); }
+
+    U simd_accumulate(U val) { return simd_all(val); }
+
+    U combine(U a, U b) { return a && b; }
 
     static constexpr constant U init = U(1);
 
@@ -89,7 +128,13 @@ template <typename U> struct All {
 };
 
 template <typename U> struct Any {
+    typedef U acc_t;
+
     U simd_reduce(U val, size_t reduce_dim) { return simd_any(val); }
+
+    U simd_accumulate(U val) { return simd_any(val); }
+
+    U combine(U a, U b) { return a || b; }
 
     static constexpr constant U init = U(0);
 
@@ -97,46 +142,94 @@ template <typename U> struct Any {
     U operator()(U acc, U a) { return acc || a; }
 };
 
-template <typename F, typename Op>
+// IdxT is uint unless the tensor holds more than u32::MAX elements; the host picks the matching
+// instantiation. Apple GPUs emulate 64-bit integer arithmetic, so the narrow form matters for
+// reductions short enough that address computation dominates.
+template <typename F, typename Op, typename IdxT>
 [[kernel]] void reduce_nd3(device const void *input_b, device void *output_b,
                            constant const size_t input_shape[3],
                            constant const size_t input_strides[3],
                            constant const size_t output_strides[3],
                            uint3 tgpig [[threadgroup_position_in_grid]],
                            uint tiisg [[thread_index_in_simdgroup]],
-                           uint tpsg [[threads_per_simdgroup]]) {
+                           uint tpsg [[threads_per_simdgroup]],
+                           uint sgitg [[simdgroup_index_in_threadgroup]],
+                           uint3 ntg [[threads_per_threadgroup]]) {
 
     device const F *input = (device const F *)input_b;
     device F *output = (device F *)output_b;
 
     Op op = Op();
 
-    size_t reduce_dim = input_shape[1];
+    IdxT reduce_dim = input_shape[1];
+    IdxT stride = input_strides[1];
 
-    size_t out_idx = tgpig.x * output_strides[2] + tgpig.y * output_strides[1] +
-                     tgpig.z * output_strides[0];
+    IdxT out_idx = IdxT(tgpig.x) * IdxT(output_strides[2]) +
+                   IdxT(tgpig.y) * IdxT(output_strides[1]) +
+                   IdxT(tgpig.z) * IdxT(output_strides[0]);
 
-    size_t base_in_idx =
-        tgpig.x * input_strides[2] + tgpig.z * input_strides[0];
+    device const F *row = input + IdxT(tgpig.x) * IdxT(input_strides[2]) +
+                          IdxT(tgpig.z) * IdxT(input_strides[0]);
+
+    IdxT nthreads = ntg.x;
+    IdxT tid = sgitg * tpsg + tiisg;
 
     auto partial_acc = Op::init;
-    for (size_t i = tiisg; i < reduce_dim; i += tpsg) {
-        F el = input[base_in_idx + i * input_strides[1]];
-        partial_acc = op(partial_acc, el);
+    if (stride == 1 && reduce_dim >= 256) {
+        IdxT blocks = reduce_dim / 4;
+        for (IdxT b = tid; b < blocks; b += nthreads) {
+            IdxT o = b * 4;
+            partial_acc = op(partial_acc, row[o]);
+            partial_acc = op(partial_acc, row[o + 1]);
+            partial_acc = op(partial_acc, row[o + 2]);
+            partial_acc = op(partial_acc, row[o + 3]);
+        }
+        for (IdxT i = blocks * 4 + tid; i < reduce_dim; i += nthreads) {
+            partial_acc = op(partial_acc, row[i]);
+        }
+    } else {
+        for (IdxT i = tid; i < reduce_dim; i += nthreads) {
+            partial_acc = op(partial_acc, row[i * stride]);
+        }
     }
-    auto acc = op.simd_reduce(partial_acc, reduce_dim);
 
+    if (nthreads <= tpsg) {
+        auto acc = op.simd_reduce(partial_acc, reduce_dim);
+        if (tiisg == 0) {
+            output[out_idx] = acc;
+        }
+        return;
+    }
+
+    // A threadgroup holds at most 1024 threads, so at most 32 simdgroups.
+    threadgroup typename Op::acc_t partials[32];
+    auto sg_acc = op.simd_accumulate(partial_acc);
     if (tiisg == 0) {
-        output[out_idx] = acc;
+        partials[sgitg] = sg_acc;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (sgitg == 0) {
+        uint nsg = (ntg.x + tpsg - 1) / tpsg;
+        auto acc = Op::init;
+        for (uint i = tiisg; i < nsg; i += tpsg) {
+            acc = op.combine(acc, partials[i]);
+        }
+        auto total = op.simd_reduce(acc, reduce_dim);
+        if (tiisg == 0) {
+            output[out_idx] = total;
+        }
     }
 }
 
-typedef decltype(reduce_nd3<float, Prod<float>>) reduce_nd3_t;
+typedef decltype(reduce_nd3<float, Prod<float>, uint>) reduce_nd3_t;
 
 #define INSTANTIATE_REDUCE(name, op, tname, type)                              \
-    template [[host_name(                                                      \
-        "nn_ops::reduce_" #name                                                \
-        "_nd3_" #tname)]] [[kernel]] reduce_nd3_t reduce_nd3<type, op<type>>;
+    template [[host_name("nn_ops::reduce_" #name "_nd3_" #tname)]] [[kernel]]   \
+    reduce_nd3_t reduce_nd3<type, op<type>, uint>;                             \
+    template [[host_name("nn_ops::reduce_" #name "_nd3_" #tname                 \
+                         "_large")]] [[kernel]] reduce_nd3_t                   \
+    reduce_nd3<type, op<type>, size_t>;
 
 INSTANTIATE_REDUCE(mean_of_squares, MeanOfSquares, f32, float)
 INSTANTIATE_REDUCE(mean_of_squares, MeanOfSquares, f16, half)

--- a/metal/src/kernels/nn/reduce.rs
+++ b/metal/src/kernels/nn/reduce.rs
@@ -7,10 +7,26 @@ use tract_gpu::tensor::DeviceTensor;
 
 pub use tract_gpu::ops::reduce::Reducer;
 
-pub fn kernel_name(reducer: &Reducer, dt: DatumType) -> TractResult<String> {
+/// Name of the `reduce_nd3` kernel for `reducer` over `dt`. `large` selects the variant indexing
+/// with 64-bit arithmetic, required once a tensor holds more than `u32::MAX` elements.
+pub fn kernel_name(reducer: &Reducer, dt: DatumType, large: bool) -> TractResult<String> {
     ensure!(reducer.is_supported_dt(dt), "Unsupported dt {dt:?} for metal reduceop {reducer:?}",);
     let tname = DeviceTensor::tname(dt)?;
-    Ok(format!("nn_ops::reduce_{}_nd3_{tname}", reducer))
+    let suffix = if large { "_large" } else { "" };
+    Ok(format!("nn_ops::reduce_{}_nd3_{tname}{suffix}", reducer))
+}
+
+/// Threads per threadgroup for a reduction over `shape[1]` of a rank-3 `[outer, K, inner]` view.
+///
+/// One threadgroup handles one output element, so a shape with few output elements leaves most of
+/// the GPU idle unless the threadgroup itself is widened. Only contiguous reductions benefit: with
+/// `inner > 1` the added lanes land `inner` elements apart and lose locality.
+fn threadgroup_width(shape_nd3: &[usize], max_threads: usize) -> usize {
+    let reduce_dim = shape_nd3[1];
+    if shape_nd3[2] != 1 || reduce_dim <= 512 {
+        return usize::min(32, reduce_dim);
+    }
+    reduce_dim.div_ceil(4).next_multiple_of(32).min(1024).min(max_threads)
 }
 
 pub fn metal_reduce_launch(
@@ -31,8 +47,9 @@ pub fn metal_reduce_launch(
         let output_shape_nd3 = utils::reshape_to_rank_3(output.shape(), axis);
         let output_strides_nd3 = Tensor::natural_strides(&output_shape_nd3);
 
-        let pipeline =
-            stream.load_pipeline(LibraryName::NNOps, &kernel_name(reducer, input.datum_type())?)?;
+        let large = input.shape().iter().product::<usize>() > u32::MAX as usize;
+        let pipeline = stream
+            .load_pipeline(LibraryName::NNOps, &kernel_name(reducer, input.datum_type(), large)?)?;
 
         let command_buffer = stream.command_buffer();
         command_buffer.encode(|encoder| {
@@ -44,8 +61,11 @@ pub fn metal_reduce_launch(
             encoder.set_slice(4, &output_strides_nd3);
 
             let grid_size = utils::build_metal_size_for_shape(&output_shape_nd3);
-            let group_size =
-                MTLSize { width: usize::min(32, input_shape_nd3[1]) as _, height: 1, depth: 1 };
+            let width = threadgroup_width(
+                &input_shape_nd3,
+                pipeline.max_total_threads_per_threadgroup() as usize,
+            );
+            let group_size = MTLSize { width: width as _, height: 1, depth: 1 };
             encoder.dispatch_thread_groups(grid_size, group_size);
         });
         Ok(())
@@ -191,6 +211,34 @@ mod tests {
             2,
             1.0 / 100.0,
         )?;
+        test_case::<f32>(
+            Reducer::MeanOfSquares,
+            TractReducer::MeanOfSquares,
+            &[3, 4096],
+            1,
+            1.0 / 10000.0,
+        )?;
+        test_case::<f32>(
+            Reducer::MeanOfSquares,
+            TractReducer::MeanOfSquares,
+            &[3, 1029],
+            1,
+            1.0 / 10000.0,
+        )?;
+        test_case::<f16>(
+            Reducer::MeanOfSquares,
+            TractReducer::MeanOfSquares,
+            &[3, 4096],
+            1,
+            1.0 / 100000.0,
+        )?;
+        test_case::<f32>(
+            Reducer::MeanOfSquares,
+            TractReducer::MeanOfSquares,
+            &[2, 1024, 3],
+            1,
+            1.0 / 10000.0,
+        )?;
         Ok(())
     }
 
@@ -206,6 +254,9 @@ mod tests {
         test_case::<f16>(Reducer::Sum, TractReducer::Sum, &[2, 2, 82, 38], 2, 1.0 / 100.0)?;
         test_case::<f32>(Reducer::Sum, TractReducer::Sum, &[2, 2, 82, 38], 1, 1.0 / 100.0)?;
         test_case::<f32>(Reducer::Sum, TractReducer::Sum, &[2, 2, 82, 38], 2, 1.0 / 100.0)?;
+        test_case::<f32>(Reducer::Sum, TractReducer::Sum, &[3, 4096], 1, 1.0 / 10000.0)?;
+        test_case::<f32>(Reducer::Sum, TractReducer::Sum, &[3, 1029], 1, 1.0 / 10000.0)?;
+        test_case::<f32>(Reducer::Sum, TractReducer::Sum, &[2, 1024, 3], 1, 1.0 / 10000.0)?;
         Ok(())
     }
 
@@ -221,6 +272,7 @@ mod tests {
         test_case::<f16>(Reducer::Prod, TractReducer::Prod, &[2, 2, 82, 38], 2, 1.0 / 100000.0)?;
         test_case::<f32>(Reducer::Prod, TractReducer::Prod, &[2, 2, 82, 38], 1, 1.0 / 100.0)?;
         test_case::<f32>(Reducer::Prod, TractReducer::Prod, &[2, 2, 82, 38], 2, 1.0 / 1000.0)?;
+        test_case::<f32>(Reducer::Prod, TractReducer::Prod, &[3, 1029], 1, 1.0 / 1000000.0)?;
         Ok(())
     }
 
@@ -236,6 +288,10 @@ mod tests {
         test_case::<f16>(Reducer::Max, TractReducer::Max, &[2, 2, 82, 38], 2, 1.0 / 100.0)?;
         test_case::<f32>(Reducer::Max, TractReducer::Max, &[2, 2, 82, 38], 1, 1.0 / 100.0)?;
         test_case::<f32>(Reducer::Max, TractReducer::Max, &[2, 2, 82, 38], 2, -1.0 / 100.0)?;
+        test_case::<f32>(Reducer::Max, TractReducer::Max, &[3, 4096], 1, 1.0 / 10000.0)?;
+        test_case::<f32>(Reducer::Max, TractReducer::Max, &[3, 1029], 1, -1.0 / 10000.0)?;
+        test_case::<f16>(Reducer::Max, TractReducer::Max, &[3, 4096], 1, 1.0 / 100000.0)?;
+        test_case::<f32>(Reducer::Max, TractReducer::Max, &[2, 1024, 3], 1, 1.0 / 10000.0)?;
         Ok(())
     }
 
@@ -251,6 +307,9 @@ mod tests {
         test_case::<f16>(Reducer::Min, TractReducer::Min, &[2, 2, 82, 38], 2, 1.0 / 100.0)?;
         test_case::<f32>(Reducer::Min, TractReducer::Min, &[2, 2, 82, 38], 1, -1.0 / 100.0)?;
         test_case::<f32>(Reducer::Min, TractReducer::Min, &[2, 2, 82, 38], 2, 1.0 / 100.0)?;
+        test_case::<f32>(Reducer::Min, TractReducer::Min, &[3, 4096], 1, 1.0 / 10000.0)?;
+        test_case::<f32>(Reducer::Min, TractReducer::Min, &[3, 1029], 1, -1.0 / 10000.0)?;
+        test_case::<f32>(Reducer::Min, TractReducer::Min, &[2, 1024, 3], 1, 1.0 / 10000.0)?;
         Ok(())
     }
 


### PR DESCRIPTION
`reduce_nd3` dispatched one 32-thread simdgroup per output element, so a reduction with few output
elements used a fraction of the GPU however long the reduced axis was: `[64, 262144]` ran 2048
threads and reached 21 GB/s where the same 67 MB reduced as `[16384, 1024]` reached 159 GB/s.
Contiguous reductions over long axes now size the threadgroup from the axis and combine their
per-simdgroup partials through threadgroup memory; strided reductions keep the single simdgroup,
where the extra lanes would only land further apart. Indexing moves to 32-bit arithmetic, with a
64-bit `_large` variant selected above `u32::MAX` elements, since Apple GPUs emulate 64-bit integer
ops.

## Performance

`cargo bench -p tract-metal --bench metal_reduce`, sum f32, 20 dispatches per iteration, criterion
median. `tg` is the number of threadgroups the shape gives the GPU, `width` the threads per
threadgroup this PR picks (32 = unchanged from main).

| shape | tg | tg/core M1P : M4 | width | M1 Pro main | M1 Pro PR | | M4 main | M4 PR | |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| `64x262144` | 64 | 4 : 8 | 1024 | 21 GB/s | 167 GB/s | **7.87x** | 30 GB/s | 103 GB/s | **3.41x** |
| `256x65536` | 256 | 16 : 32 | 1024 | 81 GB/s | 167 GB/s | **2.06x** | 92 GB/s | 105 GB/s | **1.14x** |
| `1024x16384` | 1024 | 64 : 128 | 1024 | 81 GB/s | 174 GB/s | **2.15x** | 98 GB/s | 106 GB/s | 1.08x |
| `16384x1024` | 16384 | 1024 : 2048 | 256 | 159 GB/s | 183 GB/s | **1.15x** | 104 GB/s | 102 GB/s | 0.99x |
| `32768x333` | 32768 | 2048 : 4096 | 32 | 140 GB/s | 179 GB/s | **1.28x** | 101 GB/s | 103 GB/s | 1.02x |
| `65536x64` | 65536 | 4096 : 8192 | 32 | 77 GB/s | 159 GB/s | **2.07x** | 93 GB/s | 97 GB/s | 1.05x |
| `64x1024x512` | 32768 | 2048 : 4096 | 32 | 43 GB/s | 45 GB/s | 1.03x | 44 GB/s | 43 GB/s | 0.99x |

Same 67 MB working set in the first four rows; only the split between output elements and reduced
length changes. The gain tracks threadgroups per GPU core, not chip generation: expressed that way
the two machines' curves overlay, and the PR sits near each machine's ceiling (~183 GB/s M1 Pro,
~106 GB/s M4) at every shape, where main swings from 21 to 159.

```
GB/s, shared 0-200 scale.  main: #####    this PR: =====

M1 Pro  (16 GPU cores)
  64x262144    ####                                        21
               =================================          167   7.87x
  256x65536    ################                            81
               =================================          167   2.06x
  1024x16384   ################                            81
               ===================================        174   2.15x
  16384x1024   ################################           159
               =====================================      183   1.15x
  32768x333    ############################               140
               ====================================       179   1.28x
  65536x64     ###############                             77
               ================================           159   2.07x
  strided      #########                                   43
               =========                                   45   1.03x

M4  (8 GPU cores)
  64x262144    ######                                      30
               =====================                      103   3.41x
  256x65536    ##################                          92
               =====================                      105   1.14x
  1024x16384   ####################                        98
               =====================                      106   1.08x
  16384x1024   #####################                      104
               ====================                       102   0.99x
  32768x333    ####################                       101
               =====================                      103   1.02x
  65536x64     ###################                         93
               ===================                         97   1.05x
  strided      #########                                   44
               =========                                   43   0.99x

```

## Scope and costs

- At full occupancy on the M4 this is a measurable ~1.5% regression (`16384x1024`, non-overlapping
  criterion intervals) from the threadgroup-memory barrier. Recovering it means gating the wider
  threadgroup on occupancy, which needs the GPU core count; Metal does not expose it.
- The thresholds are a broad plateau: dividing the axis by 2 to 8, capping at 256 to 1024, and
  switching at 128 to 2048 all land within 5% of each other, so nothing is tuned to one machine.
  They match what MLX uses for its Metal row reductions.
- Reductions with very few output elements stay starved whatever the threadgroup width, since the
  grid itself is too small; that regime needs a split pass and is not addressed here.
- Reads are 4 scalars per thread rather than a `float4` cast: arena offsets are not guaranteed
  16-byte aligned, and the two perform the same here.
- Accuracy is unchanged or better. `max`/`min` stay bit-exact; the two-level tree shortens the f32
  accumulation chain, so `sum` error is never worse and is up to 4x smaller on long axes.

Reduce tests previously topped out at a reduced axis of 82, so nothing exercised a multi-simdgroup
threadgroup. The added long-axis cases cover it, including `MeanOfSquares`, whose normalization must
apply exactly once across the two levels; those cases fail if it is applied per simdgroup.

Kernel written with OpenEvolve. Related to #2365, which packs element-wise kernels into full-width
threadgroups. 🍍
