### PR TITLE
ci: move the riscv64 musl cross toolchain to Bootlin

### DIFF
--- a/.travis/cross.sh
+++ b/.travis/cross.sh
@@ -210,9 +210,12 @@ case "$PLATFORM" in
                 export ARCH=riscv64
                 export QEMU_ARCH=riscv64
                 export RUSTC_TRIPLE=riscv64gc-unknown-linux-musl
-                export CUSTOM_TC=`pwd`/riscv64-linux-musl-cross
-                [ -d "$CUSTOM_TC" ] || curl -s https://tract-test-assets.tract.rs/toolchains/riscv64-linux-musl-cross.tgz | tar zx
-                export TARGET_CC=$CUSTOM_TC/bin/riscv64-linux-musl-gcc
+                # Bootlin rather than musl.cc: the linalg RVV kernels need an assembler that
+                # knows the ratified RVV 1.0 encodings, which arrived in binutils 2.38, and
+                # musl-cross-make has cut no release since 2021 and is stuck on 2.37.
+                export CUSTOM_TC=`pwd`/riscv64-lp64d--musl--stable-2025.08-1
+                [ -d "$CUSTOM_TC" ] || curl -s https://tract-test-assets.tract.rs/toolchains/riscv64-lp64d--musl--stable-2025.08-1.tar.xz | tar Jx
+                export TARGET_CC=$CUSTOM_TC/bin/riscv64-buildroot-linux-musl-gcc
                 # riscv64 musl defaults to dynamic linking (unlike the aarch64/armv7 musl
                 # targets here); force a static binary so it runs on the glibc boards, which
                 # have no musl loader.


### PR DESCRIPTION
The musl.cc toolchain the riscv64 board CLI is built with ships binutils 2.37, which predates the ratified RVV 1.0 encodings that arrived in 2.38, so vector assembly cannot be assembled at all and a riscv64 build is stuck on the generic kernels whatever linalg offers. Switch to Bootlin's riscv64-lp64d musl SDK (binutils 2.43.1, gcc 14.3.0), mirrored under the same asset host.