### PR TITLE
core,linalg: pack any format from a view

### DIFF
--- a/core/src/ops/cnn/conv/lazy_im2col.rs
+++ b/core/src/ops/cnn/conv/lazy_im2col.rs
@@ -51,6 +51,15 @@ impl MMMInputFormat for LazyIm2colParams {
         unimplemented!()
     }
 
+    fn prepare_one_view(
+        &self,
+        _t: &TensorView,
+        _k_axis: usize,
+        _mn_axis: usize,
+    ) -> TractResult<Box<dyn MMMInputValue>> {
+        bail!("Unexpected call to prepare_one_view on LazyIm2Col")
+    }
+
     fn prepare_one(
         &self,
         _t: &Tensor,

--- a/core/src/ops/matmul/pack.rs
+++ b/core/src/ops/matmul/pack.rs
@@ -1,39 +1,12 @@
 use crate::axes::Axis;
 use crate::internal::*;
 use ndarray::*;
-use tract_linalg::WeightType;
 use tract_linalg::block_quant::{
     BlockQuantStorage, PackedBlockQuantFact, PackedBlockQuantFormat, block_quant_slice,
 };
 use tract_linalg::mmm::{MMMInputFormat, MMMInputValue, PackedMatrixStorage};
-use tract_linalg::pack::{PackedFormat, PackedI8K4};
-#[cfg(target_arch = "x86_64")]
-use tract_linalg::x86_64::amx::PackedAmxA;
 
 use super::ModePicker;
-
-// Pack one (possibly strided) view with a dynamic packing format. Keeps the
-// PackedFormat fast path byte-identical; routes the K=4-inner SMOPA packer
-// (PackedI8K4) and the AMX A-side packer (PackedAmxA) through their view
-// packers. Other formats are unsupported here.
-fn pack_view_with(
-    packer: &dyn MMMInputFormat,
-    t: &TensorView,
-    k_axis: usize,
-    mn_axis: usize,
-) -> TractResult<Box<dyn MMMInputValue>> {
-    if let Some(pf) = packer.downcast_ref::<PackedFormat>() {
-        return pf.pack_tensor_view(t, k_axis, mn_axis);
-    }
-    if let Some(p4) = packer.downcast_ref::<PackedI8K4>() {
-        return p4.pack_view(t, k_axis, mn_axis);
-    }
-    #[cfg(target_arch = "x86_64")]
-    if let Some(pa) = packer.downcast_ref::<PackedAmxA>() {
-        return pa.pack_view(t, k_axis, mn_axis);
-    }
-    bail!("OptMatMulPack does not support packing format {packer:?}")
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OptMatMulPack {
@@ -114,7 +87,7 @@ impl OptMatMulPack {
             let packer = &self.packers[mode];
             let output_shape: TVec<usize> = self.output_shape(input.shape());
             let stores = if output_shape.iter().all(|d| *d == 1) {
-                let packed = pack_view_with(&**packer, &input.view(), self.k_axis, self.mn_axis)?;
+                let packed = packer.prepare_one_view(&input.view(), self.k_axis, self.mn_axis)?;
                 PackedMatrixStorage::new_batched(&output_shape, tvec![packed])
                     .into_tensor(input.datum_type())
             } else {
@@ -132,12 +105,9 @@ impl OptMatMulPack {
                         .map(|(x, s)| *x as isize * s)
                         .sum::<isize>()
                         * input.datum_type().size_of() as isize;
-                    values.push(pack_view_with(
-                        &**packer,
-                        &TensorView::from_bytes(&input, offset, input.shape(), input.strides()),
-                        self.k_axis,
-                        self.mn_axis,
-                    )?);
+                    let view =
+                        TensorView::from_bytes(&input, offset, input.shape(), input.strides());
+                    values.push(packer.prepare_one_view(&view, self.k_axis, self.mn_axis)?);
                 }
                 PackedMatrixStorage::new_batched(&output_shape, values)
                     .into_tensor(input.datum_type())
@@ -163,12 +133,7 @@ pub struct DynPackedExoticFact {
 
 impl ExoticFact for DynPackedExoticFact {
     fn buffer_sizes(&self) -> TVec<TDim> {
-        let elem_bytes = match self.packers[0].precursor() {
-            WeightType::Plain(dt) => dt.size_of(),
-            // OptMatMulPack only ever carries plain (PackedFormat / PackedI8K4) packers.
-            WeightType::BlockQuant(_) => 1,
-        };
-        tvec!(self.k.clone() * &self.mn * elem_bytes)
+        tvec!(self.packers[0].mem_size(self.k.clone(), self.mn.clone()))
     }
 }
 

--- a/linalg/src/frame/block_quant/mod.rs
+++ b/linalg/src/frame/block_quant/mod.rs
@@ -272,6 +272,15 @@ impl MMMInputFormat for PackedBlockQuantFormat {
             .into_tensor(t.datum_type()))
     }
 
+    fn prepare_one_view(
+        &self,
+        _t: &TensorView,
+        _k_axis: usize,
+        _mn_axis: usize,
+    ) -> TractResult<Box<dyn MMMInputValue>> {
+        bail!("{self} packs from block-quant storage, which a strided view cannot address")
+    }
+
     fn prepare_one(
         &self,
         t: &Tensor,

--- a/linalg/src/frame/mmm/input_store.rs
+++ b/linalg/src/frame/mmm/input_store.rs
@@ -14,12 +14,23 @@ pub trait MMMInputFormat:
     Downcast + Debug + DynHash + dyn_eq::DynEq + DynClone + Send + Sync + Display
 {
     fn prepare_tensor(&self, t: &Tensor, k_axis: usize, mn_axis: usize) -> TractResult<Tensor>;
+    /// Pack one matmul out of a possibly strided view — one batch of a batched input, which a
+    /// `&Tensor` cannot name. A format whose input is not a strided array of numbers (block
+    /// quant, lazy im2col) says so here rather than being silently unreachable.
+    fn prepare_one_view(
+        &self,
+        t: &TensorView,
+        k_axis: usize,
+        mn_axis: usize,
+    ) -> TractResult<Box<dyn MMMInputValue>>;
     fn prepare_one(
         &self,
         t: &Tensor,
         k_axis: usize,
         mn_axis: usize,
-    ) -> TractResult<Box<dyn MMMInputValue>>;
+    ) -> TractResult<Box<dyn MMMInputValue>> {
+        self.prepare_one_view(&t.view(), k_axis, mn_axis)
+    }
     fn precursor(&self) -> WeightType;
     /// Round `tensor` through the numeric precision this format stores its data
     /// in, so a reference matmul can reproduce the kernel's pack-time precision
@@ -151,5 +162,42 @@ impl Display for EagerPackedInput {
 impl Debug for EagerPackedInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         <Self as Display>::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+pub mod view_check {
+    use super::*;
+
+    /// Packing one batch of a batched tensor through a strided view must give the same bytes as
+    /// packing that batch alone: what a dynamic packing op relies on, and what an unimplemented
+    /// [`MMMInputFormat::prepare_one_view`] used to break.
+    pub fn view_matches_tensor(
+        format: &dyn MMMInputFormat,
+        k: usize,
+        mn: usize,
+    ) -> TractResult<()> {
+        let WeightType::Plain(dt) = format.precursor() else {
+            bail!("{format} does not pack a plain tensor")
+        };
+        let mut parent = Tensor::zero_dt(dt, &[2, k, mn])?;
+        parent.as_bytes_mut().iter_mut().enumerate().for_each(|(ix, b)| *b = (ix % 101) as u8 + 1);
+        let batch = parent.slice(0, 1, 2)?.into_shape(&[k, mn])?;
+        let from_tensor = format.prepare_one(&batch, 0, 1)?;
+        let offset = parent.strides()[0] * dt.size_of() as isize;
+        let view =
+            unsafe { TensorView::from_bytes(&parent, offset, parent.shape(), parent.strides()) };
+        let from_view = format.prepare_one_view(&view, 1, 2)?;
+        let bytes = |v: &dyn MMMInputValue| -> TractResult<Arc<Blob>> {
+            Ok(v.downcast_ref::<EagerPackedInput>()
+                .with_context(|| format!("{format} did not pack to an EagerPackedInput"))?
+                .packed
+                .clone())
+        };
+        ensure!(
+            *bytes(&*from_tensor)? == *bytes(&*from_view)?,
+            "{format}: packing k={k} mn={mn} from a view differs from packing it from a tensor"
+        );
+        Ok(())
     }
 }

--- a/linalg/src/frame/pack.rs
+++ b/linalg/src/frame/pack.rs
@@ -23,6 +23,14 @@ impl MMMInputFormat for PackedFormat {
         let packed = PackedFormat::pack_tensor(self, t, k_axis, mn_axis)?;
         Ok(PackedMatrixStorage::new(packed).into_tensor(t.datum_type()))
     }
+    fn prepare_one_view(
+        &self,
+        t: &TensorView,
+        k_axis: usize,
+        mn_axis: usize,
+    ) -> TractResult<Box<dyn MMMInputValue>> {
+        PackedFormat::pack_tensor_view(self, t, k_axis, mn_axis)
+    }
 
     fn prepare_one(
         &self,
@@ -186,46 +194,7 @@ impl PackedFormat {
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
         ensure!(t.datum_type().is_copy());
-        ensure!(
-            t.datum_type().unquantized() == self.dt.unquantized(),
-            "Attempting to pack for {self} tensor {t:?}"
-        );
-        let k = t.shape()[k_axis];
-        let mn = t.shape()[mn_axis];
-        let packed_len = self.len(k, mn);
-        let panel_len = self.single_panel_len(k);
-        let panel_bytes = panel_len * t.datum_type().size_of();
-        let strides = t.strides();
-        unsafe {
-            let mut packed = Blob::new_for_size_and_align(
-                t.datum_type().size_of() * packed_len,
-                self.alignment_bytes,
-            );
-            if cfg!(debug_assertions) {
-                packed.as_bytes_mut().fill(0u8);
-            } else if mn % self.r != 0 {
-                // The kernel computes on the last panel's padding lanes before
-                // their results are discarded; garbage bytes there decode to
-                // denormals and stall the fp pipeline. Zero the partial panel.
-                packed.as_bytes_mut()[(mn / self.r) * panel_bytes..].fill(0u8);
-            }
-            dispatch_copy!(Self::pack_t(t.datum_type())(
-                self,
-                packed.as_mut_ptr() as _,
-                t.as_ptr_unchecked(),
-                mn,
-                strides[k_axis],
-                strides[mn_axis],
-                0..k,
-                0..mn
-            ));
-            Ok(Box::new(EagerPackedInput {
-                fact: PackedExoticFact { format: Box::new(self.clone()), mn: mn.to_dim(), k },
-                packed: packed.into(),
-                panel_bytes,
-                mn,
-            }))
-        }
+        self.pack_tensor_view(&t.view(), k_axis, mn_axis)
     }
 
     pub fn pack_tensor_view(
@@ -1187,13 +1156,13 @@ impl MMMInputFormat for PackedI8K4 {
         Ok(PackedMatrixStorage::new(self.prepare_one(t, k_axis, mn_axis)?)
             .into_tensor(t.datum_type()))
     }
-    fn prepare_one(
+    fn prepare_one_view(
         &self,
-        t: &Tensor,
+        t: &TensorView,
         k_axis: usize,
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
-        self.pack_view(&t.view(), k_axis, mn_axis)
+        self.pack_view(t, k_axis, mn_axis)
     }
     fn precursor(&self) -> WeightType {
         WeightType::Plain(i8::datum_type())

--- a/linalg/src/x86_64/amx.rs
+++ b/linalg/src/x86_64/amx.rs
@@ -226,13 +226,13 @@ impl MMMInputFormat for PackedAmxA {
         Ok(PackedMatrixStorage::new(self.prepare_one(t, k_axis, mn_axis)?)
             .into_tensor(t.datum_type()))
     }
-    fn prepare_one(
+    fn prepare_one_view(
         &self,
-        t: &Tensor,
+        t: &TensorView,
         k_axis: usize,
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
-        self.pack_view(&t.view(), k_axis, mn_axis)
+        self.pack_view(t, k_axis, mn_axis)
     }
     fn precursor(&self) -> WeightType {
         WeightType::Plain(i8::datum_type())
@@ -260,5 +260,17 @@ impl MMMInputFormat for PackedAmxA {
     }
     fn extract_at_mn_f32(&self, _: &EagerPackedInput, _: usize, _: &mut [f32]) -> TractResult<()> {
         bail!("no f32 extract")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::frame::mmm::input_store::view_check::view_matches_tensor;
+
+    #[test]
+    fn packed_amx_a_view() -> TractResult<()> {
+        view_matches_tensor(&PackedAmxA::new(16), 64, 48)?;
+        view_matches_tensor(&PackedAmxA::new(16), 5, 7)
     }
 }

--- a/linalg/src/x86_64/amx_bf16.rs
+++ b/linalg/src/x86_64/amx_bf16.rs
@@ -166,13 +166,13 @@ impl MMMInputFormat for PackedAmxBf16A {
         Ok(PackedMatrixStorage::new(self.prepare_one(t, k_axis, mn_axis)?)
             .into_tensor(t.datum_type()))
     }
-    fn prepare_one(
+    fn prepare_one_view(
         &self,
-        t: &Tensor,
+        t: &TensorView,
         k_axis: usize,
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
-        self.pack_view(&t.view(), k_axis, mn_axis)
+        self.pack_view(t, k_axis, mn_axis)
     }
     fn k_alignment(&self) -> usize {
         // tdpbf16ps consumes 32 bf16 per K-step.
@@ -297,13 +297,13 @@ impl MMMInputFormat for PackedBf16K2 {
         Ok(PackedMatrixStorage::new(self.prepare_one(t, k_axis, mn_axis)?)
             .into_tensor(t.datum_type()))
     }
-    fn prepare_one(
+    fn prepare_one_view(
         &self,
-        t: &Tensor,
+        t: &TensorView,
         k_axis: usize,
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
-        self.pack_view(&t.view(), k_axis, mn_axis)
+        self.pack_view(t, k_axis, mn_axis)
     }
     fn k_alignment(&self) -> usize {
         2
@@ -331,5 +331,23 @@ impl MMMInputFormat for PackedBf16K2 {
     }
     fn extract_at_mn_f32(&self, _: &EagerPackedInput, _: usize, _: &mut [f32]) -> TractResult<()> {
         bail!("no f32 extract")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::frame::mmm::input_store::view_check::view_matches_tensor;
+
+    #[test]
+    fn packed_amx_bf16_a_view() -> TractResult<()> {
+        view_matches_tensor(&PackedAmxBf16A::new(16), 64, 48)?;
+        view_matches_tensor(&PackedAmxBf16A::new(16), 5, 7)
+    }
+
+    #[test]
+    fn packed_bf16_k2_view() -> TractResult<()> {
+        view_matches_tensor(&PackedBf16K2::new(16), 64, 48)?;
+        view_matches_tensor(&PackedBf16K2::new(16), 5, 7)
     }
 }

--- a/linalg/tests/virtual_im2col.rs
+++ b/linalg/tests/virtual_im2col.rs
@@ -294,9 +294,9 @@ impl MMMInputFormat for EagerIm2colSpec {
         todo!();
     }
 
-    fn prepare_one(
+    fn prepare_one_view(
         &self,
-        _t: &Tensor,
+        _t: &TensorView,
         _k_axis: usize,
         _mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
@@ -417,9 +417,9 @@ impl MMMInputFormat for LazyIm2colSpec {
     fn prepare_tensor(&self, _t: &Tensor, _k_axis: usize, _mn_axis: usize) -> TractResult<Tensor> {
         todo!();
     }
-    fn prepare_one(
+    fn prepare_one_view(
         &self,
-        _t: &Tensor,
+        _t: &TensorView,
         _k_axis: usize,
         _mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {


### PR DESCRIPTION
`OptMatMulPack` packed through a hand-written downcast allowlist naming `PackedFormat`, `PackedI8K4` and `PackedAmxA`, so a format it did not list failed at eval — at optimize time for const weights, at run time otherwise — even though `PackedAmxBf16A` and `PackedBf16K2` implement exactly the view packing it wanted, and the trait already dispatches whole-tensor packing dynamically. `MMMInputFormat::prepare_one_view` now carries that entry point and `prepare_one` defaults to it, so the allowlist is gone and a new format cannot be silently unreachable: the two formats with no strided-view semantics, block quant and lazy im2col, say so. `PackedFormat`'s twin tensor and view packers collapse onto one body, and `DynPackedExoticFact` asks the format for its own buffer size instead of assuming an unpadded plain packing.