### PR TITLE
docs: fix typos perfom -> perform, commited -> committed

### DIFF
--- a/doc/graph.md
+++ b/doc/graph.md
@@ -83,7 +83,7 @@ the value (a tensor) of each wire in the graph,
 
 tract actually does much more than running the network as described in previous
 section. It is capable of performing several optimisations, at the single node
-or at the graph level. It can also perfom specific transformation, like
+or at the graph level. It can also perform specific transformation, like
 converting a streaming network to a pulsing network.
 
 In order to perform these network rewrites, tract needs to be able to reason

--- a/examples/keras-tract-tf2/README.md
+++ b/examples/keras-tract-tf2/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 python example.py
 ```
 
-(Outputs are commited to git, you don't need to run the python step at all.)
+(Outputs are committed to git, you don't need to run the python step at all.)
 
 # Rust side inference
 


### PR DESCRIPTION
Two typo fixes:

- `doc/graph.md:86` — "It can also perfom" → "perform"
- `examples/keras-tract-tf2/README.md:17` — "Outputs are commited to git" → "committed"

Docs only.
