### PR TITLE
Fix Windows ARM64 linalg assembly builds

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -61,6 +61,21 @@ jobs:
             core.setOutput('test_ref', ref);
             core.setOutput('tract_bench_branch_name', benchBranch);
 
+  windows-arm64:
+    needs: prepare
+    runs-on: windows-11-vs2026-arm
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
+        fetch-depth: 0
+        persist-credentials: false
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      with:
+        toolchain: stable
+    - name: Check tract-linalg
+      run: cargo check -p tract-linalg
+
   linux:
     needs: prepare
     strategy:

--- a/linalg/build.rs
+++ b/linalg/build.rs
@@ -4,8 +4,23 @@ fn var(k: &str) -> String {
     env::var(k).unwrap()
 }
 
+fn target_is_windows_arm64_msvc() -> bool {
+    env::var("CARGO_CFG_TARGET_ARCH") == Ok("aarch64".to_string())
+        && env::var("CARGO_CFG_TARGET_ENV") == Ok("msvc".to_string())
+}
+
 fn use_masm() -> bool {
-    env::var("CARGO_CFG_TARGET_ENV") == Ok("msvc".to_string()) && var("HOST").contains("-windows-")
+    env::var("CARGO_CFG_TARGET_ENV") == Ok("msvc".to_string())
+        && var("HOST").contains("-windows-")
+        && !target_is_windows_arm64_msvc()
+}
+
+fn arm64_cc() -> cc::Build {
+    let mut build = cc::Build::new();
+    if target_is_windows_arm64_msvc() {
+        build.compiler("clang");
+    }
+    build
 }
 
 fn include_amx() -> bool {
@@ -44,7 +59,7 @@ fn assembler_supports_sme() -> bool {
 // SDOT kernel and the `tract_arm64_dotprod` cfg; the runtime falls back to the
 // SMLAL 8x8 i32 kernel.
 fn assembler_supports_dotprod() -> bool {
-    cc::Build::new()
+    arm64_cc()
         .file("arm64/arm64simd/dummy_dotprod.S")
         .cargo_metadata(false)
         .cargo_warnings(false)
@@ -206,7 +221,7 @@ impl ConfigForHalf {
     }
 
     fn cc(&self) -> cc::Build {
-        let mut cc = cc::Build::new();
+        let mut cc = arm64_cc();
         for flag in &self.extra_flags {
             cc.flag(flag);
         }
@@ -436,7 +451,7 @@ fn main() {
             files.retain(|f| {
                 !f.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.contains("_dot"))
             });
-            cc::Build::new().files(files).compile("arm64simd");
+            arm64_cc().files(files).compile("arm64simd");
             // The template stays in arm64/arm64simd/ (alongside the jinja partials
             // it includes) so the env can resolve its includes. The
             // `tract_arm64_dotprod` cfg gates the matching Rust extern + dispatch.
@@ -444,7 +459,7 @@ fn main() {
                 let tmpl = path::Path::new("arm64/arm64simd/arm64simd_mmm_i32_8x8_dot.S.j2");
                 let out = out_dir.join(format!("arm64simd_mmm_i32_8x8_dot_{suffix}.S"));
                 preprocess_file(tmpl, &out, &[], &suffix, false);
-                cc::Build::new().file(&out).compile("arm64simd_dot");
+                arm64_cc().file(&out).compile("arm64simd_dot");
                 println!("cargo:rustc-cfg=tract_arm64_dotprod");
             }
             if include_amx() {


### PR DESCRIPTION
`tract-linalg` currently routes generated ARM64 assembly through the MSVC/MASM path on native Windows ARM64. `cl.exe` does not assemble the generated `.S` files, while Clang needs the GNU-rendered form.

This keeps the existing MASM path for Windows x64, but uses GNU rendering and Clang for `aarch64-pc-windows-msvc`. A focused native Windows ARM64 CI job now checks `tract-linalg`.

Validation:

- `cargo fmt --all -- --check`
- `cargo check --locked -p tract-linalg` on macOS ARM64
- cross-check generated 25 AArch64 COFF objects without an external `CC` override (linking then stopped at the expected missing Windows `lib.exe` on macOS)
- [native Windows ARM64 downstream build](https://github.com/MichaelxBelmonte/melina-audio/actions/runs/32732935914/job/97449074205) linked and packaged DeepFilterNet/libDF as a PE32+ AArch64 DLL using the same assembly-path fix
- `cargo test --locked -p tract-linalg --lib`: 4444 passed, 2 ignored; the 4 SME failures reproduce unchanged on `main`
