### PR TITLE
perf(linalg): keep f32 sigmoid in range by its input clamp alone

### DIFF
--- a/linalg/arm32/armv7neon/armv7neon_sigmoid_f32_4n.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_sigmoid_f32_4n.S.j2
@@ -8,6 +8,13 @@
 /*
     s16–s31 (d8–d15, q4–q7) must be preserved
     s0–s15 (d0–d7, q0–q3) and d16–d31 (q8–q15) do not need to be preserved
+
+    The input clamp alone holds the result in [0, 1], so the sum carries none.
+    Its bound is this kernel's own: the reciprocal here is a vrecpe estimate
+    refined by two Newton steps rather than a divide, which lands two f32 steps
+    off it and leaves the sum nearer the bounds than the dividing kernels at the
+    same clamp. Raising it voids the range, as the sum crosses 1 from 15.92 up —
+    the lowest crossing of any f32 sigmoid kernel, and so what fixes 14.5.
 */
 
 armv7neon_sigmoid_f32_4n_{{suffix}}:
@@ -132,17 +139,6 @@ armv7neon_sigmoid_f32_4n_{{suffix}}:
     vmla.f32    q11, q5, q8
     vmla.f32    q12, q6, q9
 
-    // sigmoid is (0, 1): the vmla above cancels down to ~1e-8 on either tail, below the
-    // rounding error of the reciprocal, so the sum needs clamping to stay in range.
-    vmov.i32    q13, #0
-    vdup.32     q14, d6[0]
-    vmax.f32    q10, q13
-    vmax.f32    q11, q13
-    vmax.f32    q12, q13
-    vmin.f32    q10, q14
-    vmin.f32    q11, q14
-    vmin.f32    q12, q14
-
     vstmia      r0!, { q10, q11, q12 }
 
     subs        r1, #12
@@ -194,11 +190,6 @@ armv7neon_sigmoid_f32_4n_{{suffix}}:
     vdup.32     q10, d6[1]
     vmla.f32    q10, q4, q7
 
-    vmov.i32    q13, #0
-    vdup.32     q14, d6[0]
-    vmax.f32    q10, q13
-    vmin.f32    q10, q14
-
     vstmia      r0!, { q10 }
 
     subs        r1, #4;
@@ -209,8 +200,8 @@ armv7neon_sigmoid_f32_4n_{{suffix}}:
     bx          lr
 
 .coeffs_num:
-    .float -18.6                    // low
-    .float 18.6                     // high
+    .float -14.5                    // low
+    .float 14.5                     // high
     .float -4.433153405e-18         // alpha_13
     .float 1.169974371e-14
 

--- a/linalg/arm32/armv7neon/armv7neon_silu_f32_4n.S.j2
+++ b/linalg/arm32/armv7neon/armv7neon_silu_f32_4n.S.j2
@@ -8,23 +8,30 @@
 /*
     Fused SiLU kernel.
 
-    Per element (z = clamp(x, -18.6, 18.6), w = z^2):
-        SiLU(x) = f * max(0.5 + z * P(w) / Q(w), 0)
+    Per element (z = clamp(x, -14.5, 14.5), w = z^2):
+        SiLU(x) = f * (0.5 + z * P(w) / Q(w))
     where P is the degree-6 Horner polynomial over the numerator coeffs, Q the
-    degree-3 Horner polynomial over the denominator coeffs, and f = max(x, -18.6)
+    degree-3 Horner polynomial over the denominator coeffs, and f = max(x, -14.5)
     the factor the sigmoid multiplies. Reuses the sigmoid coefficients and
-    reciprocal of armv7neon_sigmoid_f32_4n.S.j2.
+    reciprocal of armv7neon_sigmoid_f32_4n.S.j2, whose own bound is derived from
+    the same error, so the two land on the same number rather than one tracking
+    the other.
 
-    f is clamped below at -18.6 but left unclamped above: the upper clamp only
+    f is clamped below at -14.5 but left unclamped above: the upper clamp only
     keeps the sigmoid polynomial argument z in range, whereas SiLU(x) ~ x as
     x -> +inf so the factor must stay unbounded above. The lower clamp keeps the
-    negative tail bounded: x < -18.6 saturates at -18.6 * sigmoid(-18.6), which
+    negative tail bounded: x < -14.5 saturates at -14.5 * sigmoid(-14.5), which
     the true SiLU approaches from below as x -> -inf.
+
+    The sigmoid needs no floor before it multiplies f: 14.5 is low enough that
+    the vmla holding `+ 0.5` stays clear of 0, which is what the argument clamp
+    buys here and not merely a bound the sigmoid polynomial needs. It is a lower
+    bound than the dividing kernels need, since the reciprocal here is a vrecpe
+    estimate refined by two Newton steps.
 
     ARMv7 has only 16 q registers, so f (q4/q5) is kept across a 2-group
     (8-element) main loop. That leaves q14/q15 as the only registers free across
-    the whole body: they hold the zero floor and the low clamp, so the high clamp
-    is the one constant still re-duped per iteration.
+    the whole body, and with no floor to hold they carry both clamp bounds.
 
     s16-s31 (d8-d15, q4-q7) must be preserved
     s0-s15 (d0-d7, q0-q3) and d16-d31 (q8-q15) do not need to be preserved
@@ -39,8 +46,8 @@ armv7neon_silu_f32_4n_{{suffix}}:
     adr         r2, .coeffs_num
     vldmia      r2!, { s0-s13 }
 
-    vmov.i32    q14, #0                    // q14 <- 0
-    vdup.32     q15, d0[0]                 // q15 <- low = -18.6
+    vdup.32     q14, d0[1]                 // q14 <- high = 14.5
+    vdup.32     q15, d0[0]                 // q15 <- low = -14.5
 
     cmp         r1, #8
     blt         .loop
@@ -49,10 +56,9 @@ armv7neon_silu_f32_4n_{{suffix}}:
     vldmia      r0, { q6, q7 }             // q6,q7 <- x
 
     vmax.f32    q4, q6, q15
-    vmax.f32    q5, q7, q15                // q4,q5 <- f = max(x, -18.6)
-    vdup.32     q10, d0[1]
-    vmin.f32    q6, q4, q10
-    vmin.f32    q7, q5, q10                // q6,q7 <- z = min(f, 18.6)
+    vmax.f32    q5, q7, q15                // q4,q5 <- f = max(x, -14.5)
+    vmin.f32    q6, q4, q14
+    vmin.f32    q7, q5, q14                // q6,q7 <- z = min(f, 14.5)
 
     vmul.f32    q8, q6, q6                 // q8,q9 <- w = z^2
     vmul.f32    q9, q7, q7
@@ -117,11 +123,6 @@ armv7neon_silu_f32_4n_{{suffix}}:
     vmla.f32    q10, q6, q8                // q10,q11 <- sigmoid = 0.5 + num/denum
     vmla.f32    q11, q7, q9
 
-    // The vmla above cancels down to ~1e-8 on the negative tail, below the rounding error
-    // of the reciprocal; a sigmoid that came out negative would flip the sign of the SiLU.
-    vmax.f32    q10, q10, q14              // q10,q11 <- sigmoid, floored at 0
-    vmax.f32    q11, q11, q14
-
     vmul.f32    q10, q10, q4               // q10,q11 <- SiLU = sigmoid * f
     vmul.f32    q11, q11, q5
 
@@ -137,9 +138,8 @@ armv7neon_silu_f32_4n_{{suffix}}:
 .loop:
     vldmia      r0, { q6 }                 // q6 <- x
 
-    vmax.f32    q4, q6, q15                // q4 <- f = max(x, -18.6)
-    vdup.32     q10, d0[1]
-    vmin.f32    q6, q4, q10                // q6 <- z = min(f, 18.6)
+    vmax.f32    q4, q6, q15                // q4 <- f = max(x, -14.5)
+    vmin.f32    q6, q4, q14                // q6 <- z = min(f, 14.5)
 
     vmul.f32    q8, q6, q6                 // q8 <- w = z^2
 
@@ -175,8 +175,6 @@ armv7neon_silu_f32_4n_{{suffix}}:
     vdup.32     q10, d6[1]
     vmla.f32    q10, q6, q8                // q10 <- sigmoid = 0.5 + num/denum
 
-    vmax.f32    q10, q10, q14              // q10 <- sigmoid, floored at 0
-
     vmul.f32    q10, q10, q4               // q10 <- SiLU = sigmoid * f
 
     vstmia      r0!, { q10 }
@@ -189,8 +187,8 @@ armv7neon_silu_f32_4n_{{suffix}}:
     bx          lr
 
 .coeffs_num:
-    .float -18.6                    // low
-    .float 18.6                     // high
+    .float -14.5                    // low
+    .float 14.5                     // high
     .float -4.433153405e-18         // alpha_13
     .float 1.169974371e-14
 

--- a/linalg/arm64/arm64simd/arm64simd_sigmoid_f32_4n.S.j2
+++ b/linalg/arm64/arm64simd/arm64simd_sigmoid_f32_4n.S.j2
@@ -17,7 +17,6 @@
     dup         v5.4s, v0.s[0]              // v5 <- low, broadcasted
     dup         v6.4s, v0.s[1]              // v6 <- high, broadcasted
     dup         v7.4s, v3.s[1]              // v7 <- 0.5, broadcasted
-    movi        v4.4s, #0                   // v4 <- 0, the output floor
 
     cmp         x1, #16
     blt         .loop
@@ -136,19 +135,6 @@
     fadd        v18.4s, v18.4s, v7.4s
     fadd        v19.4s, v19.4s, v7.4s
 
-    // sigmoid is (0, 1): the fadd above cancels down to ~1e-8 on either tail, below the
-    // rounding error of the division, so the sum needs clamping to stay in range. The loop
-    // has no register free to hold the 1.0 ceiling, so it lands over the dead x^2 in v20.
-    dup         v20.4s, v3.s[0]
-    fmax        v16.4s, v16.4s, v4.4s
-    fmax        v17.4s, v17.4s, v4.4s
-    fmax        v18.4s, v18.4s, v4.4s
-    fmax        v19.4s, v19.4s, v4.4s
-    fmin        v16.4s, v16.4s, v20.4s
-    fmin        v17.4s, v17.4s, v20.4s
-    fmin        v18.4s, v18.4s, v20.4s
-    fmin        v19.4s, v19.4s, v20.4s
-
     st1         { v16.4s, v17.4s, v18.4s, v19.4s }, [x0], #64
 
     subs        x1, x1, #16
@@ -189,10 +175,6 @@
     fdiv        v16.4s, v16.4s, v24.4s
     fadd        v16.4s, v16.4s, v7.4s
 
-    dup         v20.4s, v3.s[0]             // v20 <- 1.0
-    fmax        v16.4s, v16.4s, v4.4s
-    fmin        v16.4s, v16.4s, v20.4s
-
     st1         { v16.4s }, [x0], #16
 
     subs        x1, x1, #4
@@ -202,8 +184,8 @@
     ret
 
 .coeffs_num:
-    .float -18.6                    // low
-    .float 18.6                     // high
+    .float -14.5                    // low
+    .float 14.5                     // high
     .float -4.433153405e-18         // alpha_13
     .float 1.169974371e-14
 

--- a/linalg/src/arm64/arm64simd/silu_fused.rs
+++ b/linalg/src/arm64/arm64simd/silu_fused.rs
@@ -1,26 +1,25 @@
 // Fused SiLU kernel
 //
-// Exact formula computed per element (z = clamp(x, -18.6, 18.6), w = z²):
-//   SiLU(x) = f * max(0.5 + z * P(w) / Q(w), 0)
+// Exact formula computed per element (z = clamp(x, -14.5, 14.5), w = z²):
+//   SiLU(x) = f * (0.5 + z * P(w) / Q(w))
 // where P is the degree-6 Horner polynomial over coeffs COEFFS[2..=8], Q the
-// degree-3 Horner polynomial over coeffs COEFFS[9..=12], and f = max(x, -18.6)
+// degree-3 Horner polynomial over coeffs COEFFS[9..=12], and f = max(x, -14.5)
 // the factor the sigmoid multiplies.
 //
 // Reuses the polynomial coefficients used in the numerical approximation of the Sigmoid kernel
 // defined in arm64simd_sigmoid_f32_4n.S.j2.
 //
-// The sigmoid factor f is clamped below at -18.6 but left unclamped above: the upper clamp is
+// The sigmoid factor f is clamped below at -14.5 but left unclamped above: the upper clamp is
 // only needed to keep the sigmoid polynomial in range (z), whereas SiLU(x) ~ x as x -> +inf, so
 // the factor must stay unbounded above. The lower clamp keeps the kernel total: without it, the
-// negative tail would return x * sigmoid(-18.6), whose magnitude grows toward -inf instead of
-// decaying to 0. With it, x < -18.6 saturates at the constant -18.6 * sigmoid(-18.6) ~= -1.55e-7,
+// negative tail would return x * sigmoid(-14.5), whose magnitude grows toward -inf instead of
+// decaying to 0. With it, x < -14.5 saturates at the constant -14.5 * sigmoid(-14.5) ~= -6.9e-6,
 // which the true SiLU approaches from below as x -> -inf, so the error is bounded and tiny.
 //
-// The sigmoid factor is floored at 0 before it multiplies f: `0.5 + z * P(w) / Q(w)` cancels
-// down to ~1e-8 on the negative tail, below the rounding error of the division, and a sigmoid
-// that came out negative there would flip the sign of the whole result. It needs no matching
-// ceiling — the sigmoid kernel clamps at 1 to keep its own range, but here an overshoot of one
-// ulp only scales f by 1 + 2^-23, and SiLU has no upper bound to violate.
+// The sigmoid needs no floor before it multiplies f: 14.5 is low enough that
+// `0.5 + z * P(w) / Q(w)` stays six f32 steps above 0, which is what the argument clamp buys
+// here and not merely a bound the sigmoid polynomial needs. Nor does it need a ceiling: an
+// overshoot of one ulp would only scale f by 1 + 2^-23, and SiLU has no upper bound to violate.
 
 ew_impl_wrap!(aarch64;
     f32,
@@ -31,8 +30,8 @@ ew_impl_wrap!(aarch64;
     #[inline(never)]
     fn run(buf: &mut [f32], _: ()) {
         static COEFFS: [f32; 16] = [
-            -18.6,
-            18.6,
+            -14.5,
+            14.5,
             -4.433153405e-18,
             1.169974371e-14,
             -1.875289645e-11,
@@ -64,7 +63,6 @@ ew_impl_wrap!(aarch64;
                 dup v5.4s, v0.s[0]             // v5 <- low, broadcasted
                 dup v6.4s, v0.s[1]             // v6 <- high, broadcasted
                 dup v7.4s, v3.s[1]             // v7 <- 0.5, broadcasted
-                movi v4.4s, #0                 // v4 <- 0, the sigmoid floor
 
                 cmp {len}, #16
                 blt 9f
@@ -75,7 +73,7 @@ ew_impl_wrap!(aarch64;
                     fmax v8.4s, v8.4s, v5.4s
                     fmax v9.4s, v9.4s, v5.4s
                     fmax v10.4s, v10.4s, v5.4s
-                    fmax v11.4s, v11.4s, v5.4s     // v8 <- max(x, -18.6): SiLU factor
+                    fmax v11.4s, v11.4s, v5.4s     // v8 <- max(x, -14.5): SiLU factor
 
                     fmin v16.4s, v8.4s, v6.4s
                     fmin v17.4s, v9.4s, v6.4s
@@ -183,11 +181,6 @@ ew_impl_wrap!(aarch64;
                     fadd v18.4s, v18.4s, v7.4s
                     fadd v19.4s, v19.4s, v7.4s     // v16 <- sigmoid
 
-                    fmax v16.4s, v16.4s, v4.4s
-                    fmax v17.4s, v17.4s, v4.4s
-                    fmax v18.4s, v18.4s, v4.4s
-                    fmax v19.4s, v19.4s, v4.4s     // v16 <- sigmoid, floored at 0
-
                     fmul v16.4s, v16.4s, v8.4s
                     fmul v17.4s, v17.4s, v9.4s
                     fmul v18.4s, v18.4s, v10.4s
@@ -204,7 +197,7 @@ ew_impl_wrap!(aarch64;
                 2:
                     ld1 {{ v8.4s }}, [{ptr}]
 
-                    fmax v8.4s, v8.4s, v5.4s       // v8 <- max(x, -18.6): SiLU factor
+                    fmax v8.4s, v8.4s, v5.4s       // v8 <- max(x, -14.5): SiLU factor
                     fmin v16.4s, v8.4s, v6.4s      // v16 <- z (clamped for sigmoid)
                     fmul v20.4s, v16.4s, v16.4s    // v20 <- x2
 
@@ -230,8 +223,7 @@ ew_impl_wrap!(aarch64;
                     fmla v24.4s, v20.4s, v28.4s    // v24 <- denum
 
                     fdiv v16.4s, v16.4s, v24.4s
-                    fadd v16.4s, v16.4s, v7.4s
-                    fmax v16.4s, v16.4s, v4.4s     // v16 <- sigmoid, floored at 0
+                    fadd v16.4s, v16.4s, v7.4s     // v16 <- sigmoid
 
                     fmul v16.4s, v16.4s, v8.4s     // v16 <- SiLU (sigmoid * clamped-below x)
 
@@ -245,7 +237,7 @@ ew_impl_wrap!(aarch64;
             ptr = inout(reg) ptr => _,
             len = inout(reg) len => _,
             out("v0") _, out("v1") _, out("v2") _, out("v3") _,
-            out("v4") _, out("v5") _, out("v6") _, out("v7") _,
+            out("v5") _, out("v6") _, out("v7") _,
             out("v8") _, out("v9") _, out("v10") _, out("v11") _,
             out("v16") _, out("v17") _, out("v18") _, out("v19") _,
             out("v20") _, out("v21") _, out("v22") _, out("v23") _,

--- a/linalg/src/frame/sigmoid.rs
+++ b/linalg/src/frame/sigmoid.rs
@@ -79,6 +79,14 @@ pub mod test {
             }
 
             #[test]
+            fn sigmoid_range_on_saturating_tail_sweep() {
+                if $cond {
+                    $crate::frame::sigmoid::test::test_sigmoid_range_exhaustive_tail::<$ker, $t>()
+                        .unwrap()
+                }
+            }
+
+            #[test]
             fn sigmoid_asymptots() {
                 use tract_data::internal::*;
                 use $crate::frame::element_wise::*;
@@ -92,9 +100,16 @@ pub mod test {
                         .map(|x| <f32 as num_traits::AsPrimitive<$t>>::as_(*x))
                         .collect();
                     <$ker>::ew().run(&mut input).unwrap();
-                    tensor1(&input)
-                        .close_enough(&tensor1(&expected), Approximation::Close)
-                        .unwrap();
+                    // The input clamp stops short of saturation, so the tails land a few
+                    // ulps inside [0, 1] instead of on it. `Close` still fits f16, whose
+                    // own clamp costs it about 1e-3; f32's needs the atol widened, and a
+                    // relative bound is no use against the 0 asymptote.
+                    let approx = if <$t>::datum_type() == f16::datum_type() {
+                        Approximation::Close
+                    } else {
+                        Approximation::Custom(1e-6, 1e-6, 0.)
+                    };
+                    tensor1(&input).close_enough(&tensor1(&expected), approx).unwrap();
                 }
             }
         };
@@ -110,6 +125,50 @@ pub mod test {
             "a result in [0, 1]",
             |_, y| y >= T::zero() && y <= T::one(),
         )
+    }
+
+    /// Assert the same range over every `f32` of the saturating tail, `[13, 18]` and its
+    /// negation.
+    ///
+    /// A kernel that carries no output clamp holds its range only because its input clamp
+    /// stops short of where the `+ 0.5` cancellation runs under the rounding error of
+    /// `p / q`. The inputs that cross sit a few `1e-7` apart, so the grid
+    /// [`test_sigmoid_range`] sweeps steps over them: only enumerating the tail pins the
+    /// clamp down. `f16` is already enumerated whole, and skips this.
+    pub fn test_sigmoid_range_exhaustive_tail<K: ElementWiseKer<T>, T: LADatum + Float>()
+    -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        if T::datum_type() != <f32 as tract_data::prelude::Datum>::datum_type() {
+            return Ok(());
+        }
+        crate::setup_test_logger();
+        const CHUNK: usize = 1 << 16;
+        let end = 18f32.to_bits();
+        for sign in [1f32, -1f32] {
+            let mut inputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut outputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut bits = 13f32.to_bits();
+            while bits <= end {
+                inputs.clear();
+                while bits <= end && inputs.len() < CHUNK {
+                    inputs.push((sign * f32::from_bits(bits)).as_());
+                    bits += 1;
+                }
+                outputs.clear();
+                outputs.extend_from_slice(&inputs);
+                K::ew().run(&mut outputs).unwrap();
+                for (x, y) in inputs.iter().zip(outputs.iter()) {
+                    proptest::prop_assert!(
+                        *y >= T::zero() && *y <= T::one(),
+                        "{}({x:?}) returned {y:?}, expected a result in [0, 1]",
+                        K::name()
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn test_sigmoid<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/frame/silu.rs
+++ b/linalg/src/frame/silu.rs
@@ -56,10 +56,17 @@ pub mod test {
             }
 
             #[test]
+            fn sign_on_saturating_tail_sweep() {
+                if $cond {
+                    $crate::frame::silu::test::test_silu_sign_exhaustive_tail::<$ker, $t>().unwrap()
+                }
+            }
+
+            #[test]
             fn tails() {
                 if $cond {
                     $crate::frame::silu::test::test_silu::<$ker, $t>(&[
-                        -100.0, -30.0, -18.6, -15.0, 15.0, 18.6, 30.0, 100.0,
+                        -100.0, -30.0, -14.5, -12.0, 12.0, 14.5, 30.0, 100.0,
                     ])
                     .unwrap();
                 }
@@ -78,6 +85,51 @@ pub mod test {
             "the sign of the input",
             |x, y| if x < T::zero() { y <= T::zero() } else { y >= T::zero() },
         )
+    }
+
+    /// Assert the same sign over every `f32` of the saturating tail, `[13, 18]` and its
+    /// negation.
+    ///
+    /// A kernel that carries no floor on its sigmoid factor holds the sign only because
+    /// the argument clamp stops short of where that factor's `+ 0.5` runs under the
+    /// rounding error of `p / q`. The inputs that cross sit a few `1e-7` apart, so the
+    /// grid [`test_silu_sign`] sweeps steps over them: only enumerating the tail pins the
+    /// clamp down. `f16` is already enumerated whole, and skips this.
+    pub fn test_silu_sign_exhaustive_tail<K: ElementWiseKer<T>, T: LADatum + Float>()
+    -> TestCaseResult
+    where
+        f32: AsPrimitive<T>,
+    {
+        if T::datum_type() != <f32 as tract_data::prelude::Datum>::datum_type() {
+            return Ok(());
+        }
+        crate::setup_test_logger();
+        const CHUNK: usize = 1 << 16;
+        let end = 18f32.to_bits();
+        for sign in [1f32, -1f32] {
+            let mut inputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut outputs: Vec<T> = Vec::with_capacity(CHUNK);
+            let mut bits = 13f32.to_bits();
+            while bits <= end {
+                inputs.clear();
+                while bits <= end && inputs.len() < CHUNK {
+                    inputs.push((sign * f32::from_bits(bits)).as_());
+                    bits += 1;
+                }
+                outputs.clear();
+                outputs.extend_from_slice(&inputs);
+                K::ew().run(&mut outputs).unwrap();
+                for (x, y) in inputs.iter().zip(outputs.iter()) {
+                    let signed = if *x < T::zero() { *y <= T::zero() } else { *y >= T::zero() };
+                    proptest::prop_assert!(
+                        signed,
+                        "{}({x:?}) returned {y:?}, expected the sign of the input",
+                        K::name()
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn test_silu<K: ElementWiseKer<T>, T: LADatum + Float>(values: &[f32]) -> TestCaseResult

--- a/linalg/src/generic/sigmoid.rs
+++ b/linalg/src/generic/sigmoid.rs
@@ -2,14 +2,27 @@
 use crate::frame::element_wise::ElementWiseKer;
 use tract_data::internal::*;
 
+/// The input clamp of the f32 sigmoid fit, shared by [`ssigmoid`] and by the SiLU kernels
+/// built on the same coefficients.
+///
+/// It alone holds the result inside `[0, 1]`, so a SiLU kernel needs it as the floor of
+/// the factor its sigmoid multiplies. See [`ssigmoid`] for what fixes its value.
+pub const LOW: f32 = -14.5;
+
 /// f32 sigmoid, as a rational minimax fit of `sigmoid(x) - 0.5` over `[LOW, HIGH]`.
 ///
-/// The sum is clamped to `[0, 1]` to keep the range consumers rely on: on either tail
-/// `p / q` approaches ±0.5 and the final `+ 0.5` cancels down to ~1e-8, below the ~6e-8
-/// f32 rounding error of `p / q` itself, so the sum can land just outside the interval.
-/// NaN still propagates.
+/// The clamp keeps the `[0, 1]` range consumers rely on without an output clamp: on either
+/// tail `p / q` approaches ±0.5 and the `+ 0.5` cancels against it, so the cancellation
+/// has to stay above the ~6e-8 f32 rounding error of `p / q` rather than run down to zero.
+/// At `±14.5` the sum keeps six f32 steps of margin at both ends for every f32 input. It
+/// costs the tails their last few ulps — a saturated input returns `1 - 4.8e-7` or
+/// `4.8e-7`, not exactly 1 or 0. NaN propagates.
+///
+/// Raising the clamp voids this: `1 - sigmoid(16.29)` is already under the rounding error,
+/// so the sum crosses 1 at scattered inputs from there up. `14.5` rather than something
+/// nearer 16 because the value is shared, and `armv7neon_sigmoid_f32_4n` crosses from
+/// 15.92 — it refines a `vrecpe` estimate instead of dividing.
 pub fn ssigmoid(x: f32) -> f32 {
-    const LOW: f32 = -18.6;
     const HIGH: f32 = -LOW;
 
     const ALPHA_13: f32 = -4.433153405e-18;
@@ -42,13 +55,13 @@ pub fn ssigmoid(x: f32) -> f32 {
     let q = x2 * q + BETA_2;
     let q = x2 * q + BETA_0;
 
-    (p / q + 0.5).clamp(0.0, 1.0)
+    p / q + 0.5
 }
 
 /// f16 sigmoid, as a rational minimax fit of `sigmoid(x) - 0.5` over `[LOW, HIGH]`.
 ///
-/// Needs no output clamp, unlike [`ssigmoid`]: the `+ 0.5` cancellation stays inside
-/// (0, 1) for every non-NaN f16 input.
+/// Needs no output clamp, like [`ssigmoid`]: the `+ 0.5` cancellation stays inside
+/// (0, 1) for every non-NaN f16 input, whatever the clamp.
 pub fn hsigmoid(x: f16) -> f16 {
     /*
      * (x (0.249895 + x^2 (0.00400222 - 0.0000124702 x^2)))

--- a/linalg/src/generic/silu.rs
+++ b/linalg/src/generic/silu.rs
@@ -1,8 +1,14 @@
 #![allow(clippy::excessive_precision)]
 use crate::frame::element_wise::ElementWiseKer;
-use crate::generic::sigmoid::ssigmoid;
+use crate::generic::sigmoid::{LOW, ssigmoid};
 use tract_data::internal::*;
 
+/// f32 SiLU, as `max(x, LOW) * ssigmoid(x)`.
+///
+/// The factor is floored at [`LOW`] rather than left as `x`: past the clamp [`ssigmoid`]
+/// returns the constant `4.8e-7` instead of exactly 0, so an unfloored factor would take
+/// the negative tail to `-inf` instead of decaying to 0. Floored, `x < LOW` saturates at
+/// `LOW * ssigmoid(LOW)` ~= `-6.9e-6`, which the true SiLU approaches from below.
 #[derive(Clone, Debug)]
 pub struct SSiLU4;
 
@@ -26,10 +32,11 @@ impl ElementWiseKer<f32> for SSiLU4 {
     fn run(x: &mut [f32], _: ()) {
         debug_assert!(x.len() % Self::nr() == 0);
         debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
-        x.iter_mut().for_each(|px| *px *= ssigmoid(*px));
+        x.iter_mut().for_each(|px| *px = px.max(LOW) * ssigmoid(*px));
     }
 }
 
+/// f16 SiLU, evaluated on the f32 fit and narrowed, and floored like [`SSiLU4`].
 #[derive(Clone, Debug)]
 pub struct HSiLU8;
 
@@ -55,7 +62,7 @@ impl ElementWiseKer<f16> for HSiLU8 {
         debug_assert!(x.as_ptr() as usize % Self::alignment_bytes() == 0);
         x.iter_mut().for_each(|px| {
             let x_f32 = px.to_f32();
-            *px = f16::from_f32(x_f32 * ssigmoid(x_f32));
+            *px = f16::from_f32(x_f32.max(LOW) * ssigmoid(x_f32));
         });
     }
 }

--- a/linalg/src/wasm/act.rs
+++ b/linalg/src/wasm/act.rs
@@ -48,7 +48,7 @@ impl ElementWiseKer<f32> for WasmSigmoid4Relaxed {
 
         // Coefficients match generic/sigmoid.rs::ssigmoid bit-for-bit.
         // Output may differ by ≤1 ulp from scalar on FMA hosts (more accurate).
-        const LOW: f32 = -18.6;
+        const LOW: f32 = -14.5;
         const HIGH: f32 = -LOW;
 
         const ALPHA_13: f32 = -4.433153405e-18;
@@ -82,8 +82,6 @@ impl ElementWiseKer<f32> for WasmSigmoid4Relaxed {
             let b0 = f32x4_splat(BETA_0);
 
             let half = f32x4_splat(0.5);
-            let zero = f32x4_splat(0.0);
-            let one = f32x4_splat(1.0);
 
             let mut p = buf.as_mut_ptr();
             let end = p.add(buf.len());
@@ -108,11 +106,10 @@ impl ElementWiseKer<f32> for WasmSigmoid4Relaxed {
                 let qn = f32x4_relaxed_madd(x2, qn, b2);
                 let qn = f32x4_relaxed_madd(x2, qn, b0);
 
-                // sigmoid is (0, 1): the add below cancels down to ~1e-8 on either tail,
-                // below the rounding error of the division, so the sum needs clamping to
-                // stay in range.
+                // The clamp keeps sigmoid inside (0, 1) with no clamp on the sum: at
+                // 14.5 the cancellation below still leaves six f32 steps of margin at
+                // both ends, whether `relaxed_madd` fuses on this host or not.
                 let r = f32x4_add(f32x4_div(pn, qn), half);
-                let r = f32x4_min(one, f32x4_max(zero, r));
                 v128_store(p as *mut v128, r);
                 p = p.add(4);
             }

--- a/linalg/x86_64/avx512/sigmoid_f32.S.j2
+++ b/linalg/x86_64/avx512/sigmoid_f32.S.j2
@@ -2,8 +2,14 @@
 // vim: set syntax=asm :
 
 // AVX-512 (zmm, 16-wide) sigmoid. Uses a rational (Padé-style) approximation
-// of sigmoid clamped to [-18, 18]. Validated against the generic scalar
+// of sigmoid clamped to [-14.5, 14.5]. Validated against the generic scalar
 // reference via sigmoid_frame_tests! (see x86_64.rs).
+//
+// The coefficients are this kernel's own, not the fit the other f32 sigmoid kernels
+// share, so its clamp answers to its own error. That clamp alone holds the result
+// in [0, 1], so the sum carries none: raising it voids the range, as the sum
+// crosses 1 from 15.91 up, where 1 - sigmoid(x) has fallen under the fmadd chains'
+// rounding error.
 
 System V ABI:
     args: rdi, rsi, rdx, rcx, r8, r9
@@ -189,20 +195,6 @@ avx512_sigmoid_f32_{{suffix}} proc
     vaddps          zmm6, zmm6, zmm1
     vaddps          zmm7, zmm7, zmm1
 
-    // sigmoid is (0, 1): the vaddps above cancels down to ~1e-8 on either tail, below the
-    // rounding error of the division, so the sum needs clamping to stay in range. vpxord
-    // rather than vxorps: the latter needs AVX512DQ, this kernel only requires AVX512F.
-    vpxord          zmm0, zmm0, zmm0
-    vbroadcastss    zmm2, dword ptr [{{offset}} {{L}}coeffs_num_one]
-    vmaxps          zmm4, zmm4, zmm0
-    vmaxps          zmm5, zmm5, zmm0
-    vmaxps          zmm6, zmm6, zmm0
-    vmaxps          zmm7, zmm7, zmm0
-    vminps          zmm4, zmm4, zmm2
-    vminps          zmm5, zmm5, zmm2
-    vminps          zmm6, zmm6, zmm2
-    vminps          zmm7, zmm7, zmm2
-
     vmovaps [rdi], zmm4
     vmovaps [rdi + 64], zmm5
     vmovaps [rdi + 128], zmm6
@@ -257,11 +249,6 @@ avx512_sigmoid_f32_{{suffix}} proc
     vdivps          zmm4, zmm4, zmm12
     vaddps          zmm4, zmm4, zmm1
 
-    vpxord          zmm0, zmm0, zmm0
-    vbroadcastss    zmm2, dword ptr [{{offset}} {{L}}coeffs_num_one]
-    vmaxps          zmm4, zmm4, zmm0
-    vminps          zmm4, zmm4, zmm2
-
     vmovaps [rdi], zmm4
     add     rdi, 64
     sub     rsi, 16
@@ -304,9 +291,9 @@ avx512_sigmoid_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -18.0                    // low
+    {{float}} -14.5                    // low
 {{L}}coeffs_num_high:
-    {{float}} 18.0                     // high
+    {{float}} 14.5                     // high
 
 {{L}}coeffs_num_alpha_9:
     {{float}} 4.37031012579801e-11     // alpha_9
@@ -334,9 +321,6 @@ avx512_sigmoid_f32_{{suffix}} proc
 
 {{L}}coeffs_num_half:
     {{float}} 0.5
-
-{{L}}coeffs_num_one:
-    {{float}} 1.0
 
 {% if msvc %}
 avx512_sigmoid_f32_{{suffix}} endp

--- a/linalg/x86_64/avx512/silu_f32.S.j2
+++ b/linalg/x86_64/avx512/silu_f32.S.j2
@@ -3,24 +3,25 @@
 
 AVX-512 (zmm, 16-wide) fused SiLU.
 
-Per element (z = clamp(x, -18, 18), w = z^2):
-    SiLU(x) = f * max(0.5 + z * P(w) / Q(w), 0)
+Per element (z = clamp(x, -14.5, 14.5), w = z^2):
+    SiLU(x) = f * (0.5 + z * P(w) / Q(w))
 where P is the degree-4 Horner polynomial over the numerator coeffs, Q the
-degree-5 Horner polynomial over the denominator coeffs, and f = max(x, -18) the
-factor the sigmoid multiplies. Reuses the coefficients and the rational
-approximation of sigmoid_f32.S.j2, so the clamp bounds must stay equal to that
-kernel's.
+degree-5 Horner polynomial over the denominator coeffs, and f = max(x, -14.5)
+the factor the sigmoid multiplies. Reuses the coefficients and the rational
+approximation of sigmoid_f32.S.j2, whose own bound is derived from the same
+error, so the two land on the same number rather than one tracking the other.
 
-f is clamped below at -18 but left unclamped above: the upper clamp only keeps
+f is clamped below at -14.5 but left unclamped above: the upper clamp only keeps
 the sigmoid polynomial argument z in range, whereas SiLU(x) ~ x as x -> +inf so
 the factor must stay unbounded above. The lower clamp keeps the negative tail
-bounded: x < -18 saturates at -18 * sigmoid(-18), which the true SiLU
+bounded: x < -14.5 saturates at -14.5 * sigmoid(-14.5), which the true SiLU
 approaches from below as x -> -inf.
 
-The sigmoid factor is floored at 0 before it multiplies f: the final `+ 0.5`
-cancels to -2^-24 at the clamp point, so without the floor the entire negative
-tail comes back with the wrong sign. It needs no matching ceiling: an overshoot
-of one ulp only scales f by 1 + 2^-23, and SiLU has no upper bound to violate.
+The sigmoid needs no floor before it multiplies f: 14.5 is low enough that the
+final `+ 0.5` stays six f32 steps above 0, which is what the argument clamp buys
+here and not merely a bound the sigmoid polynomial needs. Nor does it need a
+ceiling: an overshoot of one ulp would only scale f by 1 + 2^-23, and SiLU has no
+upper bound to violate.
 
 Holding f costs nothing here: it lives in zmm16-19, which are volatile under
 both ABIs, so the 4-group (64 lanes) unrolling of the sigmoid kernel is kept
@@ -209,15 +210,6 @@ avx512_silu_f32_{{suffix}} proc
     vaddps          zmm6, zmm6, zmm1
     vaddps          zmm7, zmm7, zmm1        // zmm4..7 <- sigmoid
 
-    // The vaddps above lands on -2^-24 at the -18.0 clamp point, so the whole negative
-    // tail comes out with a sigmoid below zero, which would flip the sign of the SiLU.
-    // vpxord rather than vxorps: the latter needs AVX512DQ, this kernel only AVX512F.
-    vpxord          zmm0, zmm0, zmm0
-    vmaxps          zmm4, zmm4, zmm0
-    vmaxps          zmm5, zmm5, zmm0
-    vmaxps          zmm6, zmm6, zmm0
-    vmaxps          zmm7, zmm7, zmm0        // zmm4..7 <- sigmoid, floored at 0
-
     vmulps          zmm4, zmm4, zmm16
     vmulps          zmm5, zmm5, zmm17
     vmulps          zmm6, zmm6, zmm18
@@ -277,9 +269,6 @@ avx512_silu_f32_{{suffix}} proc
     vdivps          zmm4, zmm4, zmm12
     vaddps          zmm4, zmm4, zmm1        // zmm4 <- sigmoid
 
-    vpxord          zmm0, zmm0, zmm0
-    vmaxps          zmm4, zmm4, zmm0        // zmm4 <- sigmoid, floored at 0
-
     vmulps          zmm4, zmm4, zmm16       // zmm4 <- SiLU
 
     vmovaps [rdi], zmm4
@@ -324,9 +313,9 @@ avx512_silu_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -18.0                    // low
+    {{float}} -14.5                    // low
 {{L}}coeffs_num_high:
-    {{float}} 18.0                     // high
+    {{float}} 14.5                     // high
 
 {{L}}coeffs_num_alpha_9:
     {{float}} 4.37031012579801e-11     // alpha_9

--- a/linalg/x86_64/fma/avx_sigmoid_f32.S.j2
+++ b/linalg/x86_64/fma/avx_sigmoid_f32.S.j2
@@ -220,18 +220,6 @@ avx_sigmoid_f32_{{suffix}} proc
     vaddps          ymm6, ymm6, ymm1
     vaddps          ymm7, ymm7, ymm1
 
-    // sigmoid is (0, 1): the vaddps above cancels down to ~1e-8 on either tail, below the
-    // rounding error of the division, so the sum needs clamping to stay in range.
-    vxorps          ymm2, ymm2, ymm2
-    vmaxps          ymm4, ymm4, ymm2
-    vmaxps          ymm5, ymm5, ymm2
-    vmaxps          ymm6, ymm6, ymm2
-    vmaxps          ymm7, ymm7, ymm2
-    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
-    vminps          ymm5, ymm5, ymm0
-    vminps          ymm6, ymm6, ymm0
-    vminps          ymm7, ymm7, ymm0
-
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -295,10 +283,6 @@ avx_sigmoid_f32_{{suffix}} proc
     vdivps          ymm4, ymm4, ymm12
     vaddps          ymm4, ymm4, ymm1
 
-    vxorps          ymm2, ymm2, ymm2
-    vmaxps          ymm4, ymm4, ymm2
-    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
-
     vmovaps [rdi], ymm4
     add     rdi, 32
     sub     rsi, 8
@@ -340,9 +324,9 @@ avx_sigmoid_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -18.6                   // low
+    {{float}} -14.5                    // low
 {{L}}coeffs_num_high:
-    {{float}} 18.6                     // high         
+    {{float}} 14.5                     // high
 
 {{L}}coeffs_num_alpha_13:
     {{float}} -4.433153405e-18

--- a/linalg/x86_64/fma/fma_sigmoid_f32.S.j2
+++ b/linalg/x86_64/fma/fma_sigmoid_f32.S.j2
@@ -184,18 +184,6 @@ fma_sigmoid_f32_{{suffix}} proc
     vaddps          ymm6, ymm6, ymm1
     vaddps          ymm7, ymm7, ymm1
 
-    // sigmoid is (0, 1): the vaddps above cancels down to ~1e-8 on either tail, below the
-    // rounding error of the division, so the sum needs clamping to stay in range.
-    vxorps          ymm2, ymm2, ymm2
-    vmaxps          ymm4, ymm4, ymm2
-    vmaxps          ymm5, ymm5, ymm2
-    vmaxps          ymm6, ymm6, ymm2
-    vmaxps          ymm7, ymm7, ymm2
-    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
-    vminps          ymm5, ymm5, ymm0
-    vminps          ymm6, ymm6, ymm0
-    vminps          ymm7, ymm7, ymm0
-
     vmovaps [rdi], ymm4
     vmovaps [rdi + 32], ymm5
     vmovaps [rdi + 64], ymm6
@@ -250,10 +238,6 @@ fma_sigmoid_f32_{{suffix}} proc
     vdivps          ymm4, ymm4, ymm12
     vaddps          ymm4, ymm4, ymm1
 
-    vxorps          ymm2, ymm2, ymm2
-    vmaxps          ymm4, ymm4, ymm2
-    vminps          ymm4, ymm4, ymm0        // ymm0 still holds beta_0 = 1.0
-
     vmovaps [rdi], ymm4
     add     rdi, 32
     sub     rsi, 8
@@ -295,9 +279,9 @@ fma_sigmoid_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -18.6                   // low
+    {{float}} -14.5                    // low
 {{L}}coeffs_num_high:
-    {{float}} 18.6                     // high         
+    {{float}} 14.5                     // high
 
 {{L}}coeffs_num_alpha_13:
     {{float}} -4.433153405e-18

--- a/linalg/x86_64/fma/fma_silu_f32.S.j2
+++ b/linalg/x86_64/fma/fma_silu_f32.S.j2
@@ -3,24 +3,24 @@
 
 Fused SiLU kernel.
 
-Per element (z = clamp(x, -18.6, 18.6), w = z^2):
-    SiLU(x) = f * max(0.5 + z * P(w) / Q(w), 0)
+Per element (z = clamp(x, -14.5, 14.5), w = z^2):
+    SiLU(x) = f * (0.5 + z * P(w) / Q(w))
 where P is the degree-6 Horner polynomial over the numerator coeffs, Q the
-degree-3 Horner polynomial over the denominator coeffs, and f = max(x, -18.6)
+degree-3 Horner polynomial over the denominator coeffs, and f = max(x, -14.5)
 the factor the sigmoid multiplies. Reuses the coefficients and the rational
 approximation of fma_sigmoid_f32.S.j2.
 
-f is clamped below at -18.6 but left unclamped above: the upper clamp only
+f is clamped below at -14.5 but left unclamped above: the upper clamp only
 keeps the sigmoid polynomial argument z in range, whereas SiLU(x) ~ x as
 x -> +inf so the factor must stay unbounded above. The lower clamp keeps the
-negative tail bounded: x < -18.6 saturates at -18.6 * sigmoid(-18.6), which
+negative tail bounded: x < -14.5 saturates at -14.5 * sigmoid(-14.5), which
 the true SiLU approaches from below as x -> -inf.
 
-The sigmoid factor is floored at 0 before it multiplies f, since the final
-`+ 0.5` cancels down to ~1e-8 on the negative tail and a sigmoid that came out
-negative there would flip the sign of the whole result. It needs no matching
-ceiling: an overshoot of one ulp only scales f by 1 + 2^-23, and SiLU has no
-upper bound to violate.
+The sigmoid needs no floor before it multiplies f: 14.5 is low enough that the
+final `+ 0.5` stays six f32 steps above 0, which is what the argument clamp
+buys here and not merely a bound the sigmoid polynomial needs. Nor does it need
+a ceiling: an overshoot of one ulp would only scale f by 1 + 2^-23, and SiLU has
+no upper bound to violate.
 
 x86-64 has only 16 ymm registers and the sigmoid kernel already fills them with
 a 4-group loop, so holding f costs half the unrolling: the main loop here runs
@@ -173,12 +173,6 @@ fma_silu_f32_{{suffix}} proc
     vaddps          ymm4, ymm4, ymm1
     vaddps          ymm5, ymm5, ymm1        // ymm4..5 <- sigmoid
 
-    // The vaddps above cancels down to ~1e-8 on the negative tail, below the rounding error
-    // of the division; a sigmoid that came out negative would flip the sign of the SiLU.
-    vxorps          ymm0, ymm0, ymm0
-    vmaxps          ymm4, ymm4, ymm0
-    vmaxps          ymm5, ymm5, ymm0        // ymm4..5 <- sigmoid, floored at 0
-
     vmulps          ymm4, ymm4, ymm10
     vmulps          ymm5, ymm5, ymm11       // ymm4..5 <- SiLU
 
@@ -234,9 +228,6 @@ fma_silu_f32_{{suffix}} proc
     vdivps          ymm4, ymm4, ymm8
     vaddps          ymm4, ymm4, ymm1        // ymm4 <- sigmoid
 
-    vxorps          ymm0, ymm0, ymm0
-    vmaxps          ymm4, ymm4, ymm0        // ymm4 <- sigmoid, floored at 0
-
     vmulps          ymm4, ymm4, ymm10       // ymm4 <- SiLU
 
     vmovaps [rdi], ymm4
@@ -280,9 +271,9 @@ fma_silu_f32_{{suffix}} proc
 {% set float %}{% if msvc %} real4 {%else%} .float {%endif%}{% endset %}
 
 {{L}}coeffs_num_low:
-    {{float}} -18.6                   // low
+    {{float}} -14.5                    // low
 {{L}}coeffs_num_high:
-    {{float}} 18.6                     // high
+    {{float}} 14.5                     // high
 
 {{L}}coeffs_num_alpha_13:
     {{float}} -4.433153405e-18


### PR DESCRIPTION
Lowering the input clamp to ±14.5 leaves every `p / q + 0.5` short of both bounds, so the f32 sigmoid and SiLU kernels that clamped their result no longer need to. The bound is the arm32 kernel's: it refines a vrecpe estimate rather than dividing, and crosses 1 from 15.92 up where the others hold to 15.91 and above. The AVX-512 kernels fit their own coefficients and answer to their own error, which lands on the same bound. The generic SiLU keeps the clamp as the floor of its factor, which the sum reaching exactly 0 used to stand in for. Freeing the arm32 SiLU's zero register also hoists its high clamp out of both loops.

Saturated inputs now land within a dozen f32 steps of 0 and 1 rather than exactly on them.