### PR TITLE
harness: nemotron-3.5 multilingual CI assets + GPU-translation checks…

### DIFF
--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -214,9 +214,40 @@ jobs:
         export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli-${UNAME}/tract"
         ./harness/nemotron-speech-streaming-en-0.6b/ci.sh
 
+  nemotron-3-5-asr-streaming-06b:
+    name: ${{matrix.os}} / Nemotron 3.5 ASR streaming 0.6b
+    needs: [ prepare, cli ]
+    strategy:
+      matrix:
+        os: [ macOS, cuda-lovelace ]
+      fail-fast: false
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
+        fetch-depth: 0
+        persist-credentials: false
+    - run: echo uname=$(uname) >> $GITHUB_ENV
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: tract-cli-${{env.uname}}
+        path: tract-cli-${{env.uname}}
+
+    - name: Download and run
+      env:
+        UNAME: ${{ env.uname }}
+      run: |
+        chmod +x "tract-cli-${UNAME}/tract"
+        export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli-${UNAME}/tract"
+        ./harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
+
   report:
     name: Report result to PR
-    needs: [ prepare, cli, foundation-llms, foundation-llm, parakeet-tdt-600m-v3, nemotron-speech-streaming-en-06b ]
+    needs: [ prepare, cli, foundation-llms, foundation-llm, parakeet-tdt-600m-v3, nemotron-speech-streaming-en-06b, nemotron-3-5-asr-streaming-06b ]
     if: ${{ always() && needs.prepare.outputs.pr_number != '' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.travis/benches.toml
+++ b/.travis/benches.toml
@@ -275,6 +275,35 @@ model = "asr/608/nvidia--parakeet-tdt-0.6b-v3-f32f32/nvidia--parakeet-tdt-0.6b-v
 args = "-t transformers_detect_all --nnef-tract-transformers --set B=1 --set R=1 --set U=1"
 runtimes = ["cpu", "metal", "cuda"]
 
+[[bench]]
+kind = "net"
+name = "nemotron-3_5-asr-streaming-0_6b-f32f32-preprocessor_1s"
+model = "asr/634/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32.preprocessor.nnef.tgz"
+args = "-t transformers_detect_all --nnef-tract-transformers --set BATCH=1 --set INPUT_SIGNAL__TIME=16000"
+runtimes = ["cpu", "metal", "cuda"]
+
+[[bench]]
+kind = "net"
+name = "nemotron-3_5-asr-streaming-0_6b-f32f32-encoder_1s"
+model = "asr/634/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32.encoder.nnef.tgz"
+args = "-t transformers_detect_all --nnef-tract-transformers --set BATCH=1 --set AUDIO_SIGNAL__TIME=100"
+runtimes = ["cpu", "metal", "cuda"]
+threads = [0]
+
+[[bench]]
+kind = "net"
+name = "nemotron-3_5-asr-streaming-0_6b-f32f32-decoder_pass"
+model = "asr/634/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32.decoder.nnef.tgz"
+args = "-t transformers_detect_all --nnef-tract-transformers --set BATCH=1 --set TARGETS__TIME=1"
+runtimes = ["cpu", "metal", "cuda"]
+
+[[bench]]
+kind = "net"
+name = "nemotron-3_5-asr-streaming-0_6b-f32f32-joint_pass"
+model = "asr/634/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32.joint.nnef.tgz"
+args = "-t transformers_detect_all --nnef-tract-transformers --set ENCODER_OUTPUTS__BATCH=1 --set DECODER_OUTPUTS__BATCH=1 --set ENCODER_OUTPUTS__TIME=1 --set DECODER_OUTPUTS__TIME=1"
+runtimes = ["cpu", "metal", "cuda"]
+
 # GPU-only (no CPU run).
 
 [[bench]]

--- a/examples/nemo-nemotron-asr/nemotron35.py
+++ b/examples/nemo-nemotron-asr/nemotron35.py
@@ -1,0 +1,131 @@
+import numpy
+import soundfile as sf
+import torch
+import torch.nn.functional as F
+import os
+import nemo.collections.asr as nemo_asr
+
+model_name = "nvidia/nemotron-3.5-asr-streaming-0.6b"
+lang_id = 0  # en-US, per model cfg prompt_dictionary
+
+asr = nemo_asr.models.ASRModel.from_pretrained(model_name=model_name)
+
+asr.eval()
+device = "cuda" if torch.cuda.is_available() else "cpu"
+asr = asr.to(device)
+# RNNTJoint.joint_after_projection auto-applies log_softmax in eval mode on
+# CPU when self.log_softmax is None; the exported nnef joint graph is the raw
+# (pre-softmax) logits, so force it off to match.
+asr.joint.log_softmax = False
+
+data, sr = sf.read("examples/nemo-nemotron-asr/assets/2086-149220-0033.wav", dtype="float32")
+sig = torch.tensor(data).unsqueeze(0)  # [1, T]
+
+signal = sig.to(device)
+length = torch.tensor([signal.shape[1]], device=device, dtype=torch.int64)
+lang_id_t = torch.tensor([lang_id], device=device, dtype=torch.int64)
+
+with torch.no_grad():
+    proc_out, proc_len = asr.preprocessor(
+        input_signal=signal, length=length
+    )
+    enc_out, enc_len = asr.encoder(audio_signal=proc_out, length=proc_len)
+
+    # The exported encoder is bare_encoder + prompt_kernel fused (t2n
+    # --fuse-prompt-into-encoder): replicate torch_to_nnef_nemo's
+    # PromptKernelSubnet.forward here so "outputs" matches what the nnef
+    # graph actually produces, not the bare NeMo encoder call above.
+    feats = enc_out.transpose(1, 2)  # [B, T, D]
+    lin0 = asr.prompt_kernel[0]
+    d_model = enc_out.shape[1]
+    hidden = F.linear(feats, lin0.weight[:, :d_model], lin0.bias)
+    num_prompts = lin0.weight.shape[1] - d_model
+    slots = torch.arange(num_prompts, device=device)
+    onehot = (slots == lang_id_t.reshape(-1, 1)).to(feats.dtype)  # [1, P]
+    lang_bias = F.linear(onehot, lin0.weight[:, d_model:])  # [1, H]
+    hidden = hidden + lang_bias.unsqueeze(1)
+    conditioned = asr.prompt_kernel[1:](hidden)  # [B, T, D]
+    fused_out = conditioned.transpose(1, 2).to(enc_out.dtype)  # [B, D, T]
+
+os.makedirs(model_name + "/preprocessor", exist_ok=True)
+os.makedirs(model_name + "/encoder", exist_ok=True)
+os.makedirs(model_name + "/decoder", exist_ok=True)
+os.makedirs(model_name + "/joint", exist_ok=True)
+
+numpy.savez(model_name + "/preprocessor/io.npz",
+    input_signal=signal.cpu(),
+    length=length.cpu(),
+    processed_signal=proc_out.cpu(),
+    processed_length=proc_len.cpu()
+)
+numpy.savez(model_name + "/encoder/io.npz",
+    audio_signal=proc_out.cpu(),
+    length=proc_len.cpu(),
+    lang_id=lang_id_t.cpu(),
+    encoded_lengths=enc_len.cpu(),
+    outputs=fused_out.cpu()
+)
+
+encoded = fused_out.transpose(1, 2)  # [B, T, D], fused/conditioned
+
+T = int(enc_len[0].item())
+t = 0
+p = 0
+j = 0
+max_output_len = 6 * T + 10
+hyp = []
+
+vocab = asr.joint.vocabulary
+vocab_size = len(vocab)
+blank_id = asr.decoding.blank_id
+
+print(f"vocab_size={vocab_size} blank_id={blank_id}")
+
+decoder_golden_saved = False
+joint_golden_saved = False
+
+with torch.no_grad():
+    prediction, state = asr.decoder.predict(add_sos=True, batch_size=1)
+
+    while t < T and len(hyp) < max_output_len:
+        enc_frame = encoded[:, t:t+1, :]
+        joint_logits = asr.joint.joint(enc_frame, prediction[:, -1:, :])
+        if not joint_golden_saved:
+            numpy.savez(model_name + "/joint/io.npz",
+                encoder_outputs=enc_frame.transpose(1, 2).cpu(),
+                decoder_outputs=prediction.transpose(1, 2)[:, :, -1:].cpu(),
+                outputs=joint_logits.cpu()
+            )
+            joint_golden_saved = True
+        j += 1
+        k = int(torch.argmax(joint_logits[..., :(vocab_size + 1)], dim=-1).item())
+        print(f"t={t} k={k}")
+        if k == blank_id:
+            # Standard RNNT: advance by 1 frame on blank
+            t += 1
+        else:
+            p += 1
+            hyp.append(k)
+            last_token = torch.tensor([[k]], device=device, dtype=torch.int32)
+            target_length = torch.tensor([1], device=device, dtype=torch.int32)
+            prev_state = state
+            prediction, new_state = asr.decoder.predict(y=last_token, add_sos=False, state=state)
+            if not decoder_golden_saved:
+                numpy.savez(model_name + "/decoder/io.npz", **{
+                    "targets": last_token.cpu(),
+                    "target_length": target_length.cpu(),
+                    "states_0": prev_state[0].cpu(),
+                    "states_1": prev_state[1].cpu(),
+                    "outputs": prediction.transpose(1, 2).cpu(),
+                    "prednet_lengths": target_length.cpu(),
+                    "states_0_out": new_state[0].cpu(),
+                    "states_1_out": new_state[1].cpu(),
+                })
+                decoder_golden_saved = True
+            state = new_state
+
+print(hyp)
+print(f"p={p} j={j}")
+pieces = [vocab[i] for i in hyp if 0 <= i < len(vocab)]
+text = "".join(pieces)
+print(text)

--- a/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
+++ b/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+
+set -ex
+
+ROOT=$(realpath $(dirname $(realpath $0))/../..)
+. $ROOT/.travis/ci-system-setup.sh
+
+MODEL=nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32
+S3DIR=asr/634/$MODEL
+
+for rt in $TRACT_RUNTIMES
+do
+	gpu_assert=""
+	case "$rt" in
+		--cuda) gpu_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub,Not";;
+		--metal) gpu_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub,Not";;
+	esac
+
+	for m in preprocessor encoder decoder joint
+	do
+		nnef_file=$MODEL.$m.nnef.tgz
+		# Decoder is stepped one token per call by the caller (external state
+		# carry): assert the external_state flag and concretize the seq symbol
+		# to 1 so the Scan inlines and the LSTM body lands on the GPU instead of
+		# bouncing through CPU each step. set_symbols RON must stay space-free
+		# ($extra_transforms is passed unquoted).
+		extra_transforms=""
+		if [ "$m" = "decoder" ]; then
+			extra_transforms='-t force_scan_external_state -t set_symbols(values:{"TARGETS__TIME":1})'
+		fi
+		$CACHE_FILE \
+			$S3DIR/$nnef_file \
+			$S3DIR/$MODEL.$m.io.npz
+
+		$TRACT_RUN $MODELS/$S3DIR/$nnef_file $rt --nnef-tract-transformers -t transformers_detect_all $extra_transforms run \
+			--input-from-bundle $MODELS/$S3DIR/$MODEL.$m.io.npz --assert-output-bundle $MODELS/$S3DIR/$MODEL.$m.io.npz \
+			--approx very $gpu_assert
+	done
+done
+
+model_prefix=$MODELS/$S3DIR/$MODEL
+
+# Check that the patch transform eliminates all Iff nodes,
+# and that select_outputs can reduce the model to a single output
+$TRACT_RUN $model_prefix.preprocessor.nnef.tgz \
+	-t 'set_symbols(values: {"BATCH": 1})' \
+	-t 'patch(body: "length = tract_core_shape_of(input_signal)[1];")' \
+	-t 'select_inputs(inputs: ["input_signal"])' \
+	-t 'select_outputs(outputs: ["processed_signal"])' \
+	dump -q \
+	--assert-op-count Iff 0
+
+# Check that the preprocessor can be pulsified.
+# Pulse size (1600 audio samples, ~100ms) matches the streaming ASR example's
+# PREPROC_PULSE, not the EN model's 4800 -- the two exports use different
+# preprocessor chunking.
+$TRACT_RUN $model_prefix.preprocessor.nnef.tgz \
+	-t 'set_symbols(values: {"BATCH": 1})' \
+	-t 'patch(body: "length = tract_core_shape_of(input_signal)[1];")' \
+	-t 'select_inputs(inputs: ["input_signal"])' \
+	-t 'select_outputs(outputs: ["processed_signal"])' \
+	-t 'pulse(symbol: Some("INPUT_SIGNAL__TIME"), pulse: "1600")' \
+	dump -q
+
+# Check that pulsified preprocessor and encoder translate cleanly on each GPU
+# runtime (the GPU translator must fall back to CPU for ops it can't lower, not
+# abort the whole transform).  Allowlist what currently falls back so a
+# regression spilling another op to CPU fails CI.  Runtime numeric checks are
+# deferred; only the translation is asserted here.
+for rt in $TRACT_RUNTIMES
+do
+	case "$rt" in
+		--cuda)
+			pp_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
+			enc_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,AffineChunkTrim,PulsedRange,Not"
+			;;
+		--metal)
+			pp_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
+			enc_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,AffineChunkTrim,PulsedRange,Not"
+			;;
+		*) continue;;
+	esac
+	$TRACT_RUN $model_prefix.preprocessor.nnef.tgz $rt \
+		-t 'set_symbols(values: {"BATCH": 1})' \
+		-t 'patch(body: "length = tract_core_shape_of(input_signal)[1];")' \
+		-t 'select_outputs(outputs: ["processed_signal"])' \
+		-t 'pulse(symbol: Some("INPUT_SIGNAL__TIME"), pulse: "1600")' \
+		dump -q $pp_assert
+	$TRACT_RUN $model_prefix.encoder.nnef.tgz $rt \
+		--nnef-tract-transformers \
+		-t 'set_symbols(values: {"BATCH": 1})' \
+		-t 'patch(body: "length = tract_core_shape_of(audio_signal)[2];")' \
+		-t 'select_inputs(inputs: ["audio_signal", "lang_id"])' \
+		-t 'select_outputs(outputs: ["outputs"])' \
+		-t 'pulse(symbol: Some("AUDIO_SIGNAL__TIME"), pulse: "32")' \
+		dump -q $enc_assert
+done
+
+# Check that the encoder can be pulsified.
+# The encoder subsamples by 8x (three stride-2 convolutions) before the transformer.
+# The chunk-window mask has P=4 transformer tokens per chunk (one attention chunk),
+# so the input pulse must be 4 * 8 = 32 audio frames.
+$TRACT_RUN $model_prefix.encoder.nnef.tgz \
+	--nnef-tract-transformers \
+	-t 'set_symbols(values: {"BATCH": 1})' \
+	-t 'patch(body: "length = tract_core_shape_of(audio_signal)[2];")' \
+	-t 'select_inputs(inputs: ["audio_signal", "lang_id"])' \
+	-t 'select_outputs(outputs: ["outputs"])' \
+	-t 'pulse(symbol: Some("AUDIO_SIGNAL__TIME"), pulse: "32")' \
+	dump -q
+
+# Check that pulsified encoder output matches batch output.
+# --drop-partial-pulse truncates the input to a multiple of the pulse size,
+# and the output comparison is trimmed accordingly.
+$TRACT_RUN $model_prefix.encoder.nnef.tgz \
+	--nnef-tract-transformers \
+	-t 'set_symbols(values: {"BATCH": 1})' \
+	-t 'patch(body: "length = tract_core_shape_of(audio_signal)[2];")' \
+	-t 'select_inputs(inputs: ["audio_signal", "lang_id"])' \
+	-t 'select_outputs(outputs: ["outputs"])' \
+	-t 'pulse(symbol: Some("AUDIO_SIGNAL__TIME"), pulse: "32")' \
+	run \
+	--input-from-bundle $MODELS/$S3DIR/$MODEL.encoder.io.npz \
+	--assert-output-bundle $MODELS/$S3DIR/$MODEL.encoder.io.npz \
+	--approx very \
+	--drop-partial-pulse


### PR DESCRIPTION
… + bench entries

The multilingual nemotron-3.5 example had no harness (unlike the EN model): no CI-hosted correctness assets, no GPU-translation coverage, no bench-suite entries. Add nemotron35.py to generate the reference goldens (NeMo's RNNTJoint.joint() auto-applies log_softmax in eval mode on CPU; disabled to match the exported raw-logits graph), a new harness/nemotron-3.5-asr-streaming-0.6b/ci.sh mirroring the EN harness's per-subnet correctness loop and pulsified GPU-allowlist loop (pulse 32, lang_id input), wire it into large_models.yml, and add preprocessor/encoder/decoder/joint bench entries under the R2 key asr/634/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32.