### PR TITLE
(perf) core/cnn: prefer lazy im2col when the matmul has a single row panel

### DIFF
--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1435,6 +1435,11 @@ fn should_use_lazy(
     if eager_scratch_bytes >= lazy_im2col_max_eager_bytes() {
         return true;
     }
+    // A 1x1 kernel has nothing to gather: its im2col is a reshape, so there is no
+    // materialisation for lazy to save and its per-position indirection is pure loss.
+    if kernel_volume == 1 {
+        return false;
+    }
     // Single-panel rule. Both paths gather the same `k * n` elements: eager gathers
     // them once into scratch the matmul then streams once per row panel, lazy
     // re-gathers per row panel and builds nothing. Eager only pays for itself once

--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1432,7 +1432,21 @@ fn should_use_lazy(
     let n: usize = output_shape.hw_dims().iter().product();
     let k = pool_spec.input_channels * kernel_volume / group;
     let eager_scratch_bytes = k.saturating_mul(n).saturating_mul(dt.size_of());
-    eager_scratch_bytes >= lazy_im2col_max_eager_bytes()
+    if eager_scratch_bytes >= lazy_im2col_max_eager_bytes() {
+        return true;
+    }
+    // Single-panel rule. Both paths gather the same `k * n` elements: eager gathers
+    // them once into scratch the matmul then streams once per row panel, lazy
+    // re-gathers per row panel and builds nothing. Eager only pays for itself once
+    // there is more than one row panel to amortise the scratch over -- at a single
+    // panel lazy does the same gathers and skips the buffer entirely. Ask the kernel
+    // that will actually run rather than assuming its geometry.
+    let m = (pool_spec.output_channels / group).max(1);
+    let mr = tract_linalg::MmmDispatch::native()
+        .preferred_kernel(dt, Some(m), Some(k), Some(n))
+        .map(|mmm| mmm.mr())
+        .unwrap_or(1);
+    m <= mr
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
`should_use_lazy` decides between eager and lazy im2col on kernel volume and on an
absolute scratch-size ceiling. Neither test looks at how many times the scratch is
read, which is what decides whether materialising it can pay for itself.

Both paths gather the same `k * n` elements. Eager gathers them once into scratch
that the matmul then streams once per **row panel**; lazy re-gathers per row panel
and materialises nothing. So eager only earns its buffer once there is more than
one row panel to amortise it over — and at a single panel lazy performs the same
gathers and skips the buffer entirely.

A convolution whose output channels fit inside one kernel tile therefore built a
buffer it read exactly once. On DPDFNet's 48 kHz variants that is a 360 KB scratch
for a one-output-channel conv, where the materialisation cost more than four times
the matmul it fed (78 µs vs 18 µs by `--profile`).

The added rule asks the kernel that will actually run for its `mr` rather than
assuming the geometry, so it follows dispatch rather than duplicating its logic.

### Measured

p50 ms/frame, 7 interleaved runs on an idle machine (1-min load 9.6), single-threaded,
aarch64, against this PR's merge base. Both binaries rebuilt from the same tree and
hash-checked as distinct. Median and min are both reported: where they disagree in
sign, the row is drift rather than signal.

| model | main | this PR | median | min |
|---|---|---|---|---|
| DPDFNet baseline | 0.4734 | 0.4528 | **+4.4%** | +1.0% |
| dpdfnet8_48khz_hr | 6.9542 | 6.6813 | **+3.9%** | +0.6% |
| dpdfnet2_48khz_hr | 2.5363 | 2.4679 | **+2.7%** | +2.5% |
| dpdfnet8 | 3.9725 | 3.8823 | **+2.3%** | +2.4% |
| DeepFilterNet3 df_dec | 0.0980 | 0.0958 | **+2.2%** | +2.9% |
| dpdfnet2 | 1.3161 | 1.2904 | **+2.0%** | +0.9% |
| dpdfnet2_8khz | 1.3552 | 1.3290 | **+1.9%** | +2.3% |
| DeepFilterNet3 erb_dec | 0.1050 | 0.1033 | **+1.6%** | +1.4% |
| dpdfnet8_8khz | 3.8137 | 3.7677 | +1.2% | +1.3% |
| DeepFilterNet3 enc | 0.1268 | 0.1262 | +0.5% | +0.4% |
| gtcrn / gtcrn_simple | | | +0.4% / +0.4% | +0.1% / −0.4% |
| dpdfnet4 | 2.2409 | 2.2313 | +0.4% | +3.0% |
| dtln_model_1 / dtln_model_2 | | | +0.0% / −0.4% | +0.0% / +0.0% |

No model is negative on both statistics. The DTLN pair have no convolutions at
all, so their sub-noise cells cannot come from this change.

### Second commit: 1x1 convolutions stay eager

An earlier revision of this branch regressed `gtcrn` by 1.4%, consistently on both
median and min. Three of the five convolutions the rule flipped there are 1x1: a
1x1 kernel gathers nothing, its im2col is already a reshape, so there is no
materialisation for lazy to save and its per-position indirection is pure loss.
The second commit excludes them, which takes `gtcrn` from −1.4% to +0.4%.

Full workspace suite green, `cargo fmt` and `cargo clippy` clean, no new `unsafe`.

### Please run bench-vs-main before merging

PR #2710 changed `DEFAULT_LAZY_IM2COL_MIN_KERNEL` in this same function and was
closed after the bench fleet found real `en_tdnn_8M` and `inceptionv3` regressions
that a noise-suppression-only A/B could not see. The lesson recorded there was that
any future attempt needs a shape-aware rule rather than a global threshold, which is
what this is — it fires only when `m <= mr`, so wide-output convolutions like TDNN's
are untouched by construction. But that argument deserves checking against the fleet
rather than trusting my reasoning, and my measurements cover only the models above.

🍍



