### PR TITLE
ci: say which silicon a job drew

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -79,6 +79,9 @@ jobs:
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
+    - name: CPU features
+      run: .travis/cpu-features.sh
+
     - name: Cargo test
       # tract-linalg and the test-rt suites run thousands of tiny cases; -q
       # collapses the per-test lines to dots so the CI log stays readable.

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -97,6 +97,9 @@ jobs:
       with:
         save-if: false # restore-only: schedule/dispatch job, never save (would evict the per-PR caches under the 10 GB cap)
 
+    - name: CPU features
+      run: .travis/cpu-features.sh
+
     - name: example tests
       env:
         MATRIX_EX: ${{matrix.ex}}

--- a/.travis/ci-system-setup.sh
+++ b/.travis/ci-system-setup.sh
@@ -3,6 +3,8 @@ set -e
 
 [ -d $ROOT/.travis ] || exit 1 "\$ROOT not set correctly '$ROOT'"
 
+sh $ROOT/.travis/cpu-features.sh
+
 export RUSTUP_TOOLCHAIN
 PATH=$PATH:$HOME/.cargo/bin
 
@@ -36,7 +38,6 @@ if [ -n "$CI" -a ! -e /tmp/ci-setup-done -a -z "$TRACT_PREBUILT_CI" ]
 then
     if [ `uname` = "Darwin" ]
     then
-        sysctl -n machdep.cpu.brand_string
         python3 --version
         brew install coreutils numpy python-setuptools jshon
         PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"

--- a/.travis/cpu-features.sh
+++ b/.travis/cpu-features.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Which silicon this job drew. The hosted-runner fleet is mixed -- AMD parts without avx512 next
+# to Intel parts with amx -- so a green run says nothing about whether the kernels behind a
+# feature ran at all, unless the job says what it had.
+
+if [ "$(uname)" = "Darwin" ]
+then
+    sysctl -n machdep.cpu.brand_string
+    exit 0
+fi
+
+[ -e /proc/cpuinfo ] || exit 0
+
+grep -m1 -E '^(model name|Model)' /proc/cpuinfo || true
+grep -m1 -E '^(flags|Features)' /proc/cpuinfo | cut -d: -f2 | tr ' ' '\n' \
+    | grep -xE 'avx|avx2|fma|f16c|avx_vnni|avx512[a-z0-9_]*|amx_[a-z0-9]+|neon|asimdhp|asimddp|i8mm|bf16|sve|sve2|sme|sme2' \
+    | sort | tr '\n' ' ' || true
+echo

--- a/.travis/test-harness.sh
+++ b/.travis/test-harness.sh
@@ -3,12 +3,6 @@
 WHITE='\033[1;37m'
 NC='\033[0m' # No Color
 
-if [ -e /proc/cpuinfo ]
-then
-    grep "^flags" /proc/cpuinfo | head -1 | \
-        grep --color=always '\(s\?sse[0-9_]*\|fma\|f16c\|avx[^ ]*\)'
-fi
-
 set -x
 
 ROOT=$(dirname $0)/..

--- a/.travis/test-published-crates.sh
+++ b/.travis/test-published-crates.sh
@@ -3,12 +3,6 @@
 WHITE='\033[1;37m'
 NC='\033[0m' # No Color
 
-if [ -e /proc/cpuinfo ]
-then
-    grep "^flags" /proc/cpuinfo | head -1 | \
-        grep --color=always '\(s\?sse[0-9_]*\|fma\|f16c\|avx[^ ]*\)'
-fi
-
 set -x
 
 ROOT=$(dirname $0)/..

--- a/.travis/test-rt.sh
+++ b/.travis/test-rt.sh
@@ -3,12 +3,6 @@
 WHITE='\033[1;37m'
 NC='\033[0m' # No Color
 
-if [ -e /proc/cpuinfo ]
-then
-    grep "^flags" /proc/cpuinfo | head -1 | \
-        grep --color=always '\(s\?sse[0-9_]*\|fma\|f16c\|avx[^ ]*\)'
-fi
-
 set -x
 
 ROOT=$(dirname $0)/..


### PR DESCRIPTION
The hosted-runner fleet is mixed — seven consecutive `old-harness` draws were AMD parts with no avx512 at all, while the same night's `onnx-mobilenet-v2` job ran on a part with amx-bf16 — so a green run says nothing about whether the kernels behind a feature were exercised. Three copies of the same flags-grep lived in `.travis` test scripts, two of which no workflow runs; they move into `cpu-features.sh`, which `ci-system-setup.sh` calls for every script-driven job and which also covers the mac brand-string print it replaces. The unit-test matrix and the examples jobs run cargo directly and never source the setup, so they call it as a step of their own.