### PR TITLE
gpu: keep AffineChunkTrim on-device during pulsified encoder translation

### DIFF
--- a/gpu/src/ops/copy_based.rs
+++ b/gpu/src/ops/copy_based.rs
@@ -4,11 +4,11 @@
 
 use tract_core::internal::*;
 use tract_core::ops::array::{MultiBroadcastTo, Pad, Slice, TypedConcat};
-use tract_pulse_opl::ops::{Delay, PulsePad};
+use tract_pulse_opl::ops::{AffineChunkTrim, Delay, PulsePad};
 use tract_transformers::ops::dyn_kv_cache::DynKeyValueCache;
 
 /// Try to translate a node into a copy-based GPU op.
-/// Returns `Some(gpu_op)` if the node is one of the 7 copy-based ops.
+/// Returns `Some(gpu_op)` if the node is one of the copy-based ops handled below.
 pub fn try_make_copy_based_op(
     source: &TypedModel,
     node: &TypedNode,
@@ -37,6 +37,9 @@ pub fn try_make_copy_based_op(
     }
     if let Some(op) = node.op_as::<PulsePad>() {
         return Ok(Some(Box::new(super::pulse::GpuPulsePad::new(op)?)));
+    }
+    if let Some(op) = node.op_as::<AffineChunkTrim>() {
+        return Ok(Some(Box::new(super::pulse::GpuAffineChunkTrim::new(op))));
     }
     if let Some(op) = node.op_as::<Pad>()
         && let Some(gpu) = super::pad::GpuPad::from_core(op)

--- a/gpu/src/ops/pulse.rs
+++ b/gpu/src/ops/pulse.rs
@@ -2,11 +2,12 @@
 use crate::device::{DeviceContext, get_context};
 use crate::session_handler::make_tensor_for_node;
 use crate::tensor::{DeviceTensor, DeviceTensorExt, IntoDevice};
+use crate::utils::compute_broadcast_strides;
 use std::ops::Range;
 use tract_core::internal::*;
 use tract_core::ops::array::PadMode;
 use tract_core::trivial_op_state_freeze;
-use tract_pulse_opl::ops::{Delay, PulsePad};
+use tract_pulse_opl::ops::{AffineChunkTrim, Delay, PulsePad};
 
 // ─── GpuDelay ────────────────────────────────────────────────────────────────
 
@@ -381,3 +382,70 @@ impl OpState for GpuPulsePadState {
 }
 
 trivial_op_state_freeze!(GpuPulsePadState);
+
+// ─── GpuAffineChunkTrim ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GpuAffineChunkTrim {
+    pub inner: AffineChunkTrim,
+}
+
+impl GpuAffineChunkTrim {
+    pub fn new(inner: &AffineChunkTrim) -> Self {
+        Self { inner: inner.clone() }
+    }
+}
+
+impl Op for GpuAffineChunkTrim {
+    fn name(&self) -> StaticName {
+        "GpuAffineChunkTrim".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        self.inner.info()
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for GpuAffineChunkTrim {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval_with_session(
+        &self,
+        node_id: usize,
+        session: &TurnState,
+        inputs: TVec<TValue>,
+    ) -> TractResult<TVec<TValue>> {
+        let input_value = args_1!(inputs);
+        let input = input_value.to_device_tensor()?;
+        let axis = self.inner.axis;
+        let n = input.shape()[axis];
+        let take = if n.saturating_sub(self.inner.typed_trim) >= self.inner.target_per_pulse {
+            n - self.inner.typed_trim
+        } else {
+            n
+        };
+        if take == n {
+            return Ok(tvec!(input_value));
+        }
+        let mut o_shape: TVec<usize> = input.shape().into();
+        o_shape[axis] = take;
+        let output = make_tensor_for_node(session, node_id, input.datum_type(), &o_shape)?;
+        let broadcast_strides = compute_broadcast_strides(&o_shape, input.strides())?;
+        let ctx = get_context()?;
+        ctx.copy_nd(input, 0, &broadcast_strides, &output, 0, output.shape(), output.strides())?;
+        Ok(tvec![output.into_tensor().into_tvalue()])
+    }
+}
+
+impl TypedOp for GpuAffineChunkTrim {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        crate::utils::facts_to_device_facts(inputs, |facts| self.inner.output_facts(facts))
+            .with_context(|| format!("Error while computing output facts for {}", self.name()))
+    }
+
+    as_op!();
+}

--- a/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
+++ b/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
@@ -72,11 +72,11 @@ do
 	case "$rt" in
 		--cuda)
 			pp_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
-			enc_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,AffineChunkTrim,PulsedRange,Not"
+			enc_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,PulsedRange,Not"
 			;;
 		--metal)
 			pp_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
-			enc_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,AffineChunkTrim,PulsedRange,Not"
+			enc_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,PulsedRange,Not"
 			;;
 		*) continue;;
 	esac

--- a/harness/nemotron-speech-streaming-en-0.6b/ci.sh
+++ b/harness/nemotron-speech-streaming-en-0.6b/ci.sh
@@ -74,11 +74,11 @@ do
 	case "$rt" in
 		--cuda)
 			pp_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
-			enc_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,AffineChunkTrim,PulsedRange"
+			enc_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,PulsedRange"
 			;;
 		--metal)
 			pp_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
-			enc_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,AffineChunkTrim,PulsedRange"
+			enc_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,PulsedRange"
 			;;
 		*) continue;;
 	esac

--- a/pulse-opl/src/affine_trim.rs
+++ b/pulse-opl/src/affine_trim.rs
@@ -1,0 +1,90 @@
+//! `AffineChunkTrim` — pulse-aware "drop trailing `c` on the streaming
+//! axis" op for affine-tail dims (`c + k·S`).  Replaces a typed
+//! `Slice(0, k·S)` whose pulsifier is identity and would leave the
+//! per-pulse buffer at `c + k`, breaking the chunked Reshape downstream
+//! that expects `k`.  Some upstream pulsifiers absorb `c` into Delay
+//! state and emit `k` per pulse; others emit `c + k`.  Handles both by
+//! trimming only when the input exceeds `target_per_pulse`.
+//!
+//! Lives here (rather than in `tract-pulse`) so device backends can
+//! translate it to a device-resident op without depending on the
+//! pulsifier crate. No NNEF representation — it only appears between the
+//! pulsifier and runtime.
+
+use tract_nnef::internal::*;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct AffineChunkTrim {
+    pub axis: usize,
+    pub typed_trim: usize,
+    pub target_per_pulse: usize,
+}
+
+impl Op for AffineChunkTrim {
+    fn name(&self) -> StaticName {
+        "AffineChunkTrim".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(vec![format!(
+            "axis: {} typed_trim: {} target_per_pulse: {}",
+            self.axis, self.typed_trim, self.target_per_pulse
+        )])
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for AffineChunkTrim {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let input = args_1!(inputs);
+        let n = input.shape()[self.axis];
+        let take = if n.saturating_sub(self.typed_trim) >= self.target_per_pulse {
+            n - self.typed_trim
+        } else {
+            n
+        };
+        if take == n {
+            return Ok(tvec!(input));
+        }
+        unsafe {
+            let mut shape: TVec<usize> = input.shape().into();
+            shape[self.axis] = take;
+            let mut tensor = Tensor::uninitialized_dt(input.datum_type(), &shape)?;
+            tensor.assign_slice_unchecked(.., &input, 0..take, self.axis);
+            Ok(tvec!(tensor.into_tvalue()))
+        }
+    }
+}
+
+impl TypedOp for AffineChunkTrim {
+    as_op!();
+
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        let mut fact = inputs[0].without_value();
+        let dim = fact.shape[self.axis].clone();
+        // Mirror `eval` / `pulsed_output_facts`: trim only when the input
+        // axis is concrete *and* strictly exceeds `target_per_pulse`.  Two
+        // cases this handles:
+        //   - pre-pulse typed model with symbolic input `c + k·S`: dim is
+        //     not concretely sized → subtract `typed_trim` (`c`) as before.
+        //   - pulsified model where the upstream emits `target_per_pulse`
+        //     directly (e.g. Delay absorbed `c`): dim is concrete and equal
+        //     to `target_per_pulse` → no trim, matching eval.  Previously
+        //     this branch returned `dim - typed_trim` which lied about the
+        //     output shape and broke downstream consumers (e.g. a Reshape
+        //     keyed off `target_per_pulse`) — visible when --cuda translates
+        //     the pulsified encoder.
+        let new_dim = if let Ok(cur) = dim.to_usize() {
+            if cur > self.target_per_pulse { self.target_per_pulse.to_dim() } else { cur.to_dim() }
+        } else {
+            dim - self.typed_trim.to_dim()
+        };
+        fact.shape.set(self.axis, new_dim);
+        Ok(tvec!(fact))
+    }
+}

--- a/pulse-opl/src/lib.rs
+++ b/pulse-opl/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::collapsible_if)]
 use tract_nnef::internal::*;
 
+mod affine_trim;
 pub mod concat;
 mod deconv_delay;
 mod delay;
@@ -19,6 +20,7 @@ pub mod prelude {
 }
 
 pub mod ops {
+    pub use super::affine_trim::AffineChunkTrim;
     pub use super::deconv_delay::DeconvDelay;
     pub use super::delay::{Delay, DelayState};
     pub use super::mask::PulseMask;

--- a/pulse/src/ops/array/affine_trim.rs
+++ b/pulse/src/ops/array/affine_trim.rs
@@ -1,12 +1,5 @@
-//! `AffineChunkTrim` — pulse-aware "drop trailing `c` on the streaming
-//! axis" op for affine-tail dims (`c + k·S`).  Replaces a typed
-//! `Slice(0, k·S)` whose pulsifier is identity and would leave the
-//! per-pulse buffer at `c + k`, breaking the chunked Reshape downstream
-//! that expects `k`.  Some upstream pulsifiers absorb `c` into Delay
-//! state and emit `k` per pulse; others emit `c + k`.  Handles both by
-//! trimming only when the input exceeds `target_per_pulse`.
-
 use crate::internal::*;
+use tract_pulse_opl::ops::AffineChunkTrim;
 
 register_all!(AffineChunkTrim: pulsify);
 
@@ -21,82 +14,6 @@ fn pulsify(
 ) -> TractResult<Option<TVec<OutletId>>> {
     let input = mapping[&node.inputs[0]];
     target.wire_node(&*node.name, op.clone(), &[input]).map(Some)
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct AffineChunkTrim {
-    pub axis: usize,
-    pub typed_trim: usize,
-    pub target_per_pulse: usize,
-}
-
-impl Op for AffineChunkTrim {
-    fn name(&self) -> StaticName {
-        "AffineChunkTrim".into()
-    }
-
-    fn info(&self) -> TractResult<Vec<String>> {
-        Ok(vec![format!(
-            "axis: {} typed_trim: {} target_per_pulse: {}",
-            self.axis, self.typed_trim, self.target_per_pulse
-        )])
-    }
-
-    op_as_typed_op!();
-}
-
-impl EvalOp for AffineChunkTrim {
-    fn is_stateless(&self) -> bool {
-        true
-    }
-
-    fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        let input = args_1!(inputs);
-        let n = input.shape()[self.axis];
-        let take = if n.saturating_sub(self.typed_trim) >= self.target_per_pulse {
-            n - self.typed_trim
-        } else {
-            n
-        };
-        if take == n {
-            return Ok(tvec!(input));
-        }
-        unsafe {
-            let mut shape: TVec<usize> = input.shape().into();
-            shape[self.axis] = take;
-            let mut tensor = Tensor::uninitialized_dt(input.datum_type(), &shape)?;
-            tensor.assign_slice_unchecked(.., &input, 0..take, self.axis);
-            Ok(tvec!(tensor.into_tvalue()))
-        }
-    }
-}
-
-impl TypedOp for AffineChunkTrim {
-    as_op!();
-
-    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
-        let mut fact = inputs[0].without_value();
-        let dim = fact.shape[self.axis].clone();
-        // Mirror `eval` / `pulsed_output_facts`: trim only when the input
-        // axis is concrete *and* strictly exceeds `target_per_pulse`.  Two
-        // cases this handles:
-        //   - pre-pulse typed model with symbolic input `c + k·S`: dim is
-        //     not concretely sized → subtract `typed_trim` (`c`) as before.
-        //   - pulsified model where the upstream emits `target_per_pulse`
-        //     directly (e.g. Delay absorbed `c`): dim is concrete and equal
-        //     to `target_per_pulse` → no trim, matching eval.  Previously
-        //     this branch returned `dim - typed_trim` which lied about the
-        //     output shape and broke downstream consumers (e.g. a Reshape
-        //     keyed off `target_per_pulse`) — visible when --cuda translates
-        //     the pulsified encoder.
-        let new_dim = if let Ok(cur) = dim.to_usize() {
-            if cur > self.target_per_pulse { self.target_per_pulse.to_dim() } else { cur.to_dim() }
-        } else {
-            dim - self.typed_trim.to_dim()
-        };
-        fact.shape.set(self.axis, new_dim);
-        Ok(tvec!(fact))
-    }
 }
 
 impl PulsedOp for AffineChunkTrim {

--- a/pulse/src/ops/array/mod.rs
+++ b/pulse/src/ops/array/mod.rs
@@ -9,6 +9,6 @@ mod range;
 mod reshape;
 mod slice;
 
-pub use affine_trim::AffineChunkTrim;
+pub use tract_pulse_opl::ops::AffineChunkTrim;
 
 register_all_mod!(affine_trim, broadcast, concat, pad, range, reshape, slice);


### PR DESCRIPTION
AffineChunkTrim had no CUDA/Metal lowering, so every occurrence forced a device->host->device round trip. In the nemotron encoders (3.5 and EN) it sits in the per-layer self-attention path, ~4 times per layer, so a 32-layer encoder was ping-ponging through the host on every pulse step despite the transferred tensors being tiny.

Move AffineChunkTrim into tract-pulse-opl (alongside Delay/PulsePad/ PulsedRange) so tract-gpu can depend on it without pulling in the pulsifier crate, and add GpuAffineChunkTrim, a device-resident copy_nd-based translation wired into try_make_copy_based_op (shared by CUDA and Metal). Tighten the EN model harness's enc_assert accordingly.