### PR TITLE
ci: quiet tract-linalg's test output

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -80,9 +80,9 @@ jobs:
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Cargo test
-      # tract-linalg runs thousands of tiny kernel tests; -q collapses the
-      # per-test lines to dots so the CI log stays readable.
-      run: cargo test ${{ matrix.crate == 'tract-linalg' && '-q' || '' }} -p ${{matrix.crate}}
+      # tract-linalg and the test-rt suites run thousands of tiny cases; -q
+      # collapses the per-test lines to dots so the CI log stays readable.
+      run: cargo test ${{ (matrix.crate == 'tract-linalg' || startsWith(matrix.crate, 'test-')) && '-q' || '' }} -p ${{matrix.crate}}
 
   cuda:
     runs-on: cuda-lovelace

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -99,7 +99,7 @@ jobs:
         persist-credentials: false
 
     - name: Cargo test
-      run: cargo test -p tract-gpu -p tract-cuda -p test-cuda
+      run: cargo test -q -p tract-gpu -p tract-cuda -p test-cuda
 
   cuda-minimum-deploy:
     # Validates the BOM documented in cuda/src/context.rs. Builds tract-cli
@@ -134,7 +134,7 @@ jobs:
         persist-credentials: false
 
     - name: Cargo test
-      run: cargo test -p tract-gpu -p tract-metal -p test-metal
+      run: cargo test -q -p tract-gpu -p tract-metal -p test-metal
    
   pedantic:
     name: fmt, clippy, etc (${{matrix.os}} / ${{matrix.rust}})

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -80,7 +80,9 @@ jobs:
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Cargo test
-      run: cargo test -p ${{matrix.crate}}
+      # tract-linalg runs thousands of tiny kernel tests; -q collapses the
+      # per-test lines to dots so the CI log stays readable.
+      run: cargo test ${{ matrix.crate == 'tract-linalg' && '-q' || '' }} -p ${{matrix.crate}}
 
   cuda:
     runs-on: cuda-lovelace

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -155,7 +155,7 @@ jobs:
     - name: With assertions
       run: |
         rustup update
-        cargo test --features tract-core/paranoid_assertions -p test-onnx-core -p test-unit-core
+        cargo test -q --features tract-core/paranoid_assertions -p test-onnx-core -p test-unit-core
 
   without-default-features:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,9 +70,9 @@ jobs:
       env:
         LIBCLANG_PATH: "C:\\Program Files\\LLVM\\bin"
     - name: data / linalg / core / nnef / onnx / onnx-opl
-      run: cargo test -p tract-data -p tract-linalg -p tract-core -p tract-nnef -p tract-onnx -p tract-onnx-opl
+      run: cargo test -q -p tract-data -p tract-linalg -p tract-core -p tract-nnef -p tract-onnx -p tract-onnx-opl
     - name: Onnx test suite
       run: |
-          cargo test --release -p test-onnx-core -p test-unit-core
+          cargo test -q --release -p test-onnx-core -p test-unit-core
       env:
         TRACT_LOG: info


### PR DESCRIPTION
The crate runs thousands of tiny kernel tests; pass -q so the CI log shows dots instead of a line per test.