### PR TITLE
core, cuda: keep only session state in op_states

### DIFF
--- a/core/src/model/typed.rs
+++ b/core/src/model/typed.rs
@@ -82,7 +82,8 @@ impl SpecialOps<TypedFact, Box<dyn TypedOp>> for TypedModel {
                             .map(|t| t.into_tvalue())
                     })
                     .collect::<Option<TVec<_>>>()
-                && let Ok(outputs) = op.eval_with_turn(usize::MAX, &TurnState::default(), tensors)
+                && let Ok(outputs) =
+                    op.eval_with_turn(usize::MAX, &mut TurnState::default(), tensors)
             {
                 return outputs
                     .into_iter()
@@ -286,7 +287,7 @@ impl TypedModel {
             {
                 let inputs_ref =
                     inputs.iter().map(|f| f.konst.clone().unwrap().into_tvalue()).collect();
-                match node.op.eval_with_turn(node.id, &TurnState::default(), inputs_ref) {
+                match node.op.eval_with_turn(node.id, &mut TurnState::default(), inputs_ref) {
                     Ok(res) => {
                         drop(inputs);
                         drop(outputs);

--- a/core/src/ops/array/broadcast.rs
+++ b/core/src/ops/array/broadcast.rs
@@ -25,7 +25,7 @@ impl EvalOp for MultiBroadcastTo {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let shape = self.shape.eval_to_usize(&turn.resolved_symbols)?;

--- a/core/src/ops/array/dyn_slice.rs
+++ b/core/src/ops/array/dyn_slice.rs
@@ -32,7 +32,7 @@ impl EvalOp for DynSlice {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let start = inputs[1]

--- a/core/src/ops/array/range.rs
+++ b/core/src/ops/array/range.rs
@@ -27,7 +27,7 @@ impl EvalOp for Range {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (start, end, step) = args_3!(inputs);

--- a/core/src/ops/array/slice.rs
+++ b/core/src/ops/array/slice.rs
@@ -62,7 +62,7 @@ impl EvalOp for Slice {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/array/tile.rs
+++ b/core/src/ops/array/tile.rs
@@ -28,7 +28,7 @@ impl EvalOp for Tile {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let multipliers: TVec<usize> = self
@@ -123,7 +123,7 @@ impl EvalOp for DynTile {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let multipliers = inputs[1].cast_to::<TDim>()?;

--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -145,7 +145,7 @@ impl EvalOp for TypedBinOp {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         if let Some(result) = self.0.eval_symbolic(turn, inputs.clone())? {

--- a/core/src/ops/cast.rs
+++ b/core/src/ops/cast.rs
@@ -47,7 +47,7 @@ impl EvalOp for Cast {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        state: &TurnState,
+        state: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -654,7 +654,7 @@ impl EvalOp for AxisOp {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let mut input = args_1!(inputs).into_tensor();

--- a/core/src/ops/cnn/conv/q_sum_b.rs
+++ b/core/src/ops/cnn/conv/q_sum_b.rs
@@ -31,7 +31,7 @@ impl EvalOp for QSumB {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let n = self.n.eval_to_i64(&turn.resolved_symbols)? as usize;

--- a/core/src/ops/cnn/deconv/deconv_sum.rs
+++ b/core/src/ops/cnn/deconv/deconv_sum.rs
@@ -45,7 +45,7 @@ impl EvalOp for DeconvSum {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         self.eval_with_values(inputs, &turn.resolved_symbols)
@@ -544,7 +544,7 @@ impl EvalOp for DepthwiseDeconv {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (kernel, input, bias) = args_3!(inputs);

--- a/core/src/ops/einsum/einsum_matmul.rs
+++ b/core/src/ops/einsum/einsum_matmul.rs
@@ -531,7 +531,7 @@ impl EvalOp for EinSumMatMul {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         self.op.eval_with_turn(node_id, turn, inputs)

--- a/core/src/ops/matmul/optimized.rs
+++ b/core/src/ops/matmul/optimized.rs
@@ -423,45 +423,38 @@ impl Op for OptMatMul {
 /// micro-op's `Store` [`OutputStore`] layout (strides fixed for the output
 /// shape), so only the base pointer is refreshed per call. Constant operands
 /// are baked into the op at `fuse()`, so they need no per-call state here. Pure
-/// memoization: built lazily on first eval and reused for this node.
-/// Key for the reusable mmm scratch buffer in [`TurnState::scratch`]. Shared by
-/// every `OptMatMul` in the plan: only one op evaluates at a time, and the buffer
-/// is reallocated whenever the picked kernel cannot use the one already there.
-struct MmmScratch(Box<dyn tract_linalg::mmm::ScratchSpace>);
-
-#[derive(Clone, Debug, Default)]
-pub struct OptMatMulState {
-    trivial_stores: Option<TVec<Option<OutputStore>>>,
+/// Every `OptMatMul` in a plan shares one entry in [`TurnState::scratch`]. `space`
+/// is one reusable kernel scratch buffer -- only one op evaluates at a time, and
+/// it is reallocated whenever the picked kernel cannot use the one already there.
+/// `stores` memoizes the output-store descriptors of the trivial path per node,
+/// since those depend on that node's micro-ops.
+#[derive(Default)]
+struct MmmScratch {
+    space: Option<Box<dyn tract_linalg::mmm::ScratchSpace>>,
+    stores: HashMap<usize, TVec<Option<OutputStore>>>,
 }
 
 impl EvalOp for OptMatMul {
     fn is_stateless(&self) -> bool {
-        false
+        true
     }
 
-    fn state(&self, _turn: &TurnState, _node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        Ok(Some(Box::<OptMatMulState>::default()))
-    }
-}
-
-impl OpState for OptMatMulState {
-    fn eval(
-        &mut self,
+    fn eval_with_turn(
+        &self,
+        node_id: usize,
         turn: &mut TurnState,
-        op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        let op = op.downcast_ref::<OptMatMul>().context("OptMatMulState on non-OptMatMul op")?;
-        op.eval_with_state(turn, inputs, self)
+        self.eval_with_scratch(node_id, turn, inputs)
     }
 }
 
 impl OptMatMul {
-    fn eval_with_state(
+    fn eval_with_scratch(
         &self,
+        node_id: usize,
         turn: &mut TurnState,
         inputs: TVec<TValue>,
-        state: &mut OptMatMulState,
     ) -> TractResult<TVec<TValue>> {
         unsafe {
             let c_shape = self.c_fact.shape.eval_to_usize(&turn.resolved_symbols)?;
@@ -470,16 +463,13 @@ impl OptMatMul {
             let n = self.c_n_axis.map(|c_n| c.shape()[c_n]).unwrap_or(1);
             let mode = self.mode_picker.pick(n)?;
             let mmm = &*self.mmm[mode];
-            let slot = turn
-                .scratch
-                .entry::<MmmScratch>()
-                .or_insert_with(|| MmmScratch(mmm.allocate_scratch_space()));
-            if !mmm.can_use_scratch_space(&*slot.0) {
-                *slot = MmmScratch(mmm.allocate_scratch_space());
+            let MmmScratch { space, stores } = turn.scratch.entry::<MmmScratch>().or_default();
+            if !space.as_ref().is_some_and(|s| mmm.can_use_scratch_space(&**s)) {
+                *space = Some(mmm.allocate_scratch_space());
             }
-            let scratch = &mut slot.0;
+            let scratch = space.as_mut().unwrap();
             if self.trivial_path {
-                let stores = state.trivial_stores.get_or_insert_with(|| {
+                let stores = stores.entry(node_id).or_insert_with(|| {
                     self.micro_ops
                         .iter()
                         .map(|o| match o {

--- a/core/src/ops/matmul/pack.rs
+++ b/core/src/ops/matmul/pack.rs
@@ -36,7 +36,7 @@ impl EvalOp for OptMatMulPack {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         mut inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         self.do_eval(turn, inputs.remove(0))

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -138,7 +138,7 @@ pub trait EvalOp {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         self.eval(inputs).context("Running legacy eval")

--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -61,7 +61,7 @@ impl super::TypedPass for PropConst {
                     .iter()
                     .map(|f| f.mem_size().as_i64().unwrap_or(i64::MAX) as u64)
                     .sum();
-                match node.op.eval_with_turn(node.id, &TurnState::default(), inputs) {
+                match node.op.eval_with_turn(node.id, &mut TurnState::default(), inputs) {
                     Ok(mut res) => {
                         self.0 = node.id;
                         let output_mem: u64 = res
@@ -79,9 +79,11 @@ impl super::TypedPass for PropConst {
                             if succ.inputs.len() > 1 || !succ.op.is_stateless() {
                                 break;
                             }
-                            let Ok(succ_res) =
-                                succ.op.eval_with_turn(node.id, &TurnState::default(), res.clone())
-                            else {
+                            let Ok(succ_res) = succ.op.eval_with_turn(
+                                node.id,
+                                &mut TurnState::default(),
+                                res.clone(),
+                            ) else {
                                 break;
                             };
                             let succ_mem: u64 = succ_res

--- a/cuda/src/kernels/array/diag_gather.rs
+++ b/cuda/src/kernels/array/diag_gather.rs
@@ -155,8 +155,8 @@ mod tests {
             // TDims against the turn's resolved_symbols); pass an empty
             // TurnState since the TDims here are already concrete.
             let cpu_op = cpu_dg::DiagGather { offset: offset.to_dim(), out_len: out_len.to_dim() };
-            let turn = TurnState::default();
-            let cpu_out = cpu_op.eval_with_turn(0, &turn, tvec![cpu_in.into_tvalue()])?[0]
+            let mut turn = TurnState::default();
+            let cpu_out = cpu_op.eval_with_turn(0, &mut turn, tvec![cpu_in.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_out = DiagGather.eval(stream, &cuda_in, offset, out_len)?;

--- a/cuda/src/ops/conv.rs
+++ b/cuda/src/ops/conv.rs
@@ -80,16 +80,6 @@ impl Op for CudaConv {
     op_as_typed_op!();
 }
 
-impl EvalOp for CudaConv {
-    fn is_stateless(&self) -> bool {
-        false
-    }
-
-    fn state(&self, _turn: &TurnState, node_id: usize) -> TractResult<Option<Box<dyn OpState>>> {
-        Ok(Some(Box::new(CudaConvState::new(node_id))))
-    }
-}
-
 impl TypedOp for CudaConv {
     as_op!();
 
@@ -106,7 +96,10 @@ impl TypedOp for CudaConv {
     }
 }
 
-// OpState should be Send; cudnn descriptors aren't, so they live here instead of in CudaConvState.
+// cudnn descriptors are not Send, so they cannot live in TurnState::scratch. They
+// stay in a thread-local keyed by an id, and TurnState::scratch holds only the
+// node -> id map, which is Send. Dropping the map -- i.e. dropping the state that
+// owns it -- evicts that plan's descriptors from the cache.
 thread_local! {
     static CUDA_CONV_SCRATCH: RefCell<HashMap<usize, Box<dyn ConvKernelScratch>>> =
         RefCell::new(HashMap::new());
@@ -114,47 +107,46 @@ thread_local! {
 
 static NEXT_CUDA_CONV_SCRATCH_ID: AtomicUsize = AtomicUsize::new(0);
 
-#[derive(Debug)]
-struct CudaConvState {
-    node_id: usize,
-    scratch_id: usize,
-}
+#[derive(Debug, Default)]
+struct CudaConvScratchIds(HashMap<usize, usize>);
 
-impl CudaConvState {
-    fn new(node_id: usize) -> Self {
-        let scratch_id = NEXT_CUDA_CONV_SCRATCH_ID.fetch_add(1, Ordering::Relaxed);
-        CudaConvState { node_id, scratch_id }
+impl CudaConvScratchIds {
+    fn id_for(&mut self, node_id: usize) -> usize {
+        *self
+            .0
+            .entry(node_id)
+            .or_insert_with(|| NEXT_CUDA_CONV_SCRATCH_ID.fetch_add(1, Ordering::Relaxed))
     }
 }
 
-impl Clone for CudaConvState {
-    fn clone(&self) -> Self {
-        CudaConvState::new(self.node_id)
-    }
-}
-
-impl Drop for CudaConvState {
+impl Drop for CudaConvScratchIds {
     fn drop(&mut self) {
         CUDA_CONV_SCRATCH.with_borrow_mut(|cache| {
-            cache.remove(&self.scratch_id);
+            for id in self.0.values() {
+                cache.remove(id);
+            }
         });
     }
 }
 
-impl OpState for CudaConvState {
-    fn eval(
-        &mut self,
+impl EvalOp for CudaConv {
+    fn is_stateless(&self) -> bool {
+        true
+    }
+
+    fn eval_with_turn(
+        &self,
+        node_id: usize,
         turn: &mut TurnState,
-        op: &dyn Op,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
-        let op: &CudaConv = op.downcast_ref().context("Wrong op")?;
         let inputs =
             inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
-        let output_shape = op.op.pool_spec.output_shape(inputs[0].shape())?;
+        let output_shape = self.op.pool_spec.output_shape(inputs[0].shape())?;
+        let scratch_id = turn.scratch.entry::<CudaConvScratchIds>().or_default().id_for(node_id);
         let output = tract_gpu::turn_handler::make_tensor_for_node(
             turn,
-            self.node_id,
+            node_id,
             inputs[0].datum_type(),
             &output_shape.shape,
         )?;
@@ -162,11 +154,11 @@ impl OpState for CudaConvState {
         if output.len() > 0 {
             crate::with_cuda_stream(|stream| {
                 CUDA_CONV_SCRATCH.with_borrow_mut(|cache| {
-                    let scratch = cache.entry(self.scratch_id).or_insert_with(|| op.kernel.state());
-                    op.kernel.dispatch(
+                    let scratch = cache.entry(scratch_id).or_insert_with(|| self.kernel.state());
+                    self.kernel.dispatch(
                         &mut **scratch,
-                        self.node_id,
-                        &op.op,
+                        node_id,
+                        &self.op,
                         stream,
                         inputs[0],
                         inputs[1],

--- a/cuda/src/ops/flash_attn.rs
+++ b/cuda/src/ops/flash_attn.rs
@@ -26,7 +26,7 @@ impl EvalOp for CudaFlashAttention {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         crate::with_cuda_stream(|stream| {

--- a/cuda/src/ops/fused_axis_op.rs
+++ b/cuda/src/ops/fused_axis_op.rs
@@ -151,7 +151,7 @@ impl EvalOp for CudaFusedAxisOp {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, turn)?;

--- a/cuda/src/ops/gemm.rs
+++ b/cuda/src/ops/gemm.rs
@@ -58,7 +58,7 @@ impl EvalOp for CudaGgmlGemm {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (act_raw, weights_raw) = args_2!(inputs);

--- a/cuda/src/ops/iff.rs
+++ b/cuda/src/ops/iff.rs
@@ -22,7 +22,7 @@ impl EvalOp for CudaIff {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (cond_val, then_val, else_val) = args_3!(inputs);

--- a/cuda/src/ops/quant_q81.rs
+++ b/cuda/src/ops/quant_q81.rs
@@ -66,7 +66,7 @@ impl EvalOp for CudaGgmlQuantQ81 {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         crate::with_cuda_stream(|stream| {

--- a/gpu/src/ops/apply_rope.rs
+++ b/gpu/src/ops/apply_rope.rs
@@ -45,7 +45,7 @@ impl EvalOp for GpuApplyRope {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (input_val, cos_val, sin_val) = args_3!(inputs);

--- a/gpu/src/ops/binary.rs
+++ b/gpu/src/ops/binary.rs
@@ -68,7 +68,7 @@ impl EvalOp for GpuBinOp {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (a_val, b_val) = args_2!(inputs);

--- a/gpu/src/ops/broadcast.rs
+++ b/gpu/src/ops/broadcast.rs
@@ -29,7 +29,7 @@ impl EvalOp for GpuMultiBroadcastTo {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/cast.rs
+++ b/gpu/src/ops/cast.rs
@@ -65,7 +65,7 @@ impl EvalOp for GpuCast {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/causal_conv1d_update.rs
+++ b/gpu/src/ops/causal_conv1d_update.rs
@@ -43,7 +43,7 @@ impl EvalOp for GpuCausalConv1dUpdate {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (input, weight, state) = args_3!(inputs);

--- a/gpu/src/ops/change_axes.rs
+++ b/gpu/src/ops/change_axes.rs
@@ -78,7 +78,7 @@ impl EvalOp for GpuAxisOp {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let tensor = args_1!(inputs).into_tensor();

--- a/gpu/src/ops/concat.rs
+++ b/gpu/src/ops/concat.rs
@@ -42,7 +42,7 @@ impl EvalOp for GpuConcat {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let inputs =

--- a/gpu/src/ops/diag_gather.rs
+++ b/gpu/src/ops/diag_gather.rs
@@ -60,7 +60,7 @@ impl EvalOp for GpuDiagGather {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_val = args_1!(inputs);

--- a/gpu/src/ops/element_wise.rs
+++ b/gpu/src/ops/element_wise.rs
@@ -50,7 +50,7 @@ impl EvalOp for GpuElementWise {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/gather.rs
+++ b/gpu/src/ops/gather.rs
@@ -60,7 +60,7 @@ impl EvalOp for GpuGather {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (data_val, indices_val) = args_2!(inputs);

--- a/gpu/src/ops/gdn_recurrent.rs
+++ b/gpu/src/ops/gdn_recurrent.rs
@@ -46,7 +46,7 @@ impl EvalOp for GpuGatedDeltaNetRecurrent {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 6);

--- a/gpu/src/ops/gelu_approximate.rs
+++ b/gpu/src/ops/gelu_approximate.rs
@@ -48,7 +48,7 @@ impl EvalOp for GpuGeluApproximate {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/iff.rs
+++ b/gpu/src/ops/iff.rs
@@ -62,7 +62,7 @@ impl EvalOp for GpuIff {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (cond_val, then_val, else_val) = args_3!(inputs);

--- a/gpu/src/ops/leaky_relu.rs
+++ b/gpu/src/ops/leaky_relu.rs
@@ -48,7 +48,7 @@ impl EvalOp for GpuLeakyRelu {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/pad.rs
+++ b/gpu/src/ops/pad.rs
@@ -39,7 +39,7 @@ impl EvalOp for GpuPad {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/pulse.rs
+++ b/gpu/src/ops/pulse.rs
@@ -410,7 +410,7 @@ impl EvalOp for GpuAffineChunkTrim {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/reduce.rs
+++ b/gpu/src/ops/reduce.rs
@@ -122,7 +122,7 @@ impl EvalOp for GpuReduce {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/resize.rs
+++ b/gpu/src/ops/resize.rs
@@ -71,7 +71,7 @@ impl EvalOp for GpuResize {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let data = inputs[0].to_device_tensor()?;

--- a/gpu/src/ops/rms_norm.rs
+++ b/gpu/src/ops/rms_norm.rs
@@ -55,7 +55,7 @@ impl EvalOp for GpuRmsNorm {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/rotate_half.rs
+++ b/gpu/src/ops/rotate_half.rs
@@ -46,7 +46,7 @@ impl EvalOp for GpuRotateHalf {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/scaled_masked_softmax.rs
+++ b/gpu/src/ops/scaled_masked_softmax.rs
@@ -63,7 +63,7 @@ impl EvalOp for GpuScaledMaskedSoftmax {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (input_val, mask_val) = args_2!(inputs);

--- a/gpu/src/ops/slice.rs
+++ b/gpu/src/ops/slice.rs
@@ -34,7 +34,7 @@ impl EvalOp for GpuSlice {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/softmax.rs
+++ b/gpu/src/ops/softmax.rs
@@ -78,7 +78,7 @@ impl EvalOp for GpuSoftmax {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/stft.rs
+++ b/gpu/src/ops/stft.rs
@@ -86,7 +86,7 @@ impl EvalOp for GpuStft {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;
@@ -177,7 +177,7 @@ impl EvalOp for GpuFft {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;

--- a/metal/src/kernels/array/diag_gather.rs
+++ b/metal/src/kernels/array/diag_gather.rs
@@ -149,8 +149,8 @@ mod tests {
             let metal_in = cpu_in.clone().into_device()?;
 
             let cpu_op = cpu_dg::DiagGather { offset: offset.to_dim(), out_len: out_len.to_dim() };
-            let turn = TurnState::default();
-            let cpu_out = cpu_op.eval_with_turn(0, &turn, tvec![cpu_in.into_tvalue()])?[0]
+            let mut turn = TurnState::default();
+            let cpu_out = cpu_op.eval_with_turn(0, &mut turn, tvec![cpu_in.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_out = DiagGather.eval(stream, &metal_in, offset, out_len)?;

--- a/metal/src/kernels/matmul/mfa/mod.rs
+++ b/metal/src/kernels/matmul/mfa/mod.rs
@@ -491,7 +491,7 @@ impl EvalOp for MetalMfaSdpa {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         use tract_gpu::tensor::{DeviceTensorExt, IntoDevice};

--- a/metal/src/kernels/matmul/mlx_sdpa/mod.rs
+++ b/metal/src/kernels/matmul/mlx_sdpa/mod.rs
@@ -470,7 +470,7 @@ impl EvalOp for MetalMlxSdpa {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         use tract_gpu::tensor::DeviceTensorExt;

--- a/metal/src/ops/conv.rs
+++ b/metal/src/ops/conv.rs
@@ -64,7 +64,7 @@ impl EvalOp for MetalConv {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let inputs =

--- a/metal/src/ops/fused_axis_op.rs
+++ b/metal/src/ops/fused_axis_op.rs
@@ -150,7 +150,7 @@ impl EvalOp for MetalFusedAxisOp {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, turn)?;

--- a/metal/src/ops/gemm.rs
+++ b/metal/src/ops/gemm.rs
@@ -74,7 +74,7 @@ impl<K: GemmKernel + 'static> EvalOp for MetalGemm<K> {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let (a_raw, b_raw) = args_2!(inputs);

--- a/metal/src/ops/pool.rs
+++ b/metal/src/ops/pool.rs
@@ -51,7 +51,7 @@ impl EvalOp for MetalPool {
     fn eval_with_turn(
         &self,
         node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;

--- a/onnx/src/ops/cast.rs
+++ b/onnx/src/ops/cast.rs
@@ -51,7 +51,11 @@ impl ElementWiseMiniOp for Cast {
             }
         } else {
             tract_hir::ops::cast::cast(self.to)
-                .eval_with_turn(usize::MAX, &TurnState::default(), tvec!(t.clone().into_tvalue()))
+                .eval_with_turn(
+                    usize::MAX,
+                    &mut TurnState::default(),
+                    tvec!(t.clone().into_tvalue()),
+                )
                 .map(|mut t| t.remove(0).into_tensor())
         }
     }

--- a/transformers/src/ops/diag_gather.rs
+++ b/transformers/src/ops/diag_gather.rs
@@ -46,7 +46,7 @@ impl EvalOp for DiagGather {
     fn eval_with_turn(
         &self,
         _node_id: usize,
-        turn: &TurnState,
+        turn: &mut TurnState,
         inputs: TVec<TValue>,
     ) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);


### PR DESCRIPTION
OptMatMul and CudaConv had op states carrying nothing but scratch -- a memoized output-store descriptor and an id into a thread-local cudnn cache -- so workspace sat in the container meant for state that survives from turn to turn. Both ops become stateless and keep their scratch in TurnState::scratch: the matmul stores keyed by node, and for cudnn, whose descriptors are not Send, only the node-to-id map, whose Drop evicts that plan's descriptors. EvalOp::eval_with_turn takes a &mut TurnState so a stateless op can reach its own scratch.