### PR TITLE
(perf) linalg/wasm: add a 4x16 f32 GEMM kernel and pick it by N

### DIFF
--- a/linalg/src/wasm/dispatch_tests.rs
+++ b/linalg/src/wasm/dispatch_tests.rs
@@ -281,6 +281,7 @@ fn add_row_col_products_and_add_mat_mul_agree_on_fusion() {
     check_madd_pairing(&*crate::wasm::wasm_f32_16x1);
     check_madd_pairing(&*crate::wasm::wasm_f32_32x1);
     check_madd_pairing(&*crate::wasm::wasm_f32_8x8);
+    check_madd_pairing(&*crate::wasm::wasm_f32_4x16);
 }
 
 /// `wasm_f32_4x4` is registered at `TargetOptimized` while every other kernel
@@ -310,5 +311,49 @@ fn dispatch_never_returns_wasm_f32_4x4() {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod fastenhancer_gate {
+    // The n % 16 == 0 gate: which GEMM kernel do the speech-enhancement shapes
+    // actually land on? n is the conv's output-column count.
+    //
+    // This declaration gets rebased and ported whenever linalg moves, and a port
+    // that drops the guarded arm is invisible: every GEMM quietly falls back to
+    // 8x8, the 1.09-1.11x goes away, and every other test in this file still
+    // passes. So assert the picks rather than only tracing them.
+    fn pick(m: usize, k: usize, n: Option<usize>) -> String {
+        let ops = crate::MmmDispatch::native();
+        let mmm =
+            ops.preferred_kernel(tract_data::prelude::DatumType::F32, Some(m), Some(k), n).unwrap();
+        eprintln!("m={m} k={k} n={n:?} -> {} (mr={} nr={})", mmm.name(), mmm.mr(), mmm.nr());
+        mmm.name().to_string()
+    }
+
+    #[test]
+    fn gate_picks_4x16_only_on_multiples_of_16() {
+        for (m, k, n) in [(64, 192, 64), (64, 128, 64), (64, 64, 32), (64, 64, 48)] {
+            assert_eq!(
+                pick(m, k, Some(n)),
+                "wasm_f32_4x16",
+                "m={m} k={k} n={n}: n fills the 16-wide tile, so the wide kernel should win"
+            );
+        }
+        for (m, k, n) in [(64, 64, 8), (64, 64, 12), (64, 64, 24), (36, 36, 36)] {
+            assert_eq!(
+                pick(m, k, Some(n)),
+                "wasm_f32_8x8",
+                "m={m} k={k} n={n}: a 16-wide tile wastes columns here — n=8 runs at 0.58x, \
+                 and n=24 pays that on its second tile"
+            );
+        }
+    }
+
+    /// An n unknown at optimisation time stays on 8x8: the gate cannot know the
+    /// tile would be filled, and guessing wrong costs 0.58x at n=8.
+    #[test]
+    fn unknown_n_stays_on_8x8() {
+        assert_eq!(pick(64, 64, None), "wasm_f32_8x8");
     }
 }

--- a/linalg/src/wasm/mmm_f32_gemm.rs
+++ b/linalg/src/wasm/mmm_f32_gemm.rs
@@ -1000,3 +1000,270 @@ unsafe fn kernel_f32_8x8(mut pnl: *const FusedKerSpec<f32>) -> isize {
 bail_stub!(wasm32; unsafe fn kernel_f32_8x8(*const FusedKerSpec<f32>) -> isize);
 
 MMMRustKernel!(wasm32; kernel_f32_8x8 => wasm_f32_8x8<f32>(8,8)@(8,8) quality(ImplementationQuality::ManuallyOptimized));
+
+/// WASM SIMD f32 4x16 kernel — 4 rows x 16 cols, 16 v128 accumulators laid out
+/// row-major as `acc[r * 4 + j]`, j indexing the four v128 chunks of a row.
+///
+/// Same accumulator count as `wasm_f32_8x8`, but the tile is wide rather than
+/// square. Each k-step splats 4 A values and loads 4 B vectors, so one splat
+/// feeds four multiply-adds instead of two: the per-splat overhead is halved
+/// against the same arithmetic. Measured against `wasm_f32_8x8` on a full tiled
+/// GEMM, this is 1.09-1.11x on the 64x64 shapes and 1.21x aggregate.
+///
+/// It is NOT a general replacement: at n=8 a 16-wide tile wastes half its
+/// columns and this runs at 0.58x. Dispatch must keep 8x8 for narrow n.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+unsafe fn kernel_f32_4x16(mut pnl: *const FusedKerSpec<f32>) -> isize {
+    use std::arch::wasm32::*;
+
+    unsafe {
+        const MR: usize = 4;
+        const NV: usize = 4; // v128 chunks per row (NR = 16)
+        let mut acc = [f32x4_splat(0.0); MR * NV];
+
+        loop {
+            if pnl.is_null() {
+                break;
+            }
+            match *pnl {
+                FusedKerSpec::Done => break,
+                FusedKerSpec::Clear => acc = [f32x4_splat(0.0); MR * NV],
+                FusedKerSpec::LoadTile(_cols, rows) => {
+                    let p = rows as *const v128;
+                    for i in 0..MR * NV {
+                        acc[i] = *p.add(i);
+                    }
+                }
+                FusedKerSpec::ScalarMin(a) => {
+                    let s = f32x4_splat(a);
+                    for v in acc.iter_mut() {
+                        *v = f32x4_min(s, *v);
+                    }
+                }
+                FusedKerSpec::ScalarMax(a) => {
+                    let s = f32x4_splat(a);
+                    for v in acc.iter_mut() {
+                        *v = f32x4_max(s, *v);
+                    }
+                }
+                FusedKerSpec::ScalarAdd(a) => {
+                    let s = f32x4_splat(a);
+                    for v in acc.iter_mut() {
+                        *v = f32x4_add(s, *v);
+                    }
+                }
+                FusedKerSpec::ScalarMul(a) => {
+                    let s = f32x4_splat(a);
+                    for v in acc.iter_mut() {
+                        *v = f32x4_mul(s, *v);
+                    }
+                }
+                FusedKerSpec::ScalarSub(a) => {
+                    let s = f32x4_splat(a);
+                    for v in acc.iter_mut() {
+                        *v = f32x4_sub(s, *v);
+                    }
+                }
+                FusedKerSpec::ScalarSubF(a) => {
+                    let s = f32x4_splat(a);
+                    for v in acc.iter_mut() {
+                        *v = f32x4_sub(*v, s);
+                    }
+                }
+                FusedKerSpec::LeakyRelu(a) => {
+                    let s = f32x4_splat(a);
+                    let zero = f32x4_splat(0.0);
+                    for v in acc.iter_mut() {
+                        let m = f32x4_gt(*v, zero);
+                        *v = v128_bitselect(*v, f32x4_mul(s, *v), m);
+                    }
+                }
+                FusedKerSpec::PerRowMin(rows) => {
+                    for r in 0..MR {
+                        let s = f32x4_splat(*rows.add(r));
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_min(s, acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowMax(rows) => {
+                    for r in 0..MR {
+                        let s = f32x4_splat(*rows.add(r));
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_max(s, acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowAdd(rows) => {
+                    for r in 0..MR {
+                        let s = f32x4_splat(*rows.add(r));
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_add(s, acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowMul(rows) => {
+                    for r in 0..MR {
+                        let s = f32x4_splat(*rows.add(r));
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_mul(s, acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowSub(rows) => {
+                    for r in 0..MR {
+                        let s = f32x4_splat(*rows.add(r));
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_sub(s, acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerRowSubF(rows) => {
+                    for r in 0..MR {
+                        let s = f32x4_splat(*rows.add(r));
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_sub(acc[r * NV + j], s);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColMin(cols) => {
+                    let p = cols as *const v128;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_min(v128_load(p.add(j)), acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColMax(cols) => {
+                    let p = cols as *const v128;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_max(v128_load(p.add(j)), acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColAdd(cols) => {
+                    let p = cols as *const v128;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_add(v128_load(p.add(j)), acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColMul(cols) => {
+                    let p = cols as *const v128;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_mul(v128_load(p.add(j)), acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColSub(cols) => {
+                    let p = cols as *const v128;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_sub(v128_load(p.add(j)), acc[r * NV + j]);
+                        }
+                    }
+                }
+                FusedKerSpec::PerColSubF(cols) => {
+                    let p = cols as *const v128;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            acc[r * NV + j] = f32x4_sub(acc[r * NV + j], v128_load(p.add(j)));
+                        }
+                    }
+                }
+                FusedKerSpec::QScale(shift, rp, mult) => {
+                    let scaler = Scaler::from_fuse_params(shift, rp, mult);
+                    let s = f32x4_splat(scaler.scale);
+                    for v in acc.iter_mut() {
+                        *v = f32x4_mul(s, *v);
+                    }
+                }
+                FusedKerSpec::RoundingShiftRight(shift, _rp) => {
+                    let s = f32x4_splat(2f32.powi(-(shift as i32)));
+                    for v in acc.iter_mut() {
+                        *v = f32x4_mul(s, *v);
+                    }
+                }
+                FusedKerSpec::ShiftLeft(shift) => {
+                    let s = f32x4_splat(2f32.powi(shift as i32));
+                    for v in acc.iter_mut() {
+                        *v = f32x4_mul(s, *v);
+                    }
+                }
+                FusedKerSpec::AddRowColProducts(rows, cols) => {
+                    let p = cols as *const v128;
+                    for r in 0..MR {
+                        let rv = f32x4_splat(*rows.add(r));
+                        for j in 0..NV {
+                            acc[r * NV + j] = madd_f32x4!(acc[r * NV + j], rv, v128_load(p.add(j)));
+                        }
+                    }
+                }
+                FusedKerSpec::AddUnicast(tile) => {
+                    let mut ptr: *const u8 = tile.ptr;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            let c0 = *(ptr.offset(tile.col_byte_stride * (j * 4) as isize)
+                                as *const f32);
+                            let c1 = *(ptr.offset(tile.col_byte_stride * (j * 4 + 1) as isize)
+                                as *const f32);
+                            let c2 = *(ptr.offset(tile.col_byte_stride * (j * 4 + 2) as isize)
+                                as *const f32);
+                            let c3 = *(ptr.offset(tile.col_byte_stride * (j * 4 + 3) as isize)
+                                as *const f32);
+                            acc[r * NV + j] = f32x4_add(f32x4(c0, c1, c2, c3), acc[r * NV + j]);
+                        }
+                        ptr = ptr.add(tile.row_byte_stride as usize);
+                    }
+                }
+                FusedKerSpec::Store(tile) => {
+                    let mut ptr: *mut u8 = tile.ptr;
+                    for r in 0..MR {
+                        for j in 0..NV {
+                            let v = acc[r * NV + j];
+                            let base = (j * 4) as isize;
+                            *(ptr.offset(tile.col_byte_stride * base) as *mut f32) =
+                                f32x4_extract_lane::<0>(v);
+                            *(ptr.offset(tile.col_byte_stride * (base + 1)) as *mut f32) =
+                                f32x4_extract_lane::<1>(v);
+                            *(ptr.offset(tile.col_byte_stride * (base + 2)) as *mut f32) =
+                                f32x4_extract_lane::<2>(v);
+                            *(ptr.offset(tile.col_byte_stride * (base + 3)) as *mut f32) =
+                                f32x4_extract_lane::<3>(v);
+                        }
+                        ptr = ptr.add(tile.row_byte_stride as usize);
+                    }
+                }
+                FusedKerSpec::AddMatMul { k, pa, pb, packing: _ } => {
+                    // A: packed [k][MR=4], B: packed [k][NR=16] = 4 v128 per k
+                    let a = pa as *const f32;
+                    let b = pb as *const v128;
+                    for i in 0..k {
+                        let arow = std::slice::from_raw_parts(a.offset(4 * i as isize), 4);
+                        let bb = b.offset((4 * i) as isize);
+                        let b0 = v128_load(bb);
+                        let b1 = v128_load(bb.add(1));
+                        let b2 = v128_load(bb.add(2));
+                        let b3 = v128_load(bb.add(3));
+                        for r in 0..MR {
+                            let s = f32x4_splat(arow[r]);
+                            acc[r * NV] = madd_f32x4!(acc[r * NV], s, b0);
+                            acc[r * NV + 1] = madd_f32x4!(acc[r * NV + 1], s, b1);
+                            acc[r * NV + 2] = madd_f32x4!(acc[r * NV + 2], s, b2);
+                            acc[r * NV + 3] = madd_f32x4!(acc[r * NV + 3], s, b3);
+                        }
+                    }
+                }
+            }
+            pnl = pnl.add(1);
+        }
+        0
+    }
+}
+
+bail_stub!(wasm32; unsafe fn kernel_f32_4x16(*const FusedKerSpec<f32>) -> isize);
+
+MMMRustKernel!(wasm32; kernel_f32_4x16 => wasm_f32_4x16<f32>(4,16)@(4,16) quality(ImplementationQuality::ManuallyOptimized));

--- a/linalg/src/wasm/mod.rs
+++ b/linalg/src/wasm/mod.rs
@@ -50,6 +50,14 @@ fn preferred(
             9..=16 => &wasm_f32_16x1.name,
             _ => &wasm_f32_32x1.name,
         }),
+        // GEMM by N: a k-step of 4x16 splats one A value into four multiply-adds where 8x8
+        // gets two, so it is 1.09-1.11x on the 64-wide shapes and 1.21x aggregate. It only
+        // pays when N is a multiple of 16: at N=8 a 16-wide tile wastes half its columns
+        // (0.58x) and N=24 pays that on its second tile, and gating on N>=16 instead cost
+        // fastenhancer tiny and base 4% each. An N unknown at optimisation time stays on 8x8.
+        // Rank the two on a full tiled GEMM: over a single tile the wider tile's doubled
+        // B-panel re-reads do not show.
+        (DatumType::F32, Some(n)) if n % 16 == 0 => Some(wasm_f32_4x16.name.as_str()),
         (DatumType::F32, _) => Some(wasm_f32_8x8.name.as_str()),
         _ => None,
     }


### PR DESCRIPTION
`ops.mmm_f32` ignored `m`, `k` and `n` and returned `wasm_f32_8x8` for every f32 GEMM, so one square tile served every shape. A square tile is not the best shape here: each k-step splats MR values from A and loads NR/4 vectors from B, and **every splat feeds NR/4 multiply-adds**, so widening NR amortises the splat while widening MR does not.

`wasm_f32_4x16` keeps the same 16 v128 accumulators, laid out 4 rows × 4 vectors instead of 8 × 2.

### Numbers

Full tiled GEMM under node, plain `+simd128`, medians of 3 interleaved rounds, against `wasm_f32_8x8`:

| shape | ratio | shape | ratio | shape | ratio |
|---|---|---|---|---|---|
| 64×64×192 | 1.12 | 256×64×64 | 1.10 | 64×32×64 | 1.09 |
| 64×64×64 | 1.10 | 512×64×64 | 1.10 | 64×48×64 | 1.08 |
| 64×128×64 | 1.09 | 1024×64×64 | 1.10 | 256×256×256 | 1.13 |
| 64×256×64 | 1.10 | 1×64×128 | 2.19 | | |

It only pays when N fills the tile. At **N=8 a 16-wide tile wastes half its columns and runs at 0.58×**; N=24 pays that on its second tile (0.86×). So `mmm_f32` gates on `N % 16 == 0` and leaves everything else — including the case where N is not known at optimisation time — on 8×8. An `N >= 16` gate is not sufficient: it cost two models 4% each.

Large M does not regress: MR=4 needs twice the row-tiles of MR=8 and therefore re-reads the B panel twice as often, but the ratio holds at 1.10 through M=1024.

End to end on a speech-enhancement set (five FastEnhancer variants, GTCRN, two DTLN stages, three DeepFilterNet3 submodels), wasm32 plain simd128, five interleaved rounds:

| model | vs before | model | vs before |
|---|---|---|---|
| fastenhancer_m | **0.94** | fastenhancer_t | 0.98 |
| fastenhancer_l | **0.94** | fastenhancer_b | 0.98 |
| dfn3 erb_dec | **0.97** | dfn3 enc | 0.99 |
| fastenhancer_s | **0.97** | GTCRN, DTLN 1 & 2 | 1.00 |

No model regresses on either target. Native is untouched — the module is behind `cfg(all(target_family = "wasm", target_feature = "simd128"))`.

### Testing

`cargo test --target wasm32-wasip1 -p tract-linalg -p tract-core` under wasmtime, both `+simd128` and `+simd128,+relaxed-simd` as `.travis/cross.sh` runs them: all green, including the `packed_packed` proptests against the new kernel. The wasm backend picks its multiply-add form at compile time, so both configurations matter.

`cargo test --workspace` on macOS (minus `test-tflite` / `tract-proxy` / `tract-proxy-sys` / `test-cuda`): 106 suites, 65761 passed, with the same 70 pre-existing failures as `main` — the changed files are not compiled on a native target.

`dispatch_tests.rs` gains a trace asserting which kernel each shape lands on, in the style of the existing `dfn3_shapes` test: N of 64/32/48 route to 4×16, N of 8/12/24/36 stay on 8×8.

🍍