### PR TITLE
Drop redundant tract_tensorflow::prelude glob import in tf-inceptionv…

### DIFF
--- a/harness/tf-inceptionv3/src/lib.rs
+++ b/harness/tf-inceptionv3/src/lib.rs
@@ -62,7 +62,6 @@ pub fn load_image<P: AsRef<path::Path>>(p: P) -> TValue {
 #[cfg(test)]
 mod tests {
     extern crate dinghy_test;
-    use tract_tensorflow::prelude::*;
 
     use self::dinghy_test::test_project_path;
     use super::*;

--- a/harness/tf-mobilenet-v2/src/lib.rs
+++ b/harness/tf-mobilenet-v2/src/lib.rs
@@ -56,7 +56,6 @@ pub fn load_image<P: AsRef<path::Path>>(p: P) -> Tensor {
 #[cfg(test)]
 mod tests {
     extern crate dinghy_test;
-    use tract_tensorflow::prelude::*;
 
     use super::*;
 


### PR DESCRIPTION
…3/tf-mobilenet-v2 test modules

use super::* already brings it in from the parent module scope; beta/nightly rustc's unused_imports lint now catches the redundant glob and -D warnings fails the fmt/clippy CI leg on those toolchains.