### PR TITLE
tflite harness: drop redundant prelude glob import

### DIFF
--- a/harness/tfl-mobilenet-v2-q/src/lib.rs
+++ b/harness/tfl-mobilenet-v2-q/src/lib.rs
@@ -59,8 +59,6 @@ pub fn load_image<P: AsRef<path::Path>>(p: P) -> Tensor {
 #[cfg(test)]
 mod tests {
     extern crate dinghy_test;
-    use tract_tflite::prelude::*;
-
     use super::*;
 
     fn mobilenet_v2() -> path::PathBuf {


### PR DESCRIPTION
The test module imported tract_tflite::prelude::* alongside super::*, which already brings tract_tflite::internal::* (a superset). Newer rustc flags the redundant glob, failing the -D warnings check on beta/nightly.