### PR TITLE
linalg: prefer an mmm kernel by its architecture, not by a quality label

### DIFF
--- a/cli/src/hwbench.rs
+++ b/cli/src/hwbench.rs
@@ -7,7 +7,7 @@ use tract_core::tract_data::itertools::Itertools;
 use tract_libcli::terminal::si_prefix;
 use tract_linalg::hwbench::bandwidth::{l1_bandwidth_seq, main_memory_bandwith_seq};
 use tract_linalg::hwbench::runner::{run_bench, run_bench_fitting};
-use tract_linalg::mmm::{AsInputValue, FusedSpec, ImplementationQuality};
+use tract_linalg::mmm::{AsInputValue, FusedSpec};
 
 #[derive(serde::Serialize)]
 struct Bandwidth {
@@ -233,7 +233,7 @@ fn assert_picks(shapes: &[ShapeResult], tolerance: f64) -> TractResult<()> {
             continue;
         }
         // No viable kernel for this dtype on this target (e.g. armv7 f16 has only the
-        // emulated Dreadful kernel, which the bench skips) — nothing to assert.
+        // emulated kernel, which the bench skips) — nothing to assert.
         if shape.kernels.is_empty() {
             continue;
         }
@@ -402,16 +402,13 @@ fn bench_shape(
     let mmms = tract_linalg::MmmDispatch::native().runnable();
     let mut kernels: Vec<KernelResult> = unsafe {
         mmms.iter()
-            // Dreadful emulates the datatype op-by-op (f16->f32->f16), 100-500x off a
-            // real kernel and only ever the pick when the target has none for this
-            // dtype (e.g. armv7 f16) — the pick among fallbacks is noise, not a
-            // regression to gate on. Generic is portable Rust, so how close it comes
-            // depends on the compiler: off by default, --include-generic on targets
-            // where it is a real contender.
-            .filter(|mmm| {
-                mmm.quality() != ImplementationQuality::Dreadful
-                    && (include_generic || mmm.quality() != ImplementationQuality::Generic)
-            })
+            // An emulated kernel converts the datatype op by op (f16->f32->f16), 100-500x off
+            // a real kernel and only ever the pick when the target has none for this dtype
+            // (e.g. armv7 f16) — the pick among fallbacks is noise, not a regression to gate
+            // on. A generic kernel is portable Rust, so how close it comes depends on the
+            // compiler: off by default, --include-generic on targets where it is a real
+            // contender.
+            .filter(|mmm| !mmm.emulated() && (include_generic || mmm.arch().is_some()))
             .flat_map(|mmm| {
                 mmm.packings().iter().enumerate().map(move |(pix, (pa, pb))| (mmm, pix, pa, pb))
             })

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,8 +55,6 @@ use tract_linalg::mmm::MatMatMul;
 
 readings_probe::instrumented_allocator!();
 
-pub const QUALITY_COLORS: [nu_ansi_term::Color; 5] = [LightGreen, Green, White, Yellow, LightRed];
-
 fn info_usage(stage: &str, probe: Option<&Probe>) {
     if let Some(mon) = probe {
         let _ = mon.log_event(stage);
@@ -836,10 +834,17 @@ fn handle(matches: clap::ArgMatches, probe: Option<&Probe>) -> TractResult<()> {
         Some(("kernels", _)) => {
             println!();
             fn colored_name(m: &dyn MatMatMul) -> String {
+                let color = if m.emulated() {
+                    LightRed
+                } else if m.arch().is_some() {
+                    Green
+                } else {
+                    White
+                };
                 format!(
                     "{} {}",
-                    QUALITY_COLORS[m.quality().cost()].paint(m.name()),
-                    match m.declared_boost().signum() {
+                    color.paint(m.name()),
+                    match m.boost().signum() {
                         1 => Green.paint("●"),
                         -1 => Red.paint("●"),
                         _ => "-".to_string().into(),
@@ -854,7 +859,7 @@ fn handle(matches: clap::ArgMatches, probe: Option<&Probe>) -> TractResult<()> {
                     colored_name(&**m),
                     m.isa(),
                     m.isa().level(),
-                    m.declared_boost(),
+                    m.boost(),
                     m.stores()
                 );
                 for packings in m.packings() {

--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1,7 +1,7 @@
 use tract_data::itertools::izip;
 use tract_linalg::WeightType;
 use tract_linalg::block_quant::{BlockQuantFact, PackedBlockQuantFormat};
-use tract_linalg::mmm::retain_best_quality;
+use tract_linalg::mmm::retain_best;
 use tract_num_traits::Zero;
 
 use crate::internal::*;
@@ -571,7 +571,7 @@ impl Conv {
         };
         if weight_fact.is_exotic() {
             let mut suitable = tract_linalg::MmmDispatch::native().suitable(&query);
-            retain_best_quality(&mut suitable);
+            retain_best(&mut suitable);
             suitable
                 .into_iter()
                 .map(|(mmm, p, _)| (mmm, p))

--- a/core/src/ops/einsum/kernel_selection.rs
+++ b/core/src/ops/einsum/kernel_selection.rs
@@ -4,7 +4,7 @@ use dyn_clone::clone_box;
 use tract_itertools::Itertools;
 use tract_linalg::WeightType;
 use tract_linalg::block_quant::BlockQuantFact;
-use tract_linalg::mmm::{MMMInputFormat, Query, Suitable, pick_by_shape, retain_best_quality};
+use tract_linalg::mmm::{MMMInputFormat, Query, Suitable, pick_by_shape, retain_best};
 
 use crate::internal::*;
 use crate::ops::matmul::ModePicker;
@@ -29,7 +29,7 @@ pub fn strategize(model: &TypedModel, node: &TypedNode, op: &EinSumMatMul) -> Tr
     {
         return Ok(single_strat(chosen));
     }
-    retain_best_quality(&mut suitable);
+    retain_best(&mut suitable);
     if suitable.len() == 1 {
         return Ok(single_strat(suitable.remove(0)));
     }

--- a/linalg/src/arm32/armv7neon.rs
+++ b/linalg/src/arm32/armv7neon.rs
@@ -1,26 +1,25 @@
-use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::pack::PackedFormat;
 
-MMMExternKernel!(arm;armv7neon_mmm_f32_8x4_cortexa7 <f32>( 8, 4)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_8x4_cortexa9 <f32>( 8, 4)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_8x4_generic  <f32>( 8, 4)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_8x6_cortexa7 <f32>( 8, 6)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_8x6_cortexa9 <f32>( 8, 6)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_8x6_generic  <f32>( 8, 6)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_8x1_generic  <f32>( 8, 1)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_32x1_cortexa7<f32>(32, 1)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_32x1_cortexa9<f32>(32, 1)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
-MMMExternKernel!(arm;armv7neon_mmm_f32_32x1_generic <f32>(32, 1)@(16, 4) isa(ArmNeon) quality(ManuallyOptimized));
+MMMExternKernel!(arm;armv7neon_mmm_f32_8x4_cortexa7 <f32>( 8, 4)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_8x4_cortexa9 <f32>( 8, 4)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_8x4_generic  <f32>( 8, 4)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_8x6_cortexa7 <f32>( 8, 6)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_8x6_cortexa9 <f32>( 8, 6)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_8x6_generic  <f32>( 8, 6)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_8x1_generic  <f32>( 8, 1)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_32x1_cortexa7<f32>(32, 1)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_32x1_cortexa9<f32>(32, 1)@(16, 4) isa(ArmNeon));
+MMMExternKernel!(arm;armv7neon_mmm_f32_32x1_generic <f32>(32, 1)@(16, 4) isa(ArmNeon));
 
 MMMExternKernel!(arm;armv7neon_mmm_i32_8x4<i32>(8, 4)@(32, 4) isa(ArmNeon)
   packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 8, 32), PackedFormat::new(DatumType::I8, 4, 32));
-  quality(ManuallyOptimized)
+
   store(i8)
 );
 
 MMMExternKernel!(arm;armv7neon_mmm_i32_32x1<i32>(32, 1)@(32, 4) isa(ArmNeon)
   packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 32, 32), PackedFormat::new(DatumType::I8, 1, 4));
-  quality(ManuallyOptimized)
+
   store(i8)
 );
 

--- a/linalg/src/arm32/armvfpv2.rs
+++ b/linalg/src/arm32/armvfpv2.rs
@@ -1,5 +1,4 @@
 use crate::DatumType;
-use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::frame::mmm::*;
 use crate::isa::IsaSet;
 use crate::mmm::{Query, Suitable};
@@ -7,7 +6,7 @@ use crate::mmm_tiers::MmmTier;
 
 // Baseline VFP asm, so it runs on every armv7 core and needs no `isa`. The NEON kernels are
 // better wherever they run, which is what the instruction-set tier says.
-MMMExternKernel!(arm; armvfpv2_mmm_f32_4x4<f32>(4, 4)@(4, 4) quality(ManuallyOptimized));
+MMMExternKernel!(arm; armvfpv2_mmm_f32_4x4<f32>(4, 4)@(4, 4));
 
 /// Baseline armv7: the VFP kernel runs on every core, so this tier always applies and the NEON
 /// tier above it answers first wherever NEON is present.

--- a/linalg/src/arm64/apple_amx.rs
+++ b/linalg/src/arm64/apple_amx.rs
@@ -1,4 +1,3 @@
-use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::mmm::*;
 use tract_data::prelude::*;
 
@@ -6,10 +5,10 @@ use super::{arm64fp16_mmm_f16_16x8_gen, arm64simd_mmm_f32_8x8_gen, arm64simd_mmm
 
 const CAN_FUSE: fn(&FusedSpec) -> bool = |f| !matches!(f, &FusedSpec::LeakyRelu(_));
 
-MMMExternKernel!(aarch64; apple_amx_mmm_f32_32x32<f32>(32, 32)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE) quality(ManuallyOptimized) row_major_store(true));
-MMMExternKernel!(aarch64; apple_amx_mmm_f32_32x1<f32>(32, 1)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; apple_amx_mmm_f16_64x32<f16>(64, 32)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE) quality(ManuallyOptimized) row_major_store(true));
-MMMExternKernel!(aarch64; apple_amx_mmm_f16_64x1<f16>(64, 1)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE) quality(ManuallyOptimized));
+MMMExternKernel!(aarch64; apple_amx_mmm_f32_32x32<f32>(32, 32)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE) row_major_store(true));
+MMMExternKernel!(aarch64; apple_amx_mmm_f32_32x1<f32>(32, 1)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE));
+MMMExternKernel!(aarch64; apple_amx_mmm_f16_64x32<f16>(64, 32)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE) row_major_store(true));
+MMMExternKernel!(aarch64; apple_amx_mmm_f16_64x1<f16>(64, 1)@(128, 128) isa(Aarch64AppleAmx) can_fuse(CAN_FUSE));
 
 /// The AMX tile is 32x32, and it only pays once both M and N fill one: below that the tile
 /// padding and the AMX dispatch cost more than the NEON kernel's whole call. The f16 side keeps

--- a/linalg/src/arm64/arm64fp16/mod.rs
+++ b/linalg/src/arm64/arm64fp16/mod.rs
@@ -14,22 +14,21 @@ pub use unicast::*;
 
 use crate::block_quant::PackedBlockQuantFormat;
 use crate::block_quant::Q4_0;
-use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_16x8_gen<f16>(16, 8)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_16x8_a55<f16>(16, 8)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_32x4_gen<f16>(32, 4)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_32x4_a55<f16>(32, 4)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_128x1_gen<f16>(128,1)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_128x1_a55<f16>(128,1)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_16x8_gen<f16>(16, 8)@(16, 16) isa(Aarch64Fp16));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_16x8_a55<f16>(16, 8)@(16, 16) isa(Aarch64Fp16));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_32x4_gen<f16>(32, 4)@(16, 16) isa(Aarch64Fp16));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_32x4_a55<f16>(32, 4)@(16, 16) isa(Aarch64Fp16));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_128x1_gen<f16>(128,1)@(16, 16) isa(Aarch64Fp16));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_128x1_a55<f16>(128,1)@(16, 16) isa(Aarch64Fp16));
 
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_64x3_gen<f16>(64, 3)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64fp16_mmm_f16_32x6_gen<f16>(32, 6)@(16, 16) isa(Aarch64Fp16) quality(ManuallyOptimized));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_64x3_gen<f16>(64, 3)@(16, 16) isa(Aarch64Fp16));
+MMMExternKernel!(aarch64; arm64fp16_mmm_f16_32x6_gen<f16>(32, 6)@(16, 16) isa(Aarch64Fp16));
 
 MMMExternKernel! { aarch64; arm64fp16_mmm_f16_64x1_gen<f16>(64, 1)@(16, 16) isa(Aarch64Fp16)
     packing[1] = q40f16z16se => |k| k.with_packing_a(PackedBlockQuantFormat::new(&Q4_0, 64, 16, true));
     packing[2] = q40f16z16 => |k| k.with_packing_a(PackedBlockQuantFormat::new(&Q4_0, 64, 16, false));
-    quality(ManuallyOptimized)
+
 }
 
 routine_ew_extern!(aarch64; Tanh, f16, arm64fp16_tanh_f16_8n, 8, 8, isa(Aarch64Fp16));

--- a/linalg/src/arm64/arm64simd/mod.rs
+++ b/linalg/src/arm64/arm64simd/mod.rs
@@ -31,7 +31,6 @@ pub use sum::arm64simd_sum_f32_16n;
 pub use unicast::*;
 
 use crate::block_quant::{PackedBlockQuantFormat, Q4_0};
-use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::pack::PackedFormat;
 
 use super::Kind;
@@ -44,23 +43,23 @@ fn a53() -> isize {
     if *super::KIND == Kind::CortexA53 { 1 } else { -1 }
 }
 
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_8x8_a55 <f32>(8,  8)@(16, 16) quality(ManuallyOptimized) boost(a55));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_12x8_a55<f32>(12, 8)@(16, 16) quality(ManuallyOptimized) boost(a55));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_16x4_a55<f32>(16, 4)@(16, 16) quality(ManuallyOptimized) boost(a55));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_24x4_a55<f32>(24, 4)@(16, 16) quality(ManuallyOptimized) boost(a55));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_64x1_a55<f32>(64, 1)@(16, 16) quality(ManuallyOptimized) boost(a55));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_8x8_a55 <f32>(8,  8)@(16, 16) boost(a55));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_12x8_a55<f32>(12, 8)@(16, 16) boost(a55));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_16x4_a55<f32>(16, 4)@(16, 16) boost(a55));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_24x4_a55<f32>(24, 4)@(16, 16) boost(a55));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_64x1_a55<f32>(64, 1)@(16, 16) boost(a55));
 
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_16x4_a53<f32>(16, 4)@(16, 16) quality(ManuallyOptimized) boost(a53));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_24x4_a53<f32>(24, 4)@(16, 16) quality(ManuallyOptimized) boost(a53));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_8x8_a53 <f32>(8,  8)@(16, 16) quality(ManuallyOptimized) boost(a53));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_12x8_a53<f32>(12, 8)@(16, 16) quality(ManuallyOptimized) boost(a53));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_64x1_a53<f32>(64, 1)@(16, 16) quality(ManuallyOptimized) boost(a53));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_16x4_a53<f32>(16, 4)@(16, 16) boost(a53));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_24x4_a53<f32>(24, 4)@(16, 16) boost(a53));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_8x8_a53 <f32>(8,  8)@(16, 16) boost(a53));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_12x8_a53<f32>(12, 8)@(16, 16) boost(a53));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_64x1_a53<f32>(64, 1)@(16, 16) boost(a53));
 
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_16x4_gen<f32>(16, 4)@(16, 16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_24x4_gen<f32>(24, 4)@(16, 16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_8x8_gen <f32>(8,  8)@(16, 16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_12x8_gen<f32>(12, 8)@(16, 16) quality(ManuallyOptimized));
-MMMExternKernel!(aarch64; arm64simd_mmm_f32_64x1_gen<f32>(64, 1)@(16, 16) quality(ManuallyOptimized));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_16x4_gen<f32>(16, 4)@(16, 16));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_24x4_gen<f32>(24, 4)@(16, 16));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_8x8_gen <f32>(8,  8)@(16, 16));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_12x8_gen<f32>(12, 8)@(16, 16));
+MMMExternKernel!(aarch64; arm64simd_mmm_f32_64x1_gen<f32>(64, 1)@(16, 16));
 
 fn q40p32z16se() -> PackedBlockQuantFormat {
     PackedBlockQuantFormat::new(&Q4_0, 32, 16, true)
@@ -72,7 +71,7 @@ MMMExternKernel!(aarch64; arm64simd_mmm_f32_32x1_gen<f32>(32, 1)@(16, 16)
     packing[3] = f16f16 => |k| k.with_packing(f16::packing(32), f16::packing(1));
     packing[4] = f32f16 => |k| k.with_packing(f32::packing(32), f16::packing(1));
     packing[5] = f16f32 => |k| k.with_packing(f16::packing(32), f32::packing(1));
-    quality(ManuallyOptimized)
+
     store(f16)
 );
 
@@ -80,13 +79,13 @@ MMMExternKernel!(aarch64; arm64simd_mmm_f32_32x3_gen<f32>(32, 3)@(16, 16)
     packing[1] = f32f16 => |k| k.with_packing(f32::packing(32), f16::packing(3));
     packing[2] = f16f32 => |k| k.with_packing(f16::packing(32), f32::packing(3));
     packing[3] = f16f16 => |k| k.with_packing(f16::packing(32), f16::packing(3));
-    quality(ManuallyOptimized)
+
     store(f16)
 );
 
 MMMExternKernel!(aarch64; arm64simd_mmm_i32_8x8<i32>(8, 8)@(16, 16)
    packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 8, 16), PackedFormat::new(DatumType::I8, 8, 16));
-   quality(ManuallyOptimized)
+
    store(i8)
 );
 
@@ -101,13 +100,13 @@ MMMExternKernel!(aarch64; arm64simd_mmm_i32_8x8<i32>(8, 8)@(16, 16)
 MMMExternKernel!(aarch64; arm64simd_mmm_i32_8x8_dot<i32>(8, 8)@(16, 16)
    isa(Aarch64DotProd)
    packing[1] = i8i8 => |k| k.with_packing(crate::pack::PackedI8K4::new(8), crate::pack::PackedI8K4::new(8));
-   quality(ManuallyOptimized)
+
    store(i8)
 );
 
 MMMExternKernel!(aarch64; arm64simd_mmm_i32_64x1<i32>(64, 1)@(16, 1)
    packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 64,16), PackedFormat::new(DatumType::I8, 1, 1));
-   quality(ManuallyOptimized)
+
    store(i8)
 );
 

--- a/linalg/src/arm64/sme.rs
+++ b/linalg/src/arm64/sme.rs
@@ -1,5 +1,4 @@
 use crate::DatumType;
-use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::isa::IsaSet;
 use crate::mmm::*;
 use crate::mmm_tiers::MmmTier;
@@ -24,7 +23,7 @@ const CAN_FUSE_I32: fn(&FusedSpec) -> bool = |f| !matches!(f, FusedSpec::LeakyRe
 
 MMMExternKernel!(aarch64; sme_qmmm_i32_32x32<i32>(32,32)@(128,128) isa(Aarch64Sme2) can_fuse(CAN_FUSE_I32)
     packing[1] = i8i8 => |k| k.with_packing(crate::pack::PackedI8K4::new(32), crate::pack::PackedI8K4::new(32));
-    quality(ManuallyOptimized) store(i8));
+    store(i8));
 
 // Streaming vector length in bytes, read via `RDSVL x0, #1` (encoding
 // 0x04bf5820). RDSVL is legal in non-streaming mode, but is UNDEFINED
@@ -62,14 +61,14 @@ MMMExternKernel!(aarch64;
     sme_mmm_f32_32x32<f32>(32, 32)@(128, 128)
     isa(Aarch64Sme)
     can_fuse(CAN_FUSE)
-    quality(ManuallyOptimized)
+
 );
 
 MMMExternKernel!(aarch64;
     sme_mmv_f32_64x1<f32>(64, 1)@(128, 128)
     isa(Aarch64Sme2)
     can_fuse(CAN_FUSE)
-    quality(ManuallyOptimized)
+
 );
 
 #[cfg(target_os = "macos")]

--- a/linalg/src/arm64/sve.rs
+++ b/linalg/src/arm64/sve.rs
@@ -2,7 +2,6 @@
 // supports SVE intrinsics. The kernel registration + extern live behind it so
 // non-SVE builds never reference the (absent) C symbol.
 #[cfg(tract_sve)]
-use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 #[cfg(tract_sve)]
 use crate::mmm::*;
 #[cfg(tract_sve)]
@@ -71,7 +70,7 @@ pub fn sve_rms_norm_f32(buf: &mut [f32], eps: f32) {
 MMMRustKernel!(aarch64; sve_sys::sve_mmm_f32_kernel => sve_mmm_f32_8x8<f32>(8, 8)
     isa(Aarch64Sve2)
     can_fuse(CAN_FUSE)
-    quality(ManuallyOptimized)
+
 );
 
 // The VLA SVE f32 GEMV kernel (arm64/sve/sve_mmv_f32_64x1.c), MR=64 NR=1,
@@ -80,7 +79,7 @@ MMMRustKernel!(aarch64; sve_sys::sve_mmm_f32_kernel => sve_mmm_f32_8x8<f32>(8, 8
 MMMRustKernel!(aarch64; sve_sys::sve_mmv_f32_64x1_kernel => sve_mmv_f32_64x1<f32>(64, 1)
     isa(Aarch64Sve2)
     can_fuse(CAN_FUSE)
-    quality(ManuallyOptimized)
+
 );
 
 // The VLA SVE int8 -> int32 GEMM kernel (arm64/sve/sve_mmm_i32.c). Consumes
@@ -94,7 +93,7 @@ MMMRustKernel!(aarch64; sve_sys::sve_mmm_i32_kernel => sve_mmm_i32_8x8<i32>(8, 8
         PackedFormat::new(DatumType::I8, 8, 16),
         PackedFormat::new(DatumType::I8, 8, 16),
     );
-    quality(ManuallyOptimized)
+
     store(i8)
 );
 
@@ -109,7 +108,7 @@ MMMRustKernel!(aarch64; sve_sys::sve_mmm_i32_64x1_kernel => sve_mmm_i32_64x1<i32
         PackedFormat::new(DatumType::I8, 64, 16),
         PackedFormat::new(DatumType::I8, 1, 1),
     );
-    quality(ManuallyOptimized)
+
     store(i8)
 );
 
@@ -119,7 +118,7 @@ MMMRustKernel!(aarch64; sve_sys::sve_mmm_i32_64x1_kernel => sve_mmm_i32_64x1<i32
 MMMRustKernel!(aarch64; sve_sys::sve_mmm_f16_kernel => sve_mmm_f16_8x8<f16>(8, 8)
     isa(Aarch64Sve2, Aarch64Fp16)
     can_fuse(CAN_FUSE)
-    quality(ManuallyOptimized)
+
 );
 
 // The VLA SVE f16 GEMV kernel (arm64/sve/sve_mmv_f16_64x1.c), MR=64 NR=1,
@@ -128,7 +127,7 @@ MMMRustKernel!(aarch64; sve_sys::sve_mmm_f16_kernel => sve_mmm_f16_8x8<f16>(8, 8
 MMMRustKernel!(aarch64; sve_sys::sve_mmv_f16_64x1_kernel => sve_mmv_f16_64x1<f16>(64, 1)
     isa(Aarch64Sve2, Aarch64Fp16)
     can_fuse(CAN_FUSE)
-    quality(ManuallyOptimized)
+
 );
 
 // SVE / SVE2 backend.

--- a/linalg/src/frame/mmm/kernel.rs
+++ b/linalg/src/frame/mmm/kernel.rs
@@ -13,16 +13,27 @@ pub trait MatMatMulKer: Clone + Debug + Send + Sync + 'static {
     fn mr(&self) -> usize;
     fn nr(&self) -> usize;
 
-    fn quality(&self) -> ImplementationQuality;
+    /// Architecture this kernel is written for, `None` for the generic Rust every target
+    /// builds. Declared by the leading arch ident of the kernel macros, the same ident that
+    /// decides whether this build compiled the body.
+    fn arch(&self) -> Option<crate::isa::Arch> {
+        None
+    }
+
+    /// Whether the kernel computes its accumulator type by converting every operation to
+    /// another type, for a machine whose hardware has none.
+    fn emulated(&self) -> bool {
+        false
+    }
 
     /// The preference its author spelled out for this kernel, before the instruction-set
     /// default is added in. Zero for a kernel that claims nothing.
-    fn declared_boost(&self) -> isize;
+    fn boost(&self) -> isize;
 
-    /// [`Self::declared_boost`] plus the default owed to the instruction set the kernel was
-    /// written for, [`crate::isa::LEVEL_BOOST`] per level. Preference reads this one.
-    fn dynamic_boost(&self) -> isize {
-        self.declared_boost() + self.isa().level() as isize * crate::isa::LEVEL_BOOST
+    /// [`Self::boost`] plus the default owed to the instruction set the kernel was written
+    /// for, [`crate::isa::LEVEL_BOOST`] per level. Selection reads this one.
+    fn preference(&self) -> isize {
+        self.boost() + self.isa().level() as isize * crate::isa::LEVEL_BOOST
     }
 
     #[allow(clippy::type_complexity)]
@@ -62,7 +73,12 @@ type Kernel<Acc> = unsafe fn(&[FusedKerSpec<Acc>]) -> isize;
 pub struct DynKernel<const MR: usize, const NR: usize, Acc: LADatum> {
     pub name: String,
     pub kernel: Kernel<Acc>,
-    pub quality: ImplementationQuality,
+    /// Arch this kernel is written for, `None` for the generic Rust every target builds.
+    pub arch: Option<crate::isa::Arch>,
+    /// Reads true when the kernel emulates its accumulator type op by op, which is a fact
+    /// about the running machine rather than the declaration: the generic f16 kernels are a
+    /// real implementation on hardware that has f16 and an emulation on hardware that does not.
+    pub emulated: fn() -> bool,
     pub packings: Vec<(Box<dyn MMMInputFormat>, Box<dyn MMMInputFormat>)>,
     pub stores: Vec<DatumType>,
     /// False when this build did not assemble the kernel's asm, its arch not being the one the
@@ -82,12 +98,12 @@ impl<const MR: usize, const NR: usize, Acc: LADatum> DynKernel<MR, NR, Acc> {
         kernel: Kernel<Acc>,
         packing_a: PackedFormat,
         packing_b: PackedFormat,
-        quality: ImplementationQuality,
     ) -> Self {
         let kernel = DynKernel {
             name: name.to_string(),
             kernel,
-            quality,
+            arch: None,
+            emulated: || false,
             packings: vec![],
             stores: vec![Acc::datum_type()],
             built: true,
@@ -107,7 +123,7 @@ impl<const MR: usize, const NR: usize, Acc: LADatum> DynKernel<MR, NR, Acc> {
         self
     }
 
-    /// Sets the tie-break behind [`MatMatMulKer::dynamic_boost`] — the `boost(..)` of the kernel
+    /// Sets the tie-break behind [`MatMatMulKer::preference`] — the `boost(..)` of the kernel
     /// macros, and the one place a runtime preference belongs.
     pub fn with_boost(mut self, f: fn() -> isize) -> Self {
         self.boost = f;
@@ -166,8 +182,12 @@ impl<const MR: usize, const NR: usize, Acc: LADatum> MatMatMulKer for DynKernel<
         NR
     }
 
-    fn quality(&self) -> ImplementationQuality {
-        self.quality
+    fn arch(&self) -> Option<crate::isa::Arch> {
+        self.arch
+    }
+
+    fn emulated(&self) -> bool {
+        (self.emulated)()
     }
 
     fn built(&self) -> bool {
@@ -195,7 +215,7 @@ impl<const MR: usize, const NR: usize, Acc: LADatum> MatMatMulKer for DynKernel<
         Cow::Borrowed(&self.stores)
     }
 
-    fn declared_boost(&self) -> isize {
+    fn boost(&self) -> isize {
         (self.boost)()
     }
 

--- a/linalg/src/frame/mmm/macros.rs
+++ b/linalg/src/frame/mmm/macros.rs
@@ -38,13 +38,10 @@ macro_rules! MMMExternKernel {
             }
 
             MMMKernel!([<sys_ $func>]::rusty as $func<$ti>($mr, $nr)
-                built(cfg!($built)) $($rest)*);
+                built(cfg!($built)) arch($target) $($rest)*);
 
             inventory::submit! {
-                $crate::mmm_routines::MmmRoutine {
-                    target: $target,
-                    make: || $func.mmm(),
-                }
+                $crate::mmm_routines::MmmRoutine { make: || $func.mmm() }
             }
         }
     };
@@ -64,23 +61,22 @@ macro_rules! MMMRustKernel {
     (wasm32; $($rest:tt)*) => { MMMRustKernel!(@ Some($crate::isa::Arch::Wasm32Simd128), all(target_arch = "wasm32", target_feature = "simd128"); $($rest)*); };
 
     (@ $target:expr, $built:meta; $func:path => $id:ident<$ti:ident>($mr:expr, $nr:expr) $($rest:tt)*) => {
-        MMMRustKernel!($func => $id<$ti>($mr, $nr) built(cfg!($built)) $($rest)*);
+        MMMRustKernel!($func => $id<$ti>($mr, $nr) built(cfg!($built)) arch($target) $($rest)*);
         inventory::submit! {
-            $crate::mmm_routines::MmmRoutine {
-                target: $target,
-                make: || $id.mmm(),
-            }
+            $crate::mmm_routines::MmmRoutine { make: || $id.mmm() }
         }
     };
 
     (       $func: path =>
             $id:ident<$ti:ident>($mr: expr, $nr: expr)
             $(built($built_here:expr))?
+            $(arch($arch:expr))?
             $(@($align_a:expr, $align_b:expr))?
             $(isa($($isa:ident),+))?
             $(can_fuse($can_fuse:expr))?
             $(packing[$pnum:literal] = $pid:ident => $packing:expr;)*
-            $(quality($quality:expr))?
+            $(emulated($emulated:expr))?
+            $(boost($boost:expr))?
             $(store($($store:ty),*))?
             $(row_major_store($rms:expr))?
      ) => {
@@ -96,12 +92,13 @@ macro_rules! MMMRustKernel {
             }
             MMMKernel!([<sys_$id>]::rusty as $id<$ti>($mr, $nr)
                 $(built($built_here))?
+                $(arch($arch))?
                 $(@($align_a, $align_b))?
-                generic(true)
                 $(isa($($isa),+))?
                 $(can_fuse($can_fuse))?
                 $(packing[$pnum] = $pid => $packing;)*
-                $(quality($quality))?
+                $(emulated($emulated))?
+                $(boost($boost))?
                 $(store($($store),*))?
                 $(row_major_store($rms))?
             );
@@ -114,12 +111,12 @@ macro_rules! MMMKernel {
             $func: path as
             $id:ident<$ti:ident>($mr: expr, $nr: expr)
             $(built($built_here:expr))?
+            $(arch($arch:expr))?
             $(@($align_a:expr, $align_b:expr))?
-            $(generic($generic:expr))?
             $(isa($($isa:ident),+))?
             $(can_fuse($can_fuse:expr))?
             $(packing[$pnum:literal] = $pid:ident => $packing:expr;)*
-            $(quality($quality:expr))?
+            $(emulated($emulated:expr))?
             $(boost($boost:expr))?
             $(store($($store:ty),*))?
             $(row_major_store($rms:expr))?
@@ -138,8 +135,9 @@ macro_rules! MMMKernel {
                         packing_b = packing_b.align($align_b);
                     )?
                     #[allow(unused_mut)]
-                    let mut k = DynKernel::<$mr, $nr, $ti>::new(stringify!($id), $func, packing_a, packing_b, $crate::frame::mmm::ImplementationQuality::Dreadful);
+                    let mut k = DynKernel::<$mr, $nr, $ti>::new(stringify!($id), $func, packing_a, packing_b);
                     $(k.built = $built_here;)?
+                    $(k.arch = $arch;)?
                     k = k.with_isa(
                         $crate::isa::IsaReq::ANY
                             $(.needing(&[$($crate::isa::Isa::$isa),+]))?
@@ -153,7 +151,7 @@ macro_rules! MMMKernel {
                         k.stores.push(<$store>::datum_type());
                     )*)?
                     $(k.can_fuse = $can_fuse;)?
-                    $(k.quality = $quality;)?
+                    $(k.emulated = $emulated;)?
                     $(k = k.with_boost($boost);)?
                     $(k.row_major_store = $rms;)?
                     k

--- a/linalg/src/frame/mmm/mod.rs
+++ b/linalg/src/frame/mmm/mod.rs
@@ -18,7 +18,6 @@ pub mod tests;
 
 use crate::multithread::Executor;
 use std::borrow::Cow;
-use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::ops::Range;
 use tract_data::internal::*;
@@ -34,60 +33,33 @@ pub use storage::*;
 
 pub fn no_prefetch(_ptr: *const u8, _len: usize) {}
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum ImplementationQuality {
-    /// Individual operations are emulated by individual conversion (f16->f32->f16)
-    Dreadful,
-    /// Rust scalar operation (with whatever optimisation the compiler manages)
-    Generic,
-    /// Implicit vectorization (e.g. Rust code, some unrolled loops, explicit template instantiations for small constant)
-    RustOptimized,
-    /// Explicit vectorization (e.g. intrinsics vector code)
-    TargetOptimized,
-    /// Hand optimized (assembly)
-    ManuallyOptimized,
-}
-
-impl ImplementationQuality {
-    pub fn best_to_worst() -> &'static [ImplementationQuality] {
-        use ImplementationQuality::*;
-        &[ManuallyOptimized, TargetOptimized, RustOptimized, Generic, Dreadful]
-    }
-
-    pub fn cost(&self) -> usize {
-        ImplementationQuality::best_to_worst().iter().position(|x| x == self).unwrap()
-    }
-}
-
-impl PartialOrd for ImplementationQuality {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(usize::from(*self).cmp(&usize::from(*other)))
-    }
-}
-
-impl From<ImplementationQuality> for usize {
-    fn from(value: ImplementationQuality) -> Self {
-        value.cost()
-    }
-}
-
 pub trait MatMatMul: Debug + dyn_clone::DynClone + Send + Sync + std::any::Any {
     fn name(&self) -> &str;
     fn mr(&self) -> usize;
     fn nr(&self) -> usize;
 
-    fn quality(&self) -> ImplementationQuality;
+    /// Architecture this kernel is written for, `None` for the generic Rust every target
+    /// builds. What [`retain_best`] compares before anything else: a kernel written for the
+    /// machine at hand supersedes a portable one whatever their instruction sets.
+    fn arch(&self) -> Option<crate::isa::Arch>;
+
+    /// Whether the kernel computes its accumulator type by converting every operation to
+    /// another type, for a machine whose hardware has none. Orders of magnitude off a real
+    /// kernel, and always the only thing on offer where it is declared, so selection ignores
+    /// it and benches skip it.
+    fn emulated(&self) -> bool;
 
     /// The preference this kernel's author spelled out, before the instruction-set default.
-    fn declared_boost(&self) -> isize;
+    fn boost(&self) -> isize;
 
-    /// How strongly this kernel is preferred over its equally-qualified siblings, breaking ties inside a
-    /// quality tier ([`retain_best_quality`]). A kernel written for a more capable instruction
-    /// set outranks one written for a less capable one by default; a declared boost is how an
-    /// exception to that is spelled, and must be big enough to cross the tiers it disagrees
-    /// with. Never encode a preference in [`Self::runnable`] — that silently skips the
-    /// kernel's tests as well.
-    fn dynamic_boost(&self) -> isize;
+    /// Where this kernel sits against the siblings of its own kind, which [`retain_best`]
+    /// weighs once [`Self::arch`] has not separated them: the level of the instruction set it
+    /// is written for, plus whatever a measurement said that level gets wrong. A kernel
+    /// written for a more capable set outranks one written for a less capable one by default;
+    /// a declared boost is how an exception is spelled, and must be big enough to cross the
+    /// levels it disagrees with. Never encode a preference in [`Self::runnable`] — that
+    /// silently skips the kernel's tests as well.
+    fn preference(&self) -> isize;
 
     /// Whether this kernel can be executed here at all: this build compiled it
     /// ([`Self::built`]) and the running CPU has the instruction set it declares
@@ -96,7 +68,7 @@ pub trait MatMatMul: Debug + dyn_clone::DynClone + Send + Sync + std::any::Any {
     /// Runnability only, never preference: this answers "would executing the kernel fault",
     /// and the mmm test bodies gate on it, so a kernel that lies here has no test coverage at
     /// all on the hosts it lies on. Say a kernel is worse than its sibling with
-    /// [`Self::dynamic_boost`] instead.
+    /// [`Self::preference`] instead.
     fn runnable(&self) -> bool;
 
     /// Whether this build compiled the kernel's body at all. False for a foreign arch's
@@ -167,16 +139,20 @@ impl<K: MatMatMulKer> MatMatMul for K {
         self.nr()
     }
 
-    fn quality(&self) -> ImplementationQuality {
-        MatMatMulKer::quality(self)
+    fn arch(&self) -> Option<crate::isa::Arch> {
+        MatMatMulKer::arch(self)
     }
 
-    fn declared_boost(&self) -> isize {
-        MatMatMulKer::declared_boost(self)
+    fn emulated(&self) -> bool {
+        MatMatMulKer::emulated(self)
     }
 
-    fn dynamic_boost(&self) -> isize {
-        MatMatMulKer::dynamic_boost(self)
+    fn boost(&self) -> isize {
+        MatMatMulKer::boost(self)
+    }
+
+    fn preference(&self) -> isize {
+        MatMatMulKer::preference(self)
     }
 
     fn runnable(&self) -> bool {

--- a/linalg/src/frame/mmm/select.rs
+++ b/linalg/src/frame/mmm/select.rs
@@ -15,7 +15,7 @@ use dyn_eq::DynEq;
 use tract_data::itertools::Itertools;
 use tract_data::prelude::{DatumType, TVec, tvec};
 
-use super::{ImplementationQuality, MMMInputFormat, MatMatMul, PanelExtractor};
+use super::{MMMInputFormat, MatMatMul, PanelExtractor};
 use crate::WeightType;
 
 /// One way to compute a matmul: a kernel, which of its packings to use, and the panel
@@ -74,15 +74,17 @@ pub fn suitable_named(suitable: &[Suitable], name: &str) -> Option<usize> {
     suitable.iter().position(|(mmm, _, _)| mmm.name() == name)
 }
 
-/// Keep only the suitable kernels of the best quality: quality dominates, and a
-/// kernel's dynamic boost breaks ties within it. First rung of the generic policy,
-/// applied before any shape reasoning.
-pub fn retain_best_quality(suitable: &mut Vec<Suitable>) {
-    fn score(mmm: &dyn MatMatMul) -> isize {
-        -(mmm.quality().cost() as isize * 1000) + mmm.dynamic_boost()
+/// Keep only the suitable kernels nothing supersedes: a kernel written for this architecture
+/// beats portable Rust whatever their instruction sets, and among kernels of one kind the
+/// instruction-set level and the declared boost decide. Everything tied at the top is kept —
+/// the shape rules run over what is left. First rung of the generic policy, applied before any
+/// shape reasoning.
+pub fn retain_best(suitable: &mut Vec<Suitable>) {
+    fn key(mmm: &dyn MatMatMul) -> (bool, isize) {
+        (mmm.arch().is_some(), mmm.preference())
     }
-    if let Some(best) = suitable.iter().map(|(mmm, _, _)| score(&**mmm)).max() {
-        suitable.retain(|(mmm, _, _)| score(&**mmm) == best);
+    if let Some(best) = suitable.iter().map(|(mmm, _, _)| key(&**mmm)).max() {
+        suitable.retain(|(mmm, _, _)| key(&**mmm) == best);
     }
 }
 
@@ -231,7 +233,7 @@ impl MmmDispatch {
         let acc = *query.accumulators.first()?;
         let ix = crate::mmm_tiers::preferred(&self.isa, &self.tiers, acc, query, suitable)?;
         let chosen = &suitable[ix];
-        (chosen.0.quality() == ImplementationQuality::ManuallyOptimized).then(|| chosen.clone())
+        chosen.0.arch().is_some().then(|| chosen.clone())
     }
 
     /// One kernel for the query, for a caller that needs an answer now: the platform policy's
@@ -245,7 +247,7 @@ impl MmmDispatch {
         if let Some(chosen) = self.preferred(query, &suitable) {
             return Some(chosen);
         }
-        retain_best_quality(&mut suitable);
+        retain_best(&mut suitable);
         if suitable.len() == 1 {
             return Some(suitable.remove(0));
         }
@@ -266,7 +268,7 @@ impl MmmDispatch {
 
     /// The kernel this platform would run for a plain matmul of these dims, for a caller
     /// introspecting dispatch rather than performing it. Unlike [`MmmDispatch::preferred`] it reports
-    /// the tiers' answer whatever its quality, and it never falls back on the generic rules:
+    /// the tiers' answer whatever kind of kernel it is, and it never falls back on the generic rules:
     /// `None` means no tier had anything to say.
     pub fn preferred_kernel(
         &self,
@@ -291,7 +293,7 @@ impl crate::isa::Arch {
     /// `TRACT_CPU_ISA`, which is checked against this architecture rather than the host's. `None` when
     /// the architecture's tree was not compiled in; see the `foreign-inventory` feature.
     pub fn inspect(self) -> Option<MmmDispatch> {
-        if !crate::mmm_routines::declared().any(|r| r.target == Some(self)) {
+        if !crate::mmm_routines::declared().any(|r| (r.make)().arch() == Some(self)) {
             return None;
         }
         let isa = if self.is_native() {
@@ -320,23 +322,23 @@ mod tests {
     /// that drops a group's matvec while keeping its matrix kernel leaves that caller a group it
     /// cannot use for both, and it silently falls back on a narrower group instead.
     ///
-    /// Only the boost is held to this. The quality filter dropping the matvec is it working as
-    /// intended — a scalar fallback has no business being preferred beside a hand-written
-    /// kernel, and a group whose only matvec is a lesser implementation is a group the caller is
-    /// right to treat as matrix-only.
+    /// Only the boost is held to this. The architecture key dropping the matvec is it working as
+    /// intended — portable Rust has no business being preferred beside a kernel written for
+    /// this machine, and a group whose only matvec is generic is a group the caller is right to
+    /// treat as matrix-only.
     #[test]
     fn the_preference_keeps_a_kept_group_usable() {
         let dispatch = crate::MmmDispatch::native();
         for acc in accumulators() {
             let query = Query::plain(acc, None, None, None);
             let all = dispatch.suitable(&query);
-            let Some(best) = all.iter().map(|(mmm, _, _)| mmm.quality().cost()).min() else {
+            let Some(best) = all.iter().map(|(mmm, _, _)| mmm.arch().is_some()).max() else {
                 continue;
             };
             let peers: Vec<Suitable> =
-                all.iter().filter(|(mmm, _, _)| mmm.quality().cost() == best).cloned().collect();
+                all.iter().filter(|(mmm, _, _)| mmm.arch().is_some() == best).cloned().collect();
             let mut kept = peers.clone();
-            retain_best_quality(&mut kept);
+            retain_best(&mut kept);
             let kept: Vec<&str> = kept.iter().map(|(mmm, _, _)| mmm.name()).collect();
             for group in packing_groups(&peers) {
                 let matvecs: Vec<&str> =

--- a/linalg/src/generic/mmm.rs
+++ b/linalg/src/generic/mmm.rs
@@ -407,7 +407,7 @@ MMMRustKernel!(generic; kernel::<f16, 4, 4> => generic_f16_4x4<f16>(4,4)
     packing[7] = q40f32 => |k| k.with_packing(pq40_r4(), f32::packing(4));
     packing[8] = q20tf16 => |k| k.with_packing(pq20t_r4(), f16::packing(4));
     packing[9] = q20tf32 => |k| k.with_packing(pq20t_r4(), f32::packing(4));
-    quality(if has_fp16() { ImplementationQuality::Generic } else { ImplementationQuality::Dreadful })
+    emulated(|| !has_fp16())
     store(f32, f64)
 );
 
@@ -421,7 +421,7 @@ MMMRustKernel! { generic; kernel::<f16, 4, 1> => generic_f16_4x1<f16>(4,1)
     packing[7] = q40f32 => |k| k.with_packing(pq40_r4(), f32::packing(1));
     packing[8] = q20tf16 => |k| k.with_packing(pq20t_r4(), f16::packing(1));
     packing[9] = q20tf32 => |k| k.with_packing(pq20t_r4(), f32::packing(1));
-    quality(if has_fp16() { ImplementationQuality::Generic } else { ImplementationQuality::Dreadful })
+    emulated(|| !has_fp16())
     store(f32, f64)
 }
 
@@ -436,7 +436,6 @@ MMMRustKernel!(generic; kernel::<f32, 4, 4> => generic_f32_4x4<f32>(4,4)
     packing[7] = q40f32 => |k| k.with_packing(pq40_r4(), f32::packing(4));
     packing[8] = q20tf16 => |k| k.with_packing(pq20t_r4(), f16::packing(4));
     packing[9] = q20tf32 => |k| k.with_packing(pq20t_r4(), f32::packing(4));
-    quality(ImplementationQuality::Generic)
     store(f16, f64)
 );
 MMMRustKernel! { generic; kernel::<f32, 4, 1> => generic_f32_4x1<f32>(4,1)
@@ -449,28 +448,23 @@ MMMRustKernel! { generic; kernel::<f32, 4, 1> => generic_f32_4x1<f32>(4,1)
     packing[7] = q40f32 => |k| k.with_packing(pq40_r4(), f32::packing(1));
     packing[8] = q20tf16 => |k| k.with_packing(pq20t_r4(), f16::packing(1));
     packing[9] = q20tf32 => |k| k.with_packing(pq20t_r4(), f32::packing(1));
-    quality(ImplementationQuality::Generic)
     store(f16, f64)
 }
 
 // f64 kernels
 MMMRustKernel!(generic; kernel::<f64, 4, 4> => generic_f64_4x4<f64>(4,4)
-    quality(ImplementationQuality::Generic)
     store(f16, f32));
 MMMRustKernel!(generic; kernel::<f64, 4, 1> => generic_f64_4x1<f64>(4,1)
-    quality(ImplementationQuality::Generic)
     store(f16, f32));
 
 // I32 kernels
 MMMRustKernel! { generic; kernel::<i32, 4, 4> => generic_i32_4x4<i32>(4,4)
     packing[1] = i8i8 => |k| k.with_packing(i8::packing(4), i8::packing(4));
-    quality(ImplementationQuality::Generic)
     store(i8)
 }
 
 MMMRustKernel! { generic; kernel::<i32, 4, 1> => generic_i32_4x1<i32>(4,1)
     packing[1] = i8i8 => |k| k.with_packing(i8::packing(4), i8::packing(1));
-    quality(ImplementationQuality::Generic)
     store(i8)
 }
 

--- a/linalg/src/isa.rs
+++ b/linalg/src/isa.rs
@@ -4,7 +4,7 @@
 //! evaluated against a machine other than this one, which is what makes another cohort's
 //! dispatch inspectable. Micro-architecture is deliberately not in here — how many 512-bit FMA
 //! ports a core has is not an instruction set, and preferring a kernel is not the same as being
-//! able to run it: that belongs in [`crate::mmm::MatMatMulKer::dynamic_boost`].
+//! able to run it: that belongs in [`crate::mmm::MatMatMulKer::preference`].
 
 use std::fmt;
 use std::sync::OnceLock;
@@ -335,7 +335,7 @@ impl IsaReq {
     }
 
     /// The most capable lineage step this kernel sits in, feeding the default half of
-    /// [`crate::mmm::MatMatMulKer::dynamic_boost`].
+    /// [`crate::mmm::MatMatMulKer::preference`].
     pub fn level(&self) -> u8 {
         self.needs.iter().map(|i| i.level()).max().unwrap_or(0)
     }

--- a/linalg/src/mmm_routines.rs
+++ b/linalg/src/mmm_routines.rs
@@ -3,10 +3,9 @@
 //! Every arch-prefixed `MMMExternKernel!` / `MMMRustKernel!` invocation submits one
 //! [`MmmRoutine`] handle to the `inventory` collection, so every kernel tree this build
 //! compiled is enumerable: the full function × target matrix under the `foreign-inventory`
-//! feature, this arch's own share without it. The handle carries only what the kernel object
-//! cannot: which arch it belongs to. Everything else — name, tile, quality, datum type, whether
-//! this build compiled it, whether it runs here — is read from the [`MatMatMul`] that `make`
-//! builds, so nothing here duplicates `DynKernel`.
+//! feature, this arch's own share without it. The handle carries nothing but the constructor:
+//! arch, name, tile, datum type, whether this build compiled it and whether it runs here are
+//! all read from the [`MatMatMul`] that `make` builds, so nothing here duplicates `DynKernel`.
 //!
 //! A foreign tree's kernels are bail stubs; they answer [`MatMatMul::built`] with false, and
 //! their `make()` object is metadata-only and must never be executed.
@@ -19,9 +18,6 @@ use crate::mmm::MatMatMul;
 
 /// One mmm kernel, enumerable uniformly on every host.
 pub struct MmmRoutine {
-    /// Arch the kernel is written for, or `None` when it is generic Rust that
-    /// every target builds.
-    pub target: Option<crate::isa::Arch>,
     /// Builds the type-erased kernel. Reading its metadata is always safe; *running* it is
     /// only safe when the kernel answers [`MatMatMul::built`] with true.
     pub make: fn() -> Box<dyn MatMatMul>,
@@ -29,9 +25,10 @@ pub struct MmmRoutine {
 
 inventory::collect!(MmmRoutine);
 
-/// One panel extractor, enumerable uniformly on every host. Like [`MmmRoutine`] it carries only
-/// what the extractor cannot: which arch it belongs to. Whether this build compiled its body, and
-/// what the instruction set must offer, are fields of the [`PanelExtractor`] itself.
+/// One panel extractor, enumerable uniformly on every host. Unlike [`MmmRoutine`] the handle does
+/// carry its arch, an extractor being only ever called and never enumerated for its metadata, so
+/// nothing builds one to ask. Whether this build compiled its body, and what the instruction set
+/// must offer, are fields of the [`PanelExtractor`] itself.
 pub struct MmmExtractor {
     pub target: crate::isa::Arch,
     pub make: fn() -> crate::mmm::PanelExtractor,
@@ -70,8 +67,8 @@ pub fn declared() -> impl Iterator<Item = &'static MmmRoutine> {
 /// if actually called.
 pub fn runnable_for(target: crate::isa::Arch) -> Vec<Box<dyn MatMatMul>> {
     let mut pool: Vec<Box<dyn MatMatMul>> = declared()
-        .filter(|r| r.target.is_none_or(|t| t == target))
         .map(|r| (r.make)())
+        .filter(|kernel| kernel.arch().is_none_or(|a| a == target))
         // A kernel this build compiled has to be runnable here to be in the set; one it did
         // not compile cannot answer that, so it stays as metadata.
         .filter(|kernel| !kernel.built() || kernel.runnable())

--- a/linalg/src/wasm/dispatch_tests.rs
+++ b/linalg/src/wasm/dispatch_tests.rs
@@ -50,17 +50,14 @@ mod dispatch_trace {
     /// Regression guard for the GEMM/GEMV dispatch.
     ///
     /// `kernel_selection::strategize` honours the `mmm_f32` / `mmv_f32`
-    /// callback only when the returned kernel is `ManuallyOptimized`;
-    /// otherwise it falls through to the suitable list, where
-    /// `retain_best_quality` drops every `TargetOptimized` kernel, and for
-    /// N>1 then picks `max(nr*mr)`
-    /// over the surviving `ManuallyOptimized` GEMV kernels — i.e.
-    /// `wasm_f32_32x1`, a matrix×vector kernel, for every GEMM. So every
-    /// kernel reachable through the dispatch callbacks must be
-    /// `ManuallyOptimized`.
+    /// callback only when the returned kernel is one written for wasm; a
+    /// generic one counts as no opinion, and it then falls through to the
+    /// suitable list, where the N>1 rule picks `max(nr*mr)` over the wasm
+    /// GEMV kernels — i.e. `wasm_f32_32x1`, a matrix-vector kernel, for
+    /// every GEMM. So every kernel reachable through the dispatch callbacks
+    /// must be a wasm kernel.
     #[test]
-    fn dispatch_kernels_are_manually_optimized() {
-        use crate::mmm::ImplementationQuality::ManuallyOptimized;
+    fn dispatch_kernels_are_wasm_kernels() {
         let ops = crate::MmmDispatch::native();
         for (label, m, k, n) in [
             ("GEMM m=64 k=64 n=8", 64, 64, 8),
@@ -72,13 +69,11 @@ mod dispatch_trace {
             let mmm = ops
                 .preferred_kernel(tract_data::prelude::DatumType::F32, Some(m), Some(k), Some(n))
                 .unwrap();
-            assert_eq!(
-                mmm.quality(),
-                ManuallyOptimized,
-                "{label}: dispatch returned {} tagged {:?} — strategize would \
+            assert!(
+                mmm.arch().is_some(),
+                "{label}: dispatch returned the generic {} — strategize would \
                  discard it and reroute onto a GEMV kernel",
                 mmm.name(),
-                mmm.quality(),
             );
         }
     }
@@ -284,11 +279,10 @@ fn add_row_col_products_and_add_mat_mul_agree_on_fusion() {
     check_madd_pairing(&*crate::wasm::wasm_f32_4x16);
 }
 
-/// `wasm_f32_4x4` is registered at `TargetOptimized` while every other kernel
-/// is `ManuallyOptimized`, so `strategize`'s `retain()` drops it before
-/// selection and neither `mmm_f32` nor `mmv_f32` ever names it. Promoting it
-/// without also giving it a dispatch band would silently put a 4-wide tile in
-/// front of shapes the 8x8 and the GEMV kernels currently own.
+/// `wasm_f32_4x4` declares `NEVER_PREFERRED`, so `retain_best` drops it before selection and
+/// neither `mmm_f32` nor `mmv_f32` ever names it. Promoting it without also giving it a
+/// dispatch band would silently put a 4-wide tile in front of shapes the 8x8 and the GEMV
+/// kernels currently own.
 #[test]
 fn dispatch_never_returns_wasm_f32_4x4() {
     let ops = crate::MmmDispatch::native();
@@ -307,7 +301,7 @@ fn dispatch_never_returns_wasm_f32_4x4() {
                     mmm.name(),
                     "wasm_f32_4x4",
                     "m={m} k={k} n={n} dispatched to wasm_f32_4x4, which is registered \
-                     TargetOptimized and has no dispatch band"
+                     NEVER_PREFERRED and has no dispatch band"
                 );
             }
         }

--- a/linalg/src/wasm/mmm_f32_gemm.rs
+++ b/linalg/src/wasm/mmm_f32_gemm.rs
@@ -1,7 +1,6 @@
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 use crate::Scaler;
 use crate::mmm::FusedKerSpec;
-use crate::mmm::ImplementationQuality;
 
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 unsafe fn kernel_f32_4x4(mut pnl: *const FusedKerSpec<f32>) -> isize {
@@ -286,14 +285,14 @@ unsafe fn kernel_f32_4x4(mut pnl: *const FusedKerSpec<f32>) -> isize {
     }
 }
 
-// Reachable only by name, never through dispatch: it is the one kernel left at
-// TargetOptimized, and strategize's retain() keeps only the top quality tier.
-// Kept because it is the only f32 kernel besides 8x8 whose C tile is
-// two-dimensional, so the generated store and packing tests cover that layout
-// on a second shape. `dispatch_never_returns_wasm_f32_4x4` holds this in place.
+// Reachable only by name, never through dispatch: it declares NEVER_PREFERRED, so every
+// other wasm f32 kernel outranks it. Kept because it is the only f32 kernel besides 8x8
+// whose C tile is two-dimensional, so the generated store and packing tests cover that
+// layout on a second shape. `dispatch_never_returns_wasm_f32_4x4` holds this in place.
 bail_stub!(wasm32; unsafe fn kernel_f32_4x4(*const FusedKerSpec<f32>) -> isize);
 
-MMMRustKernel!(wasm32; kernel_f32_4x4 => wasm_f32_4x4<f32>(4,4)@(4,4) quality(ImplementationQuality::TargetOptimized));
+MMMRustKernel!(wasm32; kernel_f32_4x4 => wasm_f32_4x4<f32>(4,4)@(4,4)
+    boost(|| crate::isa::NEVER_PREFERRED));
 
 /// WASM SIMD f32 8x8 kernel — wide MM tile (8 rows × 8 cols, 16 v128 accumulators).
 /// Each row uses 2 v128: cols 0-3 in `_lo`, cols 4-7 in `_hi`. 16 accumulators
@@ -994,12 +993,9 @@ unsafe fn kernel_f32_8x8(mut pnl: *const FusedKerSpec<f32>) -> isize {
     }
 }
 
-// ManuallyOptimized so kernel_selection::strategize honours the mmm_f32
-// callback that returns it for N>1 GEMM (see the tier in `wasm.rs`) — otherwise
-// strategize drops it and routes every GEMM onto the 32x1 GEMV kernel.
 bail_stub!(wasm32; unsafe fn kernel_f32_8x8(*const FusedKerSpec<f32>) -> isize);
 
-MMMRustKernel!(wasm32; kernel_f32_8x8 => wasm_f32_8x8<f32>(8,8)@(8,8) quality(ImplementationQuality::ManuallyOptimized));
+MMMRustKernel!(wasm32; kernel_f32_8x8 => wasm_f32_8x8<f32>(8,8)@(8,8));
 
 /// WASM SIMD f32 4x16 kernel — 4 rows x 16 cols, 16 v128 accumulators laid out
 /// row-major as `acc[r * 4 + j]`, j indexing the four v128 chunks of a row.
@@ -1266,4 +1262,4 @@ unsafe fn kernel_f32_4x16(mut pnl: *const FusedKerSpec<f32>) -> isize {
 
 bail_stub!(wasm32; unsafe fn kernel_f32_4x16(*const FusedKerSpec<f32>) -> isize);
 
-MMMRustKernel!(wasm32; kernel_f32_4x16 => wasm_f32_4x16<f32>(4,16)@(4,16) quality(ImplementationQuality::ManuallyOptimized));
+MMMRustKernel!(wasm32; kernel_f32_4x16 => wasm_f32_4x16<f32>(4,16)@(4,16));

--- a/linalg/src/wasm/mmm_f32_gemv.rs
+++ b/linalg/src/wasm/mmm_f32_gemv.rs
@@ -1,7 +1,6 @@
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 use crate::Scaler;
 use crate::mmm::FusedKerSpec;
-use crate::mmm::ImplementationQuality;
 
 /// WASM SIMD f32 4x1 kernel — GEMV-shaped variant for matrix-vector products
 /// (single-column outputs, e.g., streaming-RNN inference where each frame's
@@ -159,11 +158,9 @@ unsafe fn kernel_f32_4x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
     }
 }
 
-// ManuallyOptimized so kernel_selection::strategize honours the M-band
-// dispatch in mmv_f32 below. See the tier in `wasm.rs`.
 bail_stub!(wasm32; unsafe fn kernel_f32_4x1(*const FusedKerSpec<f32>) -> isize);
 
-MMMRustKernel!(wasm32; kernel_f32_4x1 => wasm_f32_4x1<f32>(4,1)@(4,1) quality(ImplementationQuality::ManuallyOptimized));
+MMMRustKernel!(wasm32; kernel_f32_4x1 => wasm_f32_4x1<f32>(4,1)@(4,1));
 
 /// WASM SIMD f32 8x1 kernel — wider GEMV variant for matrix-vector products
 /// on large M. Uses TWO independent f32x4 accumulators (rows 0-3 in ab_top,
@@ -403,7 +400,7 @@ unsafe fn kernel_f32_8x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
 
 bail_stub!(wasm32; unsafe fn kernel_f32_8x1(*const FusedKerSpec<f32>) -> isize);
 
-MMMRustKernel!(wasm32; kernel_f32_8x1 => wasm_f32_8x1<f32>(8,1)@(8,1) quality(ImplementationQuality::ManuallyOptimized));
+MMMRustKernel!(wasm32; kernel_f32_8x1 => wasm_f32_8x1<f32>(8,1)@(8,1));
 
 /// WASM SIMD f32 16x1 kernel — wider GEMV variant for matrix-vector products
 /// on very large M. Uses FOUR independent f32x4 accumulators (rows 0-3,
@@ -663,7 +660,7 @@ unsafe fn kernel_f32_16x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
 
 bail_stub!(wasm32; unsafe fn kernel_f32_16x1(*const FusedKerSpec<f32>) -> isize);
 
-MMMRustKernel!(wasm32; kernel_f32_16x1 => wasm_f32_16x1<f32>(16,1)@(16,1) quality(ImplementationQuality::ManuallyOptimized));
+MMMRustKernel!(wasm32; kernel_f32_16x1 => wasm_f32_16x1<f32>(16,1)@(16,1));
 
 /// WASM SIMD f32 32x1 kernel — widest GEMV variant for matrix-vector products
 /// on very large M. Uses EIGHT independent f32x4 accumulators (rows 0-3, 4-7,
@@ -1049,4 +1046,4 @@ unsafe fn kernel_f32_32x1(mut pnl: *const FusedKerSpec<f32>) -> isize {
 
 bail_stub!(wasm32; unsafe fn kernel_f32_32x1(*const FusedKerSpec<f32>) -> isize);
 
-MMMRustKernel!(wasm32; kernel_f32_32x1 => wasm_f32_32x1<f32>(32,1)@(32,1) quality(ImplementationQuality::ManuallyOptimized));
+MMMRustKernel!(wasm32; kernel_f32_32x1 => wasm_f32_32x1<f32>(32,1)@(32,1));

--- a/linalg/src/wasm/mmm_i32.rs
+++ b/linalg/src/wasm/mmm_i32.rs
@@ -1,7 +1,6 @@
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 use crate::Scaler;
 use crate::mmm::FusedKerSpec;
-use crate::mmm::ImplementationQuality;
 
 // Wasm SIMD int8 -> i32 matmul kernel (4x4). Under +relaxed-simd the AddMatMul
 // K-loop uses i32x4.relaxed_dot_i8x16_i7x16_add with B sign-split so both dot
@@ -10,8 +9,8 @@ use crate::mmm::ImplementationQuality;
 // (an extmul/SMLAL-style outer product). The quant epilogue + fuse ops reuse
 // the bit-exact scalar path (q_scale/q_shr/q_shl), which is O(MR*NR) and
 // negligible vs the O(MR*NR*K) inner loop. Both paths are bit-identical to
-// generic_i32_4x4; selected for i8 matmul via its ManuallyOptimized quality
-// (WASM had no int8 matmul kernel — int8 fell back to the generic scalar one).
+// generic_i32_4x4; selected for i8 matmul because it is written for wasm and the generic
+// scalar kernel is not (WASM had no int8 matmul kernel before this one).
 #[inline(never)]
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 unsafe fn kernel_i32_4x4(mut pnl: *const FusedKerSpec<i32>) -> isize {
@@ -356,6 +355,6 @@ bail_stub!(wasm32; unsafe fn kernel_i32_4x4(*const FusedKerSpec<i32>) -> isize);
 
 MMMRustKernel!(wasm32; kernel_i32_4x4 => wasm_i32_4x4<i32>(4,4)
     packing[1] = i8i8 => |k| k.with_packing(wasm_i8_packing(), wasm_i8_packing());
-    quality(ImplementationQuality::ManuallyOptimized)
+
     store(i8)
 );

--- a/linalg/src/wasm/mod.rs
+++ b/linalg/src/wasm/mod.rs
@@ -25,10 +25,9 @@ pub use mmm_f32_gemm::*;
 pub use mmm_f32_gemv::*;
 pub use mmm_i32::*;
 
-/// Every kernel this tier names must be ManuallyOptimized: its answer is held to the suitable
-/// list, and a lesser quality would be dropped by retain_best_quality, leaving the N>1 rule to
-/// pick max(nr*mr) among the surviving GEMV kernels — i.e. wasm_f32_32x1, a matrix×vector
-/// kernel, for every GEMM.
+/// Every kernel this tier names must be one written for wasm: its answer is held to the suitable
+/// list, and a generic kernel counts as no opinion, leaving the N>1 rule to pick max(nr*mr) among
+/// the surviving GEMV kernels — i.e. wasm_f32_32x1, a matrix-vector kernel, for every GEMM.
 fn preferred(
     _isa: &crate::isa::IsaSet,
     dt: DatumType,

--- a/linalg/src/x86_64/mmm.rs
+++ b/linalg/src/x86_64/mmm.rs
@@ -3,7 +3,6 @@ use crate::block_quant::*;
 use crate::isa::Arch;
 use crate::isa::Isa;
 use crate::isa::IsaSet;
-use crate::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::mmm::{Query, Suitable};
 use crate::mmm_tiers::MmmTier;
 use crate::pack::PackedFormat;
@@ -77,13 +76,13 @@ fn pick_mmm(choices: &[KernelChoice], m: Option<usize>, n: Option<usize>) -> &'s
 // AVX-without-FMA f32 tier for pre-Haswell CPUs (Sandy Bridge / Ivy Bridge):
 // same tile geometries as their fma_ siblings but the inner loops use
 // vmulps+vaddps, and add_unicast avoids the avx2-only vgatherdps.
-MMMExternKernel!(x86_64; avx_mmm_f32_8x8 <f32>(8, 8)@(256,4) isa(X86_64Avx) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx_mmm_f32_16x5<f32>(16,5)@(256,4) isa(X86_64Avx) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx_mmm_f32_16x6<f32>(16,6)@(256,4) isa(X86_64Avx) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx_mmm_f32_24x4<f32>(24,4)@(256,4) isa(X86_64Avx) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx_mmm_f32_32x3<f32>(32,3)@(256,4) isa(X86_64Avx) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx_mmm_f32_40x2<f32>(40,2)@(256,4) isa(X86_64Avx) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx_mmm_f32_64x1<f32>(64,1)@(256,4) isa(X86_64Avx) quality(ManuallyOptimized));
+MMMExternKernel!(x86_64; avx_mmm_f32_8x8 <f32>(8, 8)@(256,4) isa(X86_64Avx));
+MMMExternKernel!(x86_64; avx_mmm_f32_16x5<f32>(16,5)@(256,4) isa(X86_64Avx));
+MMMExternKernel!(x86_64; avx_mmm_f32_16x6<f32>(16,6)@(256,4) isa(X86_64Avx));
+MMMExternKernel!(x86_64; avx_mmm_f32_24x4<f32>(24,4)@(256,4) isa(X86_64Avx));
+MMMExternKernel!(x86_64; avx_mmm_f32_32x3<f32>(32,3)@(256,4) isa(X86_64Avx));
+MMMExternKernel!(x86_64; avx_mmm_f32_40x2<f32>(40,2)@(256,4) isa(X86_64Avx));
+MMMExternKernel!(x86_64; avx_mmm_f32_64x1<f32>(64,1)@(256,4) isa(X86_64Avx));
 
 /// The 256-bit fma f32 kernels are not superseded by the avx512 ones, so they cancel the ladder
 /// step between the two and are preferred as peers. Both x86 avx512 cost models score them alongside the
@@ -92,12 +91,12 @@ MMMExternKernel!(x86_64; avx_mmm_f32_64x1<f32>(64,1)@(256,4) isa(X86_64Avx) qual
 /// packing group, whose 64x3 is the best matrix kernel at small `n`.
 const FMA_F32_PEER: fn() -> isize = || crate::isa::peer_of(Isa::X86_64Fma, Isa::X86_64Avx512f);
 
-MMMExternKernel!(x86_64; fma_mmm_f32_8x8 <f32>(8, 8)@(256,4) isa(X86_64Avx, X86_64Fma) quality(ManuallyOptimized) boost(FMA_F32_PEER));
-MMMExternKernel!(x86_64; fma_mmm_f32_16x6<f32>(16,6)@(256,4) isa(X86_64Avx, X86_64Fma) quality(ManuallyOptimized) boost(FMA_F32_PEER));
-MMMExternKernel!(x86_64; fma_mmm_f32_16x5<f32>(16,5)@(256,4) isa(X86_64Avx, X86_64Fma) quality(ManuallyOptimized) boost(FMA_F32_PEER));
-MMMExternKernel!(x86_64; fma_mmm_f32_24x4<f32>(24,4)@(256,4) isa(X86_64Avx, X86_64Fma) quality(ManuallyOptimized) boost(FMA_F32_PEER));
-MMMExternKernel!(x86_64; fma_mmm_f32_40x2<f32>(40,2)@(256,4) isa(X86_64Avx, X86_64Fma) quality(ManuallyOptimized) boost(FMA_F32_PEER));
-MMMExternKernel!(x86_64; fma_mmm_f32_64x1<f32>(64,1)@(256,4) isa(X86_64Avx, X86_64Fma) quality(ManuallyOptimized) boost(FMA_F32_PEER));
+MMMExternKernel!(x86_64; fma_mmm_f32_8x8 <f32>(8, 8)@(256,4) isa(X86_64Avx, X86_64Fma) boost(FMA_F32_PEER));
+MMMExternKernel!(x86_64; fma_mmm_f32_16x6<f32>(16,6)@(256,4) isa(X86_64Avx, X86_64Fma) boost(FMA_F32_PEER));
+MMMExternKernel!(x86_64; fma_mmm_f32_16x5<f32>(16,5)@(256,4) isa(X86_64Avx, X86_64Fma) boost(FMA_F32_PEER));
+MMMExternKernel!(x86_64; fma_mmm_f32_24x4<f32>(24,4)@(256,4) isa(X86_64Avx, X86_64Fma) boost(FMA_F32_PEER));
+MMMExternKernel!(x86_64; fma_mmm_f32_40x2<f32>(40,2)@(256,4) isa(X86_64Avx, X86_64Fma) boost(FMA_F32_PEER));
+MMMExternKernel!(x86_64; fma_mmm_f32_64x1<f32>(64,1)@(256,4) isa(X86_64Avx, X86_64Fma) boost(FMA_F32_PEER));
 
 pub fn pq40_r32() -> PackedBlockQuantFormat {
     PackedBlockQuantFormat::new(&Q4_0, 32, 16, false)
@@ -111,7 +110,7 @@ MMMExternKernel! { x86_64; fma_mmm_f32_32x1<f32>(32,1)@(256,4) isa(X86_64Avx, X8
     packing[3] = f16f16 => |k| k.with_packing(f16::packing(32), f16::packing(1));
     packing[4] = f16f32 => |k| k.with_packing(f16::packing(32), f32::packing(1));
     packing[5] = f32f16 => |k| k.with_packing(f32::packing(32), f16::packing(1));
-    quality(ManuallyOptimized)
+
     boost(FMA_F32_PEER)
     store(f16)
 }
@@ -119,33 +118,33 @@ MMMExternKernel!(x86_64; fma_mmm_f32_32x3<f32>(32,3)@(256,4) isa(X86_64Avx, X86_
  packing[1] = f32f16 => |k| k.with_packing(f32::packing(32).align(256), f16::packing(3));
  packing[2] = f16f32 => |k| k.with_packing(f16::packing(32).align(256), f32::packing(3));
  packing[3] = f16f16 => |k| k.with_packing(f16::packing(32).align(256), f16::packing(3));
- quality(ManuallyOptimized)
+
  boost(FMA_F32_PEER)
  store(f16)
 );
 
-MMMExternKernel!(x86_64; avx512_mmm_f32_128x1<f32>(128, 1)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_16x1 <f32>( 16, 1)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_16x12<f32>( 16,12)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_16x8 <f32>( 16, 8)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_32x6 <f32>( 32, 6)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_32x5 <f32>( 32, 5)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_48x4 <f32>( 48, 4)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_64x3 <f32>( 64, 3)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
-MMMExternKernel!(x86_64; avx512_mmm_f32_80x2 <f32>( 80, 2)@(512,4) isa(X86_64Avx512f) quality(ManuallyOptimized));
+MMMExternKernel!(x86_64; avx512_mmm_f32_128x1<f32>(128, 1)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_16x1 <f32>( 16, 1)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_16x12<f32>( 16,12)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_16x8 <f32>( 16, 8)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_32x6 <f32>( 32, 6)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_32x5 <f32>( 32, 5)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_48x4 <f32>( 48, 4)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_64x3 <f32>( 64, 3)@(512,4) isa(X86_64Avx512f));
+MMMExternKernel!(x86_64; avx512_mmm_f32_80x2 <f32>( 80, 2)@(512,4) isa(X86_64Avx512f));
 
 // 128-bit VEX i32 sibling of avx2_mmm_i32_8x8 for the avx-without-avx2 tier:
 // same i8i8 widening scheme (i8 products computed in i16 lanes) and the same
 // quantization epilogue semantics, on 8x4 xmm column pairs.
 MMMExternKernel! { x86_64; avx_mmm_i32_8x4<i32>(8,4)@(256,4) isa(X86_64Avx)
     packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 8, 256), PackedFormat::new(DatumType::I8, 4, 4));
-    quality(ManuallyOptimized)
+
     store(i8)
 }
 
 MMMExternKernel! { x86_64; avx2_mmm_i32_8x8<i32>(8,8)@(256,4) isa(X86_64Avx2)
     packing[1] = i8i8 => |k| k.with_packing(PackedFormat::new(DatumType::I8, 8, 256), PackedFormat::new(DatumType::I8, 8, 4));
-    quality(ManuallyOptimized)
+
     store(i8)
 }
 
@@ -161,7 +160,7 @@ MMMExternKernel! { x86_64; avx2_mmm_i32_8x8<i32>(8,8)@(256,4) isa(X86_64Avx2)
 #[cfg(tract_avx512vnni)]
 MMMExternKernel! { x86_64; avx512vnni_mmm_i32_8x8<i32>(8,8)@(256,4) isa(X86_64Avx512f, X86_64Avx512Vnni)
     packing[1] = i8i8 => |k| k.with_packing(PackedI8K4::new(8), PackedI8K4::new(8));
-    quality(ManuallyOptimized)
+
     store(i8)
 }
 
@@ -185,7 +184,7 @@ MMMExternKernel! { x86_64; avx512vnni_mmm_i32_8x8<i32>(8,8)@(256,4) isa(X86_64Av
 #[cfg(tract_avx512vnni)]
 MMMExternKernel! { x86_64; avx512vnni_mmm_i32_16x16<i32>(16,16)@(64,4) isa(X86_64Avx512f, X86_64Avx512Vnni)
     packing[1] = i8i8 => |k| k.with_packing(PackedI8K4::new(16), PackedI8K4::new(16));
-    quality(ManuallyOptimized)
+
     boost(AVX512VNNI_WIDE_TILE)
     store(i8)
 }
@@ -200,7 +199,7 @@ MMMExternKernel! { x86_64; avx512vnni_mmm_i32_16x16<i32>(16,16)@(64,4) isa(X86_6
 #[cfg(tract_avxvnni)]
 MMMExternKernel! { x86_64; avxvnni_mmm_i32_8x8<i32>(8,8)@(256,4) isa(X86_64Avx2, X86_64AvxVnni)
     packing[1] = i8i8 => |k| k.with_packing(PackedI8K4::new(8), PackedI8K4::new(8));
-    quality(ManuallyOptimized)
+
     store(i8)
 }
 
@@ -214,7 +213,7 @@ MMMExternKernel! { x86_64; avxvnni_mmm_i32_8x8<i32>(8,8)@(256,4) isa(X86_64Avx2,
 #[cfg(tract_amx_int8)]
 MMMExternKernel! { x86_64; avx512amx_mmm_i32_8x8<i32>(8,8)@(64,4) isa(X86_64Avx512f, X86_64AmxInt8)
     packing[1] = i8i8 => |k| k.with_packing(PackedAmxA::new(8), PackedI8K4::new(8));
-    quality(ManuallyOptimized)
+
     store(i8)
 }
 
@@ -223,15 +222,15 @@ MMMExternKernel! { x86_64; avx512amx_mmm_i32_8x8<i32>(8,8)@(64,4) isa(X86_64Avx5
 // accumulators (zmm{m} = row m of C) so the hot path (Clear -> AddMatMul ->
 // Store) needs no transpose.
 //
-// boost(100) pushes this kernel above the equally-ManuallyOptimized AVX-512-VNNI
-// and AMX 8x8 kernels in the einsum kernel-selection scorer (which uses
-// `-quality_cost*1000 + boost` per kernel). When more than one dim is symbolic
-// the shape-adaptive `qmmm_i32` picker isn't invoked, so the boost is what
-// causes the optimizer to prefer the 16x16 tile for unknown-shape matmuls.
+// boost(100) pushes this kernel above the AMX 8x8 kernel it shares an instruction-set level
+// with, and above the AVX-512-VNNI 8x8 a level below it, when einsum picks among the suitable
+// kernels. When more than one dim is symbolic the shape-adaptive `qmmm_i32` picker isn't
+// invoked, so the boost is what causes the optimizer to prefer the 16x16 tile for
+// unknown-shape matmuls.
 #[cfg(tract_amx_int8)]
 MMMExternKernel! { x86_64; avx512amx_mmm_i32_16x16<i32>(16,16)@(64,4) isa(X86_64Avx512f, X86_64AmxInt8)
     packing[1] = i8i8 => |k| k.with_packing(PackedAmxA::new(16), PackedI8K4::new(16));
-    quality(ManuallyOptimized)
+
     boost(|| 100)
     store(i8)
 }
@@ -247,13 +246,13 @@ MMMExternKernel! { x86_64; avx512amx_mmm_i32_16x16<i32>(16,16)@(64,4) isa(X86_64
 // Default packing[0] (the framework's PackedFormat<f32>) is retained so the
 // kernel can still be selected for f32 paths even when the BF16 packer
 // isn't a precursor match; packing[1] is the fast bf16-from-f32 path.
-// Once opted in, the boost puts this kernel above the AVX-512 f32 / FMA f32 kernels at the
-// same ManuallyOptimized tier so the einsum scorer prefers it, mirroring the i32 16x16
-// behaviour; see `AMX_BF16_OPT_IN` for the default-off half.
+// Once opted in, the boost puts this kernel above the AVX-512 f32 and FMA f32 kernels so the
+// einsum prefers it, mirroring the i32 16x16 behaviour; see `AMX_BF16_OPT_IN` for the
+// default-off half.
 #[cfg(tract_amx_bf16)]
 MMMExternKernel! { x86_64; avx512amx_mmm_f32_16x16<f32>(16,16)@(64,4) isa(X86_64Avx512f, X86_64AmxBf16)
     packing[1] = f32f32_bf16 => |k| k.with_packing(PackedAmxBf16A::new(16), PackedBf16K2::new(16));
-    quality(ManuallyOptimized)
+
     boost(AMX_BF16_OPT_IN)
 }
 


### PR DESCRIPTION
ImplementationQuality's five tiers only ever decided whether a kernel was written for this architecture or was portable Rust: arm64simd and armvfpv2 declare no isa, so they sat at level 0 beside the generic kernels and the label was the only thing lifting them. mmm now reads the arch off the kernel itself, the macros' leading ident that the inventory handle used to carry separately, and orders suitable kernels by (arch, preference) as routines.rs already does, which drops the thousand-fold weight the old score needed to keep a boost from crossing a tier. The three labels that meant something else now say it: wasm_f32_4x4 declares NEVER_PREFERRED, which is what holding it out of dispatch was for, and the generic f16 kernels declare emulated(), which is all Dreadful ever said.