### PR TITLE
core: name the per-turn state scope `turn`, not `session`

### DIFF
--- a/api/ffi/src/lib.rs
+++ b/api/ffi/src/lib.rs
@@ -871,7 +871,7 @@ pub unsafe extern "C" fn tract_runtime_release(runtime: *mut *mut TractRuntime) 
 // RUNNABLE MODEL
 pub struct TractRunnable(tract::Runnable);
 
-/// Spawn a session state from a runnable model.
+/// Spawn a state from a runnable model.
 ///
 /// This function does not take ownership of the `runnable` object, it can be used again to spawn
 /// other state instances. The runnable object is internally reference counted, it will be

--- a/cli/src/compare.rs
+++ b/cli/src/compare.rs
@@ -163,8 +163,8 @@ pub fn handle_with_model(
     let mut state = plan.spawn()?;
     let inputs = get_or_make_inputs(&(reference_model.clone() as _), run_params)?;
     for input in inputs.sources {
-        state.run_plan_with_eval(input, |session, state, node, input| -> TractResult<_> {
-            let result = tract_core::plan::eval(session, state, node, input)?;
+        state.run_plan_with_eval(input, |turn, state, node, input| -> TractResult<_> {
+            let result = tract_core::plan::eval(turn, state, node, input)?;
             if node.outputs.len() == 1 {
                 values.entry(node.name.clone()).or_default().push(Ok(result[0].clone()));
             }
@@ -363,8 +363,8 @@ pub fn handle_stream(
 
         state.run_plan_with_eval(
             tvec!(pulsed_input.into_tensor().into()),
-            |session, op_state, node, input| -> TractResult<TVec<TValue>> {
-                let result = tract_core::plan::eval(session, op_state, node, input)?;
+            |turn, op_state, node, input| -> TractResult<TVec<TValue>> {
+                let result = tract_core::plan::eval(turn, op_state, node, input)?;
 
                 if let Some(info) = pulse_meta.get(&node.name) {
                     // Skip nodes where the optimizer removed the streaming axis (e.g.
@@ -469,18 +469,18 @@ where
     let all_values: HashMap<String, &Vec<TractResult<TValue>>> =
         all_values.iter().map(|(k, v)| (canonic(k), v)).collect();
     let inputs = get_or_make_inputs(&(tract.clone() as _), run_params)?;
-    for (turn, inputs) in inputs.sources.into_iter().enumerate() {
+    for (turn_ix, inputs) in inputs.sources.into_iter().enumerate() {
         state.run_plan_with_eval(
             inputs,
-            |session_state, state, node, input| -> TractResult<TVec<TValue>> {
-                let mut returning = tract_core::plan::eval(session_state, state, node, input)?;
+            |turn, state, node, input| -> TractResult<TVec<TValue>> {
+                let mut returning = tract_core::plan::eval(turn, state, node, input)?;
                 let tags = annotations.node_mut(node.id.into());
                 let mut comparison_error = None;
                 for slot in 0..returning.len() {
                     let get_value = |label: &str| {
                         all_values
                             .get(&canonic(label))
-                            .and_then(|v| v.get(turn))
+                            .and_then(|v| v.get(turn_ix))
                             .and_then(|r| r.as_ref().ok())
                             .cloned()
                     };
@@ -508,7 +508,7 @@ where
                     let needed_type = clarified_fact.datum_type;
                     let needed_shape = clarified_fact
                         .shape
-                        .eval_to_usize(&session_state.resolved_symbols)
+                        .eval_to_usize(&turn.resolved_symbols)
                         .with_context(|| {
                             format!(
                                 "evaluating shape {:?} on node #{} {} (slot {}); known symbols: {:?}",
@@ -516,7 +516,7 @@ where
                                 node.id,
                                 node.name,
                                 slot,
-                                session_state.resolved_symbols,
+                                turn.resolved_symbols,
                             )
                         })?;
 
@@ -560,7 +560,7 @@ where
                         let mut msg = vec![Red
                             .bold()
                             .paint(format!(
-                                "At turn {turn}, wrong value for output {slot}, {e}"
+                                "At turn {turn_ix}, wrong value for output {slot}, {e}"
                             ))
                             .to_string()];
                         msg.push(format!("{:<8}: {:?}", labels.0, computed));
@@ -569,7 +569,7 @@ where
                     } else {
                         debug!(
                             "At turn {}, matching value for {:?}",
-                            turn,
+                            turn_ix,
                             OutletId::new(node.id, slot)
                         )
                     }

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -220,91 +220,90 @@ where
         };
 
     let mut sources = inputs.sources;
-    for turn in 0..sources.len() {
-        let inputs = std::mem::replace(&mut sources[turn], TVec::new());
+    for turn_ix in 0..sources.len() {
+        let inputs = std::mem::replace(&mut sources[turn_ix], TVec::new());
         if let Some((sym, val)) = &pulse_sym_binding {
             state.turn_state.resolved_symbols.set(sym, *val);
         }
-        let turn_results =
-            state.run_plan_with_eval(inputs, |session_state, state, node, input| {
+        let turn_results = state.run_plan_with_eval(inputs, |turn, state, node, input| {
+            if steps {
+                for (ix, i) in input.iter().enumerate() {
+                    eprintln!(
+                        "{} {}{}{:?}",
+                        White.bold().paint(node.to_string()),
+                        ix,
+                        Blue.bold().paint("<< "),
+                        i
+                    );
+                }
+            }
+            let r = tract_core::plan::eval(turn, state, node, input)?;
+
+            if steps || npz.is_some() || check_f16_overflow || assert_sane_floats {
+                let clarified_r = crate::utils::clarify_tvalues(&r)?;
                 if steps {
-                    for (ix, i) in input.iter().enumerate() {
+                    for (ix, o) in clarified_r.iter().enumerate() {
                         eprintln!(
                             "{} {}{}{:?}",
                             White.bold().paint(node.to_string()),
                             ix,
-                            Blue.bold().paint("<< "),
-                            i
+                            Yellow.bold().paint(">> "),
+                            o
                         );
                     }
                 }
-                let r = tract_core::plan::eval(session_state, state, node, input)?;
-
-                if steps || npz.is_some() || check_f16_overflow || assert_sane_floats {
-                    let clarified_r = crate::utils::clarify_tvalues(&r)?;
-                    if steps {
-                        for (ix, o) in clarified_r.iter().enumerate() {
-                            eprintln!(
-                                "{} {}{}{:?}",
-                                White.bold().paint(node.to_string()),
-                                ix,
-                                Yellow.bold().paint(">> "),
-                                o
-                            );
+                if let Some(npz) = npz.as_mut() {
+                    for (ix, t) in clarified_r.iter().enumerate() {
+                        let mut name = if ix == 0 {
+                            node.name.to_string()
+                        } else {
+                            format!("{}:{}", node.name, ix)
+                        };
+                        if multiturn {
+                            name = format!("turn_{turn_ix}/{name}");
                         }
+                        npz_add_tensor(npz, name, t)?;
                     }
-                    if let Some(npz) = npz.as_mut() {
-                        for (ix, t) in clarified_r.iter().enumerate() {
-                            let mut name = if ix == 0 {
-                                node.name.to_string()
-                            } else {
-                                format!("{}:{}", node.name, ix)
-                            };
-                            if multiturn {
-                                name = format!("turn_{turn}/{name}");
-                            }
-                            npz_add_tensor(npz, name, t)?;
-                        }
-                    }
-                    if check_f16_overflow {
-                        for (ix, o) in clarified_r.iter().enumerate() {
-                            if let Ok(plain) = o.try_as_plain() {
-                                if let Ok(f32s) = plain.as_slice::<f32>() {
-                                    if f32s.iter().any(|f| f.abs() > f16::MAX.to_f32()) {
-                                        warn!("{node}, output {ix} overflows f16");
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    if assert_sane_floats {
-                        for (ix, o) in clarified_r.iter().enumerate() {
-                            if node.op_is::<Im2Col>() || node.op_is::<OptMatMulPack>() {
-                                continue;
-                            }
-                            if let Ok(plain) = o.try_as_plain() {
-                                if let Ok(floats) = plain.as_slice::<f32>() {
-                                    if let Some(pos) = floats.iter().position(|f| !f.is_finite()) {
-                                        eprintln!("{floats:?}");
-                                        bail!("Found {} in output {} of {}", floats[pos], ix, node);
-                                    }
-                                } else if let Ok(floats) = plain.as_slice::<f16>() {
-                                    if let Some(pos) = floats.iter().position(|f| !f.is_finite()) {
-                                        eprintln!("{floats:?}");
-                                        bail!("Found {} in output {} of {}", floats[pos], ix, node);
-                                    }
+                }
+                if check_f16_overflow {
+                    for (ix, o) in clarified_r.iter().enumerate() {
+                        if let Ok(plain) = o.try_as_plain() {
+                            if let Ok(f32s) = plain.as_slice::<f32>() {
+                                if f32s.iter().any(|f| f.abs() > f16::MAX.to_f32()) {
+                                    warn!("{node}, output {ix} overflows f16");
                                 }
                             }
                         }
                     }
                 }
+                if assert_sane_floats {
+                    for (ix, o) in clarified_r.iter().enumerate() {
+                        if node.op_is::<Im2Col>() || node.op_is::<OptMatMulPack>() {
+                            continue;
+                        }
+                        if let Ok(plain) = o.try_as_plain() {
+                            if let Ok(floats) = plain.as_slice::<f32>() {
+                                if let Some(pos) = floats.iter().position(|f| !f.is_finite()) {
+                                    eprintln!("{floats:?}");
+                                    bail!("Found {} in output {} of {}", floats[pos], ix, node);
+                                }
+                            } else if let Ok(floats) = plain.as_slice::<f16>() {
+                                if let Some(pos) = floats.iter().position(|f| !f.is_finite()) {
+                                    eprintln!("{floats:?}");
+                                    bail!("Found {} in output {} of {}", floats[pos], ix, node);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-                Ok(r)
-            })?;
+            Ok(r)
+        })?;
         // Thread cache outputs into next turn's inputs
-        if turn + 1 < sources.len() && !cache_output_to_input.is_empty() {
+        if turn_ix + 1 < sources.len() && !cache_output_to_input.is_empty() {
             for &(out_ix, in_ix) in &cache_output_to_input {
-                sources[turn + 1][in_ix] = turn_results[out_ix].clone();
+                sources[turn_ix + 1][in_ix] = turn_results[out_ix].clone();
             }
         }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -116,7 +116,7 @@ pub mod internal {
     pub use crate::ops::change_axes::*;
     pub use crate::ops::element_wise::ElementWiseMiniOp;
     pub use crate::ops::{Cost, EvalOp, FrozenOpState, Op, OpState, Validation};
-    pub use crate::plan::{SessionStateHandler, SimplePlan, SimpleState, TurnState};
+    pub use crate::plan::{SimplePlan, SimpleState, TurnState, TurnStateHandler};
     pub use crate::prelude::*;
     pub use crate::runtime::{
         DefaultRuntime, Runnable, Runtime, State, runtime_for_name, runtimes,

--- a/core/src/model/typed.rs
+++ b/core/src/model/typed.rs
@@ -85,8 +85,7 @@ impl SpecialOps<TypedFact, Box<dyn TypedOp>> for TypedModel {
                             .map(|t| t.into_tvalue())
                     })
                     .collect::<Option<TVec<_>>>()
-                && let Ok(outputs) =
-                    op.eval_with_session(usize::MAX, &TurnState::default(), tensors)
+                && let Ok(outputs) = op.eval_with_turn(usize::MAX, &TurnState::default(), tensors)
             {
                 return outputs
                     .into_iter()
@@ -290,7 +289,7 @@ impl TypedModel {
             {
                 let inputs_ref =
                     inputs.iter().map(|f| f.konst.clone().unwrap().into_tvalue()).collect();
-                match node.op.eval_with_session(node.id, &TurnState::default(), inputs_ref) {
+                match node.op.eval_with_turn(node.id, &TurnState::default(), inputs_ref) {
                     Ok(res) => {
                         drop(inputs);
                         drop(outputs);

--- a/core/src/ops/array/broadcast.rs
+++ b/core/src/ops/array/broadcast.rs
@@ -22,13 +22,13 @@ impl EvalOp for MultiBroadcastTo {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        let shape = self.shape.eval_to_usize(&session.resolved_symbols)?;
+        let shape = self.shape.eval_to_usize(&turn.resolved_symbols)?;
         Ok(tvec!(inputs[0].broadcast_to_shape(&shape)?.into_tvalue()))
     }
 }

--- a/core/src/ops/array/dyn_slice.rs
+++ b/core/src/ops/array/dyn_slice.rs
@@ -29,26 +29,26 @@ impl EvalOp for DynSlice {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let start = inputs[1]
             .cast_to::<TDim>()?
             .try_as_plain()?
             .to_scalar::<TDim>()?
-            .eval(&session.resolved_symbols)
+            .eval(&turn.resolved_symbols)
             .to_usize()?;
         let end = inputs[2]
             .cast_to::<TDim>()?
             .try_as_plain()?
             .to_scalar::<TDim>()?
-            .eval(&session.resolved_symbols)
+            .eval(&turn.resolved_symbols)
             .to_usize()?;
         ensure!(start <= end);
-        if let Ok(len) = self.len.eval(&session.resolved_symbols).to_usize() {
+        if let Ok(len) = self.len.eval(&turn.resolved_symbols).to_usize() {
             ensure!(start + len == end);
         }
         let slice = inputs[0].slice(self.axis, start, end)?;

--- a/core/src/ops/array/range.rs
+++ b/core/src/ops/array/range.rs
@@ -24,14 +24,14 @@ impl EvalOp for Range {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (start, end, step) = args_3!(inputs);
-        Ok(tvec!(self.make(&start, &end, &step, &session.resolved_symbols)?.into_tvalue()))
+        Ok(tvec!(self.make(&start, &end, &step, &turn.resolved_symbols)?.into_tvalue()))
     }
 }
 

--- a/core/src/ops/array/slice.rs
+++ b/core/src/ops/array/slice.rs
@@ -59,15 +59,15 @@ impl EvalOp for Slice {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
-        let start = self.start.eval(&session.resolved_symbols).to_usize()?;
-        let end = self.end.eval(&session.resolved_symbols).to_usize()?;
+        let start = self.start.eval(&turn.resolved_symbols).to_usize()?;
+        let end = self.end.eval(&turn.resolved_symbols).to_usize()?;
         eval_slice(&input, self.axis, start, end)
     }
 }

--- a/core/src/ops/array/tile.rs
+++ b/core/src/ops/array/tile.rs
@@ -25,16 +25,16 @@ impl EvalOp for Tile {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let multipliers: TVec<usize> = self
             .multipliers
             .iter()
-            .map(|m| m.eval(&session.resolved_symbols).to_usize())
+            .map(|m| m.eval(&turn.resolved_symbols).to_usize())
             .collect::<Result<_, _>>()?;
         let result =
             dispatch_datum_by_size!(eval_t(inputs[0].datum_type())(&inputs[0], &multipliers))?;
@@ -120,10 +120,10 @@ impl EvalOp for DynTile {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let multipliers = inputs[1].cast_to::<TDim>()?;
@@ -131,7 +131,7 @@ impl EvalOp for DynTile {
             .try_as_plain()?
             .as_slice::<TDim>()?
             .iter()
-            .map(|m| Ok(m.eval_to_i64(&session.resolved_symbols)? as usize))
+            .map(|m| Ok(m.eval_to_i64(&turn.resolved_symbols)? as usize))
             .collect::<TractResult<_>>()?;
         let result =
             dispatch_datum_by_size!(eval_t(inputs[0].datum_type())(&inputs[0], &multipliers))?;

--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -100,7 +100,7 @@ pub trait BinMiniOp:
     #[allow(unused_variables)]
     fn eval_symbolic(
         &self,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<Option<TVec<TValue>>> {
         Ok(None)
@@ -142,13 +142,13 @@ impl EvalOp for TypedBinOp {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        if let Some(result) = self.0.eval_symbolic(session, inputs.clone())? {
+        if let Some(result) = self.0.eval_symbolic(turn, inputs.clone())? {
             return Ok(result);
         }
         let (a, b) = args_2!(inputs);

--- a/core/src/ops/cast.rs
+++ b/core/src/ops/cast.rs
@@ -44,7 +44,7 @@ impl EvalOp for Cast {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
         state: &TurnState,

--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -651,17 +651,17 @@ impl EvalOp for AxisOp {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let mut input = args_1!(inputs).into_tensor();
         match self {
             AxisOp::Reshape(skip, from, to) => {
-                let from = from.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
-                let to = to.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
+                let from = from.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
+                let to = to.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
                 AxisOp::Reshape(*skip, from, to).change_tensor(&mut input, false)?
             }
             _ => self.change_tensor(&mut input, false)?,

--- a/core/src/ops/cnn/conv/block_quant.rs
+++ b/core/src/ops/cnn/conv/block_quant.rs
@@ -19,11 +19,7 @@ impl EvalOp for BlockQuantIntoShape {
         true
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
 
@@ -75,11 +71,7 @@ impl EvalOp for SplitGroupBlockQuant {
         true
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
 

--- a/core/src/ops/cnn/conv/q_sum_b.rs
+++ b/core/src/ops/cnn/conv/q_sum_b.rs
@@ -28,13 +28,13 @@ impl EvalOp for QSumB {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        let n = self.n.eval_to_i64(&session.resolved_symbols)? as usize;
+        let n = self.n.eval_to_i64(&turn.resolved_symbols)? as usize;
         self.eval(inputs, n)
     }
 }

--- a/core/src/ops/cnn/deconv/deconv_sum.rs
+++ b/core/src/ops/cnn/deconv/deconv_sum.rs
@@ -42,13 +42,13 @@ impl EvalOp for DeconvSum {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        self.eval_with_values(inputs, &session.resolved_symbols)
+        self.eval_with_values(inputs, &turn.resolved_symbols)
     }
 }
 
@@ -541,14 +541,14 @@ impl EvalOp for DepthwiseDeconv {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (kernel, input, bias) = args_3!(inputs);
-        let input_shape = self.input_shape.eval_to_usize(&session.resolved_symbols)?.into_owned();
+        let input_shape = self.input_shape.eval_to_usize(&turn.resolved_symbols)?.into_owned();
         let input_shape = self.pool_spec.data_format.shape(input_shape)?;
         let output_shape =
             super::output_shape(&self.pool_spec, &input_shape.shape, &self.adjustments)?;

--- a/core/src/ops/einsum/einsum_matmul.rs
+++ b/core/src/ops/einsum/einsum_matmul.rs
@@ -528,13 +528,13 @@ impl EvalOp for EinSumMatMul {
     fn is_stateless(&self) -> bool {
         true
     }
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        self.op.eval_with_session(node_id, session, inputs)
+        self.op.eval_with_turn(node_id, turn, inputs)
     }
 }
 

--- a/core/src/ops/identity.rs
+++ b/core/src/ops/identity.rs
@@ -79,11 +79,7 @@ impl EvalOp for PinConst {
         Ok(inputs)
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(self.clone())))
     }
 }
@@ -91,7 +87,7 @@ impl EvalOp for PinConst {
 impl OpState for PinConst {
     fn eval(
         &mut self,
-        _session: &mut TurnState,
+        _turn: &mut TurnState,
         _op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {

--- a/core/src/ops/logic/comparison.rs
+++ b/core/src/ops/logic/comparison.rs
@@ -23,7 +23,7 @@ fn eval_comp_oop<T: Datum + PartialOrd>(
 
 // Helper for TDim symbolic eval
 fn eval_tdim_symbolic(
-    session: &TurnState,
+    turn: &TurnState,
     inputs: &TVec<TValue>,
     prove: impl Fn(&TDim, &TDim) -> TractResult<bool>,
 ) -> TractResult<Option<TVec<TValue>>> {
@@ -31,10 +31,10 @@ fn eval_tdim_symbolic(
     let mut a = inputs[0].clone().into_tensor();
     let mut b = inputs[1].clone().into_tensor();
     for a in a.try_as_plain_mut()?.as_slice_mut::<TDim>()? {
-        *a = a.eval(&session.resolved_symbols);
+        *a = a.eval(&turn.resolved_symbols);
     }
     for b in b.try_as_plain_mut()?.as_slice_mut::<TDim>()? {
-        *b = b.eval(&session.resolved_symbols);
+        *b = b.eval(&turn.resolved_symbols);
     }
     if let (Ok(a_i64), Ok(b_i64)) = (a.cast_to::<i64>(), b.cast_to::<i64>()) {
         let result = eval_comp_oop::<i64>(&a_i64, &b_i64, |a, b| {
@@ -115,10 +115,10 @@ macro_rules! comp_bin_mini_op {
 
             fn eval_symbolic(
                 &self,
-                session: &TurnState,
+                turn: &TurnState,
                 inputs: TVec<TValue>,
             ) -> TractResult<Option<TVec<TValue>>> {
-                eval_tdim_symbolic(session, &inputs, $prove_tdim)
+                eval_tdim_symbolic(turn, &inputs, $prove_tdim)
             }
 
             fn uniform_tdim_comparison(

--- a/core/src/ops/matmul/optimized.rs
+++ b/core/src/ops/matmul/optimized.rs
@@ -435,11 +435,7 @@ impl EvalOp for OptMatMul {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<OptMatMulState>::default()))
     }
 }
@@ -447,12 +443,12 @@ impl EvalOp for OptMatMul {
 impl OpState for OptMatMulState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let op = op.downcast_ref::<OptMatMul>().context("OptMatMulState on non-OptMatMul op")?;
-        op.eval_with_state(session, inputs, self)
+        op.eval_with_state(turn, inputs, self)
     }
 }
 
@@ -474,18 +470,18 @@ impl OpStateFreeze for OptMatMulState {
 impl OptMatMul {
     fn eval_with_state(
         &self,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
         state: &mut OptMatMulState,
     ) -> TractResult<TVec<TValue>> {
         unsafe {
-            let c_shape = self.c_fact.shape.eval_to_usize(&session.resolved_symbols)?;
+            let c_shape = self.c_fact.shape.eval_to_usize(&turn.resolved_symbols)?;
             let mut c = Tensor::uninitialized_dt(self.c_fact.datum_type, &c_shape)?;
             let m = self.c_m_axis.map(|c_m| c.shape()[c_m]).unwrap_or(1);
             let n = self.c_n_axis.map(|c_n| c.shape()[c_n]).unwrap_or(1);
             let mode = self.mode_picker.pick(n)?;
             let mmm = &*self.mmm[mode];
-            let mut cell = session.cached_mmm_scratch_space.borrow_mut();
+            let mut cell = turn.cached_mmm_scratch_space.borrow_mut();
             if !cell.as_ref().is_some_and(|scratch| mmm.can_use_scratch_space(&**scratch)) {
                 *cell = None
             }

--- a/core/src/ops/matmul/pack.rs
+++ b/core/src/ops/matmul/pack.rs
@@ -33,13 +33,13 @@ impl EvalOp for OptMatMulPack {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         mut inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        self.do_eval(session, inputs.remove(0))
+        self.do_eval(turn, inputs.remove(0))
     }
 }
 
@@ -81,7 +81,7 @@ impl TypedOp for OptMatMulPack {
 }
 
 impl OptMatMulPack {
-    fn do_eval(&self, _session: &TurnState, input: TValue) -> TractResult<TVec<TValue>> {
+    fn do_eval(&self, _turn: &TurnState, input: TValue) -> TractResult<TVec<TValue>> {
         unsafe {
             let mode = self.mode_picker.pick(input.shape()[self.mn_axis])?;
             let packer = &self.packers[mode];
@@ -156,11 +156,7 @@ impl EvalOp for OptSimpleMatMulPack {
         true
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
 

--- a/core/src/ops/memory/force_eval.rs
+++ b/core/src/ops/memory/force_eval.rs
@@ -30,7 +30,7 @@ impl EvalOp for ForceEval {
 
     fn state(
         &self,
-        _session: &TurnState,
+        _turn: &TurnState,
         _node_id: usize,
     ) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)

--- a/core/src/ops/memory/load.rs
+++ b/core/src/ops/memory/load.rs
@@ -30,7 +30,7 @@ impl EvalOp for Load {
 
     fn state(
         &self,
-        _session: &TurnState,
+        _turn: &TurnState,
         _node_id: usize,
     ) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(self.clone())))
@@ -54,12 +54,12 @@ impl TypedOp for Load {
 impl OpState for Load {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         _op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
-        let tensor = session
+        let tensor = turn
             .tensors
             .get(&self.id)
             .map_or_else(
@@ -81,7 +81,7 @@ impl OpState for Load {
                     Ok(tvec!(it.clone().into_tvalue()))
                 },
             )
-            .with_context(|| anyhow!("While loading tensor from session"))?;
+            .with_context(|| anyhow!("While loading tensor from turn"))?;
 
         Ok(tensor)
     }

--- a/core/src/ops/memory/store.rs
+++ b/core/src/ops/memory/store.rs
@@ -30,7 +30,7 @@ impl EvalOp for Store {
 
     fn state(
         &self,
-        _session: &TurnState,
+        _turn: &TurnState,
         _node_id: usize,
     ) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(self.clone())))
@@ -52,12 +52,12 @@ impl TypedOp for Store {
 impl OpState for Store {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         _op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (input, state) = args_2!(inputs);
-        session.tensors.insert(self.id.clone(), state.into_tensor());
+        turn.tensors.insert(self.id.clone(), state.into_tensor());
         Ok(tvec![input])
     }
 }

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -134,7 +134,7 @@ pub trait OpState: fmt::Debug + dyn_clone::DynClone + OpStateFreeze + Downcast +
 
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>>;
@@ -149,17 +149,17 @@ pub trait EvalOp {
     }
 
     #[allow(unused_variables)]
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         self.eval(inputs).context("Running legacy eval")
     }
 
     #[allow(unused_variables)]
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
 

--- a/core/src/ops/scan/decluttered.rs
+++ b/core/src/ops/scan/decluttered.rs
@@ -765,8 +765,8 @@ impl EvalOp for Scan {
     fn is_stateless(&self) -> bool {
         false
     }
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        self.to_codegen_op(false)?.state(session, node_id)
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+        self.to_codegen_op(false)?.state(turn, node_id)
     }
 }
 

--- a/core/src/ops/scan/optimized.rs
+++ b/core/src/ops/scan/optimized.rs
@@ -59,11 +59,7 @@ impl EvalOp for OptScan {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(State {
             position: 0,
             hidden_state: tvec!(),
@@ -190,7 +186,7 @@ impl State {
 impl OpState for State {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         _op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -222,7 +218,7 @@ impl OpState for State {
             if let Some((slot, info)) = output.scan {
                 let fact = op.plan.model().output_fact(ix)?;
                 let mut shape: TVec<usize> =
-                    fact.shape.eval_to_usize(&session.resolved_symbols)?.into_owned();
+                    fact.shape.eval_to_usize(&turn.resolved_symbols)?.into_owned();
                 let scanning_dim = output
                     .full_dim_hint
                     .as_ref()

--- a/core/src/ops/source.rs
+++ b/core/src/ops/source.rs
@@ -7,13 +7,12 @@ trivial_op_state_freeze!(SourceState);
 impl OpState for SourceState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         _op: &dyn Op,
         _inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         Ok(tvec!(
-            session
-                .values
+            turn.values
                 .get(self.0)
                 .and_then(|v| v.as_ref())
                 .and_then(|vs| vs.first().cloned())
@@ -39,7 +38,7 @@ impl EvalOp for TypedSource {
         false
     }
 
-    fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(SourceState(node_id))))
     }
 }

--- a/core/src/ops/submodel.rs
+++ b/core/src/ops/submodel.rs
@@ -50,8 +50,8 @@ impl EvalOp for SubmodelOp {
         false
     }
 
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        self.model.state(session, node_id)
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+        self.model.state(turn, node_id)
     }
 }
 
@@ -100,7 +100,7 @@ pub trait InnerModel: Debug + dyn_clone::DynClone + Downcast + Sync + Send + 'st
     fn is_stateless(&self) -> bool;
 
     #[allow(unused_variables)]
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
 
@@ -129,7 +129,7 @@ impl InnerModel for TypedModel {
     }
 
     #[allow(unused_variables)]
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         let plan = self.clone().into_runnable()?;
         let state = plan.spawn()?;
         Ok(Some(Box::new(state)))
@@ -154,7 +154,7 @@ pub type TypedModelOpState = TypedSimpleState;
 impl OpState for TypedModelOpState {
     fn eval(
         &mut self,
-        _session: &mut TurnState,
+        _turn: &mut TurnState,
         _op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {

--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -61,7 +61,7 @@ impl super::TypedPass for PropConst {
                     .iter()
                     .map(|f| f.mem_size().as_i64().unwrap_or(i64::MAX) as u64)
                     .sum();
-                match node.op.eval_with_session(node.id, &TurnState::default(), inputs) {
+                match node.op.eval_with_turn(node.id, &TurnState::default(), inputs) {
                     Ok(mut res) => {
                         self.0 = node.id;
                         let output_mem: u64 = res
@@ -79,11 +79,9 @@ impl super::TypedPass for PropConst {
                             if succ.inputs.len() > 1 || !succ.op.is_stateless() {
                                 break;
                             }
-                            let Ok(succ_res) = succ.op.eval_with_session(
-                                node.id,
-                                &TurnState::default(),
-                                res.clone(),
-                            ) else {
+                            let Ok(succ_res) =
+                                succ.op.eval_with_turn(node.id, &TurnState::default(), res.clone())
+                            else {
                                 break;
                             };
                             let succ_mem: u64 = succ_res

--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -44,14 +44,14 @@ impl Clone for TurnState {
     }
 }
 
-pub trait SessionStateHandler: Send + Sync + Debug {
-    fn before_plan_eval(&self, session_state: &mut TurnState) -> TractResult<()>;
-    fn after_plan_eval(&self, session_state: &mut TurnState) -> TractResult<()>;
+pub trait TurnStateHandler: Send + Sync + Debug {
+    fn before_plan_eval(&self, turn: &mut TurnState) -> TractResult<()>;
+    fn after_plan_eval(&self, turn: &mut TurnState) -> TractResult<()>;
 }
 
 impl Debug for TurnState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "SessionState({:?})", self.resolved_symbols)
+        write!(f, "TurnState({:?})", self.resolved_symbols)
     }
 }
 
@@ -68,7 +68,7 @@ where
     has_unresolved_symbols: bool,
     symbols: Vec<Symbol>,
     executor: Option<Executor>,
-    session_handler: Option<Arc<dyn SessionStateHandler + 'static>>,
+    turn_handler: Option<Arc<dyn TurnStateHandler + 'static>>,
 }
 
 impl<F, O> SimplePlan<F, O>
@@ -112,11 +112,8 @@ where
         Self::build_with_outputs_and_deps(model, outputs, &[], &RunOptions::default()).map(Arc::new)
     }
 
-    pub fn with_session_handler<H: SessionStateHandler + 'static>(
-        mut self,
-        session_handler: H,
-    ) -> Self {
-        self.session_handler = Some(Arc::new(session_handler));
+    pub fn with_turn_handler<H: TurnStateHandler + 'static>(mut self, turn_handler: H) -> Self {
+        self.turn_handler = Some(Arc::new(turn_handler));
         self
     }
 
@@ -176,7 +173,7 @@ where
             has_unresolved_symbols: !symbols.is_empty(),
             symbols: symbols.into_iter().collect(),
             executor: options.executor.clone(),
-            session_handler: None,
+            turn_handler: None,
         })
     }
 
@@ -353,7 +350,7 @@ where
         {
             self.ready_turn();
             self.plan
-                .session_handler
+                .turn_handler
                 .as_ref()
                 .map(|it| it.before_plan_eval(&mut self.turn_state))
                 .transpose()?;
@@ -464,7 +461,7 @@ where
                 self.turn_state.values[node.id] = Some(vs);
             }
             self.plan
-                .session_handler
+                .turn_handler
                 .as_ref()
                 .map(|it| it.after_plan_eval(&mut self.turn_state))
                 .transpose()?;
@@ -653,13 +650,9 @@ where
                     inputs.push(self.turn_state.values[i.node].as_ref().unwrap()[i.slot].clone())
                 }
             }
-            let &mut Self {
-                op_states: ref mut states,
-                turn_state: ref mut session_state,
-                ref plan,
-                ..
-            } = self;
-            eval(session_state, states[node].as_deref_mut(), &plan.model().nodes[node], inputs)?
+            let &mut Self { op_states: ref mut states, turn_state: ref mut turn, ref plan, .. } =
+                self;
+            eval(turn, states[node].as_deref_mut(), &plan.model().nodes[node], inputs)?
         };
         self.turn_state.values[node] = Some(values);
         Ok(self.turn_state.values[node].as_ref().unwrap())
@@ -735,7 +728,7 @@ where
 }
 
 pub fn eval<F, O>(
-    session_state: &mut TurnState,
+    turn: &mut TurnState,
     mut state: Option<&mut (dyn OpState + 'static)>,
     node: &Node<F, O>,
     input: TVec<TValue>,
@@ -745,8 +738,8 @@ where
     O: Debug + Display + AsRef<dyn Op> + AsMut<dyn Op> + Clone + 'static,
 {
     match state {
-        Some(ref mut state) => state.eval(session_state, node.op(), input),
-        None => node.op().eval_with_session(node.id, session_state, input),
+        Some(ref mut state) => state.eval(turn, node.op(), input),
+        None => node.op().eval_with_turn(node.id, turn, input),
     }
     .with_context(|| format!("Evaluating {node}"))
 }

--- a/cuda/src/kernels/array/diag_gather.rs
+++ b/cuda/src/kernels/array/diag_gather.rs
@@ -151,12 +151,12 @@ mod tests {
             let cpu_in = Tensor::from_shape(shape, &data)?;
             let cuda_in = cpu_in.clone().into_device()?;
 
-            // CPU DiagGather only implements eval_with_session (it resolves
-            // TDims against the session's resolved_symbols); pass an empty
+            // CPU DiagGather only implements eval_with_turn (it resolves
+            // TDims against the turn's resolved_symbols); pass an empty
             // TurnState since the TDims here are already concrete.
             let cpu_op = cpu_dg::DiagGather { offset: offset.to_dim(), out_len: out_len.to_dim() };
-            let session = TurnState::default();
-            let cpu_out = cpu_op.eval_with_session(0, &session, tvec![cpu_in.into_tvalue()])?[0]
+            let turn = TurnState::default();
+            let cpu_out = cpu_op.eval_with_turn(0, &turn, tvec![cpu_in.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_out = DiagGather.eval(stream, &cuda_in, offset, out_len)?;

--- a/cuda/src/lib.rs
+++ b/cuda/src/lib.rs
@@ -37,10 +37,10 @@ impl Runtime for CudaRuntime {
 
         let mut runnable = TypedSimplePlan::build(model, &options)?;
         if let Some(hints) = options.memory_sizing_hints {
-            let session_handler =
-                tract_gpu::session_handler::DeviceSessionHandler::from_plan(&runnable, &hints)
+            let turn_handler =
+                tract_gpu::turn_handler::DeviceTurnHandler::from_plan(&runnable, &hints)
                     .context("While sizing memory arena. Missing hint ?")?;
-            runnable = runnable.with_session_handler(session_handler);
+            runnable = runnable.with_turn_handler(turn_handler);
         }
 
         // Constants are uploaded to the device here on the preparing thread's stream via async

--- a/cuda/src/ops/conv.rs
+++ b/cuda/src/ops/conv.rs
@@ -86,7 +86,7 @@ impl EvalOp for CudaConv {
         false
     }
 
-    fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(CudaConvState::new(node_id))))
     }
 }
@@ -145,7 +145,7 @@ impl Drop for CudaConvState {
 impl OpState for CudaConvState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -153,8 +153,8 @@ impl OpState for CudaConvState {
         let inputs =
             inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
         let output_shape = op.op.pool_spec.output_shape(inputs[0].shape())?;
-        let output = tract_gpu::session_handler::make_tensor_for_node(
-            session,
+        let output = tract_gpu::turn_handler::make_tensor_for_node(
+            turn,
             self.node_id,
             inputs[0].datum_type(),
             &output_shape.shape,

--- a/cuda/src/ops/flash_attn.rs
+++ b/cuda/src/ops/flash_attn.rs
@@ -23,10 +23,10 @@ impl EvalOp for CudaFlashAttention {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         crate::with_cuda_stream(|stream| {
@@ -36,8 +36,8 @@ impl EvalOp for CudaFlashAttention {
             let k = inputs[1].to_device_tensor()?;
             let v = inputs[2].to_device_tensor()?;
             let mask = inputs.get(3).map(|m| m.to_device_tensor()).transpose()?;
-            let output = tract_gpu::session_handler::make_tensor_for_node(
-                session,
+            let output = tract_gpu::turn_handler::make_tensor_for_node(
+                turn,
                 node_id,
                 q.datum_type(),
                 &CudaFlashAttn.output_shape(q.shape(), k.shape(), v.shape())?,

--- a/cuda/src/ops/fused_axis_op.rs
+++ b/cuda/src/ops/fused_axis_op.rs
@@ -21,7 +21,7 @@ pub struct CudaFusedAxisOpState {
 fn compute_reshaped_inputs(
     inputs: TVec<TValue>,
     grouped_axis_ops: &TVec<TVec<GpuAxisOp>>,
-    session: &TurnState,
+    turn: &TurnState,
 ) -> TractResult<TVec<TValue>> {
     // Apply Axis Ops per input
 
@@ -39,8 +39,8 @@ fn compute_reshaped_inputs(
                     let new_shape = match &axis_op.inner {
                         AxisOp::Reshape(skip, from, to) => {
                             let from =
-                                from.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
-                            let to = to.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
+                                from.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
+                            let to = to.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
                             let mut shape: TVec<usize> = t.shape().into();
                             AxisOp::Reshape(*skip, from, to)
                                 .change_shape_array(&mut shape, false)?;
@@ -80,30 +80,30 @@ impl OpState for CudaFusedAxisOpState {
 
     fn load_from(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         states: &mut dyn Iterator<Item = tract_core::value::TValue>,
     ) -> TractResult<()> {
-        self.op_state.load_from(session, states)
+        self.op_state.load_from(turn, states)
     }
 
     fn save_to(&self, states: &mut Vec<TValue>) -> TractResult<()> {
         self.op_state.save_to(states)
     }
 
-    fn resolve_symbols(&mut self, session: &mut TurnState) -> TractResult<()> {
-        self.op_state.resolve_symbols(session)
+    fn resolve_symbols(&mut self, turn: &mut TurnState) -> TractResult<()> {
+        self.op_state.resolve_symbols(turn)
     }
 
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let fused_axis_op = op.downcast_ref::<CudaFusedAxisOp>().unwrap();
-        let inputs = compute_reshaped_inputs(inputs, &fused_axis_op.grouped_axis_ops, session)?;
+        let inputs = compute_reshaped_inputs(inputs, &fused_axis_op.grouped_axis_ops, turn)?;
         // Runner inner op
-        self.op_state.eval(session, fused_axis_op.op.as_op(), inputs)
+        self.op_state.eval(turn, fused_axis_op.op.as_op(), inputs)
     }
 }
 
@@ -162,23 +162,23 @@ impl EvalOp for CudaFusedAxisOp {
         self.op.is_stateless()
     }
 
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        if let Some(state) = self.op.state(session, node_id)? {
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+        if let Some(state) = self.op.state(turn, node_id)? {
             Ok(Some(Box::new(CudaFusedAxisOpState { op_state: state })))
         } else {
             Ok(None)
         }
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, session)?;
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, turn)?;
         // Runner inner op
-        self.op.eval_with_session(node_id, session, inputs)
+        self.op.eval_with_turn(node_id, turn, inputs)
     }
 }
 

--- a/cuda/src/ops/gemm.rs
+++ b/cuda/src/ops/gemm.rs
@@ -55,10 +55,10 @@ impl EvalOp for CudaGgmlGemm {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (act_raw, weights_raw) = args_2!(inputs);
@@ -75,8 +75,7 @@ impl EvalOp for CudaGgmlGemm {
         let out_shape = GgmlGemm.output_shape(&activ_shape, &weights_shape);
         let out_dt =
             if get_ggml_q81_fact(activs).is_some() { DatumType::F32 } else { activs.datum_type() };
-        let out =
-            tract_gpu::session_handler::make_tensor_for_node(session, node_id, out_dt, &out_shape)?;
+        let out = tract_gpu::turn_handler::make_tensor_for_node(turn, node_id, out_dt, &out_shape)?;
 
         crate::with_cuda_stream(|stream| GgmlGemm.dispatch_eval(stream, activs, weights, &out))?;
 

--- a/cuda/src/ops/iff.rs
+++ b/cuda/src/ops/iff.rs
@@ -19,10 +19,10 @@ impl EvalOp for CudaIff {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (cond_val, then_val, else_val) = args_3!(inputs);
@@ -38,7 +38,7 @@ impl EvalOp for CudaIff {
             .context("No broadcasting solution found")?;
         let out_dt = then_t.datum_type();
         let output =
-            tract_gpu::session_handler::make_tensor_for_node(session, node_id, out_dt, &out_shape)?;
+            tract_gpu::turn_handler::make_tensor_for_node(turn, node_id, out_dt, &out_shape)?;
 
         if output.len() > 0 {
             crate::with_cuda_stream(|stream| {

--- a/cuda/src/ops/quant_q81.rs
+++ b/cuda/src/ops/quant_q81.rs
@@ -1,7 +1,7 @@
 use tract_core::internal::*;
 use tract_core::tract_linalg::block_quant::{BlockQuant, Q8_1};
-use tract_gpu::session_handler::make_scalar_exotic_tensor_for_node;
 use tract_gpu::tensor::DeviceTensorExt;
+use tract_gpu::turn_handler::make_scalar_exotic_tensor_for_node;
 
 use crate::kernels::matmul::quant_act_q81::GgmlQuantQ81;
 
@@ -63,20 +63,20 @@ impl Op for CudaGgmlQuantQ81 {
 }
 
 impl EvalOp for CudaGgmlQuantQ81 {
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         crate::with_cuda_stream(|stream| {
             let input_value = args_1!(inputs);
             let input = input_value.to_device_tensor()?;
 
-            let resolved_io_facts = self.io_facts.eval(&session.resolved_symbols)?;
+            let resolved_io_facts = self.io_facts.eval(&turn.resolved_symbols)?;
 
             let output = make_scalar_exotic_tensor_for_node(
-                session,
+                turn,
                 node_id,
                 input.datum_type(),
                 Box::new(resolved_io_facts),

--- a/doc/lexicon.md
+++ b/doc/lexicon.md
@@ -1,0 +1,36 @@
+# Lexicon
+
+Words with one meaning each. Pick these when naming things in `core`, `pulse`,
+`pulse-opl`, `gpu` and the backends; do not spend them on anything else.
+
+## Execution scopes
+
+- **turn** — one `run()` call on a state. `TurnState` carries what lives for a
+  turn: resolved symbols, intermediate values, scratch. `TurnStateHandler` fires
+  once before and once after each turn.
+- **session** — the scope a state covers across many turns.
+  `SimpleState::op_states` holds it: op state built once at spawn and carried from
+  turn to turn.
+
+The split is in the type: `SimpleState { op_states, turn_state }` is exactly
+session-scoped versus turn-scoped. State belongs in the container matching its
+scope — an op that needs only per-turn workspace does not belong in `op_states`.
+
+## Reserved
+
+- **lane** — the address at which one session's state lives inside a state shared
+  by several sessions. Reserved for batched streaming runtimes; nothing
+  implements it yet.
+- **seat** — a session's position within one turn's batch, where a turn carries
+  several sessions. Reserved with `lane`.
+
+## Taken, do not reuse
+
+- **stream** — in `pulse`, the axis a model is pulsified along (`StreamInfo`,
+  `stream_sym`). Never a client connection or an audio session.
+- **slot** — a node's input or output port (`OutletId::slot`).
+- **row** — a row of a matrix or a kernel tile, in `linalg`.
+- **rank** — the number of axes of a tensor.
+
+Applications built on tract have their own Session and turn, at their own
+granularity. tract does not pick terminology to avoid colliding with them.

--- a/doc/op.md
+++ b/doc/op.md
@@ -79,7 +79,7 @@ pub trait EvalOp {
 
      fn state(
          &self,
-         session: &mut TurnState,
+         turn: &mut TurnState,
          node_id: usize,
      ) -> TractResult<Option<Box<dyn OpState>>> {
          Ok(None)
@@ -101,7 +101,7 @@ instead:
 pub trait OpState: fmt::Debug + dyn_clone::DynClone + OpStateFreeze + Downcast {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>>;
@@ -110,7 +110,7 @@ pub trait OpState: fmt::Debug + dyn_clone::DynClone + OpStateFreeze + Downcast {
 ```
 
 Here the eval implementation is free to mute some operation internal state if
-required, or access the `SessionState`.
+required, or access the `TurnState`.
 
 But most operators are stateless anyway.
 

--- a/extra/src/exp_unit_norm.rs
+++ b/extra/src/exp_unit_norm.rs
@@ -112,11 +112,7 @@ impl EvalOp for ExpUnitNorm {
         self.stateless
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<ExpUnitNormState>::default()))
     }
 
@@ -178,7 +174,7 @@ impl ExpUnitNormState {
 impl OpState for ExpUnitNormState {
     fn eval(
         &mut self,
-        _session: &mut TurnState,
+        _turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {

--- a/gpu/src/lib.rs
+++ b/gpu/src/lib.rs
@@ -3,7 +3,7 @@ pub mod fact;
 pub mod memory;
 pub mod ops;
 pub mod rewrite_rules;
-pub mod session_handler;
 pub mod sync;
 pub mod tensor;
+pub mod turn_handler;
 pub mod utils;

--- a/gpu/src/ops/apply_rope.rs
+++ b/gpu/src/ops/apply_rope.rs
@@ -42,18 +42,18 @@ impl EvalOp for GpuApplyRope {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (input_val, cos_val, sin_val) = args_3!(inputs);
         let input = input_val.to_device_tensor()?;
         let cos = cos_val.to_device_tensor()?;
         let sin = sin_val.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/binary.rs
+++ b/gpu/src/ops/binary.rs
@@ -65,10 +65,10 @@ impl EvalOp for GpuBinOp {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (a_val, b_val) = args_2!(inputs);
@@ -76,8 +76,7 @@ impl EvalOp for GpuBinOp {
         let b = b_val.to_device_tensor()?;
         let out_shape = tract_core::broadcast::multi_broadcast(&[a.shape(), b.shape()])?;
         let out_dt = self.mini_op.result_datum_type(a.datum_type(), b.datum_type())?;
-        let output =
-            crate::session_handler::make_tensor_for_node(session, node_id, out_dt, &out_shape)?;
+        let output = crate::turn_handler::make_tensor_for_node(turn, node_id, out_dt, &out_shape)?;
         if a.len() > 0 && b.len() > 0 {
             (self.dispatch)(&*self.mini_op, a, b, &output)
                 .with_context(|| format!("Error while dispatching eval for {}", self.name()))?;

--- a/gpu/src/ops/broadcast.rs
+++ b/gpu/src/ops/broadcast.rs
@@ -26,21 +26,17 @@ impl EvalOp for GpuMultiBroadcastTo {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
-        let shape = self.shape.eval_to_usize(&session.resolved_symbols)?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
-            node_id,
-            input.datum_type(),
-            &shape,
-        )?;
+        let shape = self.shape.eval_to_usize(&turn.resolved_symbols)?;
+        let output =
+            crate::turn_handler::make_tensor_for_node(turn, node_id, input.datum_type(), &shape)?;
 
         // Pad input shape/strides to output rank for broadcasting
         let mut input_strides = vec![input.strides()[0]; output.rank() - input.rank()];

--- a/gpu/src/ops/cast.rs
+++ b/gpu/src/ops/cast.rs
@@ -62,10 +62,10 @@ impl EvalOp for GpuCast {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
@@ -73,12 +73,8 @@ impl EvalOp for GpuCast {
         if input.datum_type() == self.to {
             Ok(tvec!(input_value))
         } else {
-            let output = crate::session_handler::make_tensor_for_node(
-                session,
-                node_id,
-                self.to,
-                input.shape(),
-            )?;
+            let output =
+                crate::turn_handler::make_tensor_for_node(turn, node_id, self.to, input.shape())?;
             (self.dispatch)(input, &output)?;
             Ok(tvec![output.into_tensor().into_tvalue()])
         }

--- a/gpu/src/ops/causal_conv1d_update.rs
+++ b/gpu/src/ops/causal_conv1d_update.rs
@@ -1,5 +1,5 @@
-use crate::session_handler::make_tensor_for_node;
 use crate::tensor::{DeviceTensor, DeviceTensorExt};
+use crate::turn_handler::make_tensor_for_node;
 use tract_core::internal::*;
 
 pub type DispatchCausalConv1dUpdateFn = fn(
@@ -40,17 +40,17 @@ impl EvalOp for GpuCausalConv1dUpdate {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (input, weight, state) = args_3!(inputs);
         let input = input.to_device_tensor()?;
         let weight = weight.to_device_tensor()?;
         let state = state.to_device_tensor()?;
-        let output = make_tensor_for_node(session, node_id, DatumType::F16, input.shape())?;
+        let output = make_tensor_for_node(turn, node_id, DatumType::F16, input.shape())?;
         let final_state = DeviceTensor::uninitialized_dt(DatumType::F16, state.shape())?;
         (self.dispatch)(input, weight, state, &output, &final_state)?;
         Ok(tvec![output.into_tensor().into_tvalue(), final_state.into_tensor().into_tvalue()])

--- a/gpu/src/ops/change_axes.rs
+++ b/gpu/src/ops/change_axes.rs
@@ -75,10 +75,10 @@ impl EvalOp for GpuAxisOp {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let tensor = args_1!(inputs).into_tensor();
@@ -97,8 +97,8 @@ impl EvalOp for GpuAxisOp {
                 permutation.insert(*to, *from);
 
                 let out_shape = permute_output_shape(input.shape(), &permutation)?;
-                let output = crate::session_handler::make_tensor_for_node(
-                    session,
+                let output = crate::turn_handler::make_tensor_for_node(
+                    turn,
                     node_id,
                     input.datum_type(),
                     &out_shape,
@@ -119,8 +119,8 @@ impl EvalOp for GpuAxisOp {
                 return Ok(tvec!(output.into_tensor().into_tvalue()));
             }
             AxisOp::Reshape(skip, from, to) => {
-                let from = from.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
-                let to = to.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
+                let from = from.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
+                let to = to.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
                 let mut shape: TVec<usize> = input.shape().into();
                 AxisOp::Reshape(*skip, from, to).change_shape_array(&mut shape, false)?;
                 shape
@@ -133,8 +133,8 @@ impl EvalOp for GpuAxisOp {
         };
 
         // Memcpy path (Reshape/Add/Rm) — flat copy, treat as 1D
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             &new_shape,

--- a/gpu/src/ops/concat.rs
+++ b/gpu/src/ops/concat.rs
@@ -39,10 +39,10 @@ impl EvalOp for GpuConcat {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let inputs =
@@ -50,8 +50,8 @@ impl EvalOp for GpuConcat {
 
         let mut output_shape = inputs[0].shape().to_vec();
         output_shape[self.axis] = inputs.iter().map(|it| it.shape()[self.axis]).sum();
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             inputs[0].datum_type(),
             &output_shape,

--- a/gpu/src/ops/diag_gather.rs
+++ b/gpu/src/ops/diag_gather.rs
@@ -7,7 +7,7 @@ use tract_core::internal::*;
 ///
 /// `offset` and `out_len` are TDim because the rel-pos table width and the
 /// query-axis length may both be symbolic upstream; both are resolved against
-/// `session.resolved_symbols` at eval time.
+/// `turn.resolved_symbols` at eval time.
 pub type DispatchDiagGatherFn =
     fn(input: &DeviceTensor, offset: i64, out_len: usize, output: &DeviceTensor) -> TractResult<()>;
 
@@ -57,22 +57,22 @@ impl EvalOp for GpuDiagGather {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_val = args_1!(inputs);
         let input = input_val.to_device_tensor()?;
-        let offset = self.offset.eval(&session.resolved_symbols).to_i64()?;
-        let out_len = self.out_len.eval(&session.resolved_symbols).to_usize()?;
+        let offset = self.offset.eval(&turn.resolved_symbols).to_i64()?;
+        let out_len = self.out_len.eval(&turn.resolved_symbols).to_usize()?;
         let mut out_shape: TVec<usize> = input.shape().into();
         let rank = out_shape.len();
         ensure!(rank >= 2);
         out_shape[rank - 1] = out_len;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             &out_shape,

--- a/gpu/src/ops/dyn_kv_cache.rs
+++ b/gpu/src/ops/dyn_kv_cache.rs
@@ -57,7 +57,7 @@ impl OpState for GpuDynKVCacheState {
 
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -78,8 +78,8 @@ impl OpState for GpuDynKVCacheState {
             op_inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
         let mut output_shape = inputs[0].shape().to_vec();
         output_shape[axis] = inputs.iter().map(|it| it.shape()[axis]).sum();
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             self.node_id,
             inputs[0].datum_type(),
             &output_shape,
@@ -227,7 +227,7 @@ impl EvalOp for GpuDynKVCache {
         false
     }
 
-    fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(GpuDynKVCacheState::new(
             node_id,
             self.name.clone(),

--- a/gpu/src/ops/element_wise.rs
+++ b/gpu/src/ops/element_wise.rs
@@ -47,16 +47,16 @@ impl EvalOp for GpuElementWise {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/gather.rs
+++ b/gpu/src/ops/gather.rs
@@ -57,18 +57,18 @@ impl EvalOp for GpuGather {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (data_val, indices_val) = args_2!(inputs);
         let data = data_val.to_device_tensor()?;
         let indices = indices_val.to_device_tensor()?;
         let out_shape = compute_output_shape(self.axis, data.shape(), indices.shape())?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             data.datum_type(),
             &out_shape,

--- a/gpu/src/ops/gdn_recurrent.rs
+++ b/gpu/src/ops/gdn_recurrent.rs
@@ -1,5 +1,5 @@
-use crate::session_handler::make_tensor_for_node;
 use crate::tensor::{DeviceTensor, DeviceTensorExt};
+use crate::turn_handler::make_tensor_for_node;
 use tract_core::internal::*;
 
 pub type DispatchGdnRecurrentFn = fn(
@@ -43,10 +43,10 @@ impl EvalOp for GpuGatedDeltaNetRecurrent {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 6);
@@ -54,7 +54,7 @@ impl EvalOp for GpuGatedDeltaNetRecurrent {
             .iter()
             .map(|value| value.to_device_tensor())
             .collect::<TractResult<TVec<_>>>()?;
-        let output = make_tensor_for_node(session, node_id, DatumType::F16, tensors[0].shape())?;
+        let output = make_tensor_for_node(turn, node_id, DatumType::F16, tensors[0].shape())?;
         // The memory arena is keyed by node, so a second output cannot use the
         // same arena slot as the first one.
         let final_state = DeviceTensor::uninitialized_dt(DatumType::F32, tensors[5].shape())?;

--- a/gpu/src/ops/gelu_approximate.rs
+++ b/gpu/src/ops/gelu_approximate.rs
@@ -45,16 +45,16 @@ impl EvalOp for GpuGeluApproximate {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/iff.rs
+++ b/gpu/src/ops/iff.rs
@@ -59,10 +59,10 @@ impl EvalOp for GpuIff {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (cond_val, then_val, else_val) = args_3!(inputs);
@@ -77,8 +77,7 @@ impl EvalOp for GpuIff {
         let out_shape = multi_broadcast(&[cond.shape(), then_t.shape(), else_t.shape()])
             .context("No broadcasting solution found")?;
         let out_dt = then_t.datum_type();
-        let output =
-            crate::session_handler::make_tensor_for_node(session, node_id, out_dt, &out_shape)?;
+        let output = crate::turn_handler::make_tensor_for_node(turn, node_id, out_dt, &out_shape)?;
 
         if output.len() > 0 {
             let rank = cond.rank();

--- a/gpu/src/ops/leaky_relu.rs
+++ b/gpu/src/ops/leaky_relu.rs
@@ -45,16 +45,16 @@ impl EvalOp for GpuLeakyRelu {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/pad.rs
+++ b/gpu/src/ops/pad.rs
@@ -36,10 +36,10 @@ impl EvalOp for GpuPad {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
@@ -47,8 +47,7 @@ impl EvalOp for GpuPad {
         let dt = input.datum_type();
         let out_shape = self.output_shape(input.shape());
 
-        let output =
-            crate::session_handler::make_tensor_for_node(session, node_id, dt, &out_shape)?;
+        let output = crate::turn_handler::make_tensor_for_node(turn, node_id, dt, &out_shape)?;
 
         let ctx = crate::device::get_context()?;
 

--- a/gpu/src/ops/pulse.rs
+++ b/gpu/src/ops/pulse.rs
@@ -1,7 +1,7 @@
 #![allow(unpredictable_function_pointer_comparisons)]
 use crate::device::{DeviceContext, get_context};
-use crate::session_handler::make_tensor_for_node;
 use crate::tensor::{DeviceTensor, DeviceTensorExt, IntoDevice};
+use crate::turn_handler::make_tensor_for_node;
 use crate::utils::compute_broadcast_strides;
 use std::ops::Range;
 use tract_core::internal::*;
@@ -39,7 +39,7 @@ impl EvalOp for GpuDelay {
         false
     }
 
-    fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(GpuDelayState { node_id, buffer: None, shift_scratch: None })))
     }
 }
@@ -188,7 +188,7 @@ impl EvalOp for GpuPulsePad {
         false
     }
 
-    fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(GpuPulsePadState { node_id, current_pos: 0, last_valid_frame: None })))
     }
 }
@@ -280,7 +280,7 @@ impl GpuPulsePadState {
 
     fn pad(
         &mut self,
-        session: &TurnState,
+        turn: &TurnState,
         gpu_op: &GpuPulsePad,
         input: &DeviceTensor,
     ) -> TractResult<DeviceTensor> {
@@ -290,9 +290,8 @@ impl GpuPulsePadState {
         let pulse_begin = self.current_pos;
         let pulse_end = self.current_pos + pulse;
         self.current_pos += pulse - op.overlap;
-        let end_input =
-            op.end_input.eval(&session.resolved_symbols).to_usize().unwrap_or(usize::MAX);
-        let after = op.after.eval(&session.resolved_symbols).to_usize().unwrap_or(usize::MAX);
+        let end_input = op.end_input.eval(&turn.resolved_symbols).to_usize().unwrap_or(usize::MAX);
+        let after = op.after.eval(&turn.resolved_symbols).to_usize().unwrap_or(usize::MAX);
 
         if let PadMode::Edge = op.mode
             && after != 0
@@ -307,7 +306,7 @@ impl GpuPulsePadState {
         // never materialises), so a flat memcpy would read the buffer in
         // pre-Move order; copy_nd honours `input.strides()` instead.
         let mut output =
-            make_tensor_for_node(session, self.node_id, input.datum_type(), input.shape())?;
+            make_tensor_for_node(turn, self.node_id, input.datum_type(), input.shape())?;
         ctx.copy_nd(input, 0, input.strides(), &output, 0, input.shape(), output.strides())?;
 
         // Quick return if entirely in valid or invalid range
@@ -368,7 +367,7 @@ impl GpuPulsePadState {
 impl OpState for GpuPulsePadState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -376,7 +375,7 @@ impl OpState for GpuPulsePadState {
         let gpu_op =
             op.downcast_ref::<GpuPulsePad>().ok_or_else(|| format_err!("Wrong Op type"))?;
         let device_input = input.as_device_tensor().context("Expected a GPU tensor")?;
-        let output = self.pad(session, gpu_op, device_input)?;
+        let output = self.pad(turn, gpu_op, device_input)?;
         Ok(tvec!(output.into_tensor().into_tvalue()))
     }
 }
@@ -413,10 +412,10 @@ impl EvalOp for GpuAffineChunkTrim {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
@@ -433,7 +432,7 @@ impl EvalOp for GpuAffineChunkTrim {
         }
         let mut o_shape: TVec<usize> = input.shape().into();
         o_shape[axis] = take;
-        let output = make_tensor_for_node(session, node_id, input.datum_type(), &o_shape)?;
+        let output = make_tensor_for_node(turn, node_id, input.datum_type(), &o_shape)?;
         let broadcast_strides = compute_broadcast_strides(&o_shape, input.strides())?;
         let ctx = get_context()?;
         ctx.copy_nd(input, 0, &broadcast_strides, &output, 0, output.shape(), output.strides())?;

--- a/gpu/src/ops/reduce.rs
+++ b/gpu/src/ops/reduce.rs
@@ -119,18 +119,18 @@ impl EvalOp for GpuReduce {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
         let mut output_shape = input.shape().to_vec();
         output_shape[self.axes[0]] = 1;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             &output_shape,

--- a/gpu/src/ops/resize.rs
+++ b/gpu/src/ops/resize.rs
@@ -68,10 +68,10 @@ impl EvalOp for GpuResize {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let data = inputs[0].to_device_tensor()?;
@@ -85,7 +85,7 @@ impl EvalOp for GpuResize {
             shape[axis] = self.output_shape[axis];
             let last = step + 1 == self.axes.len();
             let output = if last {
-                crate::session_handler::make_tensor_for_node(session, node_id, dt, &shape)?
+                crate::turn_handler::make_tensor_for_node(turn, node_id, dt, &shape)?
             } else {
                 DeviceTensor::uninitialized_dt(dt, &shape)?
             };

--- a/gpu/src/ops/rms_norm.rs
+++ b/gpu/src/ops/rms_norm.rs
@@ -52,16 +52,16 @@ impl EvalOp for GpuRmsNorm {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/rotate_half.rs
+++ b/gpu/src/ops/rotate_half.rs
@@ -43,16 +43,16 @@ impl EvalOp for GpuRotateHalf {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/scaled_masked_softmax.rs
+++ b/gpu/src/ops/scaled_masked_softmax.rs
@@ -60,17 +60,17 @@ impl EvalOp for GpuScaledMaskedSoftmax {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (input_val, mask_val) = args_2!(inputs);
         let input = input_val.to_device_tensor()?;
         let mask = mask_val.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/slice.rs
+++ b/gpu/src/ops/slice.rs
@@ -31,17 +31,17 @@ impl EvalOp for GpuSlice {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
 
-        let start = self.inner.start.eval(&session.resolved_symbols).to_usize()?;
-        let end = self.inner.end.eval(&session.resolved_symbols).to_usize()?;
+        let start = self.inner.start.eval(&turn.resolved_symbols).to_usize()?;
+        let end = self.inner.end.eval(&turn.resolved_symbols).to_usize()?;
         let axis = self.inner.axis;
 
         let input_shape = input.shape();
@@ -62,12 +62,8 @@ impl EvalOp for GpuSlice {
 
         let offset = (start * input_strides[axis] as usize) * input_dt.size_of();
 
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
-            node_id,
-            input.datum_type(),
-            &o_shape,
-        )?;
+        let output =
+            crate::turn_handler::make_tensor_for_node(turn, node_id, input.datum_type(), &o_shape)?;
 
         if o_shape[axis] != 0 {
             // Slice uses same strides as input (broadcast strides with matching shapes)

--- a/gpu/src/ops/softmax.rs
+++ b/gpu/src/ops/softmax.rs
@@ -75,16 +75,16 @@ impl EvalOp for GpuSoftmax {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/ops/stft.rs
+++ b/gpu/src/ops/stft.rs
@@ -83,16 +83,16 @@ impl EvalOp for GpuStft {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;
         let window = (*self.window).clone().into_device()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             &self.output_shape(input.shape()),
@@ -174,15 +174,15 @@ impl EvalOp for GpuFft {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;
-        let output = crate::session_handler::make_tensor_for_node(
-            session,
+        let output = crate::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             input.shape(),

--- a/gpu/src/turn_handler.rs
+++ b/gpu/src/turn_handler.rs
@@ -4,11 +4,11 @@ use crate::tensor::DeviceTensor;
 use tract_core::internal::*;
 
 #[derive(Debug, Clone)]
-pub struct DeviceSessionHandler {
+pub struct DeviceTurnHandler {
     pub mem_schema: DeviceMemSchema,
 }
 
-impl DeviceSessionHandler {
+impl DeviceTurnHandler {
     pub fn from_plan(plan: &TypedSimplePlan, memory_hint: &SymbolValues) -> TractResult<Self> {
         let mem_schema =
             DeviceMemSchema::build(plan.model(), plan.order_without_consts(), memory_hint)?;
@@ -16,42 +16,41 @@ impl DeviceSessionHandler {
     }
 }
 
-impl SessionStateHandler for DeviceSessionHandler {
-    fn before_plan_eval(&self, session_state: &mut TurnState) -> TractResult<()> {
-        let resolved_mem_schema = self.mem_schema.resolve(&session_state.resolved_symbols)?;
+impl TurnStateHandler for DeviceTurnHandler {
+    fn before_plan_eval(&self, turn: &mut TurnState) -> TractResult<()> {
+        let resolved_mem_schema = self.mem_schema.resolve(&turn.resolved_symbols)?;
         let memory_pool = DeviceMemoryPool::from_schema(resolved_mem_schema)?;
 
-        session_state.scratch_extensions.insert(memory_pool);
-        ensure!(session_state.scratch_extensions.get::<DeviceMemoryPool>().is_some());
+        turn.scratch_extensions.insert(memory_pool);
+        ensure!(turn.scratch_extensions.get::<DeviceMemoryPool>().is_some());
         Ok(())
     }
 
-    fn after_plan_eval(&self, session_state: &mut TurnState) -> TractResult<()> {
-        session_state.scratch_extensions.remove::<DeviceMemoryPool>();
+    fn after_plan_eval(&self, turn: &mut TurnState) -> TractResult<()> {
+        turn.scratch_extensions.remove::<DeviceMemoryPool>();
         Ok(())
     }
 }
 
 pub fn make_tensor_for_node(
-    session: &TurnState,
+    turn: &TurnState,
     node_id: usize,
     dt: DatumType,
     shape: &[usize],
 ) -> TractResult<DeviceTensor> {
-    session
-        .scratch_extensions
+    turn.scratch_extensions
         .get::<DeviceMemoryPool>()
         .map(|mem| mem.tensor_for_node(node_id, dt, shape))
         .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
 }
 
 pub fn make_scalar_exotic_tensor_for_node(
-    session: &TurnState,
+    turn: &TurnState,
     node_id: usize,
     dt: DatumType,
     exotic_fact: Box<dyn ExoticFact>,
 ) -> TractResult<DeviceTensor> {
-    match session.scratch_extensions.get::<DeviceMemoryPool>() {
+    match turn.scratch_extensions.get::<DeviceMemoryPool>() {
         Some(mem) => mem.scalar_exotic_tensor_for_node(node_id, dt, exotic_fact),
         None => DeviceTensor::uninitialized_exotic(exotic_fact),
     }

--- a/hir/src/ops/scan.rs
+++ b/hir/src/ops/scan.rs
@@ -45,8 +45,8 @@ impl EvalOp for InferenceScan {
         false
     }
 
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        self.to_mir_scan()?.state(session, node_id)
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+        self.to_mir_scan()?.state(turn, node_id)
     }
 }
 

--- a/hir/src/ops/source.rs
+++ b/hir/src/ops/source.rs
@@ -18,7 +18,7 @@ impl EvalOp for Source {
     fn is_stateless(&self) -> bool {
         false
     }
-    fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(SourceState(node_id))))
     }
 }

--- a/libcli/src/profile.rs
+++ b/libcli/src/profile.rs
@@ -290,25 +290,17 @@ pub fn rec_profiler_gpu(
     prefix: &[(usize, String)],
     before_node: &dyn Fn(usize),
 ) -> TractResult<TVec<TValue>> {
-    let r = state.run_plan_with_eval(
-        inputs.clone(),
-        |session_state, mut node_state, node, input| {
-            before_node(node.id);
-            // Profile node
-            let start = crate::time::now();
-            let res = tract_core::plan::eval(
-                session_state,
-                node_state.as_deref_mut(),
-                node,
-                input.clone(),
-            );
-            let elapsed = start.elapsed();
-            let node_id = NodeQId(prefix.into(), node.id);
-            *dg.node_mut(node_id).profile.get_or_insert(Duration::default()) += elapsed;
+    let r = state.run_plan_with_eval(inputs.clone(), |turn, mut node_state, node, input| {
+        before_node(node.id);
+        // Profile node
+        let start = crate::time::now();
+        let res = tract_core::plan::eval(turn, node_state.as_deref_mut(), node, input.clone());
+        let elapsed = start.elapsed();
+        let node_id = NodeQId(prefix.into(), node.id);
+        *dg.node_mut(node_id).profile.get_or_insert(Duration::default()) += elapsed;
 
-            res
-        },
-    )?;
+        res
+    })?;
 
     Ok(r)
 }
@@ -324,56 +316,50 @@ pub fn rec_profiler(
     time_accounted_by_inner_nodes: &mut Duration,
     folded: bool,
 ) -> TractResult<TVec<TValue>> {
-    let r = state.run_plan_with_eval(
-        inputs.clone(),
-        |session_state, mut node_state, node, input| {
-            // Keep a copy of the inputs only when a nested submodel will need them
-            // for recursive profiling. Otherwise move them straight into eval: an
-            // extra clone here holds a second Arc ref to each input and forces
-            // in-place ops (reshape, by-scalar/unicast bias add, ...) down their
-            // copy-on-shared path, inflating their measured time versus production.
-            let saved_input = (!folded && node_state.is_some()).then(|| input.clone());
-            // Profile node
+    let r = state.run_plan_with_eval(inputs.clone(), |turn, mut node_state, node, input| {
+        // Keep a copy of the inputs only when a nested submodel will need them
+        // for recursive profiling. Otherwise move them straight into eval: an
+        // extra clone here holds a second Arc ref to each input and forces
+        // in-place ops (reshape, by-scalar/unicast bias add, ...) down their
+        // copy-on-shared path, inflating their measured time versus production.
+        let saved_input = (!folded && node_state.is_some()).then(|| input.clone());
+        // Profile node
+        let start = crate::time::now();
+        let res = tract_core::plan::eval(turn, node_state.as_deref_mut(), node, input);
+        let elapsed = start.elapsed().mul_f32(multiplier.unwrap_or(1) as _);
+        let node_id = NodeQId(prefix.into(), node.id);
+        *dg.node_mut(node_id).profile.get_or_insert(Duration::default()) += elapsed;
+
+        if let Some(saved_input) = saved_input {
             let start = crate::time::now();
-            let res = tract_core::plan::eval(session_state, node_state.as_deref_mut(), node, input);
-            let elapsed = start.elapsed().mul_f32(multiplier.unwrap_or(1) as _);
-            let node_id = NodeQId(prefix.into(), node.id);
-            *dg.node_mut(node_id).profile.get_or_insert(Duration::default()) += elapsed;
+            profile_submodel(
+                node,
+                node_state,
+                saved_input,
+                dg,
+                profilers,
+                prefix,
+                time_accounted_by_inner_nodes,
+            )?;
+            *time_accounted_by_inner_nodes += start.elapsed();
+        }
 
-            if let Some(saved_input) = saved_input {
-                let start = crate::time::now();
-                profile_submodel(
-                    node,
-                    node_state,
-                    saved_input,
-                    dg,
-                    profilers,
-                    prefix,
-                    time_accounted_by_inner_nodes,
-                )?;
-                *time_accounted_by_inner_nodes += start.elapsed();
-            }
-
-            // Update parent nodes if any (childs timings are deducted from parents)
-            let prefix_vec = prefix.to_vec();
-            if !prefix_vec.is_empty() {
-                (1..prefix_vec.len() + 1).map(|idx| prefix_vec[..idx].to_vec()).for_each(
-                    |parent_path| {
-                        let parent_node = parent_path.last().map(|it| it.0).unwrap();
-                        let parent = dg
-                            .node_mut(NodeQId(
-                                parent_path[..parent_path.len() - 1].into(),
-                                parent_node,
-                            ))
-                            .profile
-                            .get_or_insert(Duration::default());
-                        *parent -= elapsed.min(*parent);
-                    },
-                );
-            }
-            res
-        },
-    )?;
+        // Update parent nodes if any (childs timings are deducted from parents)
+        let prefix_vec = prefix.to_vec();
+        if !prefix_vec.is_empty() {
+            (1..prefix_vec.len() + 1).map(|idx| prefix_vec[..idx].to_vec()).for_each(
+                |parent_path| {
+                    let parent_node = parent_path.last().map(|it| it.0).unwrap();
+                    let parent = dg
+                        .node_mut(NodeQId(parent_path[..parent_path.len() - 1].into(), parent_node))
+                        .profile
+                        .get_or_insert(Duration::default());
+                    *parent -= elapsed.min(*parent);
+                },
+            );
+        }
+        res
+    })?;
     Ok(r)
 }
 

--- a/metal/src/kernels/array/diag_gather.rs
+++ b/metal/src/kernels/array/diag_gather.rs
@@ -149,8 +149,8 @@ mod tests {
             let metal_in = cpu_in.clone().into_device()?;
 
             let cpu_op = cpu_dg::DiagGather { offset: offset.to_dim(), out_len: out_len.to_dim() };
-            let session = TurnState::default();
-            let cpu_out = cpu_op.eval_with_session(0, &session, tvec![cpu_in.into_tvalue()])?[0]
+            let turn = TurnState::default();
+            let cpu_out = cpu_op.eval_with_turn(0, &turn, tvec![cpu_in.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_out = DiagGather.eval(stream, &metal_in, offset, out_len)?;

--- a/metal/src/kernels/matmul/mfa/mod.rs
+++ b/metal/src/kernels/matmul/mfa/mod.rs
@@ -488,10 +488,10 @@ impl EvalOp for MetalMfaSdpa {
     fn is_stateless(&self) -> bool {
         true
     }
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         use tract_gpu::tensor::{DeviceTensorExt, IntoDevice};
@@ -511,12 +511,8 @@ impl EvalOp for MetalMfaSdpa {
         let sk = k.shape()[2];
         let h = b * nh;
         let dt = q.datum_type();
-        let out = tract_gpu::session_handler::make_tensor_for_node(
-            session,
-            node_id,
-            dt,
-            &[b, nh, sq, dd],
-        )?;
+        let out =
+            tract_gpu::turn_handler::make_tensor_for_node(turn, node_id, dt, &[b, nh, sq, dd])?;
         // causal -> [Sq,Sk] additive mask, bottom-right aligned (cached/cross attention)
         let mask = if self.is_causal {
             let mut m = vec![0f32; sq * sk];
@@ -1263,7 +1259,7 @@ mod tests {
         })
     }
 
-    // Slice C: the MetalMfaSdpa op end-to-end via eval_with_session on device tensors.
+    // Slice C: the MetalMfaSdpa op end-to-end via eval_with_turn on device tensors.
     #[test]
     fn test_metal_mfa_sdpa_op() -> TractResult<()> {
         use tract_gpu::tensor::{DeviceTensorExt, IntoDevice};
@@ -1322,7 +1318,7 @@ mod tests {
                 let kd = Tensor::from_shape(&[b, nh, sk, d], &kv)?.into_device()?;
                 let vd = Tensor::from_shape(&[b, nh, sk, d], &vv)?.into_device()?;
                 let op = MetalMfaSdpa { scale, is_causal };
-                let out = op.eval_with_session(
+                let out = op.eval_with_turn(
                     0,
                     &TurnState::default(),
                     tvec![

--- a/metal/src/kernels/matmul/mlx_sdpa/mod.rs
+++ b/metal/src/kernels/matmul/mlx_sdpa/mod.rs
@@ -467,10 +467,10 @@ impl EvalOp for MetalMlxSdpa {
     fn is_stateless(&self) -> bool {
         true
     }
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         use tract_gpu::tensor::DeviceTensorExt;
@@ -480,8 +480,8 @@ impl EvalOp for MetalMlxSdpa {
         let v = inputs[2].to_device_tensor()?;
         let mask = inputs.get(3).map(|m| m.to_device_tensor()).transpose()?;
         ensure!(q.rank() == 4, "expects rank-4 [B,H,Sq,D], got {:?}", q.shape());
-        let out = tract_gpu::session_handler::make_tensor_for_node(
-            session,
+        let out = tract_gpu::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             q.datum_type(),
             q.shape(),

--- a/metal/src/lib.rs
+++ b/metal/src/lib.rs
@@ -39,10 +39,10 @@ impl Runtime for MetalRuntime {
         let options = RunOptions { skip_order_opt_ram: true, ..options.clone() };
         let mut runnable = TypedSimplePlan::build(model, &options)?;
         if let Some(hints) = options.memory_sizing_hints {
-            let session_handler =
-                tract_gpu::session_handler::DeviceSessionHandler::from_plan(&runnable, &hints)
+            let turn_handler =
+                tract_gpu::turn_handler::DeviceTurnHandler::from_plan(&runnable, &hints)
                     .context("While sizing memory arena. Missing hint ?")?;
-            runnable = runnable.with_session_handler(session_handler);
+            runnable = runnable.with_turn_handler(turn_handler);
         }
 
         Ok(Box::new(Arc::new(runnable)))

--- a/metal/src/ops/conv.rs
+++ b/metal/src/ops/conv.rs
@@ -61,17 +61,17 @@ impl EvalOp for MetalConv {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let inputs =
             inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
         let output_shape = self.op.pool_spec.output_shape(inputs[0].shape())?;
-        let output = tract_gpu::session_handler::make_tensor_for_node(
-            session,
+        let output = tract_gpu::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             inputs[0].datum_type(),
             &output_shape.shape,

--- a/metal/src/ops/fused_axis_op.rs
+++ b/metal/src/ops/fused_axis_op.rs
@@ -21,7 +21,7 @@ pub struct MetalFusedAxisOpState {
 fn compute_reshaped_inputs(
     inputs: TVec<TValue>,
     grouped_axis_ops: &TVec<TVec<GpuAxisOp>>,
-    session: &TurnState,
+    turn: &TurnState,
 ) -> TractResult<TVec<TValue>> {
     // Apply Axis Ops per input
 
@@ -39,8 +39,8 @@ fn compute_reshaped_inputs(
                     let new_shape = match &axis_op.inner {
                         AxisOp::Reshape(skip, from, to) => {
                             let from =
-                                from.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
-                            let to = to.iter().map(|d| d.eval(&session.resolved_symbols)).collect();
+                                from.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
+                            let to = to.iter().map(|d| d.eval(&turn.resolved_symbols)).collect();
                             let mut shape: TVec<usize> = t.shape().into();
                             AxisOp::Reshape(*skip, from, to)
                                 .change_shape_array(&mut shape, false)?;
@@ -80,30 +80,30 @@ impl OpState for MetalFusedAxisOpState {
 
     fn load_from(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         states: &mut dyn Iterator<Item = tract_core::value::TValue>,
     ) -> TractResult<()> {
-        self.op_state.load_from(session, states)
+        self.op_state.load_from(turn, states)
     }
 
     fn save_to(&self, states: &mut Vec<TValue>) -> TractResult<()> {
         self.op_state.save_to(states)
     }
 
-    fn resolve_symbols(&mut self, session: &mut TurnState) -> TractResult<()> {
-        self.op_state.resolve_symbols(session)
+    fn resolve_symbols(&mut self, turn: &mut TurnState) -> TractResult<()> {
+        self.op_state.resolve_symbols(turn)
     }
 
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let fused_axis_op = op.downcast_ref::<MetalFusedAxisOp>().unwrap();
-        let inputs = compute_reshaped_inputs(inputs, &fused_axis_op.grouped_axis_ops, session)?;
+        let inputs = compute_reshaped_inputs(inputs, &fused_axis_op.grouped_axis_ops, turn)?;
         // Runner inner op
-        self.op_state.eval(session, fused_axis_op.op.as_op(), inputs)
+        self.op_state.eval(turn, fused_axis_op.op.as_op(), inputs)
     }
 }
 
@@ -162,22 +162,22 @@ impl EvalOp for MetalFusedAxisOp {
         self.op.is_stateless()
     }
 
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        if let Some(state) = self.op.state(session, node_id)? {
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+        if let Some(state) = self.op.state(turn, node_id)? {
             Ok(Some(Box::new(MetalFusedAxisOpState { op_state: state })))
         } else {
             Ok(None)
         }
     }
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, session)?;
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, turn)?;
         // Runner inner op
-        self.op.eval_with_session(node_id, session, inputs)
+        self.op.eval_with_turn(node_id, turn, inputs)
     }
 }
 

--- a/metal/src/ops/gemm.rs
+++ b/metal/src/ops/gemm.rs
@@ -71,10 +71,10 @@ impl<K: GemmKernel + 'static> EvalOp for MetalGemm<K> {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (a_raw, b_raw) = args_2!(inputs);
@@ -91,7 +91,7 @@ impl<K: GemmKernel + 'static> EvalOp for MetalGemm<K> {
 
         let c_dt = self.kernel.matmul.output_dt(a.datum_type(), b.datum_type())?;
         let c_shape = self.kernel.output_shape(a.shape(), &b_shape);
-        let c = tract_gpu::session_handler::make_tensor_for_node(session, node_id, c_dt, &c_shape)?;
+        let c = tract_gpu::turn_handler::make_tensor_for_node(turn, node_id, c_dt, &c_shape)?;
 
         crate::with_metal_stream(|stream| self.kernel.dispatch_eval(stream, a, b, &c))?;
 

--- a/metal/src/ops/pool.rs
+++ b/metal/src/ops/pool.rs
@@ -48,16 +48,16 @@ impl EvalOp for MetalPool {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;
         let output_shape = self.pool_spec.output_shape(input.shape())?;
-        let output = tract_gpu::session_handler::make_tensor_for_node(
-            session,
+        let output = tract_gpu::turn_handler::make_tensor_for_node(
+            turn,
             node_id,
             input.datum_type(),
             &output_shape.shape,

--- a/onnx-opl/src/random.rs
+++ b/onnx-opl/src/random.rs
@@ -108,11 +108,7 @@ impl EvalOp for Random {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         let rng = self.seed.map(SmallRng::seed_from_u64).unwrap_or_else(rand::make_rng);
         Ok(Some(Box::new(RandomState(rng))))
     }
@@ -124,7 +120,7 @@ struct RandomState(SmallRng);
 impl OpState for RandomState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         _inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -132,7 +128,7 @@ impl OpState for RandomState {
         let mut tensor = unsafe {
             Tensor::uninitialized_dt(
                 op.fact.datum_type,
-                &op.fact.shape.eval_to_usize(&session.resolved_symbols)?,
+                &op.fact.shape.eval_to_usize(&turn.resolved_symbols)?,
             )?
         };
         match &op.dist {

--- a/onnx/src/ops/cast.rs
+++ b/onnx/src/ops/cast.rs
@@ -51,11 +51,7 @@ impl ElementWiseMiniOp for Cast {
             }
         } else {
             tract_hir::ops::cast::cast(self.to)
-                .eval_with_session(
-                    usize::MAX,
-                    &TurnState::default(),
-                    tvec!(t.clone().into_tvalue()),
-                )
+                .eval_with_turn(usize::MAX, &TurnState::default(), tvec!(t.clone().into_tvalue()))
                 .map(|mut t| t.remove(0).into_tensor())
         }
     }

--- a/pulse-opl/src/concat.rs
+++ b/pulse-opl/src/concat.rs
@@ -25,11 +25,7 @@ impl EvalOp for PulsedSameAxisConcat {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulsedSameAxisConcatState>::default()))
     }
 }
@@ -60,7 +56,7 @@ trivial_op_state_freeze!(PulsedSameAxisConcatState);
 impl OpState for PulsedSameAxisConcatState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -76,7 +72,7 @@ impl OpState for PulsedSameAxisConcatState {
         let pre_length = pre.shape()[op.axis];
         let pre_offset = op.input_delay - pre_length;
         overwrite_part_of_pulse(op.axis, &mut data, current_pos, &pre, pre_offset)?;
-        if let Some(l) = op.input_len.maybe_eval_to_i64(&session.resolved_symbols) {
+        if let Some(l) = op.input_len.maybe_eval_to_i64(&turn.resolved_symbols) {
             let post_offset = op.input_delay + l as usize;
             overwrite_part_of_pulse(op.axis, &mut data, current_pos, &post, post_offset)?;
         }

--- a/pulse-opl/src/deconv_delay.rs
+++ b/pulse-opl/src/deconv_delay.rs
@@ -33,11 +33,7 @@ impl EvalOp for DeconvDelay {
         unreachable!()
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(DeconvDelayState { valid_inputed: -(self.delay as isize), buffer: None })))
     }
 }
@@ -62,7 +58,7 @@ pub struct DeconvDelayState {
 impl OpState for DeconvDelayState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -73,7 +69,7 @@ impl OpState for DeconvDelayState {
             self.buffer = Some(Tensor::zero_dt(inputs[0].datum_type(), &buffer_size)?);
         }
         let mut input = inputs[0].clone().into_tensor();
-        dispatch_numbers!(Self::eval_t(input.datum_type())(self, session, op, &mut input))?;
+        dispatch_numbers!(Self::eval_t(input.datum_type())(self, turn, op, &mut input))?;
         let output = input.slice(op.axis, 0, input.shape()[op.axis] - op.overlap)?;
         Ok(tvec!(output.into_tvalue()))
     }
@@ -82,7 +78,7 @@ impl OpState for DeconvDelayState {
 impl DeconvDelayState {
     fn eval_t<T: Datum + AddAssign + Zero>(
         &mut self,
-        session: &TurnState,
+        turn: &TurnState,
         op: &DeconvDelay,
         input: &mut Tensor,
     ) -> TractResult<()> {
@@ -94,7 +90,7 @@ impl DeconvDelayState {
         let input_pulse = input.shape()[op.axis];
         let output_pulse = input_pulse - op.overlap;
         self.valid_inputed += output_pulse as isize;
-        if let Ok(input_dim) = op.deconv_input_dim.eval(&session.resolved_symbols).to_isize() {
+        if let Ok(input_dim) = op.deconv_input_dim.eval(&turn.resolved_symbols).to_isize() {
             if self.valid_inputed > input_dim {
                 let to_be_zeroed = ((self.valid_inputed - input_dim) as usize).min(input_pulse);
                 let mut zeroed =

--- a/pulse-opl/src/delay.rs
+++ b/pulse-opl/src/delay.rs
@@ -141,11 +141,7 @@ impl EvalOp for Delay {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(DelayState { buffer: None })))
     }
 }

--- a/pulse-opl/src/mask.rs
+++ b/pulse-opl/src/mask.rs
@@ -47,29 +47,24 @@ struct PulseMaskOpState {
 impl OpState for PulseMaskOpState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs).into_tensor();
         let op = op.downcast_ref::<PulseMask>().ok_or_else(|| format_err!("Wrong Op type"))?;
-        let tensor = self.pad(session, op, input)?;
+        let tensor = self.pad(turn, op, input)?;
         Ok(tvec!(tensor.into_tvalue()))
     }
 }
 
 impl PulseMaskOpState {
-    fn pad(
-        &mut self,
-        session: &TurnState,
-        op: &PulseMask,
-        mut input: Tensor,
-    ) -> TractResult<Tensor> {
+    fn pad(&mut self, turn: &TurnState, op: &PulseMask, mut input: Tensor) -> TractResult<Tensor> {
         let pulse = input.shape()[op.axis];
         let pulse_begin = self.current_pos;
         let pulse_end = self.current_pos + pulse;
         self.current_pos += pulse;
-        let end = op.end.eval(&session.resolved_symbols).to_usize().unwrap_or(usize::MAX);
+        let end = op.end.eval(&turn.resolved_symbols).to_usize().unwrap_or(usize::MAX);
 
         // pulse is entirely in valid input, just forward
         if pulse_begin >= op.begin && pulse_end <= end {
@@ -128,11 +123,7 @@ impl EvalOp for PulseMask {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulseMaskOpState>::default()))
     }
 }

--- a/pulse-opl/src/pad.rs
+++ b/pulse-opl/src/pad.rs
@@ -110,26 +110,21 @@ struct PadLimits {
 }
 
 impl PadLimits {
-    fn resolve(
-        cache: &mut Option<PadLimits>,
-        session: &TurnState,
-        op: &PulsePad,
-    ) -> (usize, usize) {
+    fn resolve(cache: &mut Option<PadLimits>, turn: &TurnState, op: &PulsePad) -> (usize, usize) {
         if let Some(l) = cache.as_ref() {
-            if l.deps.iter().all(|(s, v)| session.resolved_symbols.get(s) == *v) {
+            if l.deps.iter().all(|(s, v)| turn.resolved_symbols.get(s) == *v) {
                 return (l.end_input, l.after);
             }
         }
-        let end_input =
-            op.end_input.eval(&session.resolved_symbols).to_usize().unwrap_or(usize::MAX);
-        let after = op.after.eval(&session.resolved_symbols).to_usize().unwrap_or(usize::MAX);
+        let end_input = op.end_input.eval(&turn.resolved_symbols).to_usize().unwrap_or(usize::MAX);
+        let after = op.after.eval(&turn.resolved_symbols).to_usize().unwrap_or(usize::MAX);
         let deps = op
             .end_input
             .symbols()
             .into_iter()
             .chain(op.after.symbols())
             .map(|s| {
-                let v = session.resolved_symbols.get(&s);
+                let v = turn.resolved_symbols.get(&s);
                 (s, v)
             })
             .collect();
@@ -141,13 +136,13 @@ impl PadLimits {
 impl OpState for PulsePadOpState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
         let op = op.downcast_ref::<PulsePad>().ok_or_else(|| format_err!("Wrong Op type"))?;
-        self.pad(session, op, input).map(|t| tvec!(t))
+        self.pad(turn, op, input).map(|t| tvec!(t))
     }
 }
 
@@ -158,12 +153,12 @@ impl PulsePadOpState {
             Some(data.index_axis(Axis(op.axis), frame).to_owned().into_tensor());
     }
 
-    fn pad(&mut self, session: &TurnState, op: &PulsePad, input: TValue) -> TractResult<TValue> {
+    fn pad(&mut self, turn: &TurnState, op: &PulsePad, input: TValue) -> TractResult<TValue> {
         let pulse = input.shape()[op.axis];
         let pulse_begin = self.current_pos;
         let pulse_end = self.current_pos + pulse;
         self.current_pos += pulse - op.overlap;
-        let (end_input, after) = PadLimits::resolve(&mut self.limits, session, op);
+        let (end_input, after) = PadLimits::resolve(&mut self.limits, turn, op);
 
         if let PadMode::Edge = op.mode {
             if after != 0 && pulse_begin < end_input {
@@ -277,11 +272,7 @@ impl EvalOp for PulsePad {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulsePadOpState>::default()))
     }
 }

--- a/pulse-opl/src/range.rs
+++ b/pulse-opl/src/range.rs
@@ -45,11 +45,7 @@ impl EvalOp for PulsedRange {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulsedRangeState>::default()))
     }
 }
@@ -70,7 +66,7 @@ struct PulsedRangeState {
 impl OpState for PulsedRangeState {
     fn eval(
         &mut self,
-        session: &mut TurnState,
+        turn: &mut TurnState,
         op: &dyn Op,
         _inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
@@ -87,13 +83,13 @@ impl OpState for PulsedRangeState {
                 .start
                 .try_as_plain()?
                 .to_scalar::<TDim>()?
-                .eval(&session.resolved_symbols)
+                .eval(&turn.resolved_symbols)
                 .to_i64()?;
             let step = op
                 .step
                 .try_as_plain()?
                 .to_scalar::<TDim>()?
-                .eval(&session.resolved_symbols)
+                .eval(&turn.resolved_symbols)
                 .to_i64()?;
             let data: Vec<i64> =
                 (0..pulse).map(|i| start + step * (base as i64 + i as i64)).collect();

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -379,8 +379,8 @@ impl EvalOp for PulseWrappingOp {
         self.0.eval(inputs)
     }
 
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        self.0.state(session, node_id)
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+        self.0.state(turn, node_id)
     }
 }
 
@@ -469,8 +469,8 @@ impl EvalOp for NonPulsingWrappingOp {
         self.0.eval(inputs)
     }
 
-    fn state(&self, session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        self.0.state(session, node_id)
+    fn state(&self, turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+        self.0.state(turn, node_id)
     }
 }
 

--- a/pulse/src/ops/source.rs
+++ b/pulse/src/ops/source.rs
@@ -47,7 +47,7 @@ impl EvalOp for PulsedSource {
         false
     }
 
-    fn state(&self, _session: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(SourceState(node_id))))
     }
 }

--- a/tensorflow/src/ops/logic.rs
+++ b/tensorflow/src/ops/logic.rs
@@ -36,11 +36,7 @@ impl EvalOp for Switch {
         true
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
 }
@@ -131,11 +127,7 @@ impl EvalOp for Merge {
         true
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
 }

--- a/test-rt/test-cuda/src/lib.rs
+++ b/test-rt/test-cuda/src/lib.rs
@@ -20,13 +20,13 @@ struct CudaTestTransformState {
 impl State for CudaTestTransformState {
     fn run(&mut self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut state = if self.use_arena {
-            let session_handler = tract_gpu::session_handler::DeviceSessionHandler::from_plan(
+            let turn_handler = tract_gpu::turn_handler::DeviceTurnHandler::from_plan(
                 self.state.plan(),
                 &self.state.turn_state.resolved_symbols,
             )?;
 
-            let plan = Arc::unwrap_or_clone(self.state.plan().clone())
-                .with_session_handler(session_handler);
+            let plan =
+                Arc::unwrap_or_clone(self.state.plan().clone()).with_turn_handler(turn_handler);
             let plan = Arc::new(plan);
             plan.spawn()?
         } else {

--- a/test-rt/test-metal/src/lib.rs
+++ b/test-rt/test-metal/src/lib.rs
@@ -23,13 +23,13 @@ struct MetalTestTransformState {
 impl State for MetalTestTransformState {
     fn run(&mut self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut state = if self.use_arena {
-            let session_handler = tract_gpu::session_handler::DeviceSessionHandler::from_plan(
+            let turn_handler = tract_gpu::turn_handler::DeviceTurnHandler::from_plan(
                 self.state.plan(),
                 &self.state.turn_state.resolved_symbols,
             )?;
 
-            let plan = Arc::unwrap_or_clone(self.state.plan().clone())
-                .with_session_handler(session_handler);
+            let plan =
+                Arc::unwrap_or_clone(self.state.plan().clone()).with_turn_handler(turn_handler);
             Arc::new(plan).spawn()?
         } else {
             self.state.clone()

--- a/transformers/src/lib.rs
+++ b/transformers/src/lib.rs
@@ -85,11 +85,11 @@ pub fn figure_out_causal_llm_b_s_p(
         model.input_fact(kv_input)?.shape.volume().symbols()
     } else {
         // Look for KVCache Op
-        let dummy_session_state = TurnState::default();
+        let dummy_turn = TurnState::default();
         let mut symbols = HashSet::new();
         for node in &model.nodes {
             if let Some((_, fact)) =
-                node.op.state(&dummy_session_state, 0)?.and_then(|state| state.init_tensor_fact())
+                node.op.state(&dummy_turn, 0)?.and_then(|state| state.init_tensor_fact())
             {
                 symbols = fact.shape.volume().symbols();
                 break;

--- a/transformers/src/ops/diag_gather.rs
+++ b/transformers/src/ops/diag_gather.rs
@@ -43,18 +43,18 @@ impl EvalOp for DiagGather {
         true
     }
 
-    fn eval_with_session(
+    fn eval_with_turn(
         &self,
         _node_id: usize,
-        session: &TurnState,
+        turn: &TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
         let rank = input.rank();
         let t = input.shape()[rank - 2];
         let r = input.shape()[rank - 1];
-        let offset = self.offset.eval(&session.resolved_symbols).to_i64()? as isize;
-        let out_len = self.out_len.eval(&session.resolved_symbols).to_usize()?;
+        let offset = self.offset.eval(&turn.resolved_symbols).to_i64()? as isize;
+        let out_len = self.out_len.eval(&turn.resolved_symbols).to_usize()?;
 
         let mut out_shape: TVec<usize> = input.shape().into();
         out_shape[rank - 1] = out_len;

--- a/transformers/src/ops/dyn_kv_cache.rs
+++ b/transformers/src/ops/dyn_kv_cache.rs
@@ -195,11 +195,7 @@ impl EvalOp for DynKeyValueCache {
         false
     }
 
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(DynKeyValueCacheState {
             name: self.name.clone(),
             axis: self.axis,
@@ -463,8 +459,8 @@ mod tests {
             axis,
         };
 
-        let mut session_state = TurnState::default();
-        let mut state = op.state(&session_state, 0)?.unwrap();
+        let mut turn = TurnState::default();
+        let mut state = op.state(&turn, 0)?.unwrap();
 
         let mut inputs = tvec![];
 
@@ -476,15 +472,13 @@ mod tests {
 
         let mut state_initializers = vec![input.into()].into_iter();
 
-        state.load_from(&mut session_state, &mut state_initializers)?;
+        state.load_from(&mut turn, &mut state_initializers)?;
 
         for shape in input_shapes {
             let len = shape.iter().product::<usize>();
             let input = Tensor::from_shape(shape, &(0..len).map(|f| f.as_()).collect::<Vec<F>>())?;
             inputs.push(input.clone().into_tvalue());
-            state.eval(&mut session_state, &op, tvec!(input.clone().into()))?[0]
-                .clone()
-                .into_tensor();
+            state.eval(&mut turn, &op, tvec!(input.clone().into()))?[0].clone().into_tensor();
         }
 
         let mut curr_states = vec![];
@@ -519,8 +513,8 @@ mod tests {
             past_sequence_fact: f32::fact(&past),
             input_sequence_fact: f32::fact(&input),
         };
-        let session = TurnState::default();
-        let state = op.state(&session, 0)?.unwrap();
+        let turn = TurnState::default();
+        let state = op.state(&turn, 0)?.unwrap();
         assert!(state.has_init_tensor_fact());
         assert_eq!(state.has_init_tensor_fact(), state.init_tensor_fact().is_some());
         Ok(())

--- a/transformers/src/ops/inplace_kv_cache.rs
+++ b/transformers/src/ops/inplace_kv_cache.rs
@@ -154,11 +154,7 @@ impl EvalOp for InPlaceKvSdpa {
     fn is_stateless(&self) -> bool {
         false
     }
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(InPlaceKvSdpaState {
             axis: self.axis,
             causal: self.causal,
@@ -595,9 +591,9 @@ mod tests {
     fn drive_fused_vs_baseline(causal: bool) -> TractResult<()> {
         let (bsz, hq, hkv, d) = (1usize, 4usize, 2usize, 16usize); // GQA: 4 q-heads / 2 kv-heads
         let op = InPlaceKvSdpa { axis: 2, causal, scale: None };
-        let session = TurnState::default();
-        let mut state = op.state(&session, 0)?.unwrap();
-        let mut session = session;
+        let turn = TurnState::default();
+        let mut state = op.state(&turn, 0)?.unwrap();
+        let mut turn = turn;
         let flash = FlashSdpaOp { causal, scale: None };
 
         let mut kc: Option<Tensor> = None;
@@ -614,7 +610,7 @@ mod tests {
 
             let o_fused = state
                 .eval(
-                    &mut session,
+                    &mut turn,
                     &op,
                     tvec![q.clone().into(), knew.clone().into(), vnew.clone().into()],
                 )?
@@ -827,14 +823,14 @@ mod tests {
         println!("   T     baseline(ms)  fused(ms)   speedup");
         for &steps in &[256usize, 512, 1024, 2048] {
             let op = InPlaceKvSdpa { axis: 2, causal: false, scale: None };
-            let session = TurnState::default();
-            let mut state = op.state(&session, 0)?.unwrap();
-            let mut session = session;
+            let turn = TurnState::default();
+            let mut state = op.state(&turn, 0)?.unwrap();
+            let mut turn = turn;
             let t_fused = {
                 let start = Instant::now();
                 for _ in 0..steps {
                     std::hint::black_box(state.eval(
-                        &mut session,
+                        &mut turn,
                         &op,
                         tvec![q.clone().into(), knew.clone().into(), vnew.clone().into()],
                     )?);
@@ -898,17 +894,17 @@ mod tests {
     #[test]
     fn resume_via_freeze_unfreeze() -> TractResult<()> {
         let op = InPlaceKvSdpa { axis: 2, causal: true, scale: None };
-        let mut session = TurnState::default();
-        let mut straight = op.state(&session, 0)?.unwrap();
-        let mut split = op.state(&session, 0)?.unwrap();
+        let mut turn = TurnState::default();
+        let mut straight = op.state(&turn, 0)?.unwrap();
+        let mut split = op.state(&turn, 0)?.unwrap();
         for (t, (q, k, v)) in decode_inputs(9).into_iter().enumerate() {
             let ins = tvec![q.into(), k.into(), v.into()];
-            let os = straight.eval(&mut session, &op, ins.clone())?.remove(0).into_tensor();
+            let os = straight.eval(&mut turn, &op, ins.clone())?.remove(0).into_tensor();
             if t == 5 {
                 let frozen = split.freeze();
                 split = frozen.unfreeze();
             }
-            let op2 = split.eval(&mut session, &op, ins)?.remove(0).into_tensor();
+            let op2 = split.eval(&mut turn, &op, ins)?.remove(0).into_tensor();
             os.close_enough(&op2, Approximation::Exact)
                 .with_context(|| format!("freeze/unfreeze resume mismatch at step {t}"))?;
         }
@@ -920,21 +916,21 @@ mod tests {
     #[test]
     fn resume_via_save_load() -> TractResult<()> {
         let op = InPlaceKvSdpa { axis: 2, causal: true, scale: None };
-        let mut session = TurnState::default();
-        let mut straight = op.state(&session, 0)?.unwrap();
-        let mut split = op.state(&session, 0)?.unwrap();
+        let mut turn = TurnState::default();
+        let mut straight = op.state(&turn, 0)?.unwrap();
+        let mut split = op.state(&turn, 0)?.unwrap();
         for (t, (q, k, v)) in decode_inputs(9).into_iter().enumerate() {
             let ins = tvec![q.into(), k.into(), v.into()];
-            let os = straight.eval(&mut session, &op, ins.clone())?.remove(0).into_tensor();
+            let os = straight.eval(&mut turn, &op, ins.clone())?.remove(0).into_tensor();
             if t == 5 {
                 let mut saved = vec![];
                 split.save_to(&mut saved)?;
                 ensure!(saved.len() == 2, "save_to should emit [K, V]");
-                let mut fresh = op.state(&session, 0)?.unwrap();
-                fresh.load_from(&mut session, &mut saved.into_iter())?;
+                let mut fresh = op.state(&turn, 0)?.unwrap();
+                fresh.load_from(&mut turn, &mut saved.into_iter())?;
                 split = fresh;
             }
-            let op2 = split.eval(&mut session, &op, ins)?.remove(0).into_tensor();
+            let op2 = split.eval(&mut turn, &op, ins)?.remove(0).into_tensor();
             os.close_enough(&op2, Approximation::Exact)
                 .with_context(|| format!("save/load resume mismatch at step {t}"))?;
         }
@@ -949,14 +945,14 @@ mod tests {
         use std::time::Instant;
         let (b, hq, hkv, d) = (1usize, 8usize, 8usize, 128usize);
         let op = InPlaceKvSdpa { axis: 2, causal: false, scale: None };
-        let session = TurnState::default();
+        let turn = TurnState::default();
         let q = seq_tensor(&[b, hq, 1, d], 7.0);
         let kv = seq_tensor(&[b, hkv, 1, d], 1.0);
         println!("\n  resume checkpoint (save_to) — one-time O(len):");
         println!("   len    save_to(ms)");
         for &len in &[256usize, 1024, 4096] {
             let mut sess = TurnState::default();
-            let mut state = op.state(&session, 0)?.unwrap();
+            let mut state = op.state(&turn, 0)?.unwrap();
             for _ in 0..len {
                 state.eval(
                     &mut sess,

--- a/transformers/src/ops/kv_quant.rs
+++ b/transformers/src/ops/kv_quant.rs
@@ -263,11 +263,7 @@ impl EvalOp for QuantizedKvSdpa {
     fn is_stateless(&self) -> bool {
         false
     }
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(QuantizedKvSdpaState {
             scale: self.scale,
             k_caches: Vec::new(),

--- a/transformers/src/ops/quant_dyn_kv_cache.rs
+++ b/transformers/src/ops/quant_dyn_kv_cache.rs
@@ -310,11 +310,7 @@ impl EvalOp for QuantizedDynKeyValueCache {
     fn is_stateless(&self) -> bool {
         false
     }
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(QuantizedDynKvCacheState {
             name: self.name.clone(),
             axis: self.axis,

--- a/transformers/src/ops/window_kv_cache.rs
+++ b/transformers/src/ops/window_kv_cache.rs
@@ -179,11 +179,7 @@ impl EvalOp for WindowKvSdpa {
     fn is_stateless(&self) -> bool {
         false
     }
-    fn state(
-        &self,
-        _session: &TurnState,
-        _node_id: usize,
-    ) -> TractResult<Option<Box<dyn OpState>>> {
+    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(WindowKvSdpaState {
             window: self.window,
             scale: self.scale,


### PR DESCRIPTION
TurnState's parameters and helpers kept the older `session` name, which now denotes the scope a state covers across many turns, while SessionStateHandler in fact fires once per plan eval. Rename the handler, its parameters, eval_with_session and DeviceSessionHandler accordingly, leaving OptimizerSession and the symbol proof-cache session alone, and record the vocabulary in doc/lexicon.md.