### PR TITLE
Make the CUDA backend optional in the tract facade and in tract-ffi

### DIFF
--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -45,7 +45,10 @@ case "$PLATFORM" in
         export RUSTC_TRIPLE=arm-unknown-linux-gnueabihf
         rustup target add $RUSTC_TRIPLE
         echo "[platforms.$PLATFORM]\nrustc_triple='$RUSTC_TRIPLE'\ntoolchain='$TOOLCHAIN'" > .dinghy.toml
-        cargo dinghy --platform $PLATFORM build --release -p tract-cli -p tract-ffi
+        cargo dinghy --platform $PLATFORM build --release -p tract-ffi --no-default-features
+        cargo dinghy --platform $PLATFORM build --release -p tract-cli \
+            --no-default-features \
+            --features "onnx,tf,pulse,pulse-opl,tflite,transformers,extra"
         ;;
 
     "aarch64-linux-android"|"armv7-linux-androideabi"|"i686-linux-android"|"x86_64-linux-android")
@@ -253,7 +256,16 @@ case "$PLATFORM" in
             cargo dinghy --platform $PLATFORM $DINGHY_TEST_ARGS test --profile opt-no-lto -p tract-core
         fi
 
-        cargo dinghy --platform $PLATFORM $DINGHY_TEST_ARGS check -p tract-ffi
+        # TRACT_CUDA_FEATURE is the only signal that a leg targets a CUDA board; every
+        # other linux cross target here is GPU-less, so keep cudarc out of its binaries.
+        if [ -n "$TRACT_CUDA_FEATURE" ]
+        then
+            cargo dinghy --platform $PLATFORM $DINGHY_TEST_ARGS check -p tract-ffi \
+                --no-default-features --features "$TRACT_CUDA_FEATURE"
+        else
+            cargo dinghy --platform $PLATFORM $DINGHY_TEST_ARGS check -p tract-ffi \
+                --no-default-features
+        fi
         # keep lto for these two are they're going to devices.
         if [ -n "$TRACT_CUDA_FEATURE" ]
         then
@@ -267,7 +279,10 @@ case "$PLATFORM" in
                 --no-default-features --features "$TRACT_CLI_FEATURES" \
                 -p tract-cli
         else
-            cargo dinghy --platform $PLATFORM build --release -p tract-cli
+            cargo dinghy --platform $PLATFORM build --release \
+                --no-default-features \
+                --features "onnx,tf,pulse,pulse-opl,tflite,transformers,extra" \
+                -p tract-cli
         fi
         ;;
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,7 @@ tract-pulse = { version = "0.23.6-pre", path = 'pulse' }
 tract-tensorflow = { version = "0.23.6-pre", path = 'tensorflow' }
 tract-tflite = { version = "0.23.6-pre", path = 'tflite' }
 tract-transformers = { version = "0.23.6-pre", path = 'transformers' }
-tract = { version = "0.23.6-pre", path = 'api/rs' }
+tract = { version = "0.23.6-pre", path = 'api/rs', default-features = false }
 tract-proxy-sys = { version = "0.23.6-pre", path = 'api/proxy/sys' }
 tract-cli = { version = "0.23.6-pre", path = 'cli' }
 tract-ffi = { version = "0.23.6-pre" }

--- a/api/ffi/Cargo.toml
+++ b/api/ffi/Cargo.toml
@@ -25,3 +25,23 @@ serde.workspace = true
 serde_json.workspace = true
 tract-api.workspace = true
 tract.workspace = true
+
+[features]
+default = ["cuda-13000"]
+
+# CUDA driver-API selectors, passed straight through to the tract facade
+# (linux/windows targets only). Exactly one must be active for CUDA support;
+# the default pulls cuda-13000. CPU-only cdylibs drop the backend entirely
+# with `--no-default-features`.
+cuda-12000 = ["tract/cuda-12000"]
+cuda-12010 = ["tract/cuda-12010"]
+cuda-12020 = ["tract/cuda-12020"]
+cuda-12030 = ["tract/cuda-12030"]
+cuda-12040 = ["tract/cuda-12040"]
+cuda-12050 = ["tract/cuda-12050"]
+cuda-12060 = ["tract/cuda-12060"]
+cuda-12080 = ["tract/cuda-12080"]
+cuda-12090 = ["tract/cuda-12090"]
+cuda-13000 = ["tract/cuda-13000"]
+cuda-13010 = ["tract/cuda-13010"]
+cuda-13020 = ["tract/cuda-13020"]

--- a/api/rs/Cargo.toml
+++ b/api/rs/Cargo.toml
@@ -34,7 +34,7 @@ serde_json.workspace = true
 tract-metal.workspace = true
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
-tract-cuda = { workspace = true, default-features = false }
+tract-cuda = { workspace = true, default-features = false, optional = true }
 
 
 [dev-dependencies]
@@ -50,17 +50,25 @@ complex = []
 # dylib = []
 # staticlib = []
 
+# Marker feature implicitly enabled by every cuda-XXXXX selector below.
+# Gates the `extern crate tract_cuda` that registers the CUDA runtime.
+# Not meant to be enabled directly — always pick a concrete cuda-XXXXX so
+# cudarc has an API version to bind against.
+cuda = []
+
 # CUDA driver-API selectors (linux/windows targets only). Pass-through to
-# tract-cuda. Exactly one must be active; the default pulls cuda-13000.
-cuda-12000 = ["tract-cuda/cuda-12000"]
-cuda-12010 = ["tract-cuda/cuda-12010"]
-cuda-12020 = ["tract-cuda/cuda-12020"]
-cuda-12030 = ["tract-cuda/cuda-12030"]
-cuda-12040 = ["tract-cuda/cuda-12040"]
-cuda-12050 = ["tract-cuda/cuda-12050"]
-cuda-12060 = ["tract-cuda/cuda-12060"]
-cuda-12080 = ["tract-cuda/cuda-12080"]
-cuda-12090 = ["tract-cuda/cuda-12090"]
-cuda-13000 = ["tract-cuda/cuda-13000"]
-cuda-13010 = ["tract-cuda/cuda-13010"]
-cuda-13020 = ["tract-cuda/cuda-13020"]
+# tract-cuda. Exactly one must be active for CUDA support; the default pulls
+# cuda-13000. CPU-only consumers drop the backend entirely with
+# `default-features = false`.
+cuda-12000 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12000"]
+cuda-12010 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12010"]
+cuda-12020 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12020"]
+cuda-12030 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12030"]
+cuda-12040 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12040"]
+cuda-12050 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12050"]
+cuda-12060 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12060"]
+cuda-12080 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12080"]
+cuda-12090 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-12090"]
+cuda-13000 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-13000"]
+cuda-13010 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-13010"]
+cuda-13020 = ["cuda", "dep:tract-cuda", "tract-cuda/cuda-13020"]

--- a/api/rs/Cargo.toml
+++ b/api/rs/Cargo.toml
@@ -18,8 +18,6 @@ boow.workspace = true
 erased-serde.workspace = true
 flate2.workspace = true
 half.workspace = true
-icu_normalizer.workspace = true
-icu_properties.workspace = true
 tract-api.workspace = true
 tract-nnef.workspace = true
 tract-onnx-opl.workspace = true
@@ -38,6 +36,8 @@ tract-cuda = { workspace = true, default-features = false, optional = true }
 
 
 [dev-dependencies]
+icu_normalizer.workspace = true
+icu_properties.workspace = true
 reqwest.workspace = true
 rustls.workspace = true
 tempfile.workspace = true

--- a/api/rs/src/lib.rs
+++ b/api/rs/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(target_vendor = "apple")]
 extern crate tract_metal;
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
 extern crate tract_cuda;
 extern crate tract_transformers;
 

--- a/examples/causal_llm/Cargo.toml
+++ b/examples/causal_llm/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 anyhow.workspace = true
 float-ord = "0.3.2"
 ndarray.workspace = true
-tract.workspace = true
+tract = { workspace = true, features = ["cuda-13000"] }
 axum = "0.8.4"
 tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
On linux/windows both the `tract` facade and `tract-ffi` depended on `tract-cuda` non-optionally, so nothing a caller could pass would drop the backend: `default-features = false` on the facade stripped only the `cuda-13000` selector and left cudarc's build script panicking for want of an API version, and `tract-ffi` couldn't reach that knob at all through its inherited dependency. Both now follow tract-cli's pattern — an optional dependency plus a `cuda-XXXXX` selector set — so a CPU-only or CUDA-12 build is `--no-default-features [--features cuda-12XXX]`, and `default = ["cuda-13000"]` is unchanged everywhere.

Note: making the workspace `tract` entry `default-features = false` is what lets `tract-ffi` opt out, so `examples/causal_llm` now requests `cuda-13000` explicitly — it is the one example that resolves the `"cuda"` runtime by name. The other examples inherit the facade without CUDA, which shortens their builds and changes nothing they use.

`.travis/cross.sh` now treats `TRACT_CUDA_FEATURE` as the single signal that a cross leg targets a CUDA board. Every other linux leg builds `tract-ffi` and `tract-cli` CPU-only: raspbian, arm32 (`armv6vfp`, `armv7` gnueabihf and musl), `aarch64-unknown-linux-musl`, `cortexa53-unknown-linux-musl` and `riscv64gc-unknown-linux-musl`. The raspbian line had to be split in two — its single `-p tract-cli -p tract-ffi` invocation would otherwise have dropped the
CLI's onnx/tf/pulse/tflite/transformers/extra defaults along with CUDA.

On aarch64 linux gnu: the generic (non-stretch) leg is CPU-only too, and aarch64 CUDA coverage stays on the `-stretch` leg that already forces `cuda-12000` for Jetson-class boards — now extended to the cdylib as well as the CLI. The generic leg was binding `cuda-13000`, which per the comment at `cross.sh:100` cannot run on the aarch64 hardware in the matrix, so it was covering a configuration nobody ships while the leg that mirrors real hardware covered only `tract-cli`. Net aarch64 CUDA coverage goes up rather than down.

That change also settles an inconsistency in the Jetson leg, which was checking a `cuda-13000` cdylib next to its `cuda-12000` CLI.