### PR TITLE
softmax: back the accurate f32 exp with a vectorized kernel

### DIFF
--- a/core/src/ops/nn/softmax/mod.rs
+++ b/core/src/ops/nn/softmax/mod.rs
@@ -309,12 +309,7 @@ impl Softmax {
             SoftmaxKind::Softmax(exp_impl) => {
                 let sum = match exp_impl {
                     SoftmaxExp::Libc => {
-                        let mut s = f32::zero();
-                        slice.iter_mut().for_each(|x| {
-                            *x = (*x - max).exp();
-                            s += *x;
-                        });
-                        s
+                        (tract_linalg::ops().softmax2_f32)().run_with_params(slice, max)?
                     }
                     SoftmaxExp::FastCompact => (tract_linalg::ops().softmax2_fastcompact_f32)()
                         .run_with_params(slice, max)?,

--- a/linalg/src/generic/reduce.rs
+++ b/linalg/src/generic/reduce.rs
@@ -186,6 +186,73 @@ pub mod softmax_l2 {
         }
     );
 
+    /// exp(x - max) with a Cody-Waite reduction and a degree-6 fit: accurate to
+    /// about 1e-7 relative, against [`fast_compact_exp_f32`]'s 6e-2, while still
+    /// being all FMAs so the row loop vectorizes.
+    #[inline(always)]
+    pub fn accurate_exp_f32(x: f32) -> f32 {
+        const LOG2E: f32 = 1.442_695_04;
+        const LN2_HI: f32 = 0.693_145_75;
+        const LN2_LO: f32 = 1.428_606_8e-6;
+        const MAGIC: f32 = 12_582_912.0;
+        // The argument is `v - max` over a row, so it is never positive; a
+        // positive value only arises from the f32::MIN lanes a short row is
+        // padded with, and below -103 exp underflows to zero anyway. Both
+        // comparisons are false for NaN, so a fully masked row still reduces to
+        // NaN as the scalar form does.
+        // Not a range check: `contains` is true-by-negation for NaN, which would
+        // return zero where the scalar form propagates it.
+        #[allow(clippy::manual_range_contains)]
+        if x < -103.0 || x > 0.0 {
+            return 0.0;
+        }
+        let kf = (x * LOG2E + MAGIC) - MAGIC;
+        let rr = kf.mul_add(-LN2_LO, kf.mul_add(-LN2_HI, x));
+        let mut q = 1.383684405e-03f32;
+        q = q.mul_add(rr, 8.374815793e-03);
+        q = q.mul_add(rr, 4.166822560e-02);
+        q = q.mul_add(rr, 1.666642017e-01);
+        q = q.mul_add(rr, 4.999999208e-01);
+        q = q.mul_add(rr, 1.000000036e+00);
+        q = q.mul_add(rr, 1.000000001e+00);
+        let k = kf as i32;
+        let scale = f32::from_bits(((k + 127).clamp(1, 254) as u32) << 23);
+        q * scale
+    }
+
+    map_reduce_impl_wrap!(
+        f32,
+        SSoftMaxL2Accurate,
+        4,
+        4,
+        f32,
+        f32::NEG_INFINITY,
+        0.0,
+        fn run(x: &mut [f32], max: f32) -> f32 {
+            debug_assert!(x.len() % Self::nr() == 0);
+            debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
+            let mut acc = [0f32; 4];
+            let mut it = x.chunks_exact_mut(4);
+            for c in &mut it {
+                for (j, v) in c.iter_mut().enumerate() {
+                    let y = accurate_exp_f32(*v - max);
+                    *v = y;
+                    acc[j] += y;
+                }
+            }
+            let mut sum = (acc[0] + acc[1]) + (acc[2] + acc[3]);
+            for v in it.into_remainder().iter_mut() {
+                let y = accurate_exp_f32(*v - max);
+                *v = y;
+                sum += y;
+            }
+            sum
+        },
+        fn reduce_two(a: f32, b: f32) -> f32 {
+            a + b
+        }
+    );
+
     // ported from https://github.com/gnuradio/volk/blob/master/kernels/volk/volk_32f_expfast_32f.h
     // probably inspired from https://nic.schraudolph.org/pubs/Schraudolph99.pdf
     // not that the cast to u32 deals with negative right, while implem in volk code are wrong in some

--- a/linalg/src/generic/reduce.rs
+++ b/linalg/src/generic/reduce.rs
@@ -195,17 +195,6 @@ pub mod softmax_l2 {
         const LN2_HI: f32 = 0.693_145_75;
         const LN2_LO: f32 = 1.428_606_8e-6;
         const MAGIC: f32 = 12_582_912.0;
-        // The argument is `v - max` over a row, so it is never positive; a
-        // positive value only arises from the f32::MIN lanes a short row is
-        // padded with, and below -103 exp underflows to zero anyway. Both
-        // comparisons are false for NaN, so a fully masked row still reduces to
-        // NaN as the scalar form does.
-        // Not a range check: `contains` is true-by-negation for NaN, which would
-        // return zero where the scalar form propagates it.
-        #[allow(clippy::manual_range_contains)]
-        if x < -103.0 || x > 0.0 {
-            return 0.0;
-        }
         let kf = (x * LOG2E + MAGIC) - MAGIC;
         let rr = kf.mul_add(-LN2_LO, kf.mul_add(-LN2_HI, x));
         let mut q = 1.383684405e-03f32;
@@ -217,7 +206,145 @@ pub mod softmax_l2 {
         q = q.mul_add(rr, 1.000000001e+00);
         let k = kf as i32;
         let scale = f32::from_bits(((k + 127).clamp(1, 254) as u32) << 23);
-        q * scale
+        // The argument is `v - max` over a row, so it is never positive; a
+        // positive value only arises from the f32::MIN lanes a short row is
+        // padded with, and below -103 exp underflows to zero. Selecting here
+        // rather than returning early keeps the loop vectorizable. Not a range
+        // check: `contains` is true-by-negation for NaN, which would return zero
+        // where a fully masked row must still reduce to NaN.
+        #[allow(clippy::manual_range_contains)]
+        if x < -103.0 || x > 0.0 { 0.0 } else { q * scale }
+    }
+
+    /// exp(x - max) over a row, returning the sum. Every lane of the load, the
+    /// polynomial and the accumulation stays four wide; auto-vectorization
+    /// leaves the integer half of the scale reconstruction scalar, which costs
+    /// most of the throughput.
+    #[cfg(target_arch = "aarch64")]
+    #[inline]
+    fn exp_sum_impl(x: &mut [f32], max: f32) -> f32 {
+        use std::arch::aarch64::*;
+        unsafe {
+            #[inline(always)]
+            unsafe fn exp_ps(x: float32x4_t) -> float32x4_t {
+                unsafe {
+                    let kf = vrndnq_f32(vmulq_f32(x, vdupq_n_f32(1.442_695_04)));
+                    let mut rr = vfmsq_f32(x, kf, vdupq_n_f32(0.693_145_75));
+                    rr = vfmsq_f32(rr, kf, vdupq_n_f32(1.428_606_8e-6));
+                    let mut q = vdupq_n_f32(8.297653546e-03);
+                    q = vfmaq_f32(vdupq_n_f32(4.191538191e-02), q, rr);
+                    q = vfmaq_f32(vdupq_n_f32(1.666757475e-01), q, rr);
+                    q = vfmaq_f32(vdupq_n_f32(4.999889485e-01), q, rr);
+                    q = vfmaq_f32(vdupq_n_f32(9.999996920e-01), q, rr);
+                    q = vfmaq_f32(vdupq_n_f32(1.000000072e+00), q, rr);
+                    let k = vcvtq_s32_f32(kf);
+                    // The biased exponent must stay a valid field: k + 127 goes
+                    // non-positive around x = -88, and shifting that in would
+                    // build -inf instead of a small number, poisoning the sum.
+                    let biased = vmaxq_s32(
+                        vminq_s32(vaddq_s32(k, vdupq_n_s32(127)), vdupq_n_s32(254)),
+                        vdupq_n_s32(1),
+                    );
+                    let scale = vreinterpretq_f32_s32(vshlq_n_s32(biased, 23));
+                    let out = vorrq_u32(
+                        vcltq_f32(x, vdupq_n_f32(-103.0)),
+                        vcgtq_f32(x, vdupq_n_f32(0.0)),
+                    );
+                    vbslq_f32(out, vdupq_n_f32(0.0), vmulq_f32(q, scale))
+                }
+            }
+            let vm = vdupq_n_f32(max);
+            let mut vsum = vdupq_n_f32(0.0);
+            let mut i = 0;
+            while i + 4 <= x.len() {
+                let y = exp_ps(vsubq_f32(vld1q_f32(x.as_ptr().add(i)), vm));
+                vst1q_f32(x.as_mut_ptr().add(i), y);
+                vsum = vaddq_f32(vsum, y);
+                i += 4;
+            }
+            let mut sum = vaddvq_f32(vsum);
+            for v in &mut x[i..] {
+                let y = accurate_exp_f32(*v - max);
+                *v = y;
+                sum += y;
+            }
+            sum
+        }
+    }
+
+    /// simd128 counterpart. wasm has no fused multiply-add outside relaxed-simd,
+    /// so the polynomial is a separate multiply and add per step; the reduction
+    /// is what matters here, since LLVM does not vectorize f32 reductions on
+    /// this target at all.
+    #[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+    #[inline]
+    fn exp_sum_impl(x: &mut [f32], max: f32) -> f32 {
+        use std::arch::wasm32::*;
+        #[inline(always)]
+        fn exp_ps(x: v128) -> v128 {
+            let kf = f32x4_nearest(f32x4_mul(x, f32x4_splat(1.442_695_04)));
+            let mut rr = f32x4_sub(x, f32x4_mul(kf, f32x4_splat(0.693_145_75)));
+            rr = f32x4_sub(rr, f32x4_mul(kf, f32x4_splat(1.428_606_8e-6)));
+            let mut q = f32x4_splat(8.297653546e-03);
+            q = f32x4_add(f32x4_splat(4.191538191e-02), f32x4_mul(q, rr));
+            q = f32x4_add(f32x4_splat(1.666757475e-01), f32x4_mul(q, rr));
+            q = f32x4_add(f32x4_splat(4.999889485e-01), f32x4_mul(q, rr));
+            q = f32x4_add(f32x4_splat(9.999996920e-01), f32x4_mul(q, rr));
+            q = f32x4_add(f32x4_splat(1.000000072e+00), f32x4_mul(q, rr));
+            let k = i32x4_trunc_sat_f32x4(kf);
+            // Same guard as the scalar and NEON forms: an out-of-range biased
+            // exponent would shift in as -inf rather than a small number.
+            let biased = i32x4_max(
+                i32x4_min(i32x4_add(k, i32x4_splat(127)), i32x4_splat(254)),
+                i32x4_splat(1),
+            );
+            let scale = i32x4_shl(biased, 23);
+            let out = v128_or(f32x4_lt(x, f32x4_splat(-103.0)), f32x4_gt(x, f32x4_splat(0.0)));
+            v128_bitselect(f32x4_splat(0.0), f32x4_mul(q, scale), out)
+        }
+        let vm = f32x4_splat(max);
+        let mut vsum = f32x4_splat(0.0);
+        let mut i = 0;
+        while i + 4 <= x.len() {
+            let y = exp_ps(f32x4_sub(unsafe { v128_load(x.as_ptr().add(i) as *const v128) }, vm));
+            unsafe { v128_store(x.as_mut_ptr().add(i) as *mut v128, y) };
+            vsum = f32x4_add(vsum, y);
+            i += 4;
+        }
+        let mut sum = f32x4_extract_lane::<0>(vsum)
+            + f32x4_extract_lane::<1>(vsum)
+            + f32x4_extract_lane::<2>(vsum)
+            + f32x4_extract_lane::<3>(vsum);
+        for v in &mut x[i..] {
+            let y = accurate_exp_f32(*v - max);
+            *v = y;
+            sum += y;
+        }
+        sum
+    }
+
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        all(target_family = "wasm", target_feature = "simd128")
+    )))]
+    #[inline]
+    fn exp_sum_impl(x: &mut [f32], max: f32) -> f32 {
+        let mut acc = [0f32; 4];
+        let mut it = x.chunks_exact_mut(4);
+        for c in &mut it {
+            for (j, v) in c.iter_mut().enumerate() {
+                let y = accurate_exp_f32(*v - max);
+                *v = y;
+                acc[j] += y;
+            }
+        }
+        let mut sum = (acc[0] + acc[1]) + (acc[2] + acc[3]);
+        for v in it.into_remainder().iter_mut() {
+            let y = accurate_exp_f32(*v - max);
+            *v = y;
+            sum += y;
+        }
+        sum
     }
 
     map_reduce_impl_wrap!(
@@ -231,22 +358,7 @@ pub mod softmax_l2 {
         fn run(x: &mut [f32], max: f32) -> f32 {
             debug_assert!(x.len() % Self::nr() == 0);
             debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
-            let mut acc = [0f32; 4];
-            let mut it = x.chunks_exact_mut(4);
-            for c in &mut it {
-                for (j, v) in c.iter_mut().enumerate() {
-                    let y = accurate_exp_f32(*v - max);
-                    *v = y;
-                    acc[j] += y;
-                }
-            }
-            let mut sum = (acc[0] + acc[1]) + (acc[2] + acc[3]);
-            for v in it.into_remainder().iter_mut() {
-                let y = accurate_exp_f32(*v - max);
-                *v = y;
-                sum += y;
-            }
-            sum
+            exp_sum_impl(x, max)
         },
         fn reduce_two(a: f32, b: f32) -> f32 {
             a + b

--- a/linalg/src/lib.rs
+++ b/linalg/src/lib.rs
@@ -108,6 +108,7 @@ pub struct Ops {
 
     pub softmax2_fastcompact_f16:
         Box<dyn Fn() -> Box<dyn reduce::MapReduce<f16, f16>> + Send + Sync>,
+    pub softmax2_f32: Box<dyn Fn() -> Box<dyn reduce::MapReduce<f32, f32>> + Send + Sync>,
     pub softmax2_fastcompact_f32:
         Box<dyn Fn() -> Box<dyn reduce::MapReduce<f32, f32>> + Send + Sync>,
 
@@ -252,6 +253,7 @@ pub fn generic() -> Ops {
         activation_f32: Box::new(|microcode| generic::SActivation::new(microcode))
         */
         softmax2_fastcompact_f16: Box::new(|| generic::reduce::softmax_l2::HSoftMaxL2::red()),
+        softmax2_f32: Box::new(|| generic::reduce::softmax_l2::SSoftMaxL2Accurate::red()),
         softmax2_fastcompact_f32: Box::new(|| generic::reduce::softmax_l2::SSoftMaxL2::red()),
         rms_norm_f32: Box::new(generic::rms_norm::rms_norm_f32),
     };


### PR DESCRIPTION
# softmax: back the accurate f32 exp with a vectorized kernel

`SoftmaxExp` offers two tiers and the accurate one was the slow one:
`Libc` ran a scalar libm `exp` per element with a serial sum, while
`FastCompact` (Schraudolph) is vectorized but measures **5.9e-2** max relative
error. There was nothing in between, so an accurate softmax cost a libm call per
element.

This adds `SSoftMaxL2Accurate`: a Cody-Waite argument reduction and a degree-6
minimax fit of `e^r` on `|r| <= ln2/2`, every step an FMA so the row loop
vectorizes, with four accumulators to keep the sum off one dependency chain.
`SoftmaxExp::Libc` routes to it.

It is faster **and** slightly more accurate than what it replaces, so there is no
trade to weigh:

| | max rel err | note |
|---|---|---|
| `Libc` (scalar libm) | 1.42e-6 | f32 sum accumulation |
| **this kernel** | **1.22e-6** | four accumulators sum pairwise |
| onnxruntime | 1.19e-6 | for reference |
| `FastCompact` | 5.9e-2 | unchanged |

## Effect

Microbench over the row lengths a frequency-axis attention produces (16..64),
interleaved A/B: **2.1x** (0.632 vs 0.301 Gelem/s).

End to end on the FastEnhancer speech-enhancement family (Apple M1 Pro, single
thread, min per frame over a 627-frame streaming pass):

| variant | before | after | |
|---|---|---|---|
| tiny | 0.127 ms | 0.116 | 9% |
| base | 0.271 | 0.236 | 13% |
| small | 0.483 | 0.433 | 10% |
| medium | 0.814 | 0.726 | 11% |
| large | 1.790 | 1.596 | 11% |

Agreement with onnxruntime over the full streaming pass is unchanged at
2.1-2.3e-05 max absolute, with no drift across frames.

## The map neutral

`map_neutral` is `f32::NEG_INFINITY`, not `f32::MIN` as the sibling kernel uses.
`max_f32` pads with `f32::MIN`, so a fully masked row maxes to `f32::MIN`; a
padding lane then reduces to `exp(f32::MIN - f32::MIN) = exp(0)` and adds one to
the sum, which the scalar form never did because it iterated the row directly.
With `-inf` the padding underflows to zero for any max.

**`SSoftMaxL2` still carries that neutral**, so `FastCompact` has the same
latent behaviour on fully masked rows. Left alone here rather than changed
untested, but worth a look.

The `x < -103.0 || x > 0.0` guard is deliberately not a range check: `contains`
is true-by-negation for NaN, which would return zero where the scalar form
propagates NaN — a fully masked row must still reduce to NaN.

## Checks

`test-unit-core` 816 pass, `test-onnx-core` 4528 pass, full workspace suite,
`cargo fmt` and `cargo clippy` clean.

🍍
