### PR TITLE
onnx: honour allowzero in Reshape

### DIFF
--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -1039,20 +1039,47 @@ pub fn perm_to_ops(input: &[usize]) -> TVec<AxisOp> {
 }
 
 pub fn compute_shape_with_tf_rules(input: &[TDim], shape_spec: &[TDim]) -> TractResult<TVec<TDim>> {
+    compute_shape_with_onnx_rules(input, shape_spec, false)
+}
+
+/// Resolve a `Reshape` target shape, honouring ONNX's `allowzero`.
+///
+/// With `allowzero` clear, a 0 in the target copies the input dimension at the same position.
+/// This is the TensorFlow rule and the ONNX default, and is what `compute_shape_with_tf_rules`
+/// asks for. With `allowzero` set, ONNX gives a 0 its literal meaning: a zero-length dimension,
+/// "not taken from input tensor". `allowzero` was added in ONNX opset 14.
+pub fn compute_shape_with_onnx_rules(
+    input: &[TDim],
+    shape_spec: &[TDim],
+    allowzero: bool,
+) -> TractResult<TVec<TDim>> {
     let mut shape: TVec<TDim> = shape_spec.into();
-    // Replace 0s with corresponding input dims (positional, per ONNX/TF spec)
-    for (i, s) in shape.iter_mut().enumerate() {
-        if *s == 0.into() {
-            *s = input
-                .get(i)
-                .with_context(|| {
-                    format!("Reshape: 0 at position {i} but input only has {} dims", input.len())
-                })?
-                .clone();
+    if !allowzero {
+        // Replace 0s with corresponding input dims (positional, per TF and ONNX allowzero=0)
+        for (i, s) in shape.iter_mut().enumerate() {
+            if *s == 0.into() {
+                *s = input
+                    .get(i)
+                    .with_context(|| {
+                        format!(
+                            "Reshape: 0 at position {i} but input only has {} dims",
+                            input.len()
+                        )
+                    })?
+                    .clone();
+            }
         }
     }
     let input_vol: TDim = input.iter().product();
     if let Some(pos) = shape.iter().position(|d| *d == (-1).into()) {
+        // ONNX: "If the attribute 'allowzero' is set, it is invalid for the specified shape to
+        // contain both a zero value and -1, as the value of the dimension corresponding to -1
+        // cannot be determined uniquely."
+        if allowzero && shape.iter().any(|d| *d == 0.into()) {
+            bail!(
+                "Reshape: allowzero is set, so the target shape {shape_spec:?} may not contain both 0 and -1"
+            )
+        }
         let shape_vol: TDim = shape.iter().filter(|d| **d != (-1).into()).product();
         let div = input_vol.maybe_div(&shape_vol)?;
         if div.1 != 1 {
@@ -1074,7 +1101,26 @@ pub fn to_axis_ops_with_tf_rules(
     input_orig: &[TDim],
     output_spec: &[TDim],
 ) -> TractResult<TVec<AxisOp>> {
-    let final_output = compute_shape_with_tf_rules(input_orig, output_spec)?;
+    to_axis_ops_with_onnx_rules(input_orig, output_spec, false)
+}
+
+/// As `to_axis_ops_with_tf_rules`, but honouring ONNX's `allowzero`.
+pub fn to_axis_ops_with_onnx_rules(
+    input_orig: &[TDim],
+    output_spec: &[TDim],
+    allowzero: bool,
+) -> TractResult<TVec<AxisOp>> {
+    let final_output = compute_shape_with_onnx_rules(input_orig, output_spec, allowzero)?;
+    // A zero-length dimension makes every group volume zero, so the greedy volume matching below
+    // finds spurious partial matches and builds an incoherent stack. There are no elements to
+    // move, so the whole reshape is one unambiguous operation.
+    if final_output.iter().chain(input_orig.iter()).any(|d| *d == 0.into()) {
+        return Ok(if *input_orig == *final_output {
+            tvec!()
+        } else {
+            tvec!(AxisOp::Reshape(0, input_orig.into(), final_output.clone()))
+        });
+    }
     let mut stack: TVec<AxisOp> = tvec!();
     'top: loop {
         let current_input =
@@ -1668,6 +1714,44 @@ mod proptests {
     #[test]
     fn compute_with_trailing_zero() {
         assert_eq!(&*compute_shape_with_tf_rules(s![3, 4, 5], s!(3, -1, 0)).unwrap(), s![3, 4, 5])
+    }
+
+    // ONNX allowzero. A 0 in the target is literal rather than copied from the input, which is
+    // only reachable through the ONNX frontend: TensorFlow has no such attribute and always
+    // takes the copy rule above.
+
+    #[test]
+    fn compute_allowzero_keeps_a_literal_zero() {
+        assert_eq!(&*compute_shape_with_onnx_rules(s![3, 0], s!(0), true).unwrap(), s![0])
+    }
+
+    #[test]
+    fn compute_without_allowzero_copies_the_input_dim() {
+        // Same model, attribute clear: the 0 becomes the input's dim 0, so 3 elements are asked
+        // of a tensor holding none.
+        assert!(compute_shape_with_onnx_rules(s![3, 0], s!(0), false).is_err())
+    }
+
+    #[test]
+    fn compute_allowzero_reordered() {
+        // ONNX's own test_reshape_allowzero_reordered case.
+        assert_eq!(
+            &*compute_shape_with_onnx_rules(s![0, 3, 4], s!(3, 4, 0), true).unwrap(),
+            s![3, 4, 0]
+        )
+    }
+
+    #[test]
+    fn compute_allowzero_rejects_zero_beside_minus_one() {
+        // "it is invalid for the specified shape to contain both a zero value and -1, as the
+        // value of the dimension corresponding to -1 cannot be determined uniquely."
+        assert!(compute_shape_with_onnx_rules(s![2, 3], s!(0, -1), true).is_err())
+    }
+
+    #[test]
+    fn to_axis_ops_allowzero_keeps_a_literal_zero() {
+        // The wiring path resolves the shape the same way, so it must agree with the rules path.
+        assert!(to_axis_ops_with_onnx_rules(s![3, 0], s!(0), true).is_ok())
     }
 
     #[test]

--- a/hir/src/ops/array/reshape.rs
+++ b/hir/src/ops/array/reshape.rs
@@ -2,7 +2,12 @@ use crate::infer::*;
 use crate::internal::*;
 
 #[derive(Debug, Clone, new, Default, Hash, PartialEq, Eq)]
-pub struct Reshape {}
+pub struct Reshape {
+    /// ONNX's `allowzero`, added in opset 14. When set, a 0 in the target shape is a literal
+    /// zero-length dimension instead of a copy of the input dimension at that position. The
+    /// TensorFlow frontend always passes false, which is its only convention.
+    pub allowzero: bool,
+}
 
 impl Expansion for Reshape {
     fn name(&self) -> StaticName {
@@ -17,11 +22,14 @@ impl Expansion for Reshape {
     ) -> InferenceResult {
         check_input_arity(inputs, 2)?;
         s.equals(&outputs[0].datum_type, &inputs[0].datum_type)?;
+        let allowzero = self.allowzero;
         s.given_2(&inputs[0].shape, &inputs[1].value, move |s, ishape, shape| {
             let shape = shape.cast_to::<TDim>()?;
             let shape = shape.try_as_plain()?.as_slice::<TDim>()?;
-            let oshape = tract_core::ops::change_axes::compute_shape_with_tf_rules(&ishape, shape)
-                .with_context(|| format!("Reshaping {ishape:?} to {shape:?}"))?;
+            let oshape = tract_core::ops::change_axes::compute_shape_with_onnx_rules(
+                &ishape, shape, allowzero,
+            )
+            .with_context(|| format!("Reshaping {ishape:?} to {shape:?}"))?;
             s.equals(&outputs[0].shape, ShapeFactoid::from(oshape))
         })
     }
@@ -37,7 +45,9 @@ impl Expansion for Reshape {
             let shape = shape.cast_to::<TDim>()?;
             let shape = shape.try_as_plain()?.as_slice::<TDim>()?;
             let mut wire = tvec!(inputs[0]);
-            for (ix, op) in to_axis_ops_with_tf_rules(&input_shape, shape)?.into_iter().enumerate()
+            for (ix, op) in to_axis_ops_with_onnx_rules(&input_shape, shape, self.allowzero)?
+                .into_iter()
+                .enumerate()
             {
                 wire = model.wire_node(format!("{prefix}.{ix}"), op, &wire)?;
             }

--- a/onnx/src/ops/array/mod.rs
+++ b/onnx/src/ops/array/mod.rs
@@ -32,7 +32,11 @@ pub fn register_all_ops(reg: &mut OnnxOpRegister) {
     reg.insert("OneHot", one_hot::one_hot);
     reg.insert("Range", |_, _| Ok((expand(array::Range), vec![])));
     reg.insert("Pad", pad::pad);
-    reg.insert("Reshape", |_, _| Ok((expand(array::Reshape::default()), vec![])));
+    reg.insert("Reshape", |_, node| {
+        // allowzero was added in opset 14; absent, it defaults to 0.
+        let allowzero = node.get_attr_opt::<i64>("allowzero")?.unwrap_or(0) != 0;
+        Ok((expand(array::Reshape::new(allowzero)), vec![]))
+    });
     reg.insert("Scatter", scatter_elements);
     reg.insert("ScatterElements", scatter_elements);
     reg.insert("ScatterND", |_, node| {

--- a/tensorflow/src/ops/array/mod.rs
+++ b/tensorflow/src/ops/array/mod.rs
@@ -24,7 +24,7 @@ pub fn register_all_ops(reg: &mut TfOpRegister) {
     reg.insert("Pack", pack::pack);
     reg.insert("Pad", pad::pad);
     reg.insert("Range", |_, _| Ok(expand(tract_hir::ops::array::Range)));
-    reg.insert("Reshape", |_, _| Ok(expand(tract_hir::ops::array::Reshape::new())));
+    reg.insert("Reshape", |_, _| Ok(expand(tract_hir::ops::array::Reshape::new(false))));
     reg.insert("Shape", |_, _| Ok(expand(tract_hir::ops::array::Shape::new(DatumType::TDim))));
     reg.insert("Slice", slice);
     reg.insert("Squeeze", squeeze::squeeze);

--- a/test-rt/suite-onnx/node.txt
+++ b/test-rt/suite-onnx/node.txt
@@ -478,6 +478,7 @@ test_reduce_sum_square_negative_axes_keepdims_random input:data
 test_reflect_pad input:x
 test_relu
 test_relu_expanded_ver18
+test_reshape_allowzero_reordered input:data
 test_reshape_extended_dims input:data
 test_reshape_negative_dim input:data
 test_reshape_negative_extended_dims input:data


### PR DESCRIPTION
fixes #2698

### Description

`Reshape` never read the `allowzero` attribute, so a `0` in the target shape was always replaced by
the input dimension at that position. That is the `allowzero=0` rule; with the attribute set, ONNX
gives a `0` its literal meaning of a zero-length dimension, "not taken from input tensor".

The registration discarded the node, and `Reshape` was a unit struct with nowhere to carry the flag:

    reg.insert("Reshape", |_, _| Ok((expand(array::Reshape::default()), vec![])));

`compute_shape_with_tf_rules` and `to_axis_ops_with_tf_rules` now delegate to `allowzero`-aware
versions and keep their signatures, so the TensorFlow path is unchanged. `Reshape` carries the flag
through `rules` and `wire`, and a `0` alongside a `-1` is rejected, which ONNX calls invalid.

Honouring the attribute is not sufficient on its own. `to_axis_ops_*` decomposes a reshape into a
sequence of primitive axis operations, pairing contiguous runs of the input and output shapes whose
volumes are equal. A zero-length dimension defeats that test, because every run containing it has
volume 0. For `[0,3,4]` to `[3,4,0]` it paired the input run `[0]` with the output run `[3,4,0]`,
both volume 0, producing `3,4,0,3,4` and then failing with
`Removing non-trivial axis #4 of dim: 3,4,0,3,4`.

A tensor with a zero-length dimension holds no elements, so there is no data movement to sequence,
only a change of shape metadata. The decomposition is therefore skipped in that case:

    if final_output.iter().chain(input_orig.iter()).any(|d| *d == 0.into()) {
        return Ok(if *input_orig == *final_output {
            tvec!()
        } else {
            tvec!(AxisOp::Reshape(0, input_orig.into(), final_output.clone()))
        });
    }

Without this second part, `test_reshape_allowzero_reordered` still fails after the attribute is
honoured.

### Motivation + Context

Two behaviours change: models that were wrongly rejected now load: `float32[3,0]` reshaped to `[0]`
with `allowzero=1` returns `[0]` instead of failing analysis with a volume mismatch. And models that
ONNX calls invalid are now rejected instead of silently mis-computed: `float32[2,3]` to `[0,3]` and
to `[0,-1]`, both with `allowzero=1`, previously came back as `[2,3]` full of data. `onnx.reference`
and ONNX Runtime agree with the new behaviour in every case.

This enables ONNX's own `test_reshape_allowzero_reordered`, which was absent from
`test-rt/suite-onnx/node.txt` while the two `allowzero=0` zero-dim cases were present, so the path
looks untested rather than deliberately unsupported. It fails without both changes above and passes
in all four suite variants with them. Unit tests cover the literal zero, the reordered case, the
`0`-with-`-1` rejection and the unchanged copy rule.

Verified on macOS ARM64: full ONNX conformance suite 4532 passed / 0 failed; tract-core 285,
tract-hir 67, tract-onnx 15 all green; tract-tensorflow compiles. Separately checked 17 single-node
models by hand against `onnx.reference` and ONNX Runtime, comparing shapes and values: all 17 agree,
where 8 disagreed before.