### PR TITLE
core/cnn: lower the lazy-im2col kernel-volume default from 6 to 3

### DIFF
--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1338,11 +1338,19 @@ impl TypedOp for Conv {
 ///
 /// LazyIm2col has per-output-position gather indirection overhead; eager Im2col has
 /// materialisation overhead (one big alloc + strided memcpy). For tiny kernels the
-/// indirection wins; for bigger kernels the materialisation cost dominates. This default
-/// is conservative — empirically lazy already wins for kernel volumes ≥ 4 on Apple AMX
-/// (and likely lower on memory-constrained targets like embedded ARM). Override via
-/// `TRACT_LAZY_IM2COL_MIN_KERNEL` env var to experiment with lower thresholds.
-const DEFAULT_LAZY_IM2COL_MIN_KERNEL: usize = 6;
+/// indirection wins; for bigger kernels the materialisation cost dominates.
+///
+/// Measured on a speech-enhancement set (five FastEnhancer variants, GTCRN, two DTLN
+/// submodels, three DeepFilterNet3 submodels), aarch64 and wasm32 simd128, five
+/// interleaved rounds with one binary and this threshold as the only variable:
+/// dropping it from 6 to 3 is worth 2-4% natively on every FastEnhancer variant and on
+/// DeepFilterNet3's erb_dec, 1-2% on wasm, and leaves the models with no kernel volume
+/// in [3, 6) where they were. A kernel volume of 3 is common in this family (1-D
+/// convolutions over time, and 3x1/1x3 factorisations), and at 6 those all took the
+/// eager path.
+///
+/// Override via the `TRACT_LAZY_IM2COL_MIN_KERNEL` env var.
+const DEFAULT_LAZY_IM2COL_MIN_KERNEL: usize = 3;
 
 crate::declare_knob!(
     TRACT_ENABLE_BLOCKED_CONV,


### PR DESCRIPTION
`DEFAULT_LAZY_IM2COL_MIN_KERNEL` picks `LazyIm2col` over eager `Im2col` by kernel volume: lazy pays per-output-position gather indirection, eager pays materialisation. The default of 6 was documented as conservative, with a note that lazy already won at volumes >= 4 on Apple AMX.

A kernel volume of 3 is common in speech-enhancement models — 1-D convolutions over time, and the 3x1 / 1x3 factorisations — and at 6 all of those took the eager path.

### Measurement

Eleven models (five FastEnhancer variants, GTCRN, two DTLN submodels, three DeepFilterNet3 submodels), aarch64 and wasm32 plain simd128, five interleaved rounds, **one binary with this threshold as the only variable** and onnxruntime measured in the same rounds:

| model | native k3/k6 | native vs ORT (k6 → k3) | wasm k3/k6 |
|---|---|---|---|
| fastenhancer tiny | 0.96 | 0.95 → 0.91 | 0.99 |
| fastenhancer base | 0.96 | **1.03 → 0.99** | 0.98 |
| fastenhancer small | 0.97 | 1.00 → 0.97 | 0.98 |
| fastenhancer medium | 0.98 | 0.74 → 0.73 | 0.99 |
| fastenhancer large | 0.97 | 0.67 → 0.65 | 1.00 |
| DeepFilterNet3 erb_dec | 0.95 | 1.15 → 1.10 | 0.99 |

2-4% natively on six models, 1-2% on wasm. The five models with no kernel volume in [3, 6) — GTCRN, both DTLN stages, DeepFilterNet3 enc and df_dec — sit at 0.99-1.01 on both targets, inside the run-to-run band; dtln-1 has no convolution at all.

Going below 3 buys nothing: a sweep of 3 / 2 / 1 moves every model by less than 1% on both targets, since a 1x1 convolution's im2col is already close to a reshape.

### Testing

`cargo test --workspace` (macOS, minus `test-tflite` / `tract-proxy` / `tract-proxy-sys` / `test-cuda`), run with `conv.rs` at this branch and reverted to `main` in the same tree: 106 suites, 69090 passed both ways, with an identical set of 73 pre-existing failures.