### PR TITLE
(perf) core/cnn: vectorise depthwise along contiguous W

### DIFF
--- a/cli/src/routines.rs
+++ b/cli/src/routines.rs
@@ -55,6 +55,7 @@ fn family(factory: &RoutineFactory) -> (u8, &'static str) {
         RoutineFactory::RmsNormF32 { .. } => (4, "fused row-wise"),
         RoutineFactory::LutU8 { .. } => (5, "look-up table"),
         RoutineFactory::BinF32 { .. } | RoutineFactory::BinF16 { .. } => (6, "binary"),
+        RoutineFactory::DepthwiseWF32 { .. } => (7, "depthwise"),
     }
 }
 

--- a/core/src/ops/cnn/conv/depth_wise.rs
+++ b/core/src/ops/cnn/conv/depth_wise.rs
@@ -206,6 +206,25 @@ macro_rules! impl_eval {
                     while !visitor.done {
                         let iptr = iptr.offset(visitor.input_center_offset);
                         let optr = optr.offset(visitor.output_offset);
+                        #[cfg(target_arch = "aarch64")]
+                        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>()
+                            && visitor.inner_loop_output_stride == 1
+                            && visitor.inner_loop_input_full_stride >= 1
+                        {
+                            let k_f32 = *(&k as *const [T; N] as *const [f32; N]);
+                            let bias_f32 = *(&bias as *const T as *const f32);
+                            neon_depthwise_w_f32::<N>(
+                                iptr as *const f32,
+                                optr as *mut f32,
+                                &k_f32,
+                                &ioffset,
+                                bias_f32,
+                                visitor.inner_loop_len,
+                                visitor.inner_loop_input_full_stride,
+                            );
+                            visitor.next_non_inner_axis();
+                            continue;
+                        }
                         let mut i = 0isize;
                         while i + (UNROLL as isize) < visitor.inner_loop_len as isize {
                             let iptr = iptr.offset(visitor.inner_loop_input_full_stride * i);
@@ -307,6 +326,113 @@ impl_eval! {
 #[target_feature(enable = "fp16")]
 #[cfg(target_arch = "aarch64")]
 aarch64fp16
+}
+
+/// Depthwise along an output-contiguous spatial axis (`output_stride == 1`).
+/// Vectorise over consecutive output points. Input may be contiguous (stride 1)
+/// or strided: DPDFNet 48 kHz encoder DW is NCHW `kw=3` with W-stride 2 or 3,
+/// which `vld2q`/`vld3q` de-interleave. Scalar `process_zone_n` stays for
+/// padded / non-unit output-stride zones. Does not touch `BlockedConv`.
+#[cfg(target_arch = "aarch64")]
+unsafe fn neon_depthwise_w_f32<const N: usize>(
+    iptr: *const f32,
+    optr: *mut f32,
+    k: &[f32; N],
+    ioffset: &[isize; N],
+    bias: f32,
+    len: usize,
+    in_stride: isize,
+) {
+    unsafe {
+        use std::arch::aarch64::*;
+        let biasv = vdupq_n_f32(bias);
+        let mut i = 0usize;
+        if in_stride == 1 {
+            while i + 8 <= len {
+                let mut acc0 = biasv;
+                let mut acc1 = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let p = iptr.offset(ioffset[n]).add(i);
+                    acc0 = vfmaq_f32(acc0, vld1q_f32(p), kn);
+                    acc1 = vfmaq_f32(acc1, vld1q_f32(p.add(4)), kn);
+                }
+                vst1q_f32(optr.add(i), acc0);
+                vst1q_f32(optr.add(i + 4), acc1);
+                i += 8;
+            }
+            while i + 4 <= len {
+                let mut acc = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    acc = vfmaq_f32(acc, vld1q_f32(iptr.offset(ioffset[n]).add(i)), kn);
+                }
+                vst1q_f32(optr.add(i), acc);
+                i += 4;
+            }
+        } else if in_stride == 2 {
+            while i + 8 <= len {
+                let mut acc0 = biasv;
+                let mut acc1 = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let p = iptr.offset(ioffset[n]).offset(i as isize * 2);
+                    // vld2 de-interleaves even/odd; even lanes are stride-2 samples.
+                    let a = vld2q_f32(p);
+                    let b = vld2q_f32(p.add(8));
+                    acc0 = vfmaq_f32(acc0, a.0, kn);
+                    acc1 = vfmaq_f32(acc1, b.0, kn);
+                }
+                vst1q_f32(optr.add(i), acc0);
+                vst1q_f32(optr.add(i + 4), acc1);
+                i += 8;
+            }
+            while i + 4 <= len {
+                let mut acc = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let a = vld2q_f32(iptr.offset(ioffset[n]).offset(i as isize * 2));
+                    acc = vfmaq_f32(acc, a.0, kn);
+                }
+                vst1q_f32(optr.add(i), acc);
+                i += 4;
+            }
+        } else if in_stride == 3 {
+            while i + 8 <= len {
+                let mut acc0 = biasv;
+                let mut acc1 = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let p = iptr.offset(ioffset[n]).offset(i as isize * 3);
+                    let a = vld3q_f32(p);
+                    let b = vld3q_f32(p.add(12));
+                    acc0 = vfmaq_f32(acc0, a.0, kn);
+                    acc1 = vfmaq_f32(acc1, b.0, kn);
+                }
+                vst1q_f32(optr.add(i), acc0);
+                vst1q_f32(optr.add(i + 4), acc1);
+                i += 8;
+            }
+            while i + 4 <= len {
+                let mut acc = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let a = vld3q_f32(iptr.offset(ioffset[n]).offset(i as isize * 3));
+                    acc = vfmaq_f32(acc, a.0, kn);
+                }
+                vst1q_f32(optr.add(i), acc);
+                i += 4;
+            }
+        }
+        while i < len {
+            let mut sum = bias;
+            for n in 0..N {
+                sum += k[n] * *iptr.offset(ioffset[n]).offset(i as isize * in_stride);
+            }
+            *optr.add(i) = sum;
+            i += 1;
+        }
+    }
 }
 //#[target_feature(enable = "fp16")] impl_eval!(aarch64fp16);
 
@@ -469,3 +595,106 @@ let sum = bias + p0 + p1 + p2 + p3;
      }
      }
      */
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ops::cnn::conv::{Conv, KernelFormat};
+    use crate::ops::cnn::{PaddingSpec, PoolSpec};
+    use crate::ops::nn::DataFormat;
+
+    fn run_dw(
+        c: usize,
+        h: usize,
+        w: usize,
+        kh: usize,
+        kw: usize,
+        pad: PaddingSpec,
+        stride: (usize, usize),
+    ) {
+        let n = 1usize;
+        let x: Vec<f32> = (0..n * c * h * w).map(|i| ((i as f32 * 0.137).sin()) * 0.7).collect();
+        let kernel: Vec<f32> = (0..c * kh * kw).map(|i| ((i as f32 * 0.091).cos()) * 0.3).collect();
+        let bias: Vec<f32> = (0..c).map(|i| (i as f32 * 0.05) - 0.1).collect();
+
+        let mut model = TypedModel::default();
+        let xv = model.add_source("x", f32::fact([n, c, h, w])).unwrap();
+        let kv =
+            model.add_const("k", Tensor::from_shape(&[c, 1, kh, kw], &kernel).unwrap()).unwrap();
+        let bv = model.add_const("b", Tensor::from_shape(&[c], &bias).unwrap()).unwrap();
+        let conv = Conv {
+            pool_spec: PoolSpec {
+                data_format: DataFormat::NCHW,
+                kernel_shape: tvec!(kh, kw),
+                padding: pad.clone(),
+                dilations: None,
+                strides: Some(tvec!(stride.0, stride.1)),
+                input_channels: c,
+                output_channels: c,
+            },
+            kernel_fmt: KernelFormat::OIHW,
+            group: c,
+            q_params: None,
+        };
+        let out = model.wire_node("dw", conv, &[xv, kv, bv]).unwrap();
+        model.select_output_outlets(&out).unwrap();
+        let model = model.into_decluttered().unwrap().into_optimized().unwrap();
+        assert!(
+            model.nodes.iter().any(|node| node.op_as::<DepthWise>().is_some()),
+            "expected DepthWiseConv, got {}",
+            model.nodes.iter().map(|node| node.op().name()).collect::<Vec<_>>().join(",")
+        );
+        let runnable = model.into_runnable().unwrap();
+        let got = runnable
+            .run(tvec![Tensor::from_shape(&[n, c, h, w], &x).unwrap().into_tvalue()])
+            .unwrap();
+        let got = got[0].to_plain_array_view::<f32>().unwrap();
+        let oshape = got.shape();
+        let oh = oshape[2];
+        let ow = oshape[3];
+        let (ph, pw) = match pad {
+            PaddingSpec::Valid => (0isize, 0isize),
+            _ => (((kh - 1) / 2) as isize, ((kw - 1) / 2) as isize),
+        };
+        let mut max_abs = 0f32;
+        for oc in 0..c {
+            for oy in 0..oh {
+                for ox in 0..ow {
+                    let mut acc = bias[oc];
+                    for ky in 0..kh {
+                        for kx in 0..kw {
+                            let iy = oy as isize * stride.0 as isize + ky as isize - ph;
+                            let ix = ox as isize * stride.1 as isize + kx as isize - pw;
+                            if iy < 0 || ix < 0 || iy >= h as isize || ix >= w as isize {
+                                continue;
+                            }
+                            let xv = x[((oc * h + iy as usize) * w) + ix as usize];
+                            let kv = kernel[((oc * kh + ky) * kw) + kx];
+                            acc += xv * kv;
+                        }
+                    }
+                    let g = got[[0, oc, oy, ox]];
+                    max_abs = max_abs.max((g - acc).abs());
+                }
+            }
+        }
+        assert!(
+            max_abs < 1e-5,
+            "DepthWise mismatch c={c} {h}x{w} k={kh}x{kw} stride={stride:?} pad={pad:?}: max_abs={max_abs}"
+        );
+    }
+
+    #[test]
+    fn depthwise_contig_w_matches_reference() {
+        // 48 kHz-like: NCHW, H=1, long W, kw=3. Inner loop is W.
+        run_dw(16, 1, 64, 1, 3, PaddingSpec::Valid, (1, 1));
+        run_dw(32, 1, 481, 1, 3, PaddingSpec::Valid, (1, 1));
+        run_dw(8, 1, 17, 1, 3, PaddingSpec::SameUpper, (1, 1));
+        run_dw(8, 12, 20, 3, 1, PaddingSpec::Valid, (1, 1));
+        run_dw(4, 9, 9, 3, 3, PaddingSpec::Valid, (1, 1));
+        // Encoder DW: stride 2 / 3 along W (vld2 / vld3 path).
+        run_dw(64, 1, 481, 1, 3, PaddingSpec::SameUpper, (1, 3));
+        run_dw(64, 1, 161, 1, 3, PaddingSpec::SameUpper, (1, 2));
+        run_dw(16, 1, 64, 1, 3, PaddingSpec::Valid, (1, 2));
+    }
+}

--- a/core/src/ops/cnn/conv/depth_wise.rs
+++ b/core/src/ops/cnn/conv/depth_wise.rs
@@ -496,7 +496,7 @@ let sum = bias + p0 + p1 + p2 + p3;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ops::cnn::conv::{Conv, KernelFormat};
+    use crate::ops::cnn::conv::{BlockedConv, Conv, KernelFormat};
     use crate::ops::cnn::{PaddingSpec, PoolSpec};
     use crate::ops::nn::DataFormat;
 
@@ -536,6 +536,12 @@ mod tests {
         let out = model.wire_node("dw", conv, &[xv, kv, bv]).unwrap();
         model.select_output_outlets(&out).unwrap();
         let model = model.into_decluttered().unwrap().into_optimized().unwrap();
+        if kw == 1 && model.nodes.iter().any(|node| node.op_as::<BlockedConv>().is_some()) {
+            // `BlockedConv` claims kw=1 NCHW f32 wherever it is enabled -- by default on
+            // wasm, opt-in elsewhere -- so this shape does not reach DepthWise there.
+            // `blocked_conv_matches_reference` covers it.
+            return;
+        }
         assert!(
             model.nodes.iter().any(|node| node.op_as::<DepthWise>().is_some()),
             "expected DepthWiseConv, got {}",
@@ -587,6 +593,7 @@ mod tests {
         run_dw(16, 1, 64, 1, 3, PaddingSpec::Valid, (1, 1));
         run_dw(32, 1, 481, 1, 3, PaddingSpec::Valid, (1, 1));
         run_dw(8, 1, 17, 1, 3, PaddingSpec::SameUpper, (1, 1));
+        // kw=1: taps a row apart, output still contiguous along W.
         run_dw(8, 12, 20, 3, 1, PaddingSpec::Valid, (1, 1));
         run_dw(4, 9, 9, 3, 3, PaddingSpec::Valid, (1, 1));
         // Encoder DW: stride 2 / 3 along W (vld2 / vld3 path).

--- a/core/src/ops/cnn/conv/depth_wise.rs
+++ b/core/src/ops/cnn/conv/depth_wise.rs
@@ -195,6 +195,11 @@ macro_rules! impl_eval {
                     ioffset[i] = zone.values_offsets[i].1;
                 }
                 let mut k = [T::zero(); N];
+                let ker = if T::datum_type() == f32::datum_type() {
+                    tract_linalg::routines::depthwise_w_f32()
+                } else {
+                    None
+                };
                 for c in 0..*dw.input_shape.c() as isize {
                     visitor.reset();
                     let iptr = iptr.offset(c_stride_i * c);
@@ -206,19 +211,17 @@ macro_rules! impl_eval {
                     while !visitor.done {
                         let iptr = iptr.offset(visitor.input_center_offset);
                         let optr = optr.offset(visitor.output_offset);
-                        #[cfg(target_arch = "aarch64")]
-                        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<f32>()
+                        if let Some(ker) = ker
                             && visitor.inner_loop_output_stride == 1
                             && visitor.inner_loop_input_full_stride >= 1
                         {
                             let k_f32 = *(&k as *const [T; N] as *const [f32; N]);
-                            let bias_f32 = *(&bias as *const T as *const f32);
-                            neon_depthwise_w_f32::<N>(
+                            ker(
                                 iptr as *const f32,
                                 optr as *mut f32,
                                 &k_f32,
                                 &ioffset,
-                                bias_f32,
+                                *(&bias as *const T as *const f32),
                                 visitor.inner_loop_len,
                                 visitor.inner_loop_input_full_stride,
                             );
@@ -328,112 +331,6 @@ impl_eval! {
 aarch64fp16
 }
 
-/// Depthwise along an output-contiguous spatial axis (`output_stride == 1`).
-/// Vectorise over consecutive output points. Input may be contiguous (stride 1)
-/// or strided: DPDFNet 48 kHz encoder DW is NCHW `kw=3` with W-stride 2 or 3,
-/// which `vld2q`/`vld3q` de-interleave. Scalar `process_zone_n` stays for
-/// padded / non-unit output-stride zones. Does not touch `BlockedConv`.
-#[cfg(target_arch = "aarch64")]
-unsafe fn neon_depthwise_w_f32<const N: usize>(
-    iptr: *const f32,
-    optr: *mut f32,
-    k: &[f32; N],
-    ioffset: &[isize; N],
-    bias: f32,
-    len: usize,
-    in_stride: isize,
-) {
-    unsafe {
-        use std::arch::aarch64::*;
-        let biasv = vdupq_n_f32(bias);
-        let mut i = 0usize;
-        if in_stride == 1 {
-            while i + 8 <= len {
-                let mut acc0 = biasv;
-                let mut acc1 = biasv;
-                for n in 0..N {
-                    let kn = vdupq_n_f32(k[n]);
-                    let p = iptr.offset(ioffset[n]).add(i);
-                    acc0 = vfmaq_f32(acc0, vld1q_f32(p), kn);
-                    acc1 = vfmaq_f32(acc1, vld1q_f32(p.add(4)), kn);
-                }
-                vst1q_f32(optr.add(i), acc0);
-                vst1q_f32(optr.add(i + 4), acc1);
-                i += 8;
-            }
-            while i + 4 <= len {
-                let mut acc = biasv;
-                for n in 0..N {
-                    let kn = vdupq_n_f32(k[n]);
-                    acc = vfmaq_f32(acc, vld1q_f32(iptr.offset(ioffset[n]).add(i)), kn);
-                }
-                vst1q_f32(optr.add(i), acc);
-                i += 4;
-            }
-        } else if in_stride == 2 {
-            while i + 8 <= len {
-                let mut acc0 = biasv;
-                let mut acc1 = biasv;
-                for n in 0..N {
-                    let kn = vdupq_n_f32(k[n]);
-                    let p = iptr.offset(ioffset[n]).offset(i as isize * 2);
-                    // vld2 de-interleaves even/odd; even lanes are stride-2 samples.
-                    let a = vld2q_f32(p);
-                    let b = vld2q_f32(p.add(8));
-                    acc0 = vfmaq_f32(acc0, a.0, kn);
-                    acc1 = vfmaq_f32(acc1, b.0, kn);
-                }
-                vst1q_f32(optr.add(i), acc0);
-                vst1q_f32(optr.add(i + 4), acc1);
-                i += 8;
-            }
-            while i + 4 <= len {
-                let mut acc = biasv;
-                for n in 0..N {
-                    let kn = vdupq_n_f32(k[n]);
-                    let a = vld2q_f32(iptr.offset(ioffset[n]).offset(i as isize * 2));
-                    acc = vfmaq_f32(acc, a.0, kn);
-                }
-                vst1q_f32(optr.add(i), acc);
-                i += 4;
-            }
-        } else if in_stride == 3 {
-            while i + 8 <= len {
-                let mut acc0 = biasv;
-                let mut acc1 = biasv;
-                for n in 0..N {
-                    let kn = vdupq_n_f32(k[n]);
-                    let p = iptr.offset(ioffset[n]).offset(i as isize * 3);
-                    let a = vld3q_f32(p);
-                    let b = vld3q_f32(p.add(12));
-                    acc0 = vfmaq_f32(acc0, a.0, kn);
-                    acc1 = vfmaq_f32(acc1, b.0, kn);
-                }
-                vst1q_f32(optr.add(i), acc0);
-                vst1q_f32(optr.add(i + 4), acc1);
-                i += 8;
-            }
-            while i + 4 <= len {
-                let mut acc = biasv;
-                for n in 0..N {
-                    let kn = vdupq_n_f32(k[n]);
-                    let a = vld3q_f32(iptr.offset(ioffset[n]).offset(i as isize * 3));
-                    acc = vfmaq_f32(acc, a.0, kn);
-                }
-                vst1q_f32(optr.add(i), acc);
-                i += 4;
-            }
-        }
-        while i < len {
-            let mut sum = bias;
-            for n in 0..N {
-                sum += k[n] * *iptr.offset(ioffset[n]).offset(i as isize * in_stride);
-            }
-            *optr.add(i) = sum;
-            i += 1;
-        }
-    }
-}
 //#[target_feature(enable = "fp16")] impl_eval!(aarch64fp16);
 
 /* partial alternative impl that may be relevant when simd gets better */

--- a/linalg/src/arm64/arm64simd/depthwise.rs
+++ b/linalg/src/arm64/arm64simd/depthwise.rs
@@ -1,0 +1,224 @@
+/// Depthwise convolution along an axis the output is contiguous on: `len` output points, each
+/// the bias plus every `taps[t] * input[offsets[t] + i * in_stride]`.
+///
+/// `taps` and `offsets` hold one kernel tap each and must be the same length. `in_stride` is the
+/// input step one output point costs, in elements: 1 is a plain load, 2 and 3 are de-interleaved
+/// by `vld2q`/`vld3q`, and anything else stays scalar. The vector loops stop early enough that
+/// no lane reads past `offsets[t] + (len - 1) * in_stride`, so a run ending on the tensor's last
+/// element is safe.
+///
+/// # Safety
+/// `input.offset(offsets[t] + i * in_stride)` must be readable for every tap and every `i` below
+/// `len`, and `len` output points writable from `output`.
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn depthwise_w_f32(
+    input: *const f32,
+    output: *mut f32,
+    taps: &[f32],
+    offsets: &[isize],
+    bias: f32,
+    len: usize,
+    in_stride: isize,
+) {
+    unsafe {
+        match taps.len() {
+            1 => vectorised::<1>(input, output, taps, offsets, bias, len, in_stride),
+            2 => vectorised::<2>(input, output, taps, offsets, bias, len, in_stride),
+            3 => vectorised::<3>(input, output, taps, offsets, bias, len, in_stride),
+            4 => vectorised::<4>(input, output, taps, offsets, bias, len, in_stride),
+            _ => scalar(input, output, taps, offsets, bias, 0, len, in_stride),
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn vectorised<const N: usize>(
+    input: *const f32,
+    output: *mut f32,
+    taps: &[f32],
+    offsets: &[isize],
+    bias: f32,
+    len: usize,
+    in_stride: isize,
+) {
+    unsafe {
+        use std::arch::aarch64::*;
+        let mut k = [0f32; N];
+        k.copy_from_slice(&taps[..N]);
+        let mut off = [0isize; N];
+        off.copy_from_slice(&offsets[..N]);
+        let biasv = vdupq_n_f32(bias);
+        let mut i = 0usize;
+        if in_stride == 1 {
+            while i + 8 <= len {
+                let mut acc0 = biasv;
+                let mut acc1 = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let p = input.offset(off[n]).add(i);
+                    acc0 = vfmaq_f32(acc0, vld1q_f32(p), kn);
+                    acc1 = vfmaq_f32(acc1, vld1q_f32(p.add(4)), kn);
+                }
+                vst1q_f32(output.add(i), acc0);
+                vst1q_f32(output.add(i + 4), acc1);
+                i += 8;
+            }
+            while i + 4 <= len {
+                let mut acc = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    acc = vfmaq_f32(acc, vld1q_f32(input.offset(off[n]).add(i)), kn);
+                }
+                vst1q_f32(output.add(i), acc);
+                i += 4;
+            }
+        } else if in_stride == 2 {
+            while i + 9 <= len {
+                let mut acc0 = biasv;
+                let mut acc1 = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let p = input.offset(off[n]).offset(i as isize * 2);
+                    acc0 = vfmaq_f32(acc0, vld2q_f32(p).0, kn);
+                    acc1 = vfmaq_f32(acc1, vld2q_f32(p.add(8)).0, kn);
+                }
+                vst1q_f32(output.add(i), acc0);
+                vst1q_f32(output.add(i + 4), acc1);
+                i += 8;
+            }
+            while i + 5 <= len {
+                let mut acc = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    acc = vfmaq_f32(
+                        acc,
+                        vld2q_f32(input.offset(off[n]).offset(i as isize * 2)).0,
+                        kn,
+                    );
+                }
+                vst1q_f32(output.add(i), acc);
+                i += 4;
+            }
+        } else if in_stride == 3 {
+            while i + 9 <= len {
+                let mut acc0 = biasv;
+                let mut acc1 = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    let p = input.offset(off[n]).offset(i as isize * 3);
+                    acc0 = vfmaq_f32(acc0, vld3q_f32(p).0, kn);
+                    acc1 = vfmaq_f32(acc1, vld3q_f32(p.add(12)).0, kn);
+                }
+                vst1q_f32(output.add(i), acc0);
+                vst1q_f32(output.add(i + 4), acc1);
+                i += 8;
+            }
+            while i + 5 <= len {
+                let mut acc = biasv;
+                for n in 0..N {
+                    let kn = vdupq_n_f32(k[n]);
+                    acc = vfmaq_f32(
+                        acc,
+                        vld3q_f32(input.offset(off[n]).offset(i as isize * 3)).0,
+                        kn,
+                    );
+                }
+                vst1q_f32(output.add(i), acc);
+                i += 4;
+            }
+        }
+        scalar(input, output, taps, offsets, bias, i, len, in_stride);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn scalar(
+    input: *const f32,
+    output: *mut f32,
+    taps: &[f32],
+    offsets: &[isize],
+    bias: f32,
+    from: usize,
+    len: usize,
+    in_stride: isize,
+) {
+    unsafe {
+        for i in from..len {
+            let mut sum = bias;
+            for (tap, offset) in taps.iter().zip(offsets) {
+                sum += tap * *input.offset(offset + i as isize * in_stride);
+            }
+            *output.add(i) = sum;
+        }
+    }
+}
+
+bail_stub!(aarch64; pub unsafe fn depthwise_w_f32(
+    *const f32, *mut f32, &[f32], &[isize], f32, usize, isize
+));
+
+submit_routine!(aarch64; DepthwiseWF32, DepthwiseW, "arm64simd_depthwise_w_f32", depthwise_w_f32);
+
+#[cfg(all(test, target_arch = "aarch64"))]
+mod tests {
+    use super::*;
+
+    fn reference(
+        input: &[f32],
+        taps: &[f32],
+        offsets: &[isize],
+        bias: f32,
+        len: usize,
+        in_stride: isize,
+        center: usize,
+    ) -> Vec<f32> {
+        (0..len)
+            .map(|i| {
+                taps.iter().zip(offsets).fold(bias, |sum, (tap, offset)| {
+                    sum + tap * input[(center as isize + offset + i as isize * in_stride) as usize]
+                })
+            })
+            .collect()
+    }
+
+    fn compare(taps: usize, len: usize, in_stride: isize) {
+        let k: Vec<f32> = (0..taps).map(|t| (t as f32 * 0.7).sin()).collect();
+        let offsets: Vec<isize> = (0..taps as isize).map(|t| t - taps as isize / 2).collect();
+        let center = taps;
+        let input: Vec<f32> = (0..center + (len - 1) * in_stride as usize + center)
+            .map(|i| (i as f32 * 0.11).cos())
+            .collect();
+        let want = reference(&input, &k, &offsets, 0.25, len, in_stride, center);
+        let mut got = vec![0f32; len];
+        unsafe {
+            depthwise_w_f32(
+                input.as_ptr().add(center),
+                got.as_mut_ptr(),
+                &k,
+                &offsets,
+                0.25,
+                len,
+                in_stride,
+            )
+        };
+        for (i, (g, w)) in got.iter().zip(&want).enumerate() {
+            assert!(
+                (g - w).abs() < 1e-5,
+                "taps={taps} len={len} stride={in_stride} at {i}: got {g}, want {w}"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_reference() {
+        for taps in [1usize, 2, 3, 4, 5] {
+            for in_stride in [1isize, 2, 3, 4] {
+                for len in [1usize, 3, 4, 7, 8, 9, 15, 16, 33, 481] {
+                    compare(taps, len, in_stride);
+                }
+            }
+        }
+    }
+}

--- a/linalg/src/arm64/arm64simd/mod.rs
+++ b/linalg/src/arm64/arm64simd/mod.rs
@@ -1,5 +1,6 @@
 mod act_f16;
 mod by_scalar;
+mod depthwise;
 mod exp;
 mod gelu;
 mod gelu_fused;
@@ -20,6 +21,7 @@ pub use act_f16::arm64simd_silu_f16_4n;
 pub use act_f16::arm64simd_silu_f16_lut_8n;
 pub use act_f16::arm64simd_tanh_f16_4n;
 pub use by_scalar::*;
+pub use depthwise::depthwise_w_f32 as arm64simd_depthwise_w_f32;
 pub use exp::arm64simd_exp_f32_16n;
 pub use gelu::arm64simd_gelu_f32_4n;
 pub use gelu_fused::arm64simd_gelu_f32_4n_fused;

--- a/linalg/src/routines.rs
+++ b/linalg/src/routines.rs
@@ -47,6 +47,8 @@ pub enum Func {
     BinByScalar(crate::BinOp),
     /// A binary operation between two slices of the same length.
     BinUnicast(crate::BinOp),
+    /// Depthwise convolution over an axis the output is contiguous on.
+    DepthwiseW,
 }
 
 impl Func {
@@ -69,7 +71,7 @@ impl Func {
         ]
     };
 
-    pub const ALL: [Func; 28] = [
+    pub const ALL: [Func; 29] = [
         Func::Sigmoid,
         Func::Tanh,
         Func::Silu,
@@ -98,6 +100,7 @@ impl Func {
         Func::BIN[9],
         Func::BIN[10],
         Func::BIN[11],
+        Func::DepthwiseW,
     ];
 
     /// Where this function sits in [`Self::ALL`], which is what indexes the dispatch table.
@@ -121,6 +124,7 @@ impl Func {
             Func::MulByScalar => 15,
             Func::BinByScalar(op) => 16 + op as usize,
             Func::BinUnicast(op) => 22 + op as usize,
+            Func::DepthwiseW => 28,
         }
     }
 
@@ -159,6 +163,7 @@ impl Func {
                 crate::BinOp::Sub => "unicast_sub",
                 crate::BinOp::SubF => "unicast_subf",
             },
+            Func::DepthwiseW => "depthwise_w",
         }
     }
 
@@ -243,6 +248,15 @@ impl Func {
     }
 }
 
+/// One depthwise output run: `len` contiguous output points, each the bias plus every
+/// `taps[t] * input[offsets[t] + i * in_stride]`. `taps` and `offsets` are one kernel tap each
+/// and are the same length; `in_stride` is the input step one output point costs, in elements.
+///
+/// # Safety
+/// `input.offset(offsets[t] + i * in_stride)` must be readable for every tap and every `i` below
+/// `len`, and `len` output points writable from `output`.
+pub type DepthwiseWF32 = unsafe fn(*const f32, *mut f32, &[f32], &[isize], f32, usize, isize);
+
 /// Builds the kernel behind a descriptor. The arm is what says which datum type the descriptor
 /// is for, so nothing repeats it as a field.
 #[allow(clippy::type_complexity)]
@@ -278,6 +292,12 @@ pub enum RoutineFactory {
         name: fn() -> &'static str,
         make: fn() -> Box<crate::BinFn>,
     },
+    /// A depthwise inner-loop kernel, a plain function rather than a boxed object, so its name
+    /// is a field.
+    DepthwiseWF32 {
+        name: &'static str,
+        run: DepthwiseWF32,
+    },
 }
 
 /// One kernel, enumerable uniformly on every host.
@@ -309,7 +329,8 @@ impl Routine {
             | RoutineFactory::F32Param(_)
             | RoutineFactory::F32Reduce(_)
             | RoutineFactory::F32MapReduce(_)
-            | RoutineFactory::RmsNormF32 { .. } => DatumType::F32,
+            | RoutineFactory::RmsNormF32 { .. }
+            | RoutineFactory::DepthwiseWF32 { .. } => DatumType::F32,
             RoutineFactory::F16(_) | RoutineFactory::F16Param(_) | RoutineFactory::F16Reduce(_) => {
                 DatumType::F16
             }
@@ -332,6 +353,7 @@ impl Routine {
             RoutineFactory::F16Reduce(f) => f().name(),
             RoutineFactory::F32MapReduce(f) => f().name(),
             RoutineFactory::RmsNormF32 { name, .. } => name,
+            RoutineFactory::DepthwiseWF32 { name, .. } => name,
             RoutineFactory::LutU8 { name, .. } => name(),
             RoutineFactory::BinF32 { name, .. } | RoutineFactory::BinF16 { name, .. } => name(),
         }
@@ -496,6 +518,16 @@ pub fn rms_norm_f32() -> TractResult<fn(&mut [f32], f32)> {
     }
 }
 
+/// The depthwise inner-loop kernel this host runs, `None` where none is written. Optional rather
+/// than fallible, like [`Func::bin`]: its caller keeps the scalar loop it needs anyway for the
+/// zones no kernel covers, so a machine without one is an ordinary answer.
+pub fn depthwise_w_f32() -> Option<DepthwiseWF32> {
+    match native_best(Func::DepthwiseW, DatumType::F32)?.factory {
+        RoutineFactory::DepthwiseWF32 { run, .. } => Some(run),
+        _ => None,
+    }
+}
+
 /// The look-up table kernel this host runs, over the table the caller owns.
 pub fn lut_u8(table: &[u8]) -> TractResult<Box<dyn Lut>> {
     match Func::Lut.best_here(DatumType::U8)?.factory {
@@ -527,6 +559,12 @@ macro_rules! submit_routine {
      $(, isa($($isa:ident),+))? $(, boost($boost:expr))?) => {
         submit_routine!(@@ $arch, $func,
             $crate::routines::RoutineFactory::RmsNormF32 { name: $name, run: $run }
+            $(, isa($($isa),+))? $(, boost($boost))?);
+    };
+    (@ $arch:expr; DepthwiseWF32, $func:ident, $name:literal, $run:path
+     $(, isa($($isa:ident),+))? $(, boost($boost:expr))?) => {
+        submit_routine!(@@ $arch, $func,
+            $crate::routines::RoutineFactory::DepthwiseWF32 { name: $name, run: $run }
             $(, isa($($isa),+))? $(, boost($boost))?);
     };
     (@ $arch:expr; BinF32, BinByScalar($op:ident), $ker:path
@@ -761,7 +799,8 @@ mod tests {
                     RoutineFactory::F32Reduce(_) => func.reduce_f32().map(|k| k.name()),
                     RoutineFactory::F16Reduce(_) => func.reduce_f16().map(|k| k.name()),
                     RoutineFactory::F32MapReduce(_) => func.map_reduce_f32().map(|k| k.name()),
-                    RoutineFactory::RmsNormF32 { name, .. } => Ok(name),
+                    RoutineFactory::RmsNormF32 { name, .. }
+                    | RoutineFactory::DepthwiseWF32 { name, .. } => Ok(name),
                     RoutineFactory::LutU8 { name, .. } => lut_u8(&[0u8; 256]).map(|_| name()),
                     RoutineFactory::BinF32 { name, .. } | RoutineFactory::BinF16 { name, .. } => {
                         func.bin(dt).map(|_| name()).ok_or_else(|| format_err!("no bin kernel"))


### PR DESCRIPTION
`DepthWiseConv`'s inner loop (`process_zone_n`) was scalar. On NCHW with W innermost and unit output stride that is a contiguous FIR along W: splat each kernel tap and FMA a 4-wide (then 8-wide) load of X.

DPDFNet 48 kHz-hr encoder DW is that shape with **stride 2 or 3** along frequency (`kw=3`, `group=C=64`, `W=481`). The stride-1 path never ran there; those taps use `vld2q` / `vld3q` to de-interleave. Padded / non-unit output-stride zones stay on the scalar loop. `BlockedConv` is untouched (wasm / `kw=1` / small `ocg`).

Does not apply to FastEnhancer or DTLN (no `DepthWiseConv`). DFN3 encoder/erb have the same DW family but it is ~1% of FMA and does not move the frame.

### Measured

p50 ms/frame, median of 3 interleaved rounds, single-threaded, M1 Pro. Same tree with and without this patch; binaries hash-checked as distinct. Median **and** min: a row whose signs disagree is drift.

| model | base | this PR | median | min |
|---|---|---|---|---|
| dpdfnet2_48khz_hr | 1.926 | 1.865 | **+3.2%** | **+3.2%** |
| dpdfnet2 | 1.276 | 1.193 | +6.5% | +0.9% |
| gtcrn | 0.605 | 0.603 | +0.2% | −0.1% |
| dfn3-enc | 4.886 | 4.720 | +3.4% | +0.1% |
| fe-tiny | 0.107 | 0.110 | −2.9% | +0.1% |
| dtln-2 | 0.052 | 0.052 | +0.2% | 0.0% |

The 48 kHz-hr row is the real one (min and median agree). dpdfnet2's p50 is one slow base round; min is ~1%. Everything else is noise or has no DepthWise op.

Vs ONNX Runtime CPU EP (intra=1, inter=1) after this patch: dpdfnet2_48khz_hr is still **1.33×** ORT. This is a few percent of tract, not a catch-up to FusedConv.

### Correctness

500-frame `dpdfnet2_48khz_hr` stream, skip-only vs this PR: max abs **8.9e-07**, max rel 1.0e-05, no frame-index drift. Not bit-identical (`vfmaq` vs scalar `*`/`+`); zero samples above 1e-6.

Same dump vs ORT: max abs 2.3e-06 (skip-only was 1.9e-06). Under the 3e-05 bar.

Unit test `depthwise_contig_w_matches_reference` covers `W=481`, `kw=3`, Valid/SameUpper, stride 1/2/3. `test-unit-core` conv filter: 501 passed.

🍍
