### PR TITLE
core/array: state ScatterNd's rewrite guards with rule_if!

### DIFF
--- a/core/src/ops/array/scatter_nd.rs
+++ b/core/src/ops/array/scatter_nd.rs
@@ -175,30 +175,21 @@ impl TypedOp for ScatterNd {
         model: &TypedModel,
         node: &TypedNode,
     ) -> TractResult<Option<TypedModelPatch>> {
-        if self.reduction != ScatterReduction::None {
-            return Ok(None);
-        }
+        rule_if!(self.reduction == ScatterReduction::None);
         let (data, indices, updates) = args_3!(model.node_input_facts(node.id)?);
         rule_if_some!(konst = &indices.konst);
         rule_if_some!(data_shape = data.shape.as_concrete());
         rule_if_some!(updates_shape = updates.shape.as_concrete());
-        if !data.is_plain()
-            || !updates.is_plain()
-            || data.datum_type != updates.datum_type
-            || konst.rank() < 2
-            || !konst.is_plain()
-            || *konst.shape().last().unwrap() != data_shape.len()
-        {
-            return Ok(None);
-        }
+        rule_if!(data.is_plain() && updates.is_plain());
+        rule_if!(data.datum_type == updates.datum_type);
+        rule_if!(konst.rank() >= 2 && konst.is_plain());
+        rule_if!(*konst.shape().last().unwrap() == data_shape.len());
         let tuples = konst.cast_to::<i64>()?;
         let tuples = tuples.try_as_plain()?.as_slice::<i64>()?;
         rule_if_some!((axis, start, len) = scattered_block(tuples, data_shape));
         let mut block: TVec<usize> = data_shape.into();
         block[axis] = len;
-        if updates_shape != &block[..] {
-            return Ok(None);
-        }
+        rule_if!(updates_shape == &block[..]);
 
         let mut patch = TypedModelPatch::new("ScatterNd as Slice/Concat");
         let data_tap = patch.tap_model(model, node.inputs[0])?;


### PR DESCRIPTION
# core/array: state ScatterNd's rewrite guards with rule_if!

Follow-up to https://github.com/sonos/tract/pull/2622, addressing @kali's review comment https://github.com/sonos/tract/pull/2622#discussion_r3796062378 ("we have `rule_if!()` for this"), which landed as the PR was merged.

The constant-index block rewrite spelled three of its bail-outs as an explicit `if`/`return`, including a six-way `||` chain that had to be read through De Morgan to see what it lets through, while the rest of the same function already used `rule_if_some!`:

```rust
if self.reduction != ScatterReduction::None {
    return Ok(None);
}
...
if !data.is_plain()
    || !updates.is_plain()
    || data.datum_type != updates.datum_type
    || konst.rank() < 2
    || !konst.is_plain()
    || *konst.shape().last().unwrap() != data_shape.len()
{
    return Ok(None);
}
...
if updates_shape != &block[..] {
    return Ok(None);
}
```

becomes

```rust
rule_if!(self.reduction == ScatterReduction::None);
...
rule_if!(data.is_plain() && updates.is_plain());
rule_if!(data.datum_type == updates.datum_type);
rule_if!(konst.rank() >= 2 && konst.is_plain());
rule_if!(*konst.shape().last().unwrap() == data_shape.len());
...
rule_if!(updates_shape == &block[..]);
```

The guards now read as the conditions the rewrite needs rather than the conditions it rejects. Order is unchanged, so the rank check still precedes the `shape().last()` that depends on it — the `||` chain short-circuited the same way.

No behaviour change: `cargo test -p tract-core` passes (276), `cargo clippy -p tract-core` and `cargo fmt --all -- --check` are clean, and `harness/nnef-test-cases/scatter-nd-block` still asserts the values against the onnxruntime bundle and that the rewrite fires (`out = concat([out_head, updates, out_tail], axis = 1)`, no `scatter_nd` surviving `-O`).

🍍
