### PR TITLE
perf(linalg): keep wasm, x86 and arm32 f32 tanh in range by input clamp

### DIFF
--- a/linalg/arm32/armv7neon/armv7neon_tanh_f32_4n.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_tanh_f32_4n.S.j2
@@ -8,6 +8,12 @@
 /*
     s16–s31 (d8–d15, q4–q7) must be preserved
     s0–s15 (d0–d7, q0–q3) and d16–d31 (q8–q15) do not need to be preserved
+
+    The input clamp alone holds the result in [-1, 1], so the quotient carries
+    none. Its bound is this kernel's own: the reciprocal here is a vrecpe
+    estimate refined by two Newton steps rather than a divide, which leaves the
+    quotient two f32 steps nearer 1 than the dividing kernels at the same clamp.
+    Raising it voids the range, as the quotient crosses 1 from 8.06 up.
 */
 
 armv7neon_tanh_f32_4n_{{suffix}}:
@@ -17,7 +23,7 @@ armv7neon_tanh_f32_4n_{{suffix}}:
     vpush       { q4-q7 }
 
     adr         r2, .coeffs_num
-    vldmia      r2!, { s0-s13 }
+    vldmia      r2!, { s0-s12 }
 
 // q4 -> q4,5,6
 // q5 -> q7,8,9
@@ -128,15 +134,6 @@ armv7neon_tanh_f32_4n_{{suffix}}:
     vmul.f32    q11, q5, q8
     vmul.f32    q12, q6, q9
 
-    vdup.32     q13, d6[1]
-    vdup.32     q14, d6[0]
-    vmax.f32    q10, q13
-    vmax.f32    q11, q13
-    vmax.f32    q12, q13
-    vmin.f32    q10, q14
-    vmin.f32    q11, q14
-    vmin.f32    q12, q14
-
     vstmia      r0!, { q10, q11, q12 }
 
     subs        r1, #12
@@ -187,11 +184,6 @@ armv7neon_tanh_f32_4n_{{suffix}}:
 
     vmul.f32    q10, q4, q7
 
-    vdup.32     q13, d6[1]
-    vdup.32     q4, d6[0]
-    vmax.f32    q10, q13
-    vmin.f32    q10, q4
-
     vstmia      r0!, { q10 }
 
     subs        r1, #4;
@@ -202,8 +194,8 @@ armv7neon_tanh_f32_4n_{{suffix}}:
     bx          lr
 
 .coeffs_num:
-    .float -8.9                     // low
-    .float 8.9                      // high
+    .float -7.5                     // low
+    .float 7.5                      // high
     .float -8.488492677e-14         // alpha_13
     .float 5.277853000e-11
 
@@ -218,6 +210,6 @@ armv7neon_tanh_f32_4n_{{suffix}}:
     .float 0.4641733162
 
     .float 1.0
-    .float -1.0                     // output clamp low
+    .float 0                        // padding
     .float 0                        // padding
     .float 0                        // padding

--- a/linalg/src/wasm/act.rs
+++ b/linalg/src/wasm/act.rs
@@ -148,8 +148,8 @@ impl ElementWiseKer<f32> for WasmTanh4Relaxed {
         debug_assert!(buf.len() % Self::nr() == 0);
         debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
 
-        const LOW: f32 = -8.9;
-        const HIGH: f32 = 8.9;
+        const LOW: f32 = -7.5;
+        const HIGH: f32 = 7.5;
 
         const ALPHA_13: f32 = -8.488492677e-14;
         const ALPHA_11: f32 = 5.277853000e-11;
@@ -181,9 +181,6 @@ impl ElementWiseKer<f32> for WasmTanh4Relaxed {
             let b2 = f32x4_splat(BETA_2);
             let b0 = f32x4_splat(BETA_0);
 
-            let one = f32x4_splat(1.0);
-            let minus_one = f32x4_splat(-1.0);
-
             let mut p = buf.as_mut_ptr();
             let end = p.add(buf.len());
             while p < end {
@@ -205,11 +202,10 @@ impl ElementWiseKer<f32> for WasmTanh4Relaxed {
                 let qn = f32x4_relaxed_madd(x2, qn, b2);
                 let qn = f32x4_relaxed_madd(x2, qn, b0);
 
-                // tanh is (-1, 1): the quotient comes within one ulp of ±1 across the top
-                // of the input range, under the kernel's own rounding error, so it needs
-                // clamping to stay in range.
+                // The clamp keeps tanh inside (-1, 1) with no clamp on the quotient:
+                // the largest quotient it admits stays seven f32 steps under 1, whether
+                // `relaxed_madd` fuses on this host or not.
                 let r = f32x4_div(pn, qn);
-                let r = f32x4_min(one, f32x4_max(minus_one, r));
                 v128_store(p as *mut v128, r);
                 p = p.add(4);
             }

--- a/linalg/x86_64/avx512/tanh_f32.S.j2
+++ b/linalg/x86_64/avx512/tanh_f32.S.j2
@@ -2,8 +2,14 @@
 // vim: set syntax=asm :
 
 // AVX-512 (zmm, 16-wide) tanh. Polynomial-numerator / polynomial-denominator
-// rational approximation of tanh clamped to [-9, 9]. Validated against the
+// rational approximation of tanh clamped to [-7.5, 7.5]. Validated against the
 // generic scalar reference via tanh_frame_tests! (see x86_64.rs).
+//
+// The coefficients are this kernel's own, not the fit the other f32 tanh kernels
+// share, so its clamp answers to its own error. That clamp alone holds the result
+// in [-1, 1], so the quotient carries none: raising it voids the range, as the
+// quotient crosses 1 from 8.13 up, where 1 - tanh(x) has fallen under the fmadd
+// chains' rounding error.
 
 System V ABI:
     args: rdi, rsi, rdx, rcx, r8, r9
@@ -184,18 +190,6 @@ avx512_tanh_f32_{{suffix}} proc
     vdivps          zmm6, zmm6, zmm14
     vdivps          zmm7, zmm7, zmm15
 
-    // This fit's beta_0 is not 1.0, so both bounds come from the table
-    vbroadcastss    zmm0, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
-    vbroadcastss    zmm1, dword ptr [{{offset}} {{L}}coeffs_num_one]
-    vmaxps          zmm4, zmm4, zmm0
-    vmaxps          zmm5, zmm5, zmm0
-    vmaxps          zmm6, zmm6, zmm0
-    vmaxps          zmm7, zmm7, zmm0
-    vminps          zmm4, zmm4, zmm1
-    vminps          zmm5, zmm5, zmm1
-    vminps          zmm6, zmm6, zmm1
-    vminps          zmm7, zmm7, zmm1
-
     vmovaps [rdi], zmm4
     vmovaps [rdi + 64], zmm5
     vmovaps [rdi + 128], zmm6
@@ -248,11 +242,6 @@ avx512_tanh_f32_{{suffix}} proc
 
     vdivps          zmm4, zmm4, zmm12
 
-    vbroadcastss    zmm0, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
-    vbroadcastss    zmm1, dword ptr [{{offset}} {{L}}coeffs_num_one]
-    vmaxps          zmm4, zmm4, zmm0
-    vminps          zmm4, zmm4, zmm1
-
     vmovaps [rdi], zmm4
     add     rdi, 64
     sub     rsi, 16
@@ -295,9 +284,9 @@ avx512_tanh_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -9.0                     // low
+    {{float}} -7.5                     // low
 {{L}}coeffs_num_high:
-    {{float}} 9.0                      // high
+    {{float}} 7.5                      // high
 
 {{L}}coeffs_num_alpha_13:
     {{float}} -2.76076847742355e-16    // alpha_13
@@ -322,11 +311,6 @@ avx512_tanh_f32_{{suffix}} proc
     {{float}} 2.26843463243900e-03     // beta_2
 {{L}}coeffs_num_beta_0:
     {{float}} 4.89352518554385e-03     // beta_0
-
-{{L}}coeffs_num_one:
-    {{float}} 1.0
-{{L}}coeffs_num_minus_one:
-    {{float}} -1.0
 
 {% if msvc %}
 avx512_tanh_f32_{{suffix}} endp

--- a/linalg/x86_64/fma/avx_tanh_f32.S.j2
+++ b/linalg/x86_64/fma/avx_tanh_f32.S.j2
@@ -216,17 +216,6 @@ avx_tanh_f32_{{suffix}} proc
     vdivps          ymm6, ymm6, ymm14
     vdivps          ymm7, ymm7, ymm15
 
-    // ymm0 still holds beta_0, which this fit sets to 1.0; the denominator chain freed ymm1
-    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
-    vmaxps          ymm4, ymm4, ymm1
-    vmaxps          ymm5, ymm5, ymm1
-    vmaxps          ymm6, ymm6, ymm1
-    vmaxps          ymm7, ymm7, ymm1
-    vminps          ymm4, ymm4, ymm0
-    vminps          ymm5, ymm5, ymm0
-    vminps          ymm6, ymm6, ymm0
-    vminps          ymm7, ymm7, ymm0
-
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -288,10 +277,6 @@ avx_tanh_f32_{{suffix}} proc
 
     vdivps          ymm4, ymm4, ymm12
 
-    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
-    vmaxps          ymm4, ymm4, ymm1
-    vminps          ymm4, ymm4, ymm0
-
     vmovaps [rdi], ymm4
     add     rdi, 32
     sub     rsi, 8
@@ -334,9 +319,9 @@ avx_tanh_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -8.9
+    {{float}} -7.5
 {{L}}coeffs_num_high:
-    {{float}} 8.9
+    {{float}} 7.5
 
 {{L}}coeffs_num_alpha_13:
     {{float}} -8.488492677e-14
@@ -361,11 +346,6 @@ avx_tanh_f32_{{suffix}} proc
     {{float}} 0.4641733162
 {{L}}coeffs_num_beta_0:
     {{float}} 1.0
-
-{{L}}coeffs_num_minus_one:
-    {{float}} -1.0
-
-
 
 {% if msvc %}
 avx_tanh_f32_{{suffix}} endp

--- a/linalg/x86_64/fma/fma_tanh_f32.S.j2
+++ b/linalg/x86_64/fma/fma_tanh_f32.S.j2
@@ -180,17 +180,6 @@ fma_tanh_f32_{{suffix}} proc
     vdivps          ymm6, ymm6, ymm14
     vdivps          ymm7, ymm7, ymm15
 
-    // ymm0 still holds beta_0, which this fit sets to 1.0; the denominator chain freed ymm1
-    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
-    vmaxps          ymm4, ymm4, ymm1
-    vmaxps          ymm5, ymm5, ymm1
-    vmaxps          ymm6, ymm6, ymm1
-    vmaxps          ymm7, ymm7, ymm1
-    vminps          ymm4, ymm4, ymm0
-    vminps          ymm5, ymm5, ymm0
-    vminps          ymm6, ymm6, ymm0
-    vminps          ymm7, ymm7, ymm0
-
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -243,10 +232,6 @@ fma_tanh_f32_{{suffix}} proc
 
     vdivps          ymm4, ymm4, ymm12
 
-    vbroadcastss    ymm1, dword ptr [{{offset}} {{L}}coeffs_num_minus_one]
-    vmaxps          ymm4, ymm4, ymm1
-    vminps          ymm4, ymm4, ymm0
-
     vmovaps [rdi], ymm4
     add     rdi, 32
     sub     rsi, 8
@@ -289,9 +274,9 @@ fma_tanh_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -8.9
+    {{float}} -7.5
 {{L}}coeffs_num_high:
-    {{float}} 8.9
+    {{float}} 7.5
 
 {{L}}coeffs_num_alpha_13:
     {{float}} -8.488492677e-14
@@ -316,11 +301,6 @@ fma_tanh_f32_{{suffix}} proc
     {{float}} 0.4641733162
 {{L}}coeffs_num_beta_0:
     {{float}} 1.0
-
-{{L}}coeffs_num_minus_one:
-    {{float}} -1.0
-
-
 
 {% if msvc %}
 fma_tanh_f32_{{suffix}} endp


### PR DESCRIPTION
Lowering the input clamp to ±7.5 leaves every quotient short of 1, so the f32 tanh kernels that still clamped their result no longer need to. The AVX-512 kernel fits its own coefficients and answers to its own bound; that one also covers the f16 tanh and the fused GELU built on it.

Saturated inputs now land within a dozen f32 steps of ±1 rather than exactly on it.

Refs: commit f84914bb635693c09d08691047d802c5102d59e6