### PR TITLE
ci: cancel superseded PR runs on cross-platform.yml

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -21,6 +21,11 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  # cancel superseded PR pushes (escape hatch); nightly keys on run_id so it never cancels
+  group: cross-platform-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event.inputs.pr_number != '' }}
+
 jobs:
   prepare:
     runs-on: ubuntu-latest


### PR DESCRIPTION
bench.yml already does this; cross-platform.yml didn't, so a rebase or force-push left the old run's jobs spinning until they either finished or hit the 6h default timeout, wasting runner time for no reason.