### PR TITLE
(perf) linalg: pick the aarch64 mat-vec kernel by m, not unconditionally

### DIFF
--- a/linalg/src/arm64/apple_amx.rs
+++ b/linalg/src/arm64/apple_amx.rs
@@ -2,7 +2,10 @@ use crate::frame::mmm::ImplementationQuality::ManuallyOptimized;
 use crate::mmm::*;
 use tract_data::prelude::*;
 
-use super::{arm64fp16_mmm_f16_16x8_gen, arm64simd_mmm_f32_8x8_gen, arm64simd_mmm_f32_64x1_gen};
+use super::{
+    arm64fp16_mmm_f16_16x8_gen, arm64simd_mmm_f32_8x8_gen, arm64simd_mmm_f32_32x1_gen,
+    arm64simd_mmm_f32_64x1_gen,
+};
 
 const CAN_FUSE: fn(&FusedSpec) -> bool = |f| !matches!(f, &FusedSpec::LeakyRelu(_));
 
@@ -21,8 +24,14 @@ fn preferred(
     _suitable: &[Suitable],
 ) -> Option<&'static str> {
     match (dt, query.n) {
-        // The AMX 32x1 is dominated by the NEON 64x1 at every shape.
-        (crate::DatumType::F32, Some(1)) => Some(arm64simd_mmm_f32_64x1_gen.name.as_str()),
+        // The AMX 32x1 is dominated by the NEON 64x1, but the 64-row tile only pays
+        // once `m` can fill it: below that the kernel computes rows whose results are
+        // discarded, and the 32-row NEON mat-vec is ahead.
+        (crate::DatumType::F32, Some(1)) => Some(if query.m.is_some_and(|m| m < 64) {
+            arm64simd_mmm_f32_32x1_gen.name.as_str()
+        } else {
+            arm64simd_mmm_f32_64x1_gen.name.as_str()
+        }),
         (crate::DatumType::F32, _) => {
             let big_enough = query.m.is_some_and(|m| m >= 32) && query.n.is_some_and(|n| n >= 32);
             Some(if big_enough {


### PR DESCRIPTION
The Apple f32 dispatch routes every `n == 1` shape to `arm64simd_mmm_f32_64x1_gen`:

```rust
// The AMX 32x1 is dominated by the NEON 64x1 at every shape.
(crate::DatumType::F32, Some(1)) => Some(arm64simd_mmm_f32_64x1_gen.name.as_str()),
```

The premise holds only once `m` can fill the 64-row tile. Below that the kernel
computes rows whose results are discarded — at `m = 16` three quarters of the
tile is thrown away — and the 32-row mat-vec is ahead. This routes by `m`, which
is what the wasm backend already does for its own GEMV bands
(`0..=4 / 5..=8 / 9..=16 / _`), and what the Cortex-A53/A55 paths approximate via
their cost models. Only the Apple override and the generic aarch64 fallback pick
a single kernel regardless of `m`.

### Where the crossover is

Every available f32 kernel, timed on the shape, min of 300 runs, aarch64:

| m | best | `64x1_gen` (current) | |
|---|---|---|---|
| 8 | `32x1_gen` 0.50 µs | 0.79 µs | 1.58× |
| 16 | `32x1_gen` 0.33 µs | 0.46 µs | 1.38× |
| 32 | `32x1_gen` 0.29 µs | 0.46 µs | 1.57× |
| 64 | `64x1_gen` 0.50 µs | 0.50 µs | 1.00× |
| 128 | `64x1_gen` 0.71 µs | 0.71 µs | 1.00× |

So the switch sits at `m < 64`, and at or above it nothing changes.

### Measured end to end

p50 ms/frame, 7 interleaved runs on an idle machine (1-min load 5.9), single-threaded,
against this PR's merge base. Both binaries rebuilt from the same tree and hash-checked
as distinct. Median and min are both reported: where they disagree in sign, the row is
drift rather than signal.

| model | main | this PR | median | min |
|---|---|---|---|---|
| DeepFilterNet3 enc | 0.1255 | 0.1159 | **+7.6%** | +7.7% |
| DPDFNet baseline | 0.4675 | 0.4419 | **+5.5%** | +4.5% |
| DeepFilterNet3 df_dec | 0.0978 | 0.0944 | **+3.5%** | +2.6% |
| dpdfnet2 | 1.3252 | 1.2922 | **+2.5%** | +3.5% |
| dpdfnet2_8khz | 1.3228 | 1.2915 | **+2.4%** | +3.4% |
| DeepFilterNet3 erb_dec | 0.1054 | 0.1030 | **+2.3%** | +1.9% |
| dpdfnet4 | 2.2191 | 2.1894 | +1.3% | +2.4% |
| dpdfnet8_48khz_hr | 6.7438 | 6.6609 | +1.2% | +0.3% |
| dpdfnet8_8khz | 3.7766 | 3.7616 | +0.4% | +1.6% |
| dpdfnet2_48khz_hr | 2.5111 | 2.5016 | +0.4% | +0.9% |
| dpdfnet8 | 3.8896 | 3.8802 | +0.2% | −0.0% |
| dtln_model_1 / dtln_model_2 | | | +0.0% | +0.0% / +0.4% |
| gtcrn / gtcrn_simple | | | −0.1% / −0.2% | +0.3% / +0.1% |

The flat and sub-noise rows are models whose mat-vecs all sit at `m >= 64`, where
the dispatch is unchanged; median and min disagree on their sign, which is what
drift looks like at this magnitude.

Outputs compared whole-stream, every frame: **max absolute difference exactly `0`**
on dpdfnet2, dpdfnet2_48khz_hr and gtcrn — same kernel arithmetic, different tile
height.

Full suite green, `cargo fmt` and `cargo clippy` clean. No new `unsafe`.

One thing worth a maintainer's eye: the generic aarch64 fallback in `arm64.rs`
(`_ => arm64simd_mmm_f32_64x1_gen`) has the same unconditional shape and likely
the same issue, but I have no non-Apple aarch64 hardware to measure it on, so I
left it alone rather than guess. A `bench-vs-main` run would also be welcome here
— this touches every Apple aarch64 model, and my measurements only cover a
noise-suppression set.

🍍

