### PR TITLE
ci: run cuda-minimum-deploy daily instead of on every PR

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -99,6 +99,8 @@ jobs:
     # on the runner (full toolkit available) then runs it against a tiny
     # model inside a container that only has the minimum runtime packages
     # pinned in harness/cuda-minimum-deploy/Dockerfile.
+    # Daily only: keeps this off the cuda-lovelace runner on every PR.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: cuda-lovelace
     needs: prepare-matrix
     env:


### PR DESCRIPTION
It only validates the pinned minimum-runtime BOM, which drifts on a release cadence, not per-PR; gating it on schedule/dispatch keeps the single cuda-lovelace runner free for the per-PR cuda test job.