### PR TITLE
core/math: lower Pow against a uniform exponent to a unary op

### DIFF
--- a/core/src/ops/math/mod.rs
+++ b/core/src/ops/math/mod.rs
@@ -488,19 +488,22 @@ fn declutter_pow(
     let b = model.outlet_fact(node.inputs[1])?;
     if let Some(b) = &b.uniform {
         let b = b.cast_to_scalar::<f32>()?;
-        if b == 2.0 {
-            return Ok(Some(TypedModelPatch::replace_single_op(
-                model,
-                node,
-                &[node.inputs[0]],
-                square(),
-            )?));
+        let dt = model.outlet_fact(node.inputs[0])?.datum_type;
+        let unary: Option<Box<dyn TypedOp>> = if b == 2.0 {
+            Some(Box::new(square()))
         } else if b == 0.5 {
+            Some(Box::new(sqrt()))
+        } else if matches!(dt, DatumType::F16 | DatumType::F32) {
+            Some(Box::new(pow_const(b)))
+        } else {
+            None
+        };
+        if let Some(unary) = unary {
             return Ok(Some(TypedModelPatch::replace_single_op(
                 model,
                 node,
                 &[node.inputs[0]],
-                sqrt(),
+                unary,
             )?));
         }
     }
@@ -529,6 +532,22 @@ element_wise!(ln, Ln, [f16, f32, f64] => |_, xs| {
 };
 q: [i8, u8, i32, i32] => f32::ln;
 validation: Validation::Rounding
+);
+
+// x^c for a constant exponent: the unary form of Pow against a uniform operand,
+// going through the same powf so results match the binary op exactly.
+element_wise!(pow_const, PowConst { exponent: f32 },
+    [f16] => |op, xs| {
+        let e = op.exponent;
+        xs.iter_mut().for_each(|x| *x = f16::from_f32(x.to_f32().powf(e)));
+        Ok(())
+    },
+    [f32] => |op, xs| {
+        let e = op.exponent;
+        xs.iter_mut().for_each(|x| *x = x.powf(e));
+        Ok(())
+    };
+    validation: Validation::Rounding
 );
 
 element_wise!(square, Square, [f16, f32, f64] => |_, xs| {

--- a/harness/nnef-test-cases/pow-const/graph.nnef
+++ b/harness/nnef-test-cases/pow-const/graph.nnef
@@ -1,0 +1,7 @@
+version 1.0;
+
+graph pow_const(input) -> (output)
+{
+    input = external<scalar>(shape = [4]);
+    output = pow(input, 2.3333);
+}

--- a/harness/nnef-test-cases/pow-const/runme.sh
+++ b/harness/nnef-test-cases/pow-const/runme.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# pow against a uniform exponent declutters to the unary PowConst, so the op has
+# to survive serialization too: without a serializer the round trip below fails
+# where the first load succeeds.
+$TRACT_RUN --nnef-tract-core . dump --assert-op-count PowConst 1
+
+rm -rf roundtrip
+$TRACT_RUN --nnef-tract-core . dump --nnef-dir roundtrip
+$TRACT_RUN --nnef-tract-core roundtrip run --allow-random-input
+rm -rf roundtrip

--- a/nnef/src/ops/core.rs
+++ b/nnef/src/ops/core.rs
@@ -16,6 +16,7 @@ mod is_inf;
 mod lstm_cell;
 mod matmul;
 mod one_hot;
+mod pow_const;
 mod qconv;
 mod qmatmul;
 mod range;
@@ -57,6 +58,7 @@ pub fn register(registry: &mut Registry) {
     fft::register(registry);
     gather::register(registry);
     gelu_approximate::register(registry);
+    pow_const::register(registry);
     grid_sample::register(registry);
     lstm_cell::register(registry);
     matmul::register(registry);

--- a/nnef/src/ops/core/pow_const.rs
+++ b/nnef/src/ops/core/pow_const.rs
@@ -1,0 +1,31 @@
+use crate::internal::*;
+use crate::ser::*;
+use std::any::TypeId;
+use tract_core::ops::element_wise::ElementWiseOp;
+use tract_core::ops::math::PowConst;
+
+fn parameters() -> Vec<Parameter> {
+    vec![TypeName::Scalar.tensor().named("input"), TypeName::Scalar.named("exponent")]
+}
+
+fn dump(ast: &mut IntoAst, node: &TypedNode) -> TractResult<Option<Arc<RValue>>> {
+    let op = node.op_as::<ElementWiseOp>().unwrap().0.downcast_ref::<PowConst>().unwrap();
+    let input = ast.mapping[&node.inputs[0]].clone();
+    Ok(Some(invocation("tract_core_pow_const", &[input], &[("exponent", numeric(op.exponent))])))
+}
+
+fn load(builder: &mut ModelBuilder, invocation: &ResolvedInvocation) -> TractResult<Value> {
+    let input = invocation.named_arg_as(builder, "input")?;
+    let exponent = invocation.named_arg_as(builder, "exponent")?;
+    builder.wire(ElementWiseOp(Box::new(PowConst { exponent }), None), &[input])
+}
+
+pub fn register(registry: &mut Registry) {
+    registry.register_element_wise(
+        "tract_core_pow_const",
+        TypeId::of::<PowConst>(),
+        Box::new(dump),
+        parameters(),
+        load,
+    );
+}


### PR DESCRIPTION
`Pow` has no by-scalar or unicast kernel — `register_all_by_scalar` and `register_all_unicast` cover Mul, Add, Sub, SubF, Min and Max — so a constant exponent still went through the generic element-wise binary and its tensor iteration. The declutter already rewrote the 2.0 and 0.5 cases to `square` and `sqrt`; this takes every other uniform float exponent to a `PowConst` element-wise op. It calls the same `powf`, so the output is bit-identical.

### Numbers

FastEnhancer (streaming speech enhancement, GRU + attention), tiny variant, aarch64, per-op share of the frame:

| | before | after |
|---|---|---|
| `Pow` / `PowConst` | 5.26 ms, **7.2%** | 1.27 ms, **1.9%** |

**4.1x on the op**, and 6% off the whole frame — none of it from arithmetic, all of it from leaving the binary path. The same model has both exponents constant (-0.7 and 2.3333), which is the common shape for a power-law compression front end.

### The serializer

The lowering on its own is a regression for anything that serializes: the registry has no serializer for the new op, so a model holding a constant-exponent pow loaded fine and then failed to dump with `No serializer found for node PowConst`. The second commit registers it against its exponent and adds `harness/nnef-test-cases/pow-const`, which asserts the op appears and then dumps, reloads and runs it.

### Tests

`cargo test -p tract-core -p tract-onnx` green, ONNX node suite 4528 green, NNEF cycle suite 2464 green, the new harness case green. `cargo fmt --all` and `cargo clippy --workspace` clean.

🍍