### PR TITLE
core/array: keep Gather's block copy off slice copies when the block is one datum

### DIFF
--- a/core/src/ops/array/gather.rs
+++ b/core/src/ops/array/gather.rs
@@ -61,16 +61,30 @@ impl Gather {
             let axis_len = data_shape[data_axis];
             let input_slice = data_view.as_slice().unwrap();
             let output_slice = &mut output_view.as_slice_mut().unwrap();
+            let resolved: TVec<usize> = indices
+                .iter()
+                .map(|i| if *i < 0 { i + axis_len as i64 } else { *i } as usize)
+                .collect();
             let mut out_offset = 0;
-            for outer in 0..outer_len {
-                let input_base = outer * axis_len * block_len;
-                for index in indices.iter() {
-                    let resolved_index =
-                        if *index < 0 { index + axis_len as i64 } else { *index } as usize;
-                    let input_offset = input_base + resolved_index * block_len;
-                    output_slice[out_offset..out_offset + block_len]
-                        .clone_from_slice(&input_slice[input_offset..input_offset + block_len]);
-                    out_offset += block_len;
+            if block_len == 1 {
+                // Gathering the innermost axis: each block is one datum, so a
+                // slice copy per element costs more than the read itself.
+                for outer in 0..outer_len {
+                    let input_base = outer * axis_len;
+                    for index in &resolved {
+                        output_slice[out_offset] = input_slice[input_base + index].clone();
+                        out_offset += 1;
+                    }
+                }
+            } else {
+                for outer in 0..outer_len {
+                    let input_base = outer * axis_len * block_len;
+                    for index in &resolved {
+                        let input_offset = input_base + index * block_len;
+                        output_slice[out_offset..out_offset + block_len]
+                            .clone_from_slice(&input_slice[input_offset..input_offset + block_len]);
+                        out_offset += block_len;
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
# core/array: keep Gather's block copy off slice copies when the block is one datum

Sibling of #2624. That one widened the block-copy path to a non-trivial outer
dimension; this one covers what the path does once it is taken.

Gathering the innermost axis leaves `block_len == 1`, so the "block copy" runs
`clone_from_slice` on single-element slices — one slice copy per datum, which
costs more than the read it performs. Resolving the indices once (they do not
vary across the outer loop) and taking `block_len == 1` through a plain indexed
loop drops a `[1,257,1,2] -> [1,257,1]` gather from **4.0 us to 0.5 us** per
node.

On FastEnhancer-tiny the four such nodes were 11.1% of the frame; afterwards
they are 1.8%.

Output is bit-identical to before on all ten models over a full streaming pass.
`test-unit-core` and `test-onnx-core` pass, fmt and clippy clean.

🍍
