### PR TITLE
fix(core): return 0 for quantized Sign at the zero point

### DIFF
--- a/core/src/ops/math/mod.rs
+++ b/core/src/ops/math/mod.rs
@@ -739,7 +739,7 @@ element_wise!(sign, Sign, [i8, i16, i32, i64, f16, f32, f64] => |_, xs| {
     xs.iter_mut().for_each(|x| *x = if x.is_zero() { *x } else { One::one() });
     Ok(())
 };
-q: [i8, u8, i32] => f32::signum);
+q: [i8, u8, i32] => |x: f32| if x.is_zero() { 0.0 } else { x.signum() });
 
 element_wise_oop!(is_inf, IsInf { detect_positive: bool, detect_negative: bool },
     [f32] => bool |op, xs, ys| {

--- a/test-rt/suite-unit/src/q_elmwise.rs
+++ b/test-rt/suite-unit/src/q_elmwise.rs
@@ -109,6 +109,15 @@ pub fn suite() -> TractResult<TestSuite> {
     );
 
     suite.add(
+        "sign_at_zero_point_case",
+        QElmWiseOpProblem {
+            operator: tract_core::ops::math::sign(),
+            tensor_input: qi8_tensor1(&[-5, 0, 5], 0, 0.5)?,
+            out_dt: qi8_dt(0, 0.01),
+        },
+    );
+
+    suite.add(
         "cos_switch_qi8_to_qu8_case",
         QElmWiseOpProblem {
             operator: tract_core::ops::math::cos(),


### PR DESCRIPTION
Sign on a quantized tensor returned 1 for elements at the input zero point, where ONNX requires 0. The quantized path applies signum, which has no zero case, and never carried the zero branch the float arm has. Nothing exercised it: the quantized element-wise suite covered only ops that are smooth through zero.

Refs: #2670