### PR TITLE
perf(linalg): compute generic GELU with the tanh polynomial

### DIFF
--- a/linalg/benches/gelu.rs
+++ b/linalg/benches/gelu.rs
@@ -3,7 +3,6 @@
 use criterion::*;
 use tract_data::prelude::*;
 
-#[cfg(target_arch = "aarch64")]
 use tract_linalg::element_wise::ElementWiseKer;
 
 fn gelu_f32(c: &mut Criterion) {
@@ -15,6 +14,7 @@ fn gelu_f32(c: &mut Criterion) {
         *x = (i as f32 / 10.0).sin() * 5.0;
     }
     group.bench_function("rust_scalar", |b| b.iter(|| rust_scalar(input)));
+    group.bench_function("generic", |b| b.iter(|| tract_linalg::generic::SGelu4::run(input, ())));
     group.bench_function("linalg", |b| b.iter(|| linalg(input)));
     #[cfg(target_arch = "aarch64")]
     group.bench_function("linalg-asm-compose", |b| {

--- a/linalg/src/generic/gelu.rs
+++ b/linalg/src/generic/gelu.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::excessive_precision)]
 use crate::frame::element_wise::ElementWiseKer;
+use crate::generic::tanh::stanh;
 use tract_data::internal::*;
 
 // Tanh-form GELU approximation matching tract's GeluApproximate (pow=3, the
@@ -39,7 +40,7 @@ impl ElementWiseKer<f32> for SGelu4 {
         x.iter_mut().for_each(|px| {
             let v = *px;
             let inner = SQRT_2_OVER_PI * (v + COEF * v * v * v);
-            *px = 0.5 * v * (1.0 + inner.tanh());
+            *px = 0.5 * v * (1.0 + stanh(inner));
         });
     }
 }
@@ -70,7 +71,7 @@ impl ElementWiseKer<f16> for HGelu8 {
         x.iter_mut().for_each(|px| {
             let v = px.to_f32();
             let inner = SQRT_2_OVER_PI * (v + COEF * v * v * v);
-            *px = f16::from_f32(0.5 * v * (1.0 + inner.tanh()));
+            *px = f16::from_f32(0.5 * v * (1.0 + stanh(inner)));
         });
     }
 }


### PR DESCRIPTION
The fallback GELU kernel called libm tanhf per element instead of the rational tanh fit the arm64 and FMA kernels evaluate. Reusing stanh makes it way faster and puts it on that shared fit, at the cost of roughly doubling its worst-case absolute error. The path is live: arm64 ships no f16 GELU assembly, so it serves every f16 GELU there, and both dtypes on FMA-only x86, arm32 and wasm. AVX-512 GELU keeps its own tanh fit.

> [!NOTE]
> `HGelu8` deliberately uses `stanh` rather than `htanh`, matching the f32 path and the AVX-512 f16 round-trip. Therefore, generic f16 GELU is no longer expressible as generic f16 Tanh.

Same kind of perf done for SiLU in commit bd96eb86ab4b7898f3002d51cc6b8027a6454d17.

This work also adds a `generic` case to `linalg/benches/gelu.rs`. `gelu_f32/rust_scalar` there is byte-identical to the pre-change `SGelu4::run` body, so one run gives before and after with no baseline juggling:

```sh
cargo bench -p tract-linalg --bench gelu
```

Output (measured on an Apple M3 Pro chip):

```
gelu_f32/rust_scalar
                        thrpt:  [549.30 Melem/s 549.55 Melem/s 549.79 Melem/s]

gelu_f32/generic
                        thrpt:  [1.2078 Gelem/s 1.2085 Gelem/s 1.2091 Gelem/s]
```

<details>
<summary>Bench results for the arm64 optimized GELU kernels</summary>

```
gelu_f32/linalg
                        thrpt:  [1.8736 Gelem/s 1.8743 Gelem/s 1.8750 Gelem/s]

gelu_f32/linalg-asm-compose
                        thrpt:  [1.8840 Gelem/s 1.8862 Gelem/s 1.8876 Gelem/s]

gelu_f32/linalg-asm-fused
                        thrpt:  [1.8864 Gelem/s 1.8873 Gelem/s 1.8881 Gelem/s]
```
</details>