### PR TITLE
perf(core): redefine TValue as a newtype on Arc<Tensor>

### DIFF
--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -1,15 +1,10 @@
 use crate::internal::*;
 use std::ops::Deref;
-use std::rc::Rc;
 
-use TValue::*;
 use tract_ndarray::Array;
 
 #[derive(Clone, Eq)]
-pub enum TValue {
-    Const(Arc<Tensor>),
-    Var(Rc<Tensor>),
-}
+pub struct TValue(Arc<Tensor>);
 
 impl std::fmt::Debug for TValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -25,37 +20,28 @@ impl PartialEq for TValue {
 
 impl TValue {
     pub fn is_exclusive(&self) -> bool {
-        match self {
-            Var(it) => Rc::strong_count(it) == 1,
-            Const(_) => false,
-        }
+        Arc::strong_count(&self.0) == 1
     }
 
     pub fn from_const(t: Arc<Tensor>) -> Self {
-        Const(t)
+        TValue(t)
     }
 
     pub fn as_arc_tensor(&self) -> Option<&Arc<Tensor>> {
-        match self {
-            Const(t) => Some(t),
-            Var(_) => None,
-        }
+        Some(&self.0)
     }
 }
 
 impl From<Tensor> for TValue {
     fn from(t: Tensor) -> Self {
-        TValue::Var(std::rc::Rc::new(t))
+        TValue(Arc::new(t))
     }
 }
 
 impl std::ops::Deref for TValue {
     type Target = Tensor;
     fn deref(&self) -> &Self::Target {
-        match self {
-            Const(it) => it,
-            Var(it) => it,
-        }
+        &self.0
     }
 }
 
@@ -67,19 +53,13 @@ impl std::borrow::Borrow<Tensor> for TValue {
 
 impl IntoTensor for TValue {
     fn into_tensor(self) -> Tensor {
-        match self {
-            Var(it) => Rc::try_unwrap(it).unwrap_or_else(|t| (*t).clone()),
-            Const(it) => it.into_tensor(),
-        }
+        self.0.into_tensor()
     }
 }
 
 impl IntoArcTensor for TValue {
     fn into_arc_tensor(self) -> Arc<Tensor> {
-        match self {
-            Var(ref _it) => self.into_tensor().into_arc_tensor(),
-            Const(t) => t,
-        }
+        self.0
     }
 }
 
@@ -95,7 +75,7 @@ impl IntoTValue for Tensor {
 
 impl IntoTValue for Arc<Tensor> {
     fn into_tvalue(self) -> TValue {
-        Const(self)
+        TValue(self)
     }
 }
 


### PR DESCRIPTION
TValue's Var(Rc<Tensor>) variant made it unconditionally non-Send, blocking Send on anything that holds one across a call, but the Rc bought nothing Arc doesn't already give: Arc::try_unwrap does the same take-when-exclusive dance Rc::try_unwrap did in into_tensor(), and Const's own is_exclusive() was already hardcoded false regardless of refcount. Collapse the Const/Var split into a single Arc<Tensor> newtype, trading non-atomic for atomic refcounting on every clone. Needs a bench before this can be trusted on the perf-sensitive path.