### PR TITLE
ci: retry+timeout the qemu/toolchain and android-jdk apt installs

### DIFF
--- a/.travis/android-ndk.sh
+++ b/.travis/android-ndk.sh
@@ -2,7 +2,10 @@
 
 set -ex
 
-which java || sudo apt install -y default-jdk
+ROOT=$(dirname $(dirname $(realpath $0)))
+. $ROOT/.travis/ci-system-setup.sh
+
+which java || apt_retry apt-get install -y default-jdk
 
 ANDROID_SDK=$HOME/cached/android-sdk
 if [ ! -d "$ANDROID_SDK" ]

--- a/.travis/ci-system-setup.sh
+++ b/.travis/ci-system-setup.sh
@@ -6,6 +6,32 @@ set -e
 export RUSTUP_TOOLCHAIN
 PATH=$PATH:$HOME/.cargo/bin
 
+# Defined unconditionally (not gated on the once-per-job /tmp/ci-setup-done
+# marker below) so every script that sources this file gets apt_retry, even
+# when ci-system-setup.sh's own one-time setup already ran in a parent shell.
+if [ `uname` != "Darwin" -a "$RUNNER_ENVIRONMENT" != "self-hosted" ]
+then
+    if [ `whoami` != "root" ]
+    then
+        SUDO=sudo
+    fi
+    apt_retry() {
+        tries=0
+        while [ $tries -lt 3 ]
+        do
+            timeout 150 $SUDO "$@" && return 0
+            tries=$((tries + 1))
+            # azure.archive.ubuntu.com is a known flaky mirror; after the
+            # first failure, drop it so the rest of the retries go
+            # straight to the canonical mirror instead of stalling again.
+            $SUDO sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt 2>/dev/null || true
+            $SUDO sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list 2>/dev/null || true
+            sleep 5
+        done
+        return 1
+    }
+fi
+
 if [ -n "$CI" -a ! -e /tmp/ci-setup-done -a -z "$TRACT_PREBUILT_CI" ]
 then
     if [ `uname` = "Darwin" ]
@@ -18,25 +44,6 @@ then
     else
         if [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]
         then
-            if [ `whoami` != "root" ]
-            then
-                SUDO=sudo
-            fi
-            apt_retry() {
-                tries=0
-                while [ $tries -lt 3 ]
-                do
-                    timeout 150 $SUDO "$@" && return 0
-                    tries=$((tries + 1))
-                    # azure.archive.ubuntu.com is a known flaky mirror; after the
-                    # first failure, drop it so the rest of the retries go
-                    # straight to the canonical mirror instead of stalling again.
-                    $SUDO sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt 2>/dev/null || true
-                    $SUDO sed -i 's/azure\.archive\.ubuntu\.com/archive.ubuntu.com/g' /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list 2>/dev/null || true
-                    sleep 5
-                done
-                return 1
-            }
             apt_retry apt-get update
             # apt_retry apt-get upgrade -y
             apt_retry apt-get install -y llvm python3 python3-numpy jshon wget curl build-essential sudo jshon clang

--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -243,7 +243,7 @@ case "$PLATFORM" in
         # The prebuilt image (TRACT_PREBUILT_CI) already carries qemu + the cross toolchains.
         if [ -z "$TRACT_PREBUILT_CI" ]
         then
-            $SUDO apt-get -y install --no-install-recommends qemu-system-arm qemu-user libssl-dev pkg-config $PACKAGES
+            apt_retry apt-get -y install --no-install-recommends qemu-system-arm qemu-user libssl-dev pkg-config $PACKAGES
         fi
         rustup target add $RUSTC_TRIPLE
         if [ -z "$SKIP_QEMU_TEST" ]


### PR DESCRIPTION
Both bypassed apt_retry (150s timeout, 3 tries, azure-mirror fallback), so a stalled apt.mirror could burn the whole 30min job timeout with no retry, as seen on aarch64-unknown-linux-musl. Hoisted apt_retry's definition out of the once-per-job guard so scripts that source ci-system-setup.sh in a fresh process (android-ndk.sh) still get it.