### PR TITLE
py: keep setuptools installable for cp39 wheel builds

### DIFF
--- a/api/py/pyproject.toml
+++ b/api/py/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-    "setuptools >=80, <83",
+    "setuptools >=80, <83; python_version < '3.10'",
+    "setuptools >=84.0.0, <85; python_version >= '3.10'",
     "setuptools_rust >=1.13.0, <1.14",
     "wheel >=0.47.0, <0.48",
     "toml >=0.10, <0.11"


### PR DESCRIPTION
setuptools 84 dropped Python <3.10 support, breaking the isolated build env for the cp39 wheel target. Mark the requirement by python_version so 3.9 keeps the older pin and 3.10+ gets the bump.