### PR TITLE
(perf) core/einsum: do not pick AMX/SME when C's n axis is strided

### DIFF
--- a/core/src/ops/einsum/kernel_selection.rs
+++ b/core/src/ops/einsum/kernel_selection.rs
@@ -18,6 +18,29 @@ fn single_strat(it: Impl) -> Strat {
     (ModePicker::Single, it.0.packings()[it.1].0.clone(), vec![it])
 }
 
+/// True when C's n axis is the innermost non-unit axis, so a row-major AMX/SME
+/// store hits its aligned bulk path (`col_byte_stride == item_size`).
+fn n_axis_contiguous(model: &TypedModel, node: &TypedNode, op: &EinSumMatMul) -> bool {
+    let Some(cn) = op.c_n() else {
+        return true;
+    };
+    let Ok(fact) = model.outlet_fact(node.id.into()) else {
+        return true;
+    };
+    fact.shape.iter().skip(cn + 1).all(|d| d.is_one())
+}
+
+/// AMX and SME 32x32 `stz`/`st1w` write a contiguous 128-byte row. A strided n
+/// axis makes that kernel 20× slower in-graph than isolated (50 µs vs 2.4 µs
+/// on DPDFNet 48 kHz 160×64×64). NEON 8x8 is the right pick there. GEMV
+/// (nr==1) is unaffected.
+fn tile_store_needs_n_contiguous(name: &str, nr: usize) -> bool {
+    nr > 1
+        && (name.starts_with("apple_amx")
+            || name.starts_with("sme_mmm")
+            || name.starts_with("sme_qmmm"))
+}
+
 pub fn strategize(model: &TypedModel, node: &TypedNode, op: &EinSumMatMul) -> TractResult<Strat> {
     let query = query(model, node, op)?;
     let mut suitable = tract_linalg::MmmDispatch::native().suitable(&query);
@@ -27,7 +50,17 @@ pub fn strategize(model: &TypedModel, node: &TypedNode, op: &EinSumMatMul) -> Tr
     if query.n.is_some()
         && let Some(chosen) = tract_linalg::MmmDispatch::native().preferred(&query, &suitable)
     {
-        return Ok(single_strat(chosen));
+        if tile_store_needs_n_contiguous(chosen.0.name(), chosen.0.nr())
+            && !n_axis_contiguous(model, node, op)
+        {
+            suitable.retain(|(k, _, _)| !tile_store_needs_n_contiguous(k.name(), k.nr()));
+            if let Some(fallback) = tract_linalg::MmmDispatch::native().preferred(&query, &suitable)
+            {
+                return Ok(single_strat(fallback));
+            }
+        } else {
+            return Ok(single_strat(chosen));
+        }
     }
     retain_best(&mut suitable);
     if suitable.len() == 1 {
@@ -114,4 +147,64 @@ pub fn query(model: &TypedModel, node: &TypedNode, op: &EinSumMatMul) -> TractRe
         k: op.k.as_i64().map(|d| d as usize),
         n: op.n.as_i64().map(|d| d as usize),
     })
+}
+
+#[cfg(test)]
+mod amx_strided_store {
+    use super::*;
+    use crate::ops::einsum::EinSum;
+    use crate::ops::matmul::optimized::OptMatMul;
+
+    fn optimize_mn(m: usize, k: usize, n: usize) -> TypedModel {
+        let mut model = TypedModel::default();
+        let a = model.add_source("a", f32::fact([m, k])).unwrap();
+        let b = model.add_source("b", f32::fact([k, n])).unwrap();
+        let out = model
+            .wire_node(
+                "gemm",
+                EinSum::new("mk,kn->mn".parse().unwrap(), f32::datum_type()),
+                &[a, b],
+            )
+            .unwrap();
+        model.select_output_outlets(&out).unwrap();
+        model.optimize().unwrap();
+        model
+    }
+
+    fn has_tile_kernel() -> bool {
+        tract_linalg::MmmDispatch::native()
+            .runnable()
+            .iter()
+            .any(|k| tile_store_needs_n_contiguous(k.name(), k.nr()))
+    }
+
+    /// m<n transposes so n is no longer innermost. AMX/SME 32x32 must not be the kernel.
+    #[test]
+    fn strided_n_does_not_select_amx_32x32() {
+        if !has_tile_kernel() {
+            return;
+        }
+        let model = optimize_mn(64, 64, 160);
+        let mm = model.nodes.iter().find_map(|n| n.op_as::<OptMatMul>()).expect("OptMatMul");
+        assert!(
+            !tile_store_needs_n_contiguous(mm.mmm[0].name(), mm.mmm[0].nr()),
+            "strided-n GEMM selected {}",
+            mm.mmm[0].name()
+        );
+    }
+
+    /// m>n keeps n innermost. AMX 32x32 (M1–M3) or SME 32x32 (M4+) is correct.
+    #[test]
+    fn contiguous_n_selects_wide_tile() {
+        if !has_tile_kernel() {
+            return;
+        }
+        let model = optimize_mn(160, 64, 64);
+        let mm = model.nodes.iter().find_map(|n| n.op_as::<OptMatMul>()).expect("OptMatMul");
+        assert!(
+            tile_store_needs_n_contiguous(mm.mmm[0].name(), mm.mmm[0].nr()),
+            "contiguous-n GEMM selected {}",
+            mm.mmm[0].name()
+        );
+    }
 }


### PR DESCRIPTION
Apple AMX (and SME on M4+) 32x32 stores require `col_byte_stride == item_size`: `stz` / `st1w` write a contiguous 128-byte row. When C's n axis is not innermost — which is what tract's m<n transpose does to a 160x64x64 encoder/decoder GEMM — the kernel takes the generic scatter path instead.

Isolated, that AMX tile is ~2.4 µs. In-graph on DPDFNet 48 kHz-hr it is ~50 µs. NEON 8x8 does the same shape in ~16 µs. So the preferred 32x32 pick is the wrong kernel whenever n is strided.

This keeps the AMX/SME 32x32 choice when n *is* innermost, and otherwise drops those tiles and re-picks (NEON). GEMV (`nr == 1`) is unaffected. wasm GEMM already stores at arbitrary `col_byte_stride`; the name match never fires there.

### Measured

p50 ms/frame, median of 3 interleaved rounds, single-threaded, M1 Pro. Same tree with and without this patch; binaries hash-checked as distinct. Median **and** min: a row whose signs disagree is drift.

| model | base | this PR | median | min |
|---|---|---|---|---|
| dpdfnet2_48khz_hr | 1.836 | 1.577 | **+14%** | +12% |
| dpdfnet8_48khz_hr | 4.785 | 4.144 | **+13%** | +6% |
| gtcrn | 0.412 | 0.410 | +0.5% | +0.4% |
| DPDFNet baseline | 0.392 | 0.386 | +1.5% | +1.1% |
| dpdfnet2 | 1.020 | 1.023 | −0.2% | −0.4% |
| dpdfnet4 | 1.690 | 1.695 | −0.3% | +0.4% |
| dpdfnet8 | 2.903 | 2.914 | −0.4% | −1.8% |
| dpdfnet2_8khz | 1.046 | 1.053 | −0.6% | −1.3% |
| dpdfnet8_8khz | 2.842 | 2.839 | +0.1% | +0.5% |

The 16 kHz / 8 kHz / gtcrn rows are noise. The win is the 48 kHz-hr encoder/decoder GEMMs, whose first conv runs on linear frequency (481 bins) rather than 32 ERB, so the 160x64x64 tiles after the m<n transpose actually show up.

Wiring AMX to still `stz` into scratch and `set_from_tile` into strided C is correct but slower than NEON on these shapes (~5% on 48 kHz-2, flat on 48 kHz-8). Skipping the tile is the right dispatch.

Outputs vs ONNX Runtime, whole-stream: max abs ≤ 2.68e-05, no frame-index drift, on gtcrn / dpdfnet2 / both 48 kHz-hr models.

Two tests drive the shipped path: `m=64,n=160` must not select AMX/SME 32x32; `m=160,n=64` still must. They skip on hosts without those kernels.

No new `unsafe`. wasm-plain binaries change only by the extra branch (no AMX/SME names to match); a 3-round wasm A/B sits inside noise (0.987–1.006).

🍍