### PR TITLE
core/cnn: give padded 1-D convolution its own im2col patcher

### DIFF
--- a/core/src/ops/cnn/conv/im2col.rs
+++ b/core/src/ops/cnn/conv/im2col.rs
@@ -60,14 +60,12 @@ impl ResolveTo<ConcreteGeometry> for SymbolicGeometry {
     type Param = [usize];
     fn resolve(&self, input_full_shape: &[usize]) -> TractResult<ConcreteGeometry> {
         let pool = self.pool_geometry.to_concrete(input_full_shape)?.into_owned();
-        let patcher = if !pool.patch.padded && pool.patch.rank() == 2 {
-            Patcher::Valid2d
-        } else if pool.patch.rank() == 2 {
-            Patcher::Padded2d
-        } else if !pool.patch.padded && pool.patch.rank() == 1 {
-            Patcher::Valid1d
-        } else {
-            Patcher::Generic
+        let patcher = match (pool.patch.rank(), pool.patch.padded) {
+            (1, false) => Patcher::Valid1d,
+            (1, true) => Patcher::Padded1d,
+            (2, false) => Patcher::Valid2d,
+            (2, true) => Patcher::Padded2d,
+            _ => Patcher::Generic,
         };
         let ci_per_group = pool.input_shape.c_dim() / self.group;
         let n = pool.output_shape.hw_dims().iter().product();
@@ -266,6 +264,7 @@ enum Patcher {
     Generic,
     Valid1d,
     Valid2d,
+    Padded1d,
     Padded2d,
 }
 
@@ -304,6 +303,13 @@ impl Patcher {
         match self {
             Patcher::Valid1d => Self::valid_1d::<T, W>(geo, input, g, writer),
             Patcher::Valid2d => Self::valid_2d::<T, W>(geo, input, g, writer),
+            Patcher::Padded1d => Self::padded_1d::<T, W>(
+                geo,
+                input,
+                g,
+                pad_value.unwrap_or(&Tensor::zero_scalar::<T>()?),
+                writer,
+            ),
             Patcher::Padded2d => Self::padded_2d::<T, W>(
                 geo,
                 input,
@@ -400,6 +406,56 @@ impl Patcher {
     }
 
     #[inline(never)]
+    fn padded_1d<T: Copy + Datum, W: PackingWriter<T>>(
+        geometry: &ConcreteGeometry,
+        input: &TensorView,
+        g: usize,
+        pad_value: &Tensor,
+        writer: &mut W,
+    ) -> TractResult<()> {
+        unsafe {
+            let pad_value = *pad_value.to_scalar_unchecked();
+            let shape = &geometry.input_shape_with_n;
+            let x_stride = geometry.pool.patch.spec.strides[0] as isize;
+            let x_stride_ptr = x_stride * *shape.h_stride() as isize;
+            let c_stride_ptr = *shape.c_stride() as isize;
+            let input_width = shape.hw_dims()[0] as isize;
+            let kernel_len = geometry.pool.patch.standard_layout_data_field.len();
+            let iptr = input.as_ptr_unchecked::<T>();
+            let iptr = iptr.add(g * geometry.ci_per_group * shape.c_stride());
+            let output_width = *geometry.pool.patch.output_shape.get_unchecked(0);
+            for ci in 0..geometry.ci_per_group {
+                let iptr = iptr.offset(ci as isize * c_stride_ptr);
+                for kitem in 0..kernel_len {
+                    let dx = *geometry.pool.patch.data_field.as_ptr().add(kitem);
+                    let valid_x_start =
+                        Integer::div_ceil(&-dx, &x_stride).max(0).min(output_width as _);
+                    let valid_x_end = Integer::div_ceil(&(input_width - dx), &x_stride)
+                        .max(0)
+                        .min(output_width as _);
+                    let iptr = iptr.offset(
+                        *geometry.pool.patch.standard_layout_data_field.get_unchecked(kitem),
+                    );
+                    Self::padded_invalid_x_loop(valid_x_start as usize, pad_value, &mut *writer);
+                    Self::padded_valid_x_loop(
+                        valid_x_start,
+                        valid_x_end,
+                        x_stride_ptr,
+                        iptr,
+                        &mut *writer,
+                    );
+                    Self::padded_invalid_x_loop(
+                        output_width - valid_x_end as usize,
+                        pad_value,
+                        &mut *writer,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[inline(never)]
     fn padded_2d<T: Copy + Datum, W: PackingWriter<T>>(
         geometry: &ConcreteGeometry,
         input: &TensorView,
@@ -440,25 +496,25 @@ impl Patcher {
                         let y = yo as isize * y_stride + dy;
                         let iptr = iptr.offset(yo as isize * y_stride_ptr);
                         if y >= 0 && y < input_heigth {
-                            Self::padded_2d_invalid_x_loop(
+                            Self::padded_invalid_x_loop(
                                 valid_x_start as usize,
                                 pad_value,
                                 &mut *writer,
                             );
-                            Self::padded_2d_valid_x_loop(
+                            Self::padded_valid_x_loop(
                                 valid_x_start,
                                 valid_x_end,
                                 x_stride_ptr,
                                 iptr,
                                 &mut *writer,
                             );
-                            Self::padded_2d_invalid_x_loop(
+                            Self::padded_invalid_x_loop(
                                 output_width - valid_x_end as usize,
                                 pad_value,
                                 &mut *writer,
                             );
                         } else {
-                            Self::padded_2d_invalid_x_loop(output_width, pad_value, &mut *writer);
+                            Self::padded_invalid_x_loop(output_width, pad_value, &mut *writer);
                         }
                     }
                 }
@@ -468,7 +524,7 @@ impl Patcher {
     }
 
     #[inline(never)]
-    unsafe fn padded_2d_invalid_x_loop<T: Copy + Datum, W: PackingWriter<T>>(
+    unsafe fn padded_invalid_x_loop<T: Copy + Datum, W: PackingWriter<T>>(
         count: usize,
         pad_value: T,
         writer: &mut W,
@@ -479,7 +535,7 @@ impl Patcher {
     }
 
     #[inline(never)]
-    unsafe fn padded_2d_valid_x_loop<T: Copy + Datum, W: PackingWriter<T>>(
+    unsafe fn padded_valid_x_loop<T: Copy + Datum, W: PackingWriter<T>>(
         x_min: isize,
         x_max: isize,
         x_stride_ptr: isize,


### PR DESCRIPTION
# core/cnn: give padded 1-D convolution its own im2col patcher

`Im2Col` picks a patcher from the patch's rank and padding, and there is a
`Valid1d`, a `Valid2d` and a `Padded2d` — but no `Padded1d`. A padded rank-1
patch therefore falls to `Patcher::Generic`, which allocates a `[k, n]` matrix
per call, fills it one element at a time through an `Option<isize>`, and copies
it out again, where the valid run could be a single `write_slice`.

Padded 1-D convolution over the frequency axis is the standard shape for
streaming audio front-ends, so this is a hot path for that whole model class.

Identical Conv, only `pads` differing:

| graph | patcher | time |
|---|---|---|
| rank-1, `pads=[0,0]` | `Valid1d` | 0.002 ms |
| rank-1, `pads=[1,1]` | `Generic` | **0.023 ms** |
| rank-2 `[k,1]`, `pads=[1,0,1,0]` | `Padded2d` | 0.011 ms |

The same convolution expressed as a rank-2 patch with a unit axis is 2x faster
than as rank-1, purely because `Padded2d` exists.

`Padded1d` gives the single-spatial-axis case the same invalid-prefix /
valid-slice / invalid-suffix split `padded_2d` already uses; the two x-loop
helpers are now shared and lose their `_2d` prefix.

## Effect

On the FastEnhancer speech-enhancement family (Apple M1 Pro, single thread,
min per frame over a 627-frame streaming pass), `Im2col` was 60-67% of every
frame and this alone gives:

| variant | before | after |
|---|---|---|
| tiny | 0.388 ms | 0.148 |
| base | 0.847 | 0.300 |
| small | 1.544 | 0.506 |
| medium | 2.183 | 0.797 |
| large | 4.280 | 1.724 |

## Correctness

- 324 generated rank-1 padded convolutions (kernel 1/2/3/5 x stride 1/2/3 x
  dilation 1/2 x group 1/4 x pads `(1,1) (2,2) (1,0) (0,1) (2,0) (3,3)
  SAME_UPPER SAME_LOWER`) against onnxruntime: worst `|tract - ORT|` is
  **0.000e+00**, and output is bit-identical to tract before the change on all
  324.
- Deliberately shifting the new valid window by one makes **320 of those 324
  wrong**, so the suite does exercise the new path.
- Bit-identical output on ten real models (5 sizes x 2 sample rates), full
  streaming pass, `cmp` reporting no differing byte.
- `test-unit-core` (its conv proptests generate `geo_rank` 1..4 with
  `SameUpper`) and `test-onnx-core` pass; `cargo fmt` and
  `cargo clippy -p tract-core` clean.

🍍
