### PR TITLE
ci: cap build/linux job runtime at 30 minutes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -98,6 +98,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.enabled == 'true'
     runs-on: ${{ matrix.host }}
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: read      # pull the prebuilt cross-build image (ghcr, private)

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -80,6 +80,7 @@ jobs:
           - wasm32-wasi
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read

--- a/.travis/ci-system-setup.sh
+++ b/.travis/ci-system-setup.sh
@@ -22,9 +22,19 @@ then
             then
                 SUDO=sudo
             fi
-            $SUDO apt-get update
-            # $SUDO apt-get upgrade -y
-            $SUDO apt-get install -y llvm python3 python3-numpy jshon wget curl build-essential sudo jshon clang
+            apt_retry() {
+                tries=0
+                while [ $tries -lt 3 ]
+                do
+                    timeout 120 $SUDO "$@" && return 0
+                    tries=$((tries + 1))
+                    sleep 5
+                done
+                return 1
+            }
+            apt_retry apt-get update
+            # apt_retry apt-get upgrade -y
+            apt_retry apt-get install -y llvm python3 python3-numpy jshon wget curl build-essential sudo jshon clang
         fi
     fi
 

--- a/.travis/ci-system-setup.sh
+++ b/.travis/ci-system-setup.sh
@@ -26,8 +26,13 @@ then
                 tries=0
                 while [ $tries -lt 3 ]
                 do
-                    timeout 120 $SUDO "$@" && return 0
+                    timeout 150 $SUDO "$@" && return 0
                     tries=$((tries + 1))
+                    # azure.archive.ubuntu.com is a known flaky mirror; after the
+                    # first failure, drop it so the rest of the retries go
+                    # straight to the canonical mirror instead of stalling again.
+                    $SUDO sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt 2>/dev/null || true
+                    $SUDO sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list 2>/dev/null || true
                     sleep 5
                 done
                 return 1


### PR DESCRIPTION
Both jobs shell out to apt-get during setup with no per-job timeout, so a stalled mirror fetch runs until GitHub's 6h default kills it instead of failing fast. Normal runtime is under 20 minutes.