### PR TITLE
linalg/generic: compute SiLU with the sigmoid polynomial

### DIFF
--- a/linalg/src/generic/silu.rs
+++ b/linalg/src/generic/silu.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::excessive_precision)]
 use crate::frame::element_wise::ElementWiseKer;
+use crate::generic::sigmoid::ssigmoid;
 use tract_data::internal::*;
 
 #[derive(Clone, Debug)]
@@ -25,10 +26,7 @@ impl ElementWiseKer<f32> for SSiLU4 {
     fn run(x: &mut [f32], _: ()) {
         debug_assert!(x.len() % Self::nr() == 0);
         debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
-        x.iter_mut().for_each(|px| {
-            let sigmoid = 1.0 / (1.0 + (-*px).exp());
-            *px *= sigmoid;
-        });
+        x.iter_mut().for_each(|px| *px *= ssigmoid(*px));
     }
 }
 
@@ -57,8 +55,7 @@ impl ElementWiseKer<f16> for HSiLU8 {
         debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
         x.iter_mut().for_each(|px| {
             let x_f32 = px.to_f32();
-            let sigmoid = 1.0 / (1.0 + (-x_f32).exp());
-            *px = f16::from_f32(x_f32 * sigmoid);
+            *px = f16::from_f32(x_f32 * ssigmoid(x_f32));
         });
     }
 }


### PR DESCRIPTION
The generic SiLU kernel called libm `expf` per element, while every SIMD SiLU kernel evaluates the rational sigmoid polynomial the generic Sigmoid kernel already ships — `arm64simd_silu_f32_4n_fused`, `fma_silu_f32`, and `armv7neon_silu_f32_4n` all carry the same coefficients and the same 18.6 clamp. Only the fallback was different, and it was the slow one. Reuse `ssigmoid` so the fallback agrees with the optimized kernels instead of diverging from all of them.

### Numbers

`wasm32-wasip1` under wasmtime, f32, values drawn over [-100, 100]:

| | Gelem/s |
|---|---|
| libm `expf` | 0.33 |
| `ssigmoid` polynomial | 1.18 |

**3.6x.** The gap is that large because `expf` is a call per element that nothing vectorizes; the polynomial is a plain loop LLVM widens on its own. (A hand-written simd128 kernel for it measured no faster than the auto-vectorized scalar form, so there is nothing to add there — the same reason this file has no simd128 sigmoid or tanh.)

### Accuracy

Max absolute error against an f64 reference over the same range moves from 1.04e-6 to 2.01e-6 — the accuracy every SIMD target already gets, since they all evaluate this polynomial. `ssigmoid` clamps its result to [0, 1], so the negative tail decays to zero rather than growing: checked at -1e3, -1e6, -1e30 and `f32::MIN`, and `-inf`/NaN behave as they did before.

### Tests

`silu` frame tests green for f32 and f16, including `tails` and `sign_on_tails`; `-p tract-linalg` green natively and on `wasm32-wasip1` (2236). `cargo fmt --all` and clippy clean.

🍍