### PR TITLE
onnx: let the facade pass loader options

### DIFF
--- a/api/ffi/src/lib.rs
+++ b/api/ffi/src/lib.rs
@@ -2,13 +2,12 @@
 
 use anyhow::{Context, Result};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::ffi::{CStr, CString, c_char, c_void};
 use tract::{State, Tensor};
 use tract_api::{
     AsFact, DatumType, DimInterface, FactInterface, InferenceModelInterface, ModelInterface,
-    NnefInterface, OnnxInterface, RunnableInterface, RuntimeInterface, StateInterface,
-    TensorInterface,
+    NnefInterface, OnnxInterface, OnnxOptions, OnnxOptionsSpec, RunnableInterface,
+    RuntimeInterface, StateInterface, TensorInterface,
 };
 
 /// Used as a return type of functions that can encounter errors.
@@ -315,52 +314,31 @@ pub unsafe extern "C" fn tract_onnx_load(
     })
 }
 
-/// Read `len` key and value pairs from two parallel arrays of null-terminated
-/// utf-8 strings.
-unsafe fn read_options(
-    keys: *const *const c_char,
-    values: *const *const c_char,
-    len: usize,
-) -> Result<HashMap<String, String>> {
-    if len == 0 {
-        return Ok(HashMap::new());
+/// Read the loader options: a JSON object, or null for the defaults.
+unsafe fn read_options(options: *const c_char) -> Result<OnnxOptionsSpec> {
+    if options.is_null() {
+        return Ok(OnnxOptions::new().into());
     }
-    check_not_null!(keys, values);
-    let mut options = HashMap::new();
-    for i in 0..len {
-        unsafe {
-            let key = *keys.add(i);
-            let value = *values.add(i);
-            check_not_null!(key, value);
-            options.insert(
-                CStr::from_ptr(key).to_str()?.to_string(),
-                CStr::from_ptr(value).to_str()?.to_string(),
-            );
-        }
-    }
-    Ok(options)
+    Ok(unsafe { CStr::from_ptr(options) }.to_str()?.into())
 }
 
 /// Parse and load an ONNX model as a tract InferenceModel, with loader options.
 ///
-/// `option_keys` and `option_values` are two parallel arrays of `option_len`
-/// null-terminated utf-8 strings. See `OnnxInterface::load_with_options` in the
-/// Rust API for the keys. An unknown key is an error.
+/// `options` is a null-terminated utf-8 JSON object, or null for the defaults.
+/// See `OnnxOptions` in the Rust API for the fields. An unknown field is an error.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tract_onnx_load_with_options(
     onnx: *const TractOnnx,
     path: *const c_char,
-    option_keys: *const *const c_char,
-    option_values: *const *const c_char,
-    option_len: usize,
+    options: *const c_char,
     model: *mut *mut TractInferenceModel,
 ) -> TRACT_RESULT {
     wrap(|| unsafe {
         check_not_null!(onnx, path, model);
         *model = std::ptr::null_mut();
         let path = CStr::from_ptr(path).to_str()?;
-        let options = read_options(option_keys, option_values, option_len)?;
-        let m = Box::new(TractInferenceModel((*onnx).0.load_with_options(path, &options)?));
+        let options = read_options(options)?;
+        let m = Box::new(TractInferenceModel((*onnx).0.load_with_options(path, options)?));
         *model = Box::into_raw(m);
         Ok(())
     })
@@ -368,23 +346,21 @@ pub unsafe extern "C" fn tract_onnx_load_with_options(
 
 /// Parse and load an ONNX buffer as a tract InferenceModel, with loader options.
 ///
-/// See `tract_onnx_load_with_options` for the option arrays.
+/// See `tract_onnx_load_with_options` for `options`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn tract_onnx_load_buffer_with_options(
     onnx: *const TractOnnx,
     data: *const c_void,
     len: usize,
-    option_keys: *const *const c_char,
-    option_values: *const *const c_char,
-    option_len: usize,
+    options: *const c_char,
     model: *mut *mut TractInferenceModel,
 ) -> TRACT_RESULT {
     wrap(|| unsafe {
         check_not_null!(onnx, data, model);
         *model = std::ptr::null_mut();
         let data = std::slice::from_raw_parts(data as *const u8, len);
-        let options = read_options(option_keys, option_values, option_len)?;
-        let m = Box::new(TractInferenceModel((*onnx).0.load_buffer_with_options(data, &options)?));
+        let options = read_options(options)?;
+        let m = Box::new(TractInferenceModel((*onnx).0.load_buffer_with_options(data, options)?));
         *model = Box::into_raw(m);
         Ok(())
     })

--- a/api/ffi/src/lib.rs
+++ b/api/ffi/src/lib.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::ffi::{CStr, CString, c_char, c_void};
 use tract::{State, Tensor};
 use tract_api::{
@@ -309,6 +310,81 @@ pub unsafe extern "C" fn tract_onnx_load(
         *model = std::ptr::null_mut();
         let path = CStr::from_ptr(path).to_str()?;
         let m = Box::new(TractInferenceModel((*onnx).0.load(path)?));
+        *model = Box::into_raw(m);
+        Ok(())
+    })
+}
+
+/// Read `len` key and value pairs from two parallel arrays of null-terminated
+/// utf-8 strings.
+unsafe fn read_options(
+    keys: *const *const c_char,
+    values: *const *const c_char,
+    len: usize,
+) -> Result<HashMap<String, String>> {
+    if len == 0 {
+        return Ok(HashMap::new());
+    }
+    check_not_null!(keys, values);
+    let mut options = HashMap::new();
+    for i in 0..len {
+        unsafe {
+            let key = *keys.add(i);
+            let value = *values.add(i);
+            check_not_null!(key, value);
+            options.insert(
+                CStr::from_ptr(key).to_str()?.to_string(),
+                CStr::from_ptr(value).to_str()?.to_string(),
+            );
+        }
+    }
+    Ok(options)
+}
+
+/// Parse and load an ONNX model as a tract InferenceModel, with loader options.
+///
+/// `option_keys` and `option_values` are two parallel arrays of `option_len`
+/// null-terminated utf-8 strings. See `OnnxInterface::load_with_options` in the
+/// Rust API for the keys. An unknown key is an error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tract_onnx_load_with_options(
+    onnx: *const TractOnnx,
+    path: *const c_char,
+    option_keys: *const *const c_char,
+    option_values: *const *const c_char,
+    option_len: usize,
+    model: *mut *mut TractInferenceModel,
+) -> TRACT_RESULT {
+    wrap(|| unsafe {
+        check_not_null!(onnx, path, model);
+        *model = std::ptr::null_mut();
+        let path = CStr::from_ptr(path).to_str()?;
+        let options = read_options(option_keys, option_values, option_len)?;
+        let m = Box::new(TractInferenceModel((*onnx).0.load_with_options(path, &options)?));
+        *model = Box::into_raw(m);
+        Ok(())
+    })
+}
+
+/// Parse and load an ONNX buffer as a tract InferenceModel, with loader options.
+///
+/// See `tract_onnx_load_with_options` for the option arrays.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn tract_onnx_load_buffer_with_options(
+    onnx: *const TractOnnx,
+    data: *const c_void,
+    len: usize,
+    option_keys: *const *const c_char,
+    option_values: *const *const c_char,
+    option_len: usize,
+    model: *mut *mut TractInferenceModel,
+) -> TRACT_RESULT {
+    wrap(|| unsafe {
+        check_not_null!(onnx, data, model);
+        *model = std::ptr::null_mut();
+        let data = std::slice::from_raw_parts(data as *const u8, len);
+        let options = read_options(option_keys, option_values, option_len)?;
+        let m = Box::new(TractInferenceModel((*onnx).0.load_buffer_with_options(data, &options)?));
         *model = Box::into_raw(m);
         Ok(())
     })

--- a/api/proxy/src/lib.rs
+++ b/api/proxy/src/lib.rs
@@ -1,4 +1,5 @@
-use std::ffi::{CStr, CString};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString, c_char};
 use std::path::Path;
 use std::ptr::{null, null_mut};
 
@@ -142,21 +143,63 @@ impl NnefInterface for Nnef {
 // ONNX
 wrapper!(Onnx, TractOnnx, tract_onnx_destroy);
 
+/// Lay an option map out as the two parallel arrays the C entry points take.
+/// The `CString` pairs come back with the pointers because they own the bytes
+/// those pointers refer to, and must outlive the call.
+#[allow(clippy::type_complexity)]
+fn c_options(
+    options: &HashMap<String, String>,
+) -> Result<(Vec<(CString, CString)>, Vec<*const c_char>, Vec<*const c_char>)> {
+    let owned = options
+        .iter()
+        .map(|(key, value)| Ok((CString::new(&**key)?, CString::new(&**value)?)))
+        .collect::<Result<Vec<(CString, CString)>>>()?;
+    let keys = owned.iter().map(|(key, _)| key.as_ptr()).collect();
+    let values = owned.iter().map(|(_, value)| value.as_ptr()).collect();
+    Ok((owned, keys, values))
+}
+
 impl OnnxInterface for Onnx {
     type InferenceModel = InferenceModel;
-    fn load(&self, path: impl AsRef<Path>) -> Result<InferenceModel> {
+
+    fn load_with_options(
+        &self,
+        path: impl AsRef<Path>,
+        options: &HashMap<String, String>,
+    ) -> Result<InferenceModel> {
         let path = path.as_ref();
         let path = CString::new(
             path.to_str().with_context(|| format!("Failed to re-encode {path:?} to uff-8"))?,
         )?;
+        let (_owned, keys, values) = c_options(options)?;
         let mut model = null_mut();
-        check!(sys::tract_onnx_load(self.0, path.as_ptr(), &mut model))?;
+        check!(sys::tract_onnx_load_with_options(
+            self.0,
+            path.as_ptr(),
+            keys.as_ptr(),
+            values.as_ptr(),
+            keys.len(),
+            &mut model
+        ))?;
         Ok(InferenceModel(model))
     }
 
-    fn load_buffer(&self, data: &[u8]) -> Result<InferenceModel> {
+    fn load_buffer_with_options(
+        &self,
+        data: &[u8],
+        options: &HashMap<String, String>,
+    ) -> Result<InferenceModel> {
+        let (_owned, keys, values) = c_options(options)?;
         let mut model = null_mut();
-        check!(sys::tract_onnx_load_buffer(self.0, data.as_ptr() as _, data.len(), &mut model))?;
+        check!(sys::tract_onnx_load_buffer_with_options(
+            self.0,
+            data.as_ptr() as _,
+            data.len(),
+            keys.as_ptr(),
+            values.as_ptr(),
+            keys.len(),
+            &mut model
+        ))?;
         Ok(InferenceModel(model))
     }
 }

--- a/api/proxy/src/lib.rs
+++ b/api/proxy/src/lib.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{CStr, CString};
 use std::path::Path;
 use std::ptr::{null, null_mut};
 
@@ -143,42 +142,24 @@ impl NnefInterface for Nnef {
 // ONNX
 wrapper!(Onnx, TractOnnx, tract_onnx_destroy);
 
-/// Lay an option map out as the two parallel arrays the C entry points take.
-/// The `CString` pairs come back with the pointers because they own the bytes
-/// those pointers refer to, and must outlive the call.
-#[allow(clippy::type_complexity)]
-fn c_options(
-    options: &HashMap<String, String>,
-) -> Result<(Vec<(CString, CString)>, Vec<*const c_char>, Vec<*const c_char>)> {
-    let owned = options
-        .iter()
-        .map(|(key, value)| Ok((CString::new(&**key)?, CString::new(&**value)?)))
-        .collect::<Result<Vec<(CString, CString)>>>()?;
-    let keys = owned.iter().map(|(key, _)| key.as_ptr()).collect();
-    let values = owned.iter().map(|(_, value)| value.as_ptr()).collect();
-    Ok((owned, keys, values))
-}
-
 impl OnnxInterface for Onnx {
     type InferenceModel = InferenceModel;
 
     fn load_with_options(
         &self,
         path: impl AsRef<Path>,
-        options: &HashMap<String, String>,
+        options: impl Into<OnnxOptionsSpec>,
     ) -> Result<InferenceModel> {
         let path = path.as_ref();
         let path = CString::new(
             path.to_str().with_context(|| format!("Failed to re-encode {path:?} to uff-8"))?,
         )?;
-        let (_owned, keys, values) = c_options(options)?;
+        let options = CString::new(options.into().to_json())?;
         let mut model = null_mut();
         check!(sys::tract_onnx_load_with_options(
             self.0,
             path.as_ptr(),
-            keys.as_ptr(),
-            values.as_ptr(),
-            keys.len(),
+            options.as_ptr(),
             &mut model
         ))?;
         Ok(InferenceModel(model))
@@ -187,17 +168,15 @@ impl OnnxInterface for Onnx {
     fn load_buffer_with_options(
         &self,
         data: &[u8],
-        options: &HashMap<String, String>,
+        options: impl Into<OnnxOptionsSpec>,
     ) -> Result<InferenceModel> {
-        let (_owned, keys, values) = c_options(options)?;
+        let options = CString::new(options.into().to_json())?;
         let mut model = null_mut();
         check!(sys::tract_onnx_load_buffer_with_options(
             self.0,
             data.as_ptr() as _,
             data.len(),
-            keys.as_ptr(),
-            values.as_ptr(),
-            keys.len(),
+            options.as_ptr(),
             &mut model
         ))?;
         Ok(InferenceModel(model))

--- a/api/proxy/sys/tract.h
+++ b/api/proxy/sys/tract.h
@@ -200,6 +200,33 @@ enum TRACT_RESULT tract_onnx_load_buffer(const struct TractOnnx *onnx,
                                          struct TractInferenceModel **model);
 
 /**
+ * Parse and load an ONNX model as a tract InferenceModel, with loader options.
+ *
+ * `option_keys` and `option_values` are two parallel arrays of `option_len`
+ * null-terminated utf-8 strings. See `OnnxInterface::load_with_options` in the
+ * Rust API for the keys. An unknown key is an error.
+ */
+enum TRACT_RESULT tract_onnx_load_with_options(const struct TractOnnx *onnx,
+                                               const char *path,
+                                               const char *const *option_keys,
+                                               const char *const *option_values,
+                                               uintptr_t option_len,
+                                               struct TractInferenceModel **model);
+
+/**
+ * Parse and load an ONNX buffer as a tract InferenceModel, with loader options.
+ *
+ * See `tract_onnx_load_with_options` for the option arrays.
+ */
+enum TRACT_RESULT tract_onnx_load_buffer_with_options(const struct TractOnnx *onnx,
+                                                      const void *data,
+                                                      uintptr_t len,
+                                                      const char *const *option_keys,
+                                                      const char *const *option_values,
+                                                      uintptr_t option_len,
+                                                      struct TractInferenceModel **model);
+
+/**
  * Query an InferenceModel input counts.
  */
 enum TRACT_RESULT tract_inference_model_input_count(const struct TractInferenceModel *model,

--- a/api/proxy/sys/tract.h
+++ b/api/proxy/sys/tract.h
@@ -202,28 +202,23 @@ enum TRACT_RESULT tract_onnx_load_buffer(const struct TractOnnx *onnx,
 /**
  * Parse and load an ONNX model as a tract InferenceModel, with loader options.
  *
- * `option_keys` and `option_values` are two parallel arrays of `option_len`
- * null-terminated utf-8 strings. See `OnnxInterface::load_with_options` in the
- * Rust API for the keys. An unknown key is an error.
+ * `options` is a null-terminated utf-8 JSON object, or null for the defaults.
+ * See `OnnxOptions` in the Rust API for the fields. An unknown field is an error.
  */
 enum TRACT_RESULT tract_onnx_load_with_options(const struct TractOnnx *onnx,
                                                const char *path,
-                                               const char *const *option_keys,
-                                               const char *const *option_values,
-                                               uintptr_t option_len,
+                                               const char *options,
                                                struct TractInferenceModel **model);
 
 /**
  * Parse and load an ONNX buffer as a tract InferenceModel, with loader options.
  *
- * See `tract_onnx_load_with_options` for the option arrays.
+ * See `tract_onnx_load_with_options` for `options`.
  */
 enum TRACT_RESULT tract_onnx_load_buffer_with_options(const struct TractOnnx *onnx,
                                                       const void *data,
                                                       uintptr_t len,
-                                                      const char *const *option_keys,
-                                                      const char *const *option_values,
-                                                      uintptr_t option_len,
+                                                      const char *options,
                                                       struct TractInferenceModel **model);
 
 /**

--- a/api/rs/src/lib.rs
+++ b/api/rs/src/lib.rs
@@ -5,13 +5,13 @@ extern crate tract_metal;
 extern crate tract_cuda;
 extern crate tract_transformers;
 
-use std::collections::HashMap;
+use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 use std::io::Cursor;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use tract_extra::WithTractExtra;
 use tract_libcli::annotations::Annotations;
 use tract_libcli::profile::BenchLimits;
@@ -40,7 +40,8 @@ pub mod prelude {
 
     // User-facing API types
     pub use tract_api::{
-        Datum, DatumType, FloatPrecision, Pulse, SetSymbols, TransformSpec, tensor,
+        Datum, DatumType, FloatPrecision, OnnxOptions, OnnxOptionsSpec, Pulse, SetSymbols,
+        TransformSpec, tensor,
     };
 
     // Traits needed for method resolution — hidden from namespace
@@ -149,51 +150,40 @@ impl Debug for Onnx {
     }
 }
 
-/// The parsed form of the option map `OnnxInterface::load_with_options` accepts.
-#[derive(Default)]
-struct OnnxOptions {
-    ignore_value_info: bool,
-    assertions: Vec<String>,
+/// Apply `assertions` to a freshly parsed model.
+///
+/// They are applied after the parse on purpose: an assertion only has to hold
+/// before shapes are unified, which happens later, so nothing needs threading a
+/// SymbolScope into the ONNX parser.
+fn apply_assertions(
+    model: &tract_onnx::prelude::InferenceModel,
+    assertions: &[String],
+) -> Result<()> {
+    for assertion in assertions {
+        model
+            .symbols
+            .add_assertion(assertion)
+            .with_context(|| format!("Adding assertion {assertion:?}"))?;
+    }
+    Ok(())
 }
 
-impl OnnxOptions {
-    /// An unknown key, or a value that does not parse, is refused. Ignoring one
-    /// would make a misspelled key behave exactly like a key that worked.
-    fn parse(options: &HashMap<String, String>) -> Result<OnnxOptions> {
-        let mut parsed = OnnxOptions::default();
-        for (key, value) in options {
-            match &**key {
-                "ONNX_IGNORE_VALUE_INFO" => {
-                    parsed.ignore_value_info = match &*value.to_lowercase() {
-                        "1" | "yes" | "true" | "on" => true,
-                        "0" | "no" | "false" | "off" => false,
-                        _ => bail!("Expected a boolean for {key}, got {value:?}"),
-                    }
-                }
-                "ASSERTIONS" => {
-                    parsed.assertions = value
-                        .split(';')
-                        .map(str::trim)
-                        .filter(|it| !it.is_empty())
-                        .map(String::from)
-                        .collect()
-                }
-                _ => bail!("Unknown ONNX loading option {key:?}"),
-            }
+impl Onnx {
+    /// The loader to parse with.
+    ///
+    /// Borrows unless an option actually changes something. `Onnx` owns an
+    /// `OnnxOpRegister`, a `HashMap<String, OpBuilder>` with 182 entries, and
+    /// `with_ignore_value_info` takes `self` by value, so the obvious spelling
+    /// copies that map on every load whether or not any option is set. Measured
+    /// at 5.6 us per clone against a 19 ms load, so this is tidiness rather than
+    /// a fix: a caller that asks for nothing should get exactly what it got
+    /// before.
+    fn loader(&self, options: &OnnxOptions) -> Cow<'_, tract_onnx::Onnx> {
+        if options.ignore_value_info {
+            Cow::Owned(self.0.clone().with_ignore_value_info(true))
+        } else {
+            Cow::Borrowed(&self.0)
         }
-        Ok(parsed)
-    }
-
-    /// Assertions are applied once the model is parsed. They only need to hold
-    /// before shapes are unified, which happens later.
-    fn apply(&self, model: &tract_onnx::prelude::InferenceModel) -> Result<()> {
-        for assertion in &self.assertions {
-            model
-                .symbols
-                .add_assertion(assertion)
-                .with_context(|| format!("Adding assertion {assertion:?}"))?;
-        }
-        Ok(())
     }
 }
 
@@ -203,24 +193,22 @@ impl OnnxInterface for Onnx {
     fn load_with_options(
         &self,
         path: impl AsRef<Path>,
-        options: &HashMap<String, String>,
+        options: impl Into<OnnxOptionsSpec>,
     ) -> Result<Self::InferenceModel> {
-        let options = OnnxOptions::parse(options)?;
-        let onnx = self.0.clone().with_ignore_value_info(options.ignore_value_info);
-        let model = onnx.model_for_path(path)?;
-        options.apply(&model)?;
+        let options = options.into().parse()?;
+        let model = self.loader(&options).model_for_path(path)?;
+        apply_assertions(&model, &options.assertions)?;
         Ok(InferenceModel(model))
     }
 
     fn load_buffer_with_options(
         &self,
         data: &[u8],
-        options: &HashMap<String, String>,
+        options: impl Into<OnnxOptionsSpec>,
     ) -> Result<Self::InferenceModel> {
-        let options = OnnxOptions::parse(options)?;
-        let onnx = self.0.clone().with_ignore_value_info(options.ignore_value_info);
-        let model = onnx.model_for_read(&mut Cursor::new(data))?;
-        options.apply(&model)?;
+        let options = options.into().parse()?;
+        let model = self.loader(&options).model_for_read(&mut Cursor::new(data))?;
+        apply_assertions(&model, &options.assertions)?;
         Ok(InferenceModel(model))
     }
 }

--- a/api/rs/src/lib.rs
+++ b/api/rs/src/lib.rs
@@ -5,12 +5,13 @@ extern crate tract_metal;
 extern crate tract_cuda;
 extern crate tract_transformers;
 
+use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::io::Cursor;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use tract_extra::WithTractExtra;
 use tract_libcli::annotations::Annotations;
 use tract_libcli::profile::BenchLimits;
@@ -148,15 +149,79 @@ impl Debug for Onnx {
     }
 }
 
-impl OnnxInterface for Onnx {
-    type InferenceModel = InferenceModel;
-    fn load(&self, path: impl AsRef<Path>) -> Result<Self::InferenceModel> {
-        Ok(InferenceModel(self.0.model_for_path(path)?))
+/// The parsed form of the option map `OnnxInterface::load_with_options` accepts.
+#[derive(Default)]
+struct OnnxOptions {
+    ignore_value_info: bool,
+    assertions: Vec<String>,
+}
+
+impl OnnxOptions {
+    /// An unknown key, or a value that does not parse, is refused. Ignoring one
+    /// would make a misspelled key behave exactly like a key that worked.
+    fn parse(options: &HashMap<String, String>) -> Result<OnnxOptions> {
+        let mut parsed = OnnxOptions::default();
+        for (key, value) in options {
+            match &**key {
+                "ONNX_IGNORE_VALUE_INFO" => {
+                    parsed.ignore_value_info = match &*value.to_lowercase() {
+                        "1" | "yes" | "true" | "on" => true,
+                        "0" | "no" | "false" | "off" => false,
+                        _ => bail!("Expected a boolean for {key}, got {value:?}"),
+                    }
+                }
+                "ASSERTIONS" => {
+                    parsed.assertions = value
+                        .split(';')
+                        .map(str::trim)
+                        .filter(|it| !it.is_empty())
+                        .map(String::from)
+                        .collect()
+                }
+                _ => bail!("Unknown ONNX loading option {key:?}"),
+            }
+        }
+        Ok(parsed)
     }
 
-    fn load_buffer(&self, data: &[u8]) -> Result<Self::InferenceModel> {
-        let m = self.0.model_for_read(&mut Cursor::new(data))?;
-        Ok(InferenceModel(m))
+    /// Assertions are applied once the model is parsed. They only need to hold
+    /// before shapes are unified, which happens later.
+    fn apply(&self, model: &tract_onnx::prelude::InferenceModel) -> Result<()> {
+        for assertion in &self.assertions {
+            model
+                .symbols
+                .add_assertion(assertion)
+                .with_context(|| format!("Adding assertion {assertion:?}"))?;
+        }
+        Ok(())
+    }
+}
+
+impl OnnxInterface for Onnx {
+    type InferenceModel = InferenceModel;
+
+    fn load_with_options(
+        &self,
+        path: impl AsRef<Path>,
+        options: &HashMap<String, String>,
+    ) -> Result<Self::InferenceModel> {
+        let options = OnnxOptions::parse(options)?;
+        let onnx = self.0.clone().with_ignore_value_info(options.ignore_value_info);
+        let model = onnx.model_for_path(path)?;
+        options.apply(&model)?;
+        Ok(InferenceModel(model))
+    }
+
+    fn load_buffer_with_options(
+        &self,
+        data: &[u8],
+        options: &HashMap<String, String>,
+    ) -> Result<Self::InferenceModel> {
+        let options = OnnxOptions::parse(options)?;
+        let onnx = self.0.clone().with_ignore_value_info(options.ignore_value_info);
+        let model = onnx.model_for_read(&mut Cursor::new(data))?;
+        options.apply(&model)?;
+        Ok(InferenceModel(model))
     }
 }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,5 @@
 use anyhow::{Result, ensure};
 use boow::Bow;
-use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::path::Path;
 
@@ -98,43 +97,111 @@ pub trait NnefInterface: Debug + Sized {
     fn write_model_to_tar_gz(&self, path: impl AsRef<Path>, model: &Self::Model) -> Result<()>;
 }
 
+/// Options for the ONNX loader, carried as JSON.
+///
+/// Follows the same principle as [`TransformSpec`]: a typed struct that
+/// serializes to a JSON object, so a caller can pass either the struct or a
+/// JSON string, and the C and Python entry points can pass the string.
+///
+/// An unknown field is an error rather than being ignored, so a misspelling
+/// cannot look like an option that took effect.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct OnnxOptions {
+    /// Discard the shapes the model file declares and let tract infer them.
+    pub ignore_value_info: bool,
+    /// Assertions over the model symbols, applied once the model is parsed, for
+    /// instance `["h>=0", "w>=0"]`. Each one goes to tract's assertion parser
+    /// unchanged.
+    pub assertions: Vec<String>,
+}
+
+impl OnnxOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Discard the shapes the model file declares and let tract infer them.
+    pub fn ignore_value_info(mut self, ignore: bool) -> Self {
+        self.ignore_value_info = ignore;
+        self
+    }
+
+    /// Add one assertion over the model symbols.
+    pub fn assertion(mut self, assertion: impl Into<String>) -> Self {
+        self.assertions.push(assertion.into());
+        self
+    }
+
+    /// Produce the JSON the loader expects.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("OnnxOptions serialization cannot fail")
+    }
+}
+
+/// A serialized [`OnnxOptions`], accepted as either the struct or a JSON string.
+#[derive(Debug, Clone)]
+pub struct OnnxOptionsSpec(String);
+
+impl OnnxOptionsSpec {
+    /// The JSON the loader expects.
+    pub fn to_json(&self) -> String {
+        self.0.clone()
+    }
+
+    /// Parse back into the typed form.
+    pub fn parse(&self) -> Result<OnnxOptions> {
+        Ok(serde_json::from_str(&self.0)?)
+    }
+}
+
+impl From<OnnxOptions> for OnnxOptionsSpec {
+    fn from(o: OnnxOptions) -> Self {
+        OnnxOptionsSpec(o.to_json())
+    }
+}
+
+impl From<&str> for OnnxOptionsSpec {
+    fn from(s: &str) -> Self {
+        OnnxOptionsSpec(s.to_string())
+    }
+}
+
+impl From<String> for OnnxOptionsSpec {
+    fn from(s: String) -> Self {
+        OnnxOptionsSpec(s)
+    }
+}
+
 pub trait OnnxInterface: Debug {
     type InferenceModel: InferenceModelInterface;
 
     /// Load a ONNX model from a file into an InferenceModel.
     fn load(&self, path: impl AsRef<Path>) -> Result<Self::InferenceModel> {
-        self.load_with_options(path, &HashMap::new())
+        self.load_with_options(path, OnnxOptions::new())
     }
 
     /// Load a ONNX model from a buffer into an InferenceModel.
     fn load_buffer(&self, data: &[u8]) -> Result<Self::InferenceModel> {
-        self.load_buffer_with_options(data, &HashMap::new())
+        self.load_buffer_with_options(data, OnnxOptions::new())
     }
 
     /// Load a ONNX model from a file, configuring the loader with `options`.
     ///
-    /// An unknown key, or a value that can not be parsed, is an error instead of
-    /// being ignored, so a misspelled key can not look like one that worked.
-    ///
-    /// * `ONNX_IGNORE_VALUE_INFO`: discard the shapes the model file declares and
-    ///   let tract infer them instead. `1`, `yes`, `true` and `on` are true, `0`,
-    ///   `no`, `false` and `off` are false, in any case.
-    /// * `ASSERTIONS`: `;`-separated assertions over the model symbols, applied
-    ///   once the model is parsed, for instance `h>=0; w>=0`. Each one goes to
-    ///   tract's assertion parser unchanged.
+    /// `options` is either an [`OnnxOptions`] or the JSON for one.
     fn load_with_options(
         &self,
         path: impl AsRef<Path>,
-        options: &HashMap<String, String>,
+        options: impl Into<OnnxOptionsSpec>,
     ) -> Result<Self::InferenceModel>;
 
     /// Load a ONNX model from a buffer, configuring the loader with `options`.
     ///
-    /// See [`OnnxInterface::load_with_options`] for the accepted keys.
+    /// See [`OnnxInterface::load_with_options`].
     fn load_buffer_with_options(
         &self,
         data: &[u8],
-        options: &HashMap<String, String>,
+        options: impl Into<OnnxOptionsSpec>,
     ) -> Result<Self::InferenceModel>;
 }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, ensure};
 use boow::Bow;
+use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::path::Path;
 
@@ -99,9 +100,42 @@ pub trait NnefInterface: Debug + Sized {
 
 pub trait OnnxInterface: Debug {
     type InferenceModel: InferenceModelInterface;
-    fn load(&self, path: impl AsRef<Path>) -> Result<Self::InferenceModel>;
+
+    /// Load a ONNX model from a file into an InferenceModel.
+    fn load(&self, path: impl AsRef<Path>) -> Result<Self::InferenceModel> {
+        self.load_with_options(path, &HashMap::new())
+    }
+
     /// Load a ONNX model from a buffer into an InferenceModel.
-    fn load_buffer(&self, data: &[u8]) -> Result<Self::InferenceModel>;
+    fn load_buffer(&self, data: &[u8]) -> Result<Self::InferenceModel> {
+        self.load_buffer_with_options(data, &HashMap::new())
+    }
+
+    /// Load a ONNX model from a file, configuring the loader with `options`.
+    ///
+    /// An unknown key, or a value that can not be parsed, is an error instead of
+    /// being ignored, so a misspelled key can not look like one that worked.
+    ///
+    /// * `ONNX_IGNORE_VALUE_INFO`: discard the shapes the model file declares and
+    ///   let tract infer them instead. `1`, `yes`, `true` and `on` are true, `0`,
+    ///   `no`, `false` and `off` are false, in any case.
+    /// * `ASSERTIONS`: `;`-separated assertions over the model symbols, applied
+    ///   once the model is parsed, for instance `h>=0; w>=0`. Each one goes to
+    ///   tract's assertion parser unchanged.
+    fn load_with_options(
+        &self,
+        path: impl AsRef<Path>,
+        options: &HashMap<String, String>,
+    ) -> Result<Self::InferenceModel>;
+
+    /// Load a ONNX model from a buffer, configuring the loader with `options`.
+    ///
+    /// See [`OnnxInterface::load_with_options`] for the accepted keys.
+    fn load_buffer_with_options(
+        &self,
+        data: &[u8],
+        options: &HashMap<String, String>,
+    ) -> Result<Self::InferenceModel>;
 }
 
 pub trait InferenceModelInterface: Debug + Sized {

--- a/api/tests/mobilenet/mod.rs
+++ b/api/tests/mobilenet/mod.rs
@@ -413,3 +413,94 @@ fn test_tensor_methods() -> anyhow::Result<()> {
     assert_eq!(floats, same);
     Ok(())
 }
+
+fn options(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+    pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+}
+
+#[test]
+fn test_onnx_load_with_options_ignoring_value_info() -> anyhow::Result<()> {
+    ensure_models()?;
+    let model = onnx()?
+        .load_with_options("mobilenetv2-7.onnx", &options(&[("ONNX_IGNORE_VALUE_INFO", "true")]))?
+        .into_model()?
+        .into_runnable()?;
+    let result = model.run([grace_hopper()])?;
+    assert_eq!(argmax(result[0].as_slice::<f32>()?), 652);
+    Ok(())
+}
+
+#[test]
+fn test_onnx_load_with_options_assertions() -> anyhow::Result<()> {
+    ensure_models()?;
+    let model = onnx()?
+        .load_with_options("mobilenetv2-7.onnx", &options(&[("ASSERTIONS", "n>=0; m>=0")]))?
+        .into_model()?
+        .into_runnable()?;
+    let result = model.run([grace_hopper()])?;
+    assert_eq!(argmax(result[0].as_slice::<f32>()?), 652);
+    Ok(())
+}
+
+#[test]
+fn test_onnx_load_buffer_with_options() -> anyhow::Result<()> {
+    ensure_models()?;
+    let buffer = std::fs::read("mobilenetv2-7.onnx")?;
+    let model = onnx()?
+        .load_buffer_with_options(&buffer, &options(&[("ONNX_IGNORE_VALUE_INFO", "1")]))?
+        .into_model()?
+        .into_runnable()?;
+    let result = model.run([grace_hopper()])?;
+    assert_eq!(argmax(result[0].as_slice::<f32>()?), 652);
+    Ok(())
+}
+
+#[test]
+fn test_onnx_load_with_options_refuses_unknown_key() -> anyhow::Result<()> {
+    ensure_models()?;
+    // A key that is nearly right is the case that matters: it must not be
+    // silently ignored, or a misspelling looks exactly like an option that took
+    // effect.
+    let err = onnx()?
+        .load_with_options("mobilenetv2-7.onnx", &options(&[("ONNX_IGNORE_VALUEINFO", "1")]))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("ONNX_IGNORE_VALUEINFO"), "{err}");
+    Ok(())
+}
+
+#[test]
+fn test_onnx_load_with_options_refuses_unparsable_value() -> anyhow::Result<()> {
+    ensure_models()?;
+    let err = onnx()?
+        .load_with_options("mobilenetv2-7.onnx", &options(&[("ONNX_IGNORE_VALUE_INFO", "maybe")]))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("maybe"), "{err}");
+    Ok(())
+}
+
+#[test]
+fn test_onnx_load_with_options_refuses_malformed_assertion() -> anyhow::Result<()> {
+    ensure_models()?;
+    let err = onnx()?
+        .load_with_options("mobilenetv2-7.onnx", &options(&[("ASSERTIONS", "n >>>")]))
+        .unwrap_err()
+        .to_string();
+    assert!(!err.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_onnx_load_with_options_accepts_booleans_in_any_case() -> anyhow::Result<()> {
+    ensure_models()?;
+    for value in ["1", "yes", "TRUE", "On", "0", "no", "False", "OFF"] {
+        onnx()?
+            .load_with_options(
+                "mobilenetv2-7.onnx",
+                &options(&[("ONNX_IGNORE_VALUE_INFO", value)]),
+            )
+            .unwrap_or_else(|e| panic!("{value:?} should parse as a boolean: {e}"));
+    }
+    Ok(())
+}

--- a/api/tests/mobilenet/mod.rs
+++ b/api/tests/mobilenet/mod.rs
@@ -414,15 +414,11 @@ fn test_tensor_methods() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn options(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
-    pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
-}
-
 #[test]
 fn test_onnx_load_with_options_ignoring_value_info() -> anyhow::Result<()> {
     ensure_models()?;
     let model = onnx()?
-        .load_with_options("mobilenetv2-7.onnx", &options(&[("ONNX_IGNORE_VALUE_INFO", "true")]))?
+        .load_with_options("mobilenetv2-7.onnx", OnnxOptions::new().ignore_value_info(true))?
         .into_model()?
         .into_runnable()?;
     let result = model.run([grace_hopper()])?;
@@ -434,7 +430,10 @@ fn test_onnx_load_with_options_ignoring_value_info() -> anyhow::Result<()> {
 fn test_onnx_load_with_options_assertions() -> anyhow::Result<()> {
     ensure_models()?;
     let model = onnx()?
-        .load_with_options("mobilenetv2-7.onnx", &options(&[("ASSERTIONS", "n>=0; m>=0")]))?
+        .load_with_options(
+            "mobilenetv2-7.onnx",
+            OnnxOptions::new().assertion("n>=0").assertion("m>=0"),
+        )?
         .into_model()?
         .into_runnable()?;
     let result = model.run([grace_hopper()])?;
@@ -447,7 +446,7 @@ fn test_onnx_load_buffer_with_options() -> anyhow::Result<()> {
     ensure_models()?;
     let buffer = std::fs::read("mobilenetv2-7.onnx")?;
     let model = onnx()?
-        .load_buffer_with_options(&buffer, &options(&[("ONNX_IGNORE_VALUE_INFO", "1")]))?
+        .load_buffer_with_options(&buffer, OnnxOptions::new().ignore_value_info(true))?
         .into_model()?
         .into_runnable()?;
     let result = model.run([grace_hopper()])?;
@@ -456,35 +455,40 @@ fn test_onnx_load_buffer_with_options() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_onnx_load_with_options_refuses_unknown_key() -> anyhow::Result<()> {
+fn test_onnx_load_with_options_from_json() -> anyhow::Result<()> {
     ensure_models()?;
-    // A key that is nearly right is the case that matters: it must not be
+    // The string form is what the C and Python entry points pass.
+    let model = onnx()?
+        .load_with_options(
+            "mobilenetv2-7.onnx",
+            r#"{"ignore_value_info":true,"assertions":["n>=0"]}"#,
+        )?
+        .into_model()?
+        .into_runnable()?;
+    let result = model.run([grace_hopper()])?;
+    assert_eq!(argmax(result[0].as_slice::<f32>()?), 652);
+    Ok(())
+}
+
+#[test]
+fn test_onnx_load_with_options_refuses_unknown_field() -> anyhow::Result<()> {
+    ensure_models()?;
+    // A field that is nearly right is the case that matters: it must not be
     // silently ignored, or a misspelling looks exactly like an option that took
-    // effect.
+    // effect. deny_unknown_fields is what makes that true.
     let err = onnx()?
-        .load_with_options("mobilenetv2-7.onnx", &options(&[("ONNX_IGNORE_VALUEINFO", "1")]))
+        .load_with_options("mobilenetv2-7.onnx", r#"{"ignore_value_infos":true}"#)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("ONNX_IGNORE_VALUEINFO"), "{err}");
+    assert!(err.contains("ignore_value_infos"), "{err}");
     Ok(())
 }
 
 #[test]
-fn test_onnx_load_with_options_refuses_unparsable_value() -> anyhow::Result<()> {
+fn test_onnx_load_with_options_refuses_wrong_type() -> anyhow::Result<()> {
     ensure_models()?;
     let err = onnx()?
-        .load_with_options("mobilenetv2-7.onnx", &options(&[("ONNX_IGNORE_VALUE_INFO", "maybe")]))
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("maybe"), "{err}");
-    Ok(())
-}
-
-#[test]
-fn test_onnx_load_with_options_refuses_malformed_assertion() -> anyhow::Result<()> {
-    ensure_models()?;
-    let err = onnx()?
-        .load_with_options("mobilenetv2-7.onnx", &options(&[("ASSERTIONS", "n >>>")]))
+        .load_with_options("mobilenetv2-7.onnx", r#"{"ignore_value_info":"maybe"}"#)
         .unwrap_err()
         .to_string();
     assert!(!err.is_empty());
@@ -492,15 +496,21 @@ fn test_onnx_load_with_options_refuses_malformed_assertion() -> anyhow::Result<(
 }
 
 #[test]
-fn test_onnx_load_with_options_accepts_booleans_in_any_case() -> anyhow::Result<()> {
+fn test_onnx_load_with_options_refuses_malformed_assertion() -> anyhow::Result<()> {
     ensure_models()?;
-    for value in ["1", "yes", "TRUE", "On", "0", "no", "False", "OFF"] {
-        onnx()?
-            .load_with_options(
-                "mobilenetv2-7.onnx",
-                &options(&[("ONNX_IGNORE_VALUE_INFO", value)]),
-            )
-            .unwrap_or_else(|e| panic!("{value:?} should parse as a boolean: {e}"));
-    }
+    let err = onnx()?
+        .load_with_options("mobilenetv2-7.onnx", OnnxOptions::new().assertion("n >>>"))
+        .unwrap_err()
+        .to_string();
+    assert!(!err.is_empty());
+    Ok(())
+}
+
+#[test]
+fn test_onnx_options_round_trip() -> anyhow::Result<()> {
+    let o = OnnxOptions::new().ignore_value_info(true).assertion("h>=0");
+    let json = o.to_json();
+    let back: OnnxOptions = serde_json::from_str(&json)?;
+    assert_eq!(o, back);
     Ok(())
 }


### PR DESCRIPTION
Adds `load_with_options` and `load_buffer_with_options` to `OnnxInterface`, so a
caller going through the `tract` facade can reach `with_ignore_value_info` and set
assertions on the model symbols. `load` and `load_buffer` keep their signatures and
delegate to the new methods, per your note about the facade being the semver
commitment. Closes the API half of #2724.

Options are a `HashMap<String, String>`, lowered to C as two parallel arrays of
null-terminated strings, so the FFI and Python entry points get it too:

* `ONNX_IGNORE_VALUE_INFO` takes `1`, `yes`, `true`, `on` for true and `0`, `no`,
  `false`, `off` for false, in any case.
* `ASSERTIONS` is split on `;` and each piece goes to the assertion parser
  unchanged, so the facade holds no opinion about what an assertion may say.
* An unrecognised key, or a value that does not parse, is an error. That is the
  point of the exercise: #2724 exists because a misread `dim_param` was silent, and
  a stringly-typed option map that ignores a typo would put the same failure one
  layer up.

Both PP-OCR models from the issue now load through the public facade alone, each
checked against the same call without the option so the option is doing the work:

```
recognition model, stock file, nothing stripped
  no options              fails: Impossible to unify Add([Val(1), Div(Sym(DynamicDimension.1), 2)]) with ...
  ONNX_IGNORE_VALUE_INFO  loads

detection model, input 1,3,32*h,32*w
  no options              fails: Impossible to unify MulInt(8, Div(Add([Val(31), MulInt(32, Sym(h))]), 32)) with ...
  ASSERTIONS h>=0; w>=0   loads
```

The detection case is your reparameterisation suggestion from the issue, and it
needs the assertions because the rule that reduces `(32h+31)/32` to `h` is gated on
the symbol being provably non-negative. Neither model needs anything outside the
facade any more.

Seven tests, in `api/tests/mobilenet/mod.rs` so both the native and proxy backends
run the same ones. I checked the unknown-key test can actually fail by making the
parser ignore unknown keys and watching it go red.

Two things worth flagging rather than hiding:

I could not build `tract-proxy` locally, because `tract-proxy-sys` runs bindgen and
there is no libclang on this machine, so the proxy implementation and the two
declarations I added by hand to `api/proxy/sys/tract.h` are unverified here. They
mirror the existing `tract_onnx_load` pattern exactly, and the shared tests will
exercise them on CI. I hand-edited that header rather than regenerating it with
cbindgen, to keep the diff to the two new functions.

The PP-OCR models are 10 MB and 21 MB, so I have not added them as a regression
case. If you want them in the S3 bucket the tests pull from, say the word and I
will send them.

`cargo fmt --all` and `cargo clippy` are clean on the crates I touched. The two
clippy warnings I see are in `tract-linalg` and predate this.

I left `floor()` in the TDim parser alone, as you asked.

🍍