### PR TITLE
fix(linalg/x86_64): clamp the avx no-fma Sigmoid output into [0, 1]

### DIFF
--- a/linalg/x86_64/fma/avx_sigmoid_f32.S.j2
+++ b/linalg/x86_64/fma/avx_sigmoid_f32.S.j2
@@ -220,6 +220,18 @@ avx_sigmoid_f32_{{suffix}} proc
     vaddps          ymm6, ymm6, ymm1
     vaddps          ymm7, ymm7, ymm1
 
+    // sigmoid is (0, 1): the vaddps above cancels down to ~1e-8 on either tail, below the
+    // rounding error of the division, so the sum needs clamping to stay in range.
+    vxorps          ymm2, ymm2, ymm2
+    vmaxps          ymm4, ymm4, ymm2
+    vmaxps          ymm5, ymm5, ymm2
+    vmaxps          ymm6, ymm6, ymm2
+    vmaxps          ymm7, ymm7, ymm2
+    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
+    vminps          ymm5, ymm5, ymm0
+    vminps          ymm6, ymm6, ymm0
+    vminps          ymm7, ymm7, ymm0
+
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -282,6 +294,10 @@ avx_sigmoid_f32_{{suffix}} proc
 
     vdivps          ymm4, ymm4, ymm12
     vaddps          ymm4, ymm4, ymm1
+
+    vxorps          ymm2, ymm2, ymm2
+    vmaxps          ymm4, ymm4, ymm2
+    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
 
     vmovaps [rdi], ymm4
     add     rdi, 32


### PR DESCRIPTION
The avx no-fma sigmoid kernel was ported from fma_sigmoid_f32 before its clamp landed, so the closing vaddps of 0.5 could cancel to ~1e-8 below the division's rounding error and return values just outside sigmoid's range. Clamp both loops with the same vmaxps/vminps pair the fma kernel uses.