### PR TITLE
perf(linalg): keep f32 tanh in range by its input clamp alone

### DIFF
--- a/linalg/arm64/arm64simd/arm64simd_tanh_f32_4n.S.j2
+++ b/linalg/arm64/arm64simd/arm64simd_tanh_f32_4n.S.j2
@@ -16,8 +16,6 @@
     ld1         { v0.4s, v1.4s, v2.4s, v3.4s }, [x2]
     dup         v5.4s, v0.s[0]              // v5 <- low, broadcasted
     dup         v6.4s, v0.s[1]              // v6 <- high, broadcasted
-    dup         v4.4s, v3.s[0]              // v4 <- 1.0, broadcasted
-    dup         v7.4s, v3.s[1]              // v7 <- -1.0, broadcasted
 
     cmp         x1, #16
     blt         .loop
@@ -131,16 +129,6 @@
     fdiv        v18.4s, v18.4s, v26.4s
     fdiv        v19.4s, v19.4s, v27.4s
 
-    fmax        v16.4s, v16.4s, v7.4s
-    fmax        v17.4s, v17.4s, v7.4s
-    fmax        v18.4s, v18.4s, v7.4s
-    fmax        v19.4s, v19.4s, v7.4s
-
-    fmin        v16.4s, v16.4s, v4.4s
-    fmin        v17.4s, v17.4s, v4.4s
-    fmin        v18.4s, v18.4s, v4.4s
-    fmin        v19.4s, v19.4s, v4.4s
-
     st1         { v16.4s, v17.4s, v18.4s, v19.4s }, [x0], #64
 
     subs        x1, x1, #16
@@ -180,9 +168,6 @@
 
     fdiv        v16.4s, v16.4s, v24.4s
 
-    fmax        v16.4s, v16.4s, v7.4s
-    fmin        v16.4s, v16.4s, v4.4s
-
     st1         { v16.4s }, [x0], #16
 
     subs        x1, x1, #4
@@ -192,8 +177,8 @@
     ret
 
 .coeffs_num:
-    .float -8.9                     // low
-    .float 8.9                      // high
+    .float -7.5                     // low
+    .float 7.5                      // high
     .float -8.488492677e-14         // alpha_13
     .float 5.277853000e-11
 
@@ -208,6 +193,6 @@
     .float 0.4641733162
 
     .float 1.0
-    .float -1.0                     // output clamp low
+    .float 0                        // padding
     .float 0                        // padding
     .float 0                        // padding

--- a/linalg/src/arm64/arm64simd/gelu_fused.rs
+++ b/linalg/src/arm64/arm64simd/gelu_fused.rs
@@ -20,8 +20,8 @@ ew_impl_wrap!(aarch64;
         //   index 14: sqrt(2/pi)              ≈ 0.7978846
         //   index 15: 0.044715 * sqrt(2/pi)   ≈ 0.0356774
         static COEFFS: [f32; 16] = [
-            -8.9,
-            8.9,
+            -7.5,
+            7.5,
             -8.488492677e-14,
             5.277853000e-11,
             -2.022500419e-8,
@@ -51,12 +51,12 @@ ew_impl_wrap!(aarch64;
             // Register layout (loop4):
             //   v0-v3: coefficients
             //   v4:    sqrt(2/pi)  (broadcast of v3.s[2])
-            //   v5:    tanh clamp low (-8.9, dup v0.s[0])
-            //   v6:    tanh clamp high (8.9, dup v0.s[1])
+            //   v5:    tanh clamp low (-7.5, dup v0.s[0])
+            //   v6:    tanh clamp high (7.5, dup v0.s[1])
             //   v7:    0.5 (broadcast of v3.s[1])
             //   v8-v11: 0.5 * original x (saved after load)
             //   v16-v19: working (load -> pre_tanh -> clamped -> numerator)
-            //   v20-v23: x² for tanh polynomial (v20/v21 reused for the tanh clamp)
+            //   v20-v23: x² for tanh polynomial
             //   v24-v27: polynomial intermediates (denominator at end)
             //   v28-v31: polynomial intermediates (also x³ temp before tanh)
             std::arch::asm!("
@@ -209,21 +209,9 @@ ew_impl_wrap!(aarch64;
                     fdiv v18.4s, v18.4s, v26.4s
                     fdiv v19.4s, v19.4s, v27.4s
 
-                    // The quotient can reach ±(1 + 2^-23), which takes the 0.5*(1 + tanh)
-                    // factor out of (0, 1): below 0 it flips the result's sign, above 1 it
-                    // pushes the result past x. x² is dead here, so v20/v21 carry the bounds.
-                    fmov v20.4s, #-1.0
-                    fmov v21.4s, #1.0
-                    fmax v16.4s, v16.4s, v20.4s
-                    fmax v17.4s, v17.4s, v20.4s
-                    fmax v18.4s, v18.4s, v20.4s
-                    fmax v19.4s, v19.4s, v20.4s
-                    fmin v16.4s, v16.4s, v21.4s
-                    fmin v17.4s, v17.4s, v21.4s
-                    fmin v18.4s, v18.4s, v21.4s
-                    fmin v19.4s, v19.4s, v21.4s
-
-                    // result = 0.5*x * (1 + tanh) = (0.5*x) + (0.5*x) * tanh
+                    // result = 0.5*x * (1 + tanh) = (0.5*x) + (0.5*x) * tanh, one
+                    // rounding, so the sign holds as long as the quotient holds [-1, 1] —
+                    // which is what keeps the argument clamp at 7.5 and not higher.
                     fmla v8.4s, v8.4s, v16.4s
                     fmla v9.4s, v9.4s, v17.4s
                     fmla v10.4s, v10.4s, v18.4s
@@ -274,11 +262,6 @@ ew_impl_wrap!(aarch64;
                     fmla v24.4s, v20.4s, v28.4s
 
                     fdiv v16.4s, v16.4s, v24.4s
-
-                    fmov v20.4s, #-1.0
-                    fmov v21.4s, #1.0
-                    fmax v16.4s, v16.4s, v20.4s
-                    fmin v16.4s, v16.4s, v21.4s
 
                     fmla v8.4s, v8.4s, v16.4s
 

--- a/linalg/src/frame/gelu.rs
+++ b/linalg/src/frame/gelu.rs
@@ -52,6 +52,13 @@ pub mod test {
                     $crate::frame::gelu::test::test_gelu_magnitude::<$ker, $t>().unwrap()
                 }
             }
+
+            #[test]
+            fn sign_and_magnitude_on_saturating_tail_sweep() {
+                if $cond {
+                    $crate::frame::gelu::test::test_gelu_exhaustive_tail::<$ker, $t>().unwrap()
+                }
+            }
         };
     }
 
@@ -80,6 +87,51 @@ pub mod test {
             "a magnitude not above the input's",
             |x, y| y.abs() <= x.abs(),
         )
+    }
+
+    /// Assert both invariants over every `f32` of `[3, 6]` and its negation, the band where
+    /// the pre-tanh argument crosses the clamp a fused kernel applies to it.
+    ///
+    /// A fused kernel that carries no clamp on the tanh quotient holds these invariants
+    /// only because that argument clamp stops short of where the quotient's own rounding
+    /// would cross `±1`. The arguments that cross land a few `1e-7` apart, so the grid
+    /// [`test_gelu_sign`] and [`test_gelu_magnitude`] sweep steps over them. `f16` skips
+    /// this: its own grid enumerates the whole type.
+    pub fn test_gelu_exhaustive_tail<K: ElementWiseKer<T>, T: LADatum + Float>() -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        if T::datum_type() != <f32 as tract_data::prelude::Datum>::datum_type() {
+            return Ok(());
+        }
+        crate::setup_test_logger();
+        const CHUNK: usize = 1 << 16;
+        let end = 6f32.to_bits();
+        for sign in [1f32, -1f32] {
+            let mut inputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut outputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut bits = 3f32.to_bits();
+            while bits <= end {
+                inputs.clear();
+                while bits <= end && inputs.len() < CHUNK {
+                    inputs.push((sign * f32::from_bits(bits)).as_());
+                    bits += 1;
+                }
+                outputs.clear();
+                outputs.extend_from_slice(&inputs);
+                K::ew().run(&mut outputs).unwrap();
+                for (x, y) in inputs.iter().zip(outputs.iter()) {
+                    let signed = if *x < T::zero() { *y <= T::zero() } else { *y >= T::zero() };
+                    proptest::prop_assert!(
+                        signed && y.abs() <= x.abs(),
+                        "{}({x:?}) returned {y:?}, expected the input's sign and no more \
+                         than its magnitude",
+                        K::name()
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn test_gelu<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/frame/tanh.rs
+++ b/linalg/src/frame/tanh.rs
@@ -86,6 +86,14 @@ pub mod test {
             }
 
             #[test]
+            fn tanh_range_on_saturating_tail_sweep() {
+                if $cond {
+                    $crate::frame::tanh::test::test_tanh_range_exhaustive_tail::<$ker, $t>()
+                        .unwrap()
+                }
+            }
+
+            #[test]
             fn tanh_asymptots() {
                 use tract_data::internal::*;
                 use $crate::frame::element_wise::*;
@@ -99,8 +107,10 @@ pub mod test {
                         .map(|x| <f32 as num_traits::AsPrimitive<$t>>::as_(*x))
                         .collect();
                     <$ker>::ew().run(&mut input).unwrap();
+                    // The input clamp stops short of saturation, so the tails land a few
+                    // ulps inside ±1 instead of on it.
                     tensor1(&input)
-                        .close_enough(&tensor1(&expected), Approximation::Close)
+                        .close_enough(&tensor1(&expected), Approximation::Ulp(16))
                         .unwrap();
                 }
             }
@@ -118,6 +128,50 @@ pub mod test {
             "a result in [-1, 1]",
             |_, y| y >= -T::one() && y <= T::one(),
         )
+    }
+
+    /// Assert the same range over every `f32` of the saturating tail, `[6, 9]` and its
+    /// negation.
+    ///
+    /// A kernel that carries no output clamp holds its range only because its input clamp
+    /// stops short of where the quotient's own rounding would cross `±1`. The inputs that
+    /// cross sit a few `1e-7` apart, so the grid [`test_tanh_range`] sweeps steps over
+    /// them: only enumerating the tail pins the clamp down. `f16` is already enumerated
+    /// whole, and skips this.
+    pub fn test_tanh_range_exhaustive_tail<K: ElementWiseKer<T>, T: LADatum + Float>()
+    -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        if T::datum_type() != <f32 as tract_data::prelude::Datum>::datum_type() {
+            return Ok(());
+        }
+        crate::setup_test_logger();
+        const CHUNK: usize = 1 << 16;
+        let end = 9f32.to_bits();
+        for sign in [1f32, -1f32] {
+            let mut inputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut outputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut bits = 6f32.to_bits();
+            while bits <= end {
+                inputs.clear();
+                while bits <= end && inputs.len() < CHUNK {
+                    inputs.push((sign * f32::from_bits(bits)).as_());
+                    bits += 1;
+                }
+                outputs.clear();
+                outputs.extend_from_slice(&inputs);
+                K::ew().run(&mut outputs).unwrap();
+                for (x, y) in inputs.iter().zip(outputs.iter()) {
+                    proptest::prop_assert!(
+                        *y >= -T::one() && *y <= T::one(),
+                        "{}({x:?}) returned {y:?}, expected a result in [-1, 1]",
+                        K::name()
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn test_tanh<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/generic/tanh.rs
+++ b/linalg/src/generic/tanh.rs
@@ -4,14 +4,16 @@ use tract_data::internal::*;
 
 /// f32 tanh, as a rational minimax fit of `tanh` over `[LOW, HIGH]`.
 ///
-/// The quotient is clamped to `[-1, 1]` to keep the range consumers rely on. Across the
-/// top of the input range the correctly rounded result is already within one ulp of `±1`
-/// — `1 - tanh(8.9)` is `3.7e-8`, under the `2^-24` f32 step just below 1 — while the two
-/// Horner chains and the division leave a few ulps of relative error, so an upward
-/// rounding lands on `±(1 + 2^-22)`. NaN still propagates.
+/// The clamp keeps the `[-1, 1]` range consumers rely on without an output clamp: the two
+/// Horner chains and the division leave a few ulps of relative error, and the largest
+/// quotient any f32 input produces stays seven f32 steps under 1. It costs the tails their
+/// last few ulps — a saturated input returns `±(1 - 6.1e-7)`, not `±1`. NaN propagates.
+///
+/// Raising the clamp voids this: `1 - tanh(8.18)` is already under the rounding error, so
+/// the quotient crosses 1 at scattered inputs from there up.
 pub fn stanh(x: f32) -> f32 {
-    const LOW: f32 = -8.9;
-    const HIGH: f32 = 8.9;
+    const LOW: f32 = -7.5;
+    const HIGH: f32 = 7.5;
 
     const ALPHA_13: f32 = -8.488492677e-14;
     const ALPHA_11: f32 = 5.277853000e-11;
@@ -44,13 +46,13 @@ pub fn stanh(x: f32) -> f32 {
     let q = x2 * q + BETA_2;
     let q = x2 * q + BETA_0;
 
-    (p / q).clamp(-1.0, 1.0)
+    p / q
 }
 
 /// f16 tanh, as a rational minimax fit of `tanh` over `[LOW, HIGH]`.
 ///
-/// Needs no output clamp, unlike [`stanh`]: `1 - tanh(3.84)` is `9.3e-4`, about two f16
-/// steps below 1, so the quotient keeps its margin for every f16 input.
+/// Needs no output clamp, like [`stanh`]: `1 - tanh(3.84)` is `9.3e-4`, about two
+/// f16 steps below 1, so the quotient keeps its margin for every f16 input.
 pub fn htanh(x: f16) -> f16 {
     const LOW: f16 = f16::from_f32_const(-3.84);
     const HIGH: f16 = f16::from_f32_const(3.84);


### PR DESCRIPTION
Lowering the input clamp to ±7.5 leaves the quotient seven f32 steps under 1 for every input, so f32 tanh and the fused GELU hold their range with no clamp on the result.

Saturated inputs now return ±(1 - 6.1e-7) rather than exactly ±1.