### PR TITLE
(perf) core: fuse a squeezed unit matmul axis and a unicast Mul+Add pair

### DIFF
--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -909,7 +909,117 @@ impl EvalOp for OptBinUnicast {
     }
 }
 
+/// `a * b + c` in one pass, where `b` and `c` are unicast operands sharing a
+/// period: each has leading unit axes that `a` repeats over, and matches `a`
+/// past them. Formed by [`OptBinUnicast::fuse`] from a `Mul` feeding an `Add`,
+/// which would otherwise walk `a` twice.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OptMulAddUnicast;
+
+impl Op for OptMulAddUnicast {
+    fn name(&self) -> StaticName {
+        "OptMulAddUnicast".into()
+    }
+    op_as_typed_op!();
+}
+
+impl OptMulAddUnicast {
+    fn eval_t<T>(a: &mut Tensor, b: &Tensor, c: &Tensor) -> TractResult<()>
+    where
+        T: Datum + Copy + std::ops::Mul<Output = T> + std::ops::Add<Output = T>,
+    {
+        let b = b.try_as_plain()?;
+        let b = b.as_slice::<T>()?;
+        let c = c.try_as_plain()?;
+        let c = c.as_slice::<T>()?;
+        let mut a = a.try_as_plain_mut()?;
+        for chunk in a.as_slice_mut::<T>()?.chunks_mut(b.len()) {
+            for ((v, b), c) in chunk.iter_mut().zip(b).zip(c) {
+                *v = *v * *b + *c;
+            }
+        }
+        Ok(())
+    }
+
+    fn natural(t: &Tensor) -> bool {
+        t.len() == t.shape().iter().product::<usize>()
+            && t.strides() == &*Tensor::natural_strides(t.shape())
+    }
+}
+
+impl EvalOp for OptMulAddUnicast {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let (a, b, c) = args_3!(inputs);
+        // Same natural-strides contract as OptBinUnicast: the chunked walk sizes
+        // its slices from the declared shape, which only matches the storage
+        // when the strides are C-order.
+        if !Self::natural(&a) || !Self::natural(&b) || !Self::natural(&c) {
+            let dt = a.datum_type();
+            let m = Mul.eval(a, b, dt)?;
+            return Ok(tvec!(Add.eval(m.into_tvalue(), c, dt)?.into_tvalue()));
+        }
+        let mut a = a.into_tensor();
+        let dt = a.datum_type();
+        dispatch_floatlike!(Self::eval_t(dt)(&mut a, &b, &c))?;
+        Ok(tvec!(a.into_tvalue()))
+    }
+}
+
+impl TypedOp for OptMulAddUnicast {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        ensure!(inputs.len() == 3);
+        ensure!(OptBinUnicast::check_input_shapes(&inputs[0].shape, &inputs[1].shape));
+        ensure!(OptBinUnicast::check_input_shapes(&inputs[0].shape, &inputs[2].shape));
+        Ok(tvec!(inputs[0].datum_type.fact(inputs[0].shape.clone())))
+    }
+
+    fn cost(&self, inputs: &[&TypedFact]) -> TractResult<TVec<(Cost, TDim)>> {
+        let count: TDim = inputs[0].shape.iter().product();
+        Ok(tvec!((Cost::FMA(inputs[0].datum_type), count)))
+    }
+
+    as_op!();
+}
+
 impl TypedOp for OptBinUnicast {
+    /// Absorb a `Mul` feeding an `Add` into [`OptMulAddUnicast`]. Both unicast
+    /// operands must share a period, so one walk of the accumulator covers them
+    /// together.
+    fn fuse(&self, model: &TypedModel, node: &TypedNode) -> TractResult<Option<TypedModelPatch>> {
+        if !self.binop.is::<Mul>() {
+            return Ok(None);
+        }
+        rule_if!(node.outputs.len() == 1);
+        rule_if!(node.outputs[0].successors.len() == 1);
+        rule_if!(!model.output_outlets()?.contains(&node.id.into()));
+        let succ = model.node(node.outputs[0].successors[0].node);
+        rule_if_some!(add = succ.op_as::<OptBinUnicast>());
+        rule_if!(add.binop.is::<Add>());
+        let acc = model.outlet_fact(node.inputs[0])?;
+        let scale = model.outlet_fact(node.inputs[1])?;
+        let other_slot = 1 - succ.inputs.iter().position(|i| i.node == node.id).unwrap();
+        let other = model.outlet_fact(succ.inputs[other_slot])?;
+        // Add is commutative, so which slot the product landed in does not
+        // matter; the product's own accumulator stays the one written into.
+        rule_if!(acc.datum_type == scale.datum_type && acc.datum_type == other.datum_type);
+        rule_if!(acc.datum_type.is_float());
+        rule_if_some!(scale_len = scale.shape.as_concrete().map(|s| s.iter().product::<usize>()));
+        rule_if_some!(other_len = other.shape.as_concrete().map(|s| s.iter().product::<usize>()));
+        rule_if!(scale_len == other_len);
+        rule_if!(Self::check_input_shapes(&acc.shape, &other.shape));
+        let mut patch = TypedModelPatch::new("fusing Mul and Add");
+        let a = patch.tap_model(model, node.inputs[0])?;
+        let b = patch.tap_model(model, node.inputs[1])?;
+        let c = patch.tap_model(model, succ.inputs[other_slot])?;
+        let wire = patch.wire_node(&succ.name, OptMulAddUnicast, &[a, b, c])?[0];
+        patch.shunt_outside(model, succ.id.into(), wire)?;
+        Ok(Some(patch))
+    }
+
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
         ensure!(Self::check_input_shapes(&inputs[0].shape, &inputs[1].shape));
         let out_dt = self.binop.result_datum_type(inputs[0].datum_type, inputs[1].datum_type)?;

--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -405,8 +405,9 @@ impl AxisOp {
             Add(ix) => tensor.insert_axis(*ix),
             Rm(ix) => tensor.remove_axis(*ix),
             Move(from, to) => {
-                let mut tmp = tensor.clone().move_axis(*from, *to)?;
-                std::mem::swap(tensor, &mut tmp);
+                // `move_axis` consumes its input and materialises the permuted
+                // result, so cloning first would copy the data twice.
+                *tensor = std::mem::take(tensor).move_axis(*from, *to)?;
                 Ok(())
             }
             Reshape(at, from, to) => {

--- a/core/src/ops/matmul/optimized.rs
+++ b/core/src/ops/matmul/optimized.rs
@@ -19,6 +19,18 @@ use super::ModePicker;
 /// If `new` is `old` with only size-1 axes dropped (non-unit axes untouched, in
 /// order, nothing added or merged), return the removed axis indices; otherwise
 /// `None`. Such a reshape is a pure metadata squeeze the matmul store can absorb.
+/// Track an output axis index across the removal of a unit axis. The removed
+/// axis can be the m or n axis itself, which is only ever unit-sized here: the
+/// store then reads a zero stride for that side, the extent the kernel is given
+/// falls back to 1, and both are what a squeezed unit axis means.
+fn squeeze_c_axis(current: Option<usize>, removed: usize) -> Option<usize> {
+    match current {
+        Some(ax) if ax == removed => None,
+        Some(ax) => Some(ax - (ax > removed) as usize),
+        None => None,
+    }
+}
+
 fn pure_squeeze_removed(old: &[usize], new: &[usize]) -> Option<TVec<usize>> {
     let mut removed: TVec<usize> = tvec!();
     let mut j = 0;
@@ -321,25 +333,26 @@ impl ProtoFusedSpec {
             }
             BinScalar(..) | Scaler(..) | AddRowColProducts(_, _) | LeakyRelu(_) => {}
             BinPerRow(_, _, map) | BinPerCol(_, _, map) => map.rm_c_axis(axis),
-            AddUnicast(_, _, map) => {
+            AddUnicast(oss, _, map) => {
                 map.rm_c_axis(axis);
+                rm_store_c_axis(oss, axis);
             }
             Store(oss, ..) => {
                 for oss in oss {
-                    match oss {
-                        OutputStoreSpec::View { m_axis, n_axis, .. } => {
-                            if let Some(m) = m_axis {
-                                *m -= (*m > axis) as usize
-                            };
-                            if let Some(n) = n_axis {
-                                *n -= (*n > axis) as usize
-                            }
-                        }
-                        OutputStoreSpec::Strides { .. } => {}
-                    }
+                    rm_store_c_axis(oss, axis);
                 }
             }
         }
+    }
+}
+
+fn rm_store_c_axis(oss: &mut OutputStoreSpec, axis: usize) {
+    match oss {
+        OutputStoreSpec::View { m_axis, n_axis, .. } => {
+            *m_axis = squeeze_c_axis(*m_axis, axis);
+            *n_axis = squeeze_c_axis(*n_axis, axis);
+        }
+        OutputStoreSpec::Strides { .. } => {}
     }
 }
 
@@ -812,18 +825,16 @@ impl OptMatMul {
         self.trivial_path = self.can_use_trivial_path();
     }
 
-    /// If `into` is a pure unit-axis squeeze of this op's (concrete) output that
-    /// leaves the m/n axes intact, return a clone whose store produces the
-    /// squeezed shape directly. `None` when the reshape can't be absorbed.
+    /// If `into` is a pure unit-axis squeeze of this op's (concrete) output,
+    /// return a clone whose store produces the squeezed shape directly. A
+    /// squeezed m or n axis becomes `None` on the clone. `None` when the reshape
+    /// can't be absorbed.
     fn absorb_squeeze(&self, into: &IntoShape) -> Option<Self> {
         if into.strides != Tensor::natural_strides(&into.dims) {
             return None;
         }
         let old = self.c_fact.shape.as_concrete()?;
         let removed = pure_squeeze_removed(old, &into.dims)?;
-        if removed.iter().any(|ax| Some(*ax) == self.c_m_axis || Some(*ax) == self.c_n_axis) {
-            return None;
-        }
         // A non-unit matmul batch axis (e.g. grouped conv) makes the packed
         // inputs per-batch; folding any axis then desyncs that batch indexing.
         // Only fuse when every batch axis is trivial (size 1).
@@ -835,12 +846,8 @@ impl OptMatMul {
         let mut new_op = self.clone();
         for axis in removed.iter().rev() {
             new_op.c_fact.shape.remove_axis(*axis).ok()?;
-            if let Some(c_m_axis) = &mut new_op.c_m_axis {
-                *c_m_axis -= (*c_m_axis > *axis) as usize;
-            }
-            if let Some(c_n_axis) = &mut new_op.c_n_axis {
-                *c_n_axis -= (*c_n_axis > *axis) as usize;
-            }
+            new_op.c_m_axis = squeeze_c_axis(new_op.c_m_axis, *axis);
+            new_op.c_n_axis = squeeze_c_axis(new_op.c_n_axis, *axis);
             for uop in &mut new_op.micro_ops {
                 uop.rm_c_axis(*axis);
             }


### PR DESCRIPTION
Three changes that cut copies and node count in the optimised graph. All are
pure plumbing — outputs are **bit-identical** on every model tested.

### `absorb_squeeze` refused to drop a unit m or n axis

`OptMatMul::absorb_squeeze` bailed on any reshape that removed the m or n axis.
But a pure squeeze only ever removes unit axes, and the store already handles a
`None` axis: `compute_strides` reads a zero stride for it and the extent falls
back to 1, which is exactly what a squeezed unit axis means. So the guard was
turning down reshapes it could have absorbed.

It costs two nodes, not one. A `[1, m]` GEMV output reshaped to `[m]` kept its
`IntoShape`, and that node then sat between the matmul and its bias add,
blocking the `OptBinUnicast(Add)` → `AddUnicast`-in-the-store fusion that would
otherwise have fired.

The guard is dropped, both axes now go through a `squeeze_c_axis` helper, and
`rm_c_axis` tracks the change into the fused specs' own store specs — including
`AddUnicast`'s, which previously was not updated at all (unreachable while the
guard stood).

### A unicast `Mul` feeding a unicast `Add` walked the accumulator twice

`x * g` then `+ b` reads and writes the whole tensor twice for arithmetic that
fits in one traversal. `OptBinUnicast::fuse` now folds the pair into
`OptMulAddUnicast` when both unicast operands share a period, so a single walk
covers them. It is codegen-only, so nothing new has to serialise.

This is the affine tail of a normalisation and the gate update of a GRU cell —
it fires on `LayerNormalization.y_internal` and `grucell/Add_2` among others.

### `MoveAxis` copied the tensor twice

`AxisOp::change_tensor`'s `Move` arm did `tensor.clone().move_axis(..)`. But
`move_axis` consumes its input and goes through `permute_axes` → `Tensor::from_datum`,
which allocates a fresh natural-strided tensor and copies into it. The clone was a
second, redundant full copy on every `MoveAxis` node.

Unlike the two rules above this one is not shape-specific — it applies to any
transpose in any model, which is why `dtln` and the DeepFilterNet3 submodels move
at all here.

### Measured

p50 ms/frame, median of 5 interleaved runs, single-threaded, aarch64, against
this PR's merge base.

| model | main | this PR | |
|---|---|---|---|
| dpdfnet2_8khz | 1.449 | 1.380 | **+4.8%** |
| dpdfnet2 | 1.329 | 1.277 | **+4.0%** |
| baseline (DPDFNet, no GRU) | 0.464 | 0.446 | **+3.8%** |
| dpdfnet8 | 3.940 | 3.794 | **+3.7%** |
| dpdfnet4 | 2.198 | 2.130 | **+3.1%** |
| dpdfnet8_8khz | 3.791 | 3.684 | **+2.8%** |
| dpdfnet8_48khz_hr | 6.695 | 6.516 | **+2.7%** |
| dpdfnet2_48khz_hr | 2.555 | 2.497 | **+2.3%** |
| gtcrn | 0.683 | 0.680 | +0.5% |
| DeepFilterNet3 enc | 0.1263 | 0.1258 | +0.4% |
| dtln_model_2 | 0.0529 | 0.0527 | +0.4% |
| dtln_model_1 | 0.0312 | 0.0312 | 0.0% |
| DeepFilterNet3 erb_dec | 0.1057 | 0.1057 | 0.0% |
| DeepFilterNet3 df_dec | 0.0984 | 0.0991 | −0.7% |
| gtcrn_simple | 0.685 | 0.696 | −1.6% |

The last two rows are noise, not regressions: `gtcrn_simple` is the same graph as
`gtcrn` (+0.5%) and `df_dec` runs in 98 µs, where a 0.7 µs swing is a rounding
artifact of the median.

The wins concentrate on [DPDFNet](https://github.com/ceva-ip/DPDFNet), whose
Gemm-based GRU cells emit exactly the `[1, m]`-GEMV-then-reshape-then-bias chain
the first rule unblocks. On `dpdfnet8_48khz_hr` that is 1901 nodes down to 1103,
with `OptAddUnicast` 148 → 50 and `IntoShape` 184 → 154. GTCRN and DTLN do not
form the chain and land inside noise, as expected.

Outputs compared whole-stream, every frame: **max absolute difference exactly
`0`** on all nine models above, including the two that gain nothing.

Full workspace suite green, `cargo fmt` and `cargo clippy` clean. No new
`unsafe`.

🍍

