### PR TITLE
core: name the predicate for what it gates rather than for purity

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -137,7 +137,7 @@ pub mod internal {
     };
     pub use tvec;
     pub use {args_1, args_2, args_3, args_4, args_5, args_6, args_7, args_8};
-    pub use {as_op, not_a_typed_op, op_as_typed_op};
+    pub use {as_op, not_a_typed_op, not_out_of_plan, op_as_typed_op, op_out_of_plan};
     pub use {bin_to_super_type, element_wise, element_wise_oop};
     pub use {rule_if, rule_if_let, rule_if_some};
 }

--- a/core/src/model/typed.rs
+++ b/core/src/model/typed.rs
@@ -70,8 +70,7 @@ impl SpecialOps<TypedFact, Box<dyn TypedOp>> for TypedModel {
                 o.consistent()?;
             }
 
-            if op.is_pure_function()
-                && input_facts.len() > 0
+            if input_facts.len() > 0
                 && let Some(tensors) = input_facts
                     .iter()
                     .map(|f| {
@@ -82,7 +81,7 @@ impl SpecialOps<TypedFact, Box<dyn TypedOp>> for TypedModel {
                             .map(|t| t.into_tvalue())
                     })
                     .collect::<Option<TVec<_>>>()
-                && let Ok(outputs) = op.eval(&EvalContext::pure(), tensors)
+                && let Ok(Some(outputs)) = op.eval_out_of_plan(tensors)
             {
                 return outputs
                     .into_iter()
@@ -280,14 +279,14 @@ impl TypedModel {
         for n in self.eval_order()? {
             let node = self.node(n);
             let (inputs, outputs) = self.node_facts(n)?;
-            if node.op.is_pure_function()
-                && inputs.iter().all(|i| i.konst.as_ref().is_some_and(|k| k.is_plain()))
+            if inputs.iter().all(|i| i.konst.as_ref().is_some_and(|k| k.is_plain()))
                 && outputs.iter().any(|o| o.konst.is_none())
             {
                 let inputs_ref =
                     inputs.iter().map(|f| f.konst.clone().unwrap().into_tvalue()).collect();
-                match node.op.eval(&EvalContext::pure(), inputs_ref) {
-                    Ok(res) => {
+                match node.op.eval_out_of_plan(inputs_ref) {
+                    Ok(None) => (),
+                    Ok(Some(res)) => {
                         drop(inputs);
                         drop(outputs);
                         for (ix, output) in res.into_iter().enumerate() {

--- a/core/src/ops/array/broadcast.rs
+++ b/core/src/ops/array/broadcast.rs
@@ -18,9 +18,7 @@ impl Op for MultiBroadcastTo {
 }
 
 impl EvalOp for MultiBroadcastTo {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let shape = self.shape.eval_to_usize(ctx.symbols)?;

--- a/core/src/ops/array/concat.rs
+++ b/core/src/ops/array/concat.rs
@@ -147,9 +147,7 @@ impl TypedOp for TypedConcat {
 }
 
 impl EvalOp for TypedConcat {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let result = Tensor::stack_tensors(self.axis, &inputs)?;

--- a/core/src/ops/array/dyn_slice.rs
+++ b/core/src/ops/array/dyn_slice.rs
@@ -25,9 +25,7 @@ impl Op for DynSlice {
 }
 
 impl EvalOp for DynSlice {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let start = inputs[1]

--- a/core/src/ops/array/gather.rs
+++ b/core/src/ops/array/gather.rs
@@ -322,9 +322,7 @@ impl TypedOp for Gather {
 }
 
 impl EvalOp for Gather {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (data, indices) = args_2!(inputs);
@@ -357,7 +355,10 @@ mod tests {
         for idx in 2..3 {
             let index = Tensor::from(arr0(idx));
             let outputs = gatherer
-                .eval(&EvalContext::pure(), tvec![data.clone().into_tvalue(), index.into_tvalue()])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![data.clone().into_tvalue(), index.into_tvalue()],
+                )
                 .unwrap();
             let output = &outputs[0];
             assert_eq!(output.shape().len(), 0);

--- a/core/src/ops/array/gather_elements.rs
+++ b/core/src/ops/array/gather_elements.rs
@@ -114,9 +114,7 @@ impl TypedOp for GatherElements {
 }
 
 impl EvalOp for GatherElements {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (data, indices) = args_2!(inputs);
@@ -142,7 +140,7 @@ mod tests {
         let data = Tensor::from_shape(data_shape, &(0..len).map(|i| i as f32).collect::<Vec<_>>())?;
         let indices = Tensor::from_shape(&[1, indices.len()], indices)?;
         let mut outputs = GatherElements::new(data_shape.len() - 1)
-            .eval(&EvalContext::pure(), tvec!(data.into_tvalue(), indices.into_tvalue()))?;
+            .eval(&EvalContext::out_of_plan(), tvec!(data.into_tvalue(), indices.into_tvalue()))?;
         Ok(outputs.remove(0))
     }
 

--- a/core/src/ops/array/gather_nd.rs
+++ b/core/src/ops/array/gather_nd.rs
@@ -90,9 +90,7 @@ impl Op for GatherNd {
 }
 
 impl EvalOp for GatherNd {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (data, indices) = args_2!(inputs);

--- a/core/src/ops/array/one_hot.rs
+++ b/core/src/ops/array/one_hot.rs
@@ -48,9 +48,7 @@ impl TypedOp for OneHot {
 }
 
 impl EvalOp for OneHot {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/array/pad.rs
+++ b/core/src/ops/array/pad.rs
@@ -97,9 +97,7 @@ impl Op for Pad {
 }
 
 impl EvalOp for Pad {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/array/range.rs
+++ b/core/src/ops/array/range.rs
@@ -20,9 +20,7 @@ impl Op for Range {
 }
 
 impl EvalOp for Range {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (start, end, step) = args_3!(inputs);

--- a/core/src/ops/array/reshape.rs
+++ b/core/src/ops/array/reshape.rs
@@ -19,9 +19,7 @@ impl Op for FiniteReshape {
 }
 
 impl EvalOp for FiniteReshape {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/array/scatter_elements.rs
+++ b/core/src/ops/array/scatter_elements.rs
@@ -83,9 +83,7 @@ impl TypedOp for ScatterElements {
 }
 
 impl EvalOp for ScatterElements {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (data, indices, updates) = args_3!(inputs);

--- a/core/src/ops/array/scatter_nd.rs
+++ b/core/src/ops/array/scatter_nd.rs
@@ -224,9 +224,7 @@ impl TypedOp for ScatterNd {
 }
 
 impl EvalOp for ScatterNd {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (data, indices, updates) = args_3!(inputs);

--- a/core/src/ops/array/slice.rs
+++ b/core/src/ops/array/slice.rs
@@ -55,9 +55,7 @@ impl Op for Slice {
 }
 
 impl EvalOp for Slice {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/array/strided_slice.rs
+++ b/core/src/ops/array/strided_slice.rs
@@ -270,9 +270,7 @@ impl Op for StridedSlice {
 }
 
 impl EvalOp for StridedSlice {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut model = TypedModel::default();
@@ -352,7 +350,7 @@ mod tests {
         if let Some(stride) = stride {
             inputs.push(tensor1(&[stride as i32]).into());
         }
-        op.eval_pure(inputs).unwrap().remove(0)
+        op.eval(&EvalContext::out_of_plan(), inputs).unwrap().remove(0)
     }
 
     #[test]

--- a/core/src/ops/array/tile.rs
+++ b/core/src/ops/array/tile.rs
@@ -21,9 +21,7 @@ impl Op for Tile {
 }
 
 impl EvalOp for Tile {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let multipliers: TVec<usize> = self
@@ -111,9 +109,7 @@ impl Op for DynTile {
 }
 
 impl EvalOp for DynTile {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let multipliers = inputs[1].cast_to::<TDim>()?;

--- a/core/src/ops/array/topk.rs
+++ b/core/src/ops/array/topk.rs
@@ -21,9 +21,7 @@ impl Op for Topk {
 }
 
 impl EvalOp for Topk {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, k) = args_2!(inputs);

--- a/core/src/ops/array/trilu.rs
+++ b/core/src/ops/array/trilu.rs
@@ -14,9 +14,7 @@ impl Op for Trilu {
 }
 
 impl EvalOp for Trilu {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, k) = args_2!(inputs);

--- a/core/src/ops/binary.rs
+++ b/core/src/ops/binary.rs
@@ -138,9 +138,7 @@ impl TypedBinOp {
 }
 
 impl EvalOp for TypedBinOp {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         if let Some(result) = self.0.eval_symbolic(ctx, inputs.clone())? {
@@ -715,9 +713,7 @@ impl Op for OptBinByScalar {
 }
 
 impl EvalOp for OptBinByScalar {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (a, b) = args_2!(inputs);
@@ -855,9 +851,7 @@ impl Op for OptBinUnicast {
 }
 
 impl EvalOp for OptBinUnicast {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (a, b) = args_2!(inputs);
@@ -1317,7 +1311,8 @@ mod tests {
             .expect("f32 unicast Add kernel available");
         let op = OptBinUnicast { binop: Box::new(Add), eval_fn: Arc::from(linalg_fn) };
 
-        let out = op.eval(&EvalContext::pure(), tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
+        let out =
+            op.eval(&EvalContext::out_of_plan(), tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
         let out = &out[0];
         assert_eq!(out.shape(), &[1, 1, 640]);
         let plain = out.try_as_plain().unwrap();
@@ -1344,7 +1339,8 @@ mod tests {
             eval_fn: Arc::from(linalg_fn),
             linalg_op: BinOp::Add,
         };
-        let out = op.eval(&EvalContext::pure(), tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
+        let out =
+            op.eval(&EvalContext::out_of_plan(), tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
         assert_eq!(out[0].shape(), &[0, 4, 8]);
 
         let a = Tensor::zero::<f32>(&[0, 4, 16]).unwrap();
@@ -1353,7 +1349,8 @@ mod tests {
             .bin(f32::datum_type())
             .expect("f32 unicast Add kernel available");
         let op = OptBinUnicast { binop: Box::new(Add), eval_fn: Arc::from(linalg_fn) };
-        let out = op.eval(&EvalContext::pure(), tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
+        let out =
+            op.eval(&EvalContext::out_of_plan(), tvec!(a.into_tvalue(), b.into_tvalue())).unwrap();
         assert_eq!(out[0].shape(), &[0, 4, 16]);
     }
 

--- a/core/src/ops/cast.rs
+++ b/core/src/ops/cast.rs
@@ -40,9 +40,7 @@ impl Op for Cast {
 }
 
 impl EvalOp for Cast {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/change_axes.rs
+++ b/core/src/ops/change_axes.rs
@@ -647,9 +647,7 @@ impl Op for AxisOp {
 }
 
 impl EvalOp for AxisOp {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut input = args_1!(inputs).into_tensor();
@@ -1197,9 +1195,7 @@ impl Op for IntoShape {
 }
 
 impl EvalOp for IntoShape {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut input = args_1!(inputs).into_tensor();

--- a/core/src/ops/cnn/conv/block_quant.rs
+++ b/core/src/ops/cnn/conv/block_quant.rs
@@ -15,9 +15,7 @@ impl Op for BlockQuantIntoShape {
 }
 
 impl EvalOp for BlockQuantIntoShape {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
@@ -67,9 +65,7 @@ impl Op for SplitGroupBlockQuant {
 }
 
 impl EvalOp for SplitGroupBlockQuant {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)

--- a/core/src/ops/cnn/conv/blocked.rs
+++ b/core/src/ops/cnn/conv/blocked.rs
@@ -81,9 +81,7 @@ impl Op for BlockedConv {
 }
 
 impl EvalOp for BlockedConv {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let x_t = inputs[0].cast_to::<f32>()?;
@@ -349,7 +347,7 @@ mod tests {
         let want = reference(&op, &x, &kernel, &bias);
         let got = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![
                     Tensor::from_shape(&[1, c_in, h_in, w], &x).unwrap().into_tvalue(),
                     Tensor::from_shape(&[oc, icg * kh], &kernel).unwrap().into_tvalue(),

--- a/core/src/ops/cnn/conv/conv.rs
+++ b/core/src/ops/cnn/conv/conv.rs
@@ -1004,9 +1004,7 @@ impl Op for Conv {
 }
 
 impl EvalOp for Conv {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut model = TypedModel::default();
@@ -1489,7 +1487,7 @@ mod test {
             rctensor0(1.0f32),
         );
         let input = input.into_iter().map(IntoTValue::into_tvalue).collect::<TVec<_>>();
-        let output = op.eval_pure(input).unwrap();
+        let output = op.eval(&EvalContext::out_of_plan(), input).unwrap();
         assert_eq!(*output[0], tensor4(&[[[[8i32, 12], [20, 24]]]]));
     }
 

--- a/core/src/ops/cnn/conv/depth_wise.rs
+++ b/core/src/ops/cnn/conv/depth_wise.rs
@@ -28,9 +28,7 @@ impl Op for DepthWise {
 }
 
 impl EvalOp for DepthWise {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let dt = inputs[0].datum_type();

--- a/core/src/ops/cnn/conv/im2col.rs
+++ b/core/src/ops/cnn/conv/im2col.rs
@@ -139,9 +139,7 @@ impl Op for Im2Col {
 }
 
 impl EvalOp for Im2Col {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let geometry = self.geometry.to_concrete(inputs[0].shape())?;

--- a/core/src/ops/cnn/conv/lazy_im2col.rs
+++ b/core/src/ops/cnn/conv/lazy_im2col.rs
@@ -107,9 +107,7 @@ impl Op for LazyIm2Col {
 }
 
 impl EvalOp for LazyIm2Col {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let tensor = args_1!(inputs);

--- a/core/src/ops/cnn/conv/q_sum_b.rs
+++ b/core/src/ops/cnn/conv/q_sum_b.rs
@@ -24,9 +24,7 @@ impl Op for QSumB {
 }
 
 impl EvalOp for QSumB {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let n = self.n.eval_to_i64(ctx.symbols)? as usize;

--- a/core/src/ops/cnn/deconv/deconv.rs
+++ b/core/src/ops/cnn/deconv/deconv.rs
@@ -180,9 +180,7 @@ impl Op for Deconv {
 }
 
 impl EvalOp for Deconv {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 3);

--- a/core/src/ops/cnn/deconv/deconv_sum.rs
+++ b/core/src/ops/cnn/deconv/deconv_sum.rs
@@ -38,9 +38,7 @@ impl Op for DeconvSum {
 }
 
 impl EvalOp for DeconvSum {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         self.eval_with_values(inputs, ctx.symbols)
@@ -532,9 +530,7 @@ impl Op for DepthwiseDeconv {
 }
 
 impl EvalOp for DepthwiseDeconv {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (kernel, input, bias) = args_3!(inputs);

--- a/core/src/ops/cnn/maxpool.rs
+++ b/core/src/ops/cnn/maxpool.rs
@@ -22,9 +22,7 @@ impl Op for MaxPool {
 }
 
 impl EvalOp for MaxPool {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let shape: TVec<TDim> = inputs[0].shape().iter().map(|d| d.to_dim()).collect();
@@ -120,9 +118,7 @@ impl Op for OptMaxPool {
 }
 
 impl EvalOp for OptMaxPool {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/cnn/sumpool.rs
+++ b/core/src/ops/cnn/sumpool.rs
@@ -36,9 +36,7 @@ impl Op for SumPool {
 }
 
 impl EvalOp for SumPool {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let shape: TVec<TDim> = inputs[0].shape().iter().map(|d| d.to_dim()).collect();
@@ -124,9 +122,7 @@ impl Op for OptSumPool {
 }
 
 impl EvalOp for OptSumPool {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
@@ -608,7 +604,8 @@ mod tests {
         .into_tensor();
 
         // generic zoned kernel (knob off by default)
-        let generic = op.eval(&EvalContext::pure(), tvec![input.clone().into_tvalue()]).unwrap();
+        let generic =
+            op.eval(&EvalContext::out_of_plan(), tvec![input.clone().into_tvalue()]).unwrap();
         let generic = generic[0].try_as_plain().unwrap().as_slice::<f32>().unwrap().to_vec();
 
         // separable kernel, called directly
@@ -653,7 +650,8 @@ mod tests {
         .into_tensor();
 
         // generic zoned kernel (knob off by default)
-        let generic = op.eval(&EvalContext::pure(), tvec![input.clone().into_tvalue()]).unwrap();
+        let generic =
+            op.eval(&EvalContext::out_of_plan(), tvec![input.clone().into_tvalue()]).unwrap();
         let generic = generic[0].try_as_plain().unwrap().as_slice::<f32>().unwrap().to_vec();
 
         // separable NHWC kernel, called directly

--- a/core/src/ops/downsample/mod.rs
+++ b/core/src/ops/downsample/mod.rs
@@ -50,9 +50,7 @@ impl Op for Downsample {
 }
 
 impl EvalOp for Downsample {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/dummy.rs
+++ b/core/src/ops/dummy.rs
@@ -12,9 +12,7 @@ impl Op for Dummy {
 }
 
 impl EvalOp for Dummy {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, _inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         bail!("eval() called on a Dummy op. This is a bug.")

--- a/core/src/ops/einsum/einsum_matmul.rs
+++ b/core/src/ops/einsum/einsum_matmul.rs
@@ -525,9 +525,7 @@ impl Op for EinSumMatMul {
 }
 
 impl EvalOp for EinSumMatMul {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         self.op.eval(ctx, inputs)
     }

--- a/core/src/ops/einsum/mod.rs
+++ b/core/src/ops/einsum/mod.rs
@@ -158,9 +158,7 @@ impl Op for EinSum {
 }
 
 impl EvalOp for EinSum {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         if inputs.iter().all(|i| i.datum_type().is_number() && i.is_plain()) {

--- a/core/src/ops/einsum/prefix_matmul.rs
+++ b/core/src/ops/einsum/prefix_matmul.rs
@@ -251,9 +251,7 @@ impl Op for PrefixMatMul {
 }
 
 impl EvalOp for PrefixMatMul {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let c_dt = self.operating_dt.unwrap_or_else(|| {

--- a/core/src/ops/element_wise.rs
+++ b/core/src/ops/element_wise.rs
@@ -88,9 +88,7 @@ impl Op for ElementWiseOp {
 }
 
 impl EvalOp for ElementWiseOp {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         if let Some(_dt) = self.0.output_type(inputs[0].datum_type()) {

--- a/core/src/ops/fft.rs
+++ b/core/src/ops/fft.rs
@@ -60,9 +60,7 @@ impl Op for Fft {
 }
 
 impl EvalOp for Fft {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut tensor = args_1!(inputs).into_tensor();
@@ -219,9 +217,7 @@ impl Op for Stft {
 }
 
 impl EvalOp for Stft {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/core/src/ops/gru_cell.rs
+++ b/core/src/ops/gru_cell.rs
@@ -44,9 +44,7 @@ impl Op for GruEpilogue {
 }
 
 impl EvalOp for GruEpilogue {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         match inputs[0].datum_type().unquantized() {
@@ -156,7 +154,7 @@ mod tests {
         let op = GruEpilogue { hidden: h };
         let out = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec!(xh_t.into_tvalue(), rh_t.into_tvalue(), hprev_t.into_tvalue()),
             )
             .unwrap();

--- a/core/src/ops/identity.rs
+++ b/core/src/ops/identity.rs
@@ -12,9 +12,7 @@ impl Op for Identity {
 }
 
 impl EvalOp for Identity {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     /// Evaluates the operation given the input tensors.
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {

--- a/core/src/ops/konst.rs
+++ b/core/src/ops/konst.rs
@@ -41,9 +41,7 @@ impl Op for Const {
 }
 
 impl EvalOp for Const {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, _inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(tvec![Arc::clone(&self.0).into_tvalue()])

--- a/core/src/ops/logic.rs
+++ b/core/src/ops/logic.rs
@@ -74,9 +74,7 @@ impl Op for Iff {
 }
 
 impl EvalOp for Iff {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (cond, t, f) = args_3!(inputs);

--- a/core/src/ops/logic/ite.rs
+++ b/core/src/ops/logic/ite.rs
@@ -83,9 +83,7 @@ impl TypedOp for IfThenElse {
 }
 
 impl EvalOp for IfThenElse {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let cond = inputs[0].cast_to_scalar::<bool>()?;

--- a/core/src/ops/lstm_cell.rs
+++ b/core/src/ops/lstm_cell.rs
@@ -38,9 +38,7 @@ impl Op for LstmEpilogue {
 }
 
 impl EvalOp for LstmEpilogue {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         // Dispatch on the dtype the precision transform left the graph in. The
@@ -142,7 +140,7 @@ mod tests {
         let cprev_t = Tensor::from_shape(&[batch, h], &cprev).unwrap();
         let op = LstmEpilogue { hidden: h };
         let out = op
-            .eval(&EvalContext::pure(), tvec!(pre_t.into_tvalue(), cprev_t.into_tvalue()))
+            .eval(&EvalContext::out_of_plan(), tvec!(pre_t.into_tvalue(), cprev_t.into_tvalue()))
             .unwrap();
         let ht = unsafe { out[0].as_slice_unchecked::<f32>() };
         let ct = unsafe { out[1].as_slice_unchecked::<f32>() };

--- a/core/src/ops/macros.rs
+++ b/core/src/ops/macros.rs
@@ -30,6 +30,24 @@ macro_rules! not_a_typed_op {
 }
 
 #[macro_export]
+macro_rules! op_out_of_plan {
+    () => {
+        fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+            Ok(Some(EvalOp::eval(self, &EvalContext::out_of_plan(), inputs)?))
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! not_out_of_plan {
+    () => {
+        fn eval_out_of_plan(&self, _inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+            Ok(None)
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! args_1 {
     ($inputs:expr) => {{
         let mut inputs = $inputs;

--- a/core/src/ops/math/complex.rs
+++ b/core/src/ops/math/complex.rs
@@ -14,9 +14,7 @@ impl Op for InnerDimToComplex {
 }
 
 impl EvalOp for InnerDimToComplex {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(tvec!(reinterpret_inner_dim_as_complex(inputs.remove(0).into_tensor())?.into_tvalue()))
@@ -50,9 +48,7 @@ impl Op for ComplexToInnerDim {
 }
 
 impl EvalOp for ComplexToInnerDim {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(tvec!(reinterpret_complex_as_inner_dim(inputs.remove(0).into_tensor())?.into_tvalue()))

--- a/core/src/ops/math/mod.rs
+++ b/core/src/ops/math/mod.rs
@@ -428,7 +428,7 @@ fn declutter_mul_const_mul_const(
     rule_if!(const_fact.datum_type.is_float());
     let result = mul()
         .eval(
-            &EvalContext::pure(),
+            &EvalContext::out_of_plan(),
             tvec!(
                 const_fact.konst.clone().unwrap().into_tvalue(),
                 prec_const_fact.konst.clone().unwrap().into_tvalue()

--- a/core/src/ops/matmul/optimized.rs
+++ b/core/src/ops/matmul/optimized.rs
@@ -442,9 +442,7 @@ thread_local! {
 }
 
 impl EvalOp for OptMatMul {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         MMM_SCRATCH.with_borrow_mut(|per_session| {

--- a/core/src/ops/matmul/pack.rs
+++ b/core/src/ops/matmul/pack.rs
@@ -29,9 +29,7 @@ impl Op for OptMatMulPack {
 }
 
 impl EvalOp for OptMatMulPack {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         self.do_eval(ctx, inputs.remove(0))
@@ -147,9 +145,7 @@ impl Op for OptSimpleMatMulPack {
 }
 
 impl EvalOp for OptSimpleMatMulPack {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)

--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -145,12 +145,13 @@ pub trait EvalOp {
         bail!("{} has neither eval nor state", std::any::type_name::<Self>())
     }
 
-    /// Evaluate with no context, for callers that have none: const folding, shape
-    /// inference, tests. Only meaningful for an op reporting
-    /// `is_pure_function()`. Convenience over [`EvalOp::eval`] -- do not override.
-    fn eval_pure(&self, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        self.eval(&EvalContext::pure(), inputs)
-    }
+    /// Evaluate with no plan around the node -- const folding, shape inference,
+    /// tests -- or `None` when there is no answer without one, because the op
+    /// reads the context or keeps state between turns. Required, with no default:
+    /// an op answering `Some` has produced the value from `inputs` alone, by
+    /// construction, so the claim and the act cannot disagree. Write it with
+    /// `op_out_of_plan!()` or `not_out_of_plan!()`.
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>>;
 
     /// Build this node's inter-turn state, or `None` when the op keeps nothing
     /// between turns. This is what decides whether the plan holds an
@@ -159,12 +160,6 @@ pub trait EvalOp {
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
     }
-
-    /// Whether evaluating depends on nothing but `inputs`, so the op can be run
-    /// outside a plan -- during const folding and shape inference, where there
-    /// is no meaningful context. False for anything that reads `ctx` or keeps
-    /// state.
-    fn is_pure_function(&self) -> bool;
 
     /// Release whatever the op manages for `session`, called for every node as a
     /// state is dropped. Ops keeping scratch keyed by `(session, node_id)` must

--- a/core/src/ops/nn/grid_sample.rs
+++ b/core/src/ops/nn/grid_sample.rs
@@ -260,9 +260,7 @@ impl Op for GridSample {
 }
 
 impl EvalOp for GridSample {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (x, grid) = args_2!(inputs);

--- a/core/src/ops/nn/reduce.rs
+++ b/core/src/ops/nn/reduce.rs
@@ -392,9 +392,7 @@ impl Op for Reduce {
 }
 
 impl EvalOp for Reduce {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(tvec!(self.reducer.reduce(&self.axes, &inputs[0])?.into()))

--- a/core/src/ops/nn/resize.rs
+++ b/core/src/ops/nn/resize.rs
@@ -385,9 +385,7 @@ impl Op for Resize {
 }
 
 impl EvalOp for Resize {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_dt = inputs[0].datum_type();
@@ -590,7 +588,7 @@ mod tests {
             optional_scales_input: Some(1),
             optional_sizes_input: None,
         };
-        op.eval(&EvalContext::pure(), tvec!(input.into_tvalue(), scales.into_tvalue()))
+        op.eval(&EvalContext::out_of_plan(), tvec!(input.into_tvalue(), scales.into_tvalue()))
             .unwrap()
             .remove(0)
             .into_tensor()

--- a/core/src/ops/nn/rms_norm.rs
+++ b/core/src/ops/nn/rms_norm.rs
@@ -22,9 +22,7 @@ impl Op for RmsNorm {
 }
 
 impl EvalOp for RmsNorm {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
@@ -235,7 +233,7 @@ mod tests {
         let eps = tensor0(to_h(1e-5)).into_arc_tensor();
         let op = RmsNorm { axis: 0, eps };
         let out = op
-            .eval(&EvalContext::pure(), tvec!(input.clone().into()))
+            .eval(&EvalContext::out_of_plan(), tvec!(input.clone().into()))
             .expect("eval should not panic");
         let out = out.into_iter().next().unwrap().into_tensor();
         assert_eq!(out.datum_type(), DatumType::F16);
@@ -266,8 +264,9 @@ mod tests {
         let input = tensor2(&[[1.0_f32, 2.0, 3.0], [4.0, 5.0, 6.0]]);
         let eps = tensor0(0.0_f32).into_arc_tensor();
         let op = RmsNorm { axis: 0, eps };
-        let out =
-            op.eval(&EvalContext::pure(), tvec!(input.into())).expect("eval should not panic");
+        let out = op
+            .eval(&EvalContext::out_of_plan(), tvec!(input.into()))
+            .expect("eval should not panic");
         let out = out.into_iter().next().unwrap().into_tensor();
         assert_eq!(out.datum_type(), DatumType::F32);
         assert_eq!(out.shape(), &[2, 3]);

--- a/core/src/ops/nn/softmax/mod.rs
+++ b/core/src/ops/nn/softmax/mod.rs
@@ -111,9 +111,7 @@ impl TypedOp for Softmax {
 }
 
 impl EvalOp for Softmax {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
@@ -477,7 +475,7 @@ mod test {
                 Softmax { axes: self.axes.clone(), quant_output_dt, ..Softmax::default() };
 
             // Compute quantized output
-            let result = softmax.eval_pure(inputs)?;
+            let result = softmax.eval(&EvalContext::out_of_plan(), inputs)?;
             let result = args_1!(result);
             let result_float = result.cast_to::<f32>()?;
 
@@ -485,7 +483,7 @@ mod test {
             let input_float = self.data.cast_to::<f32>()?;
             let inputs_float = tvec!(input_float.into_owned().into_tvalue());
             let softmax_float = Softmax { axes: self.axes.clone(), ..Softmax::default() };
-            let reference_float = softmax_float.eval_pure(inputs_float)?;
+            let reference_float = softmax_float.eval(&EvalContext::out_of_plan(), inputs_float)?;
             let reference_array = args_1!(reference_float);
             let reference = reference_array.to_plain_array_view::<f32>()?;
 

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -109,9 +109,7 @@ impl Op for DequantizeLinearF32 {
 }
 
 impl EvalOp for DequantizeLinearF32 {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let output = match inputs[0].datum_type() {
             DatumType::I8 => self.eval_t::<i8>(&inputs[0])?,

--- a/core/src/ops/scan/decluttered.rs
+++ b/core/src/ops/scan/decluttered.rs
@@ -762,9 +762,7 @@ impl Op for Scan {
 }
 
 impl EvalOp for Scan {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         self.to_codegen_op(false)?.state(ctx)
     }

--- a/core/src/ops/scan/optimized.rs
+++ b/core/src/ops/scan/optimized.rs
@@ -53,9 +53,7 @@ impl Op for OptScan {
 }
 
 impl EvalOp for OptScan {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(State {

--- a/core/src/ops/source.rs
+++ b/core/src/ops/source.rs
@@ -13,9 +13,7 @@ impl Op for TypedSource {
 }
 
 impl EvalOp for TypedSource {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(!inputs.is_empty(), "Input for node {} is missing", ctx.node_id);

--- a/core/src/ops/submodel.rs
+++ b/core/src/ops/submodel.rs
@@ -46,9 +46,7 @@ impl Op for SubmodelOp {
 }
 
 impl EvalOp for SubmodelOp {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         self.model.state(ctx)
@@ -97,7 +95,6 @@ impl TypedOp for SubmodelOp {
 pub trait InnerModel: Debug + dyn_clone::DynClone + Downcast + Sync + Send + 'static {
     #[allow(unused_variables)]
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>>;
-    fn is_pure_function(&self) -> bool;
 
     #[allow(unused_variables)]
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
@@ -124,10 +121,6 @@ impl InnerModel for TypedModel {
             .collect::<TractResult<TVec<_>>>()?;
         Ok(facts)
     }
-    fn is_pure_function(&self) -> bool {
-        false
-    }
-
     #[allow(unused_variables)]
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         let plan = self.clone().into_runnable()?;

--- a/core/src/ops/unimpl.rs
+++ b/core/src/ops/unimpl.rs
@@ -26,7 +26,5 @@ impl Op for UnimplementedOp {
 }
 
 impl EvalOp for UnimplementedOp {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 }

--- a/core/src/optim/prop_const.rs
+++ b/core/src/optim/prop_const.rs
@@ -42,7 +42,6 @@ impl super::TypedPass for PropConst {
             if !node.op_is::<Const>()
                 && !node.op_is::<Dummy>()
                 && !node.op_is::<TypedSource>()
-                && node.op.is_pure_function()
                 && inputs.iter().zip(&node.inputs).all(|(fact, outlet)| {
                     fact.konst.is_some()
                         && (model.node(outlet.node).outputs[outlet.slot].successors.len() == 1
@@ -61,8 +60,9 @@ impl super::TypedPass for PropConst {
                     .iter()
                     .map(|f| f.mem_size().as_i64().unwrap_or(i64::MAX) as u64)
                     .sum();
-                match node.op.eval(&EvalContext::pure(), inputs) {
-                    Ok(mut res) => {
+                match node.op.eval_out_of_plan(inputs) {
+                    Ok(None) => (),
+                    Ok(Some(mut res)) => {
                         self.0 = node.id;
                         let output_mem: u64 = res
                             .iter()
@@ -76,11 +76,10 @@ impl super::TypedPass for PropConst {
                             let Some(succ) = model.single_succ(node.id)? else {
                                 break;
                             };
-                            if succ.inputs.len() > 1 || !succ.op.is_pure_function() {
+                            if succ.inputs.len() > 1 {
                                 break;
                             }
-                            let Ok(succ_res) = succ.op.eval(&EvalContext::pure(), res.clone())
-                            else {
+                            let Ok(Some(succ_res)) = succ.op.eval_out_of_plan(res.clone()) else {
                                 break;
                             };
                             let succ_mem: u64 = succ_res

--- a/core/src/plan.rs
+++ b/core/src/plan.rs
@@ -117,9 +117,9 @@ pub struct TurnState {
 
 impl EvalContext<'static> {
     /// Context for evaluating outside any plan -- const folding and shape
-    /// inference. Only valid for an op reporting `is_pure_function()`: no symbol
-    /// is bound and no shared resource is reachable.
-    pub fn pure() -> EvalContext<'static> {
+    /// inference. What [`EvalOp::eval_out_of_plan`] hands the op: no symbol is
+    /// bound and no shared resource is reachable.
+    pub fn out_of_plan() -> EvalContext<'static> {
         static SYMBOLS: std::sync::OnceLock<SymbolValues> = std::sync::OnceLock::new();
         static SEATING: std::sync::OnceLock<Seating> = std::sync::OnceLock::new();
         EvalContext {

--- a/cuda/src/kernels/array/diag_gather.rs
+++ b/cuda/src/kernels/array/diag_gather.rs
@@ -155,7 +155,9 @@ mod tests {
             // TDims against the turn's resolved_symbols); pass an empty
             // TurnState since the TDims here are already concrete.
             let cpu_op = cpu_dg::DiagGather { offset: offset.to_dim(), out_len: out_len.to_dim() };
-            let cpu_out = cpu_op.eval_pure(tvec![cpu_in.into_tvalue()])?[0].clone().into_tensor();
+            let cpu_out = cpu_op.eval(&EvalContext::out_of_plan(), tvec![cpu_in.into_tvalue()])?[0]
+                .clone()
+                .into_tensor();
             let cuda_out = DiagGather.eval(stream, &cuda_in, offset, out_len)?;
             cpu_out
                 .close_enough(&cuda_out.to_host()?.into_tensor(), Approximation::Exact)

--- a/cuda/src/kernels/array/gather.rs
+++ b/cuda/src/kernels/array/gather.rs
@@ -150,8 +150,10 @@ mod tests {
             let cuda_indices = indices.clone().into_device()?;
 
             let cpu_op = CpuGather::new(axis);
-            let cpu_out = cpu_op
-                .eval(&EvalContext::pure(), tvec![data.into_tvalue(), indices.into_tvalue()])?[0]
+            let cpu_out = cpu_op.eval(
+                &EvalContext::out_of_plan(),
+                tvec![data.into_tvalue(), indices.into_tvalue()],
+            )?[0]
                 .clone()
                 .into_tensor();
             let cuda_out = Gather.eval(stream, &cuda_data, &cuda_indices, axis)?;

--- a/cuda/src/kernels/array/rotate_half.rs
+++ b/cuda/src/kernels/array/rotate_half.rs
@@ -117,7 +117,7 @@ mod tests {
             let cuda_a = a.clone().into_device()?;
 
             let cpu_output = apply_rope::RotateHalf
-                .eval(&EvalContext::pure(), tvec![a.clone().into()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.clone().into()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_output = RotateHalf.eval(stream, &cuda_a)?;

--- a/cuda/src/kernels/fft.rs
+++ b/cuda/src/kernels/fft.rs
@@ -309,7 +309,8 @@ mod tests {
                 stride,
                 window: Some(std::sync::Arc::new(Tensor::from_shape(&[win_len], &win)?)),
             };
-            let reference = stft.eval(&EvalContext::pure(), tvec!(signal.clone().into_tvalue()))?;
+            let reference =
+                stft.eval(&EvalContext::out_of_plan(), tvec!(signal.clone().into_tvalue()))?;
             let reference = reference[0].to_plain_array_view::<f32>()?;
             let reference = reference.as_slice().unwrap();
 

--- a/cuda/src/kernels/flash_attn.rs
+++ b/cuda/src/kernels/flash_attn.rs
@@ -265,7 +265,7 @@ mod tests {
                 acc_datum_type: DatumType::F32,
                 is_causal,
             }
-            .eval_pure(ref_inputs)?;
+            .eval(&EvalContext::out_of_plan(), ref_inputs)?;
 
             cuda_output.to_host()?.close_enough(&ref_output[0], Approximation::Approximate)?;
             Ok(())

--- a/cuda/src/kernels/matmul/mod.rs
+++ b/cuda/src/kernels/matmul/mod.rs
@@ -700,11 +700,10 @@ mod tests {
                 weights = weights.clone().cast_to_dt(DatumType::F32).unwrap().into_owned();
             }
 
-            let output =
-                args_1!(matmul.eval(
-                    &EvalContext::pure(),
-                    tvec![activs.into_tvalue(), weights.into_tvalue()]
-                )?);
+            let output = args_1!(matmul.eval(
+                &EvalContext::out_of_plan(),
+                tvec![activs.into_tvalue(), weights.into_tvalue()]
+            )?);
             cuda_output.to_host()?.close_enough(&output, Approximation::VeryApproximate)?;
             Ok(())
         })
@@ -889,7 +888,7 @@ mod tests {
                 rhs_tensor = Q4_0.simulate_precision_loss(rhs_tensor, 2)?
             };
             let output = matmul.eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![lhs_tensor.into_tvalue(), rhs_tensor.into_tvalue()],
             )?;
 

--- a/cuda/src/kernels/nn/apply_rope.rs
+++ b/cuda/src/kernels/nn/apply_rope.rs
@@ -176,7 +176,7 @@ mod tests {
             let cuda_cos = cos.clone().into_device()?;
 
             let cpu_output = apply_rope::ApplyRope.eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![a.clone().into(), cos.clone().into(), sin.clone().into(),],
             )?[0]
                 .clone()

--- a/cuda/src/kernels/nn/gelu_approximate.rs
+++ b/cuda/src/kernels/nn/gelu_approximate.rs
@@ -137,7 +137,7 @@ mod tests {
             .into_device()?;
 
             let cpu_output = gelu_approximate::gelu_approximate(false)
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_output = gelu_approx.eval(stream, &a)?;
@@ -282,7 +282,7 @@ mod tests {
             let a = Tensor::from_shape(self.shape.as_slice(), &self.input)?;
 
             let cpu_output = gelu_approximate::gelu_approximate(false)
-                .eval(&EvalContext::pure(), tvec![a.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
 

--- a/cuda/src/kernels/nn/rms_norm.rs
+++ b/cuda/src/kernels/nn/rms_norm.rs
@@ -133,7 +133,7 @@ mod tests {
             let cpu_rms = rms_norm::RmsNorm { axis, eps: Arc::clone(&eps) };
 
             let cpu_output = cpu_rms
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_output = RmsNorm.eval(stream, &a, axis, &eps)?;
@@ -241,7 +241,7 @@ mod tests {
 
             let cpu_rms = rms_norm::RmsNorm { axis: self.axis, eps: Arc::clone(&self.eps) };
 
-            let cpu_output = cpu_rms.eval(&EvalContext::pure(), tvec![a.into_tvalue()])?[0]
+            let cpu_output = cpu_rms.eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
 

--- a/cuda/src/kernels/nn/scaled_masked_softmax.rs
+++ b/cuda/src/kernels/nn/scaled_masked_softmax.rs
@@ -193,7 +193,7 @@ mod tests {
             };
 
             let cpu_output = cpu.eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![a.to_host()?.into_tvalue(), mask.to_host()?.into_tvalue()],
             )?[0]
                 .clone()
@@ -236,7 +236,7 @@ mod tests {
                     post_softmax_mask: post,
                 };
                 let cpu_out = cpu.eval(
-                    &EvalContext::pure(),
+                    &EvalContext::out_of_plan(),
                     tvec![a.to_host()?.into_tvalue(), mask.to_host()?.into_tvalue()],
                 )?[0]
                     .clone()
@@ -337,7 +337,10 @@ mod tests {
 
             let cpu_output =
                 scaled_masked_softmax::ScaledMaskedSoftmax { scale, post_softmax_mask: false }
-                    .eval(&EvalContext::pure(), tvec![a.into_tvalue(), mask.into_tvalue()])?[0]
+                    .eval(
+                        &EvalContext::out_of_plan(),
+                        tvec![a.into_tvalue(), mask.into_tvalue()],
+                    )?[0]
                     .clone()
                     .into_tensor();
             Ok(cpu_output)

--- a/cuda/src/kernels/nn/softmax.rs
+++ b/cuda/src/kernels/nn/softmax.rs
@@ -121,7 +121,7 @@ mod tests {
             };
 
             let cpu_output = cpu_softmax
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_output = Softmax.eval(stream, &a, axis)?;
@@ -152,7 +152,7 @@ mod tests {
             };
 
             let cpu_output = cpu_softmax
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_output = Softmax.eval(stream, &a, axis)?;
@@ -182,7 +182,7 @@ mod tests {
             };
 
             let cpu_output = cpu_softmax
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let cuda_output = Softmax.eval(stream, &a, axis)?;
@@ -269,7 +269,8 @@ mod tests {
                 quant_output_dt: None,
                 kind: SoftmaxKind::Softmax,
             };
-            let cpu_output = cpu_softmax.eval(&EvalContext::pure(), tvec![a.into_tvalue()])?[0]
+            let cpu_output = cpu_softmax
+                .eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             Ok(cpu_output)

--- a/cuda/src/ops/conv.rs
+++ b/cuda/src/ops/conv.rs
@@ -104,9 +104,7 @@ thread_local! {
 }
 
 impl EvalOp for CudaConv {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let inputs =

--- a/cuda/src/ops/flash_attn.rs
+++ b/cuda/src/ops/flash_attn.rs
@@ -19,9 +19,7 @@ impl Op for CudaFlashAttention {
 }
 
 impl EvalOp for CudaFlashAttention {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         crate::with_cuda_stream(|stream| {

--- a/cuda/src/ops/fused_axis_op.rs
+++ b/cuda/src/ops/fused_axis_op.rs
@@ -139,8 +139,10 @@ impl Op for CudaFusedAxisOp {
 }
 
 impl EvalOp for CudaFusedAxisOp {
-    fn is_pure_function(&self) -> bool {
-        self.op.is_pure_function()
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        let ctx = EvalContext::out_of_plan();
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, &ctx)?;
+        self.op.eval_out_of_plan(inputs)
     }
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {

--- a/cuda/src/ops/gemm.rs
+++ b/cuda/src/ops/gemm.rs
@@ -51,9 +51,7 @@ impl CudaGgmlGemm {
     }
 }
 impl EvalOp for CudaGgmlGemm {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (act_raw, weights_raw) = args_2!(inputs);

--- a/cuda/src/ops/iff.rs
+++ b/cuda/src/ops/iff.rs
@@ -15,9 +15,7 @@ impl Op for CudaIff {
 }
 
 impl EvalOp for CudaIff {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (cond_val, then_val, else_val) = args_3!(inputs);

--- a/cuda/src/ops/quant_q81.rs
+++ b/cuda/src/ops/quant_q81.rs
@@ -82,9 +82,7 @@ impl EvalOp for CudaGgmlQuantQ81 {
         })
     }
 
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 }
 
 impl TypedOp for CudaGgmlQuantQ81 {

--- a/extra/src/exp_unit_norm.rs
+++ b/extra/src/exp_unit_norm.rs
@@ -106,8 +106,12 @@ impl Op for ExpUnitNorm {
 }
 
 impl EvalOp for ExpUnitNorm {
-    fn is_pure_function(&self) -> bool {
-        self.stateless
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        if self.stateless {
+            Ok(Some(self.eval(&EvalContext::out_of_plan(), inputs)?))
+        } else {
+            Ok(None)
+        }
     }
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {

--- a/gpu/src/ops/apply_rope.rs
+++ b/gpu/src/ops/apply_rope.rs
@@ -38,9 +38,7 @@ impl Op for GpuApplyRope {
 }
 
 impl EvalOp for GpuApplyRope {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input_val, cos_val, sin_val) = args_3!(inputs);

--- a/gpu/src/ops/binary.rs
+++ b/gpu/src/ops/binary.rs
@@ -61,9 +61,7 @@ impl Op for GpuBinOp {
 }
 
 impl EvalOp for GpuBinOp {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (a_val, b_val) = args_2!(inputs);

--- a/gpu/src/ops/broadcast.rs
+++ b/gpu/src/ops/broadcast.rs
@@ -22,9 +22,7 @@ impl Op for GpuMultiBroadcastTo {
 }
 
 impl EvalOp for GpuMultiBroadcastTo {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/cast.rs
+++ b/gpu/src/ops/cast.rs
@@ -58,9 +58,7 @@ impl Op for GpuCast {
 }
 
 impl EvalOp for GpuCast {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/causal_conv1d_update.rs
+++ b/gpu/src/ops/causal_conv1d_update.rs
@@ -36,9 +36,7 @@ impl Op for GpuCausalConv1dUpdate {
 }
 
 impl EvalOp for GpuCausalConv1dUpdate {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, weight, state) = args_3!(inputs);

--- a/gpu/src/ops/change_axes.rs
+++ b/gpu/src/ops/change_axes.rs
@@ -71,9 +71,7 @@ impl Op for GpuAxisOp {
 }
 
 impl EvalOp for GpuAxisOp {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let tensor = args_1!(inputs).into_tensor();

--- a/gpu/src/ops/concat.rs
+++ b/gpu/src/ops/concat.rs
@@ -35,9 +35,7 @@ impl Op for GpuConcat {
 }
 
 impl EvalOp for GpuConcat {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let inputs =

--- a/gpu/src/ops/diag_gather.rs
+++ b/gpu/src/ops/diag_gather.rs
@@ -53,9 +53,7 @@ impl Op for GpuDiagGather {
 }
 
 impl EvalOp for GpuDiagGather {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_val = args_1!(inputs);

--- a/gpu/src/ops/dyn_kv_cache.rs
+++ b/gpu/src/ops/dyn_kv_cache.rs
@@ -178,9 +178,7 @@ impl Op for GpuDynKVCache {
 }
 
 impl EvalOp for GpuDynKVCache {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(GpuDynKVCacheState::new(

--- a/gpu/src/ops/element_wise.rs
+++ b/gpu/src/ops/element_wise.rs
@@ -43,9 +43,7 @@ impl Op for GpuElementWise {
 }
 
 impl EvalOp for GpuElementWise {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/gather.rs
+++ b/gpu/src/ops/gather.rs
@@ -53,9 +53,7 @@ impl Op for GpuGather {
 }
 
 impl EvalOp for GpuGather {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (data_val, indices_val) = args_2!(inputs);

--- a/gpu/src/ops/gdn_recurrent.rs
+++ b/gpu/src/ops/gdn_recurrent.rs
@@ -39,9 +39,7 @@ impl Op for GpuGatedDeltaNetRecurrent {
 }
 
 impl EvalOp for GpuGatedDeltaNetRecurrent {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 6);

--- a/gpu/src/ops/gelu_approximate.rs
+++ b/gpu/src/ops/gelu_approximate.rs
@@ -41,9 +41,7 @@ impl Op for GpuGeluApproximate {
 }
 
 impl EvalOp for GpuGeluApproximate {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/iff.rs
+++ b/gpu/src/ops/iff.rs
@@ -55,9 +55,7 @@ impl Op for GpuIff {
 }
 
 impl EvalOp for GpuIff {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (cond_val, then_val, else_val) = args_3!(inputs);

--- a/gpu/src/ops/leaky_relu.rs
+++ b/gpu/src/ops/leaky_relu.rs
@@ -41,9 +41,7 @@ impl Op for GpuLeakyRelu {
 }
 
 impl EvalOp for GpuLeakyRelu {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/pad.rs
+++ b/gpu/src/ops/pad.rs
@@ -32,9 +32,7 @@ impl Op for GpuPad {
 }
 
 impl EvalOp for GpuPad {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/pulse.rs
+++ b/gpu/src/ops/pulse.rs
@@ -34,9 +34,7 @@ impl Op for GpuDelay {
 }
 
 impl EvalOp for GpuDelay {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(GpuDelayState {
@@ -189,9 +187,7 @@ impl Op for GpuPulsePad {
 }
 
 impl EvalOp for GpuPulsePad {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(GpuPulsePadState {
@@ -418,9 +414,7 @@ impl Op for GpuAffineChunkTrim {
 }
 
 impl EvalOp for GpuAffineChunkTrim {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/reduce.rs
+++ b/gpu/src/ops/reduce.rs
@@ -115,9 +115,7 @@ impl Op for GpuReduce {
 }
 
 impl EvalOp for GpuReduce {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/resize.rs
+++ b/gpu/src/ops/resize.rs
@@ -64,9 +64,7 @@ impl Op for GpuResize {
 }
 
 impl EvalOp for GpuResize {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let data = inputs[0].to_device_tensor()?;

--- a/gpu/src/ops/rms_norm.rs
+++ b/gpu/src/ops/rms_norm.rs
@@ -48,9 +48,7 @@ impl Op for GpuRmsNorm {
 }
 
 impl EvalOp for GpuRmsNorm {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/rotate_half.rs
+++ b/gpu/src/ops/rotate_half.rs
@@ -39,9 +39,7 @@ impl Op for GpuRotateHalf {
 }
 
 impl EvalOp for GpuRotateHalf {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/scaled_masked_softmax.rs
+++ b/gpu/src/ops/scaled_masked_softmax.rs
@@ -56,9 +56,7 @@ impl Op for GpuScaledMaskedSoftmax {
 }
 
 impl EvalOp for GpuScaledMaskedSoftmax {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input_val, mask_val) = args_2!(inputs);

--- a/gpu/src/ops/slice.rs
+++ b/gpu/src/ops/slice.rs
@@ -27,9 +27,7 @@ impl Op for GpuSlice {
 }
 
 impl EvalOp for GpuSlice {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/softmax.rs
+++ b/gpu/src/ops/softmax.rs
@@ -71,9 +71,7 @@ impl Op for GpuSoftmax {
 }
 
 impl EvalOp for GpuSoftmax {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);

--- a/gpu/src/ops/stft.rs
+++ b/gpu/src/ops/stft.rs
@@ -79,9 +79,7 @@ impl Op for GpuStft {
 }
 
 impl EvalOp for GpuStft {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;
@@ -164,9 +162,7 @@ impl Op for GpuFft {
 }
 
 impl EvalOp for GpuFft {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;

--- a/gpu/src/sync.rs
+++ b/gpu/src/sync.rs
@@ -32,9 +32,7 @@ impl Op for DeviceSync {
 }
 
 impl EvalOp for DeviceSync {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/hir/src/infer/helpers.rs
+++ b/hir/src/infer/helpers.rs
@@ -14,8 +14,8 @@ pub fn infer_forward_concrete(
     }
     let input_values = input_values.iter().map(|t| t.clone().into_tvalue()).collect();
     // If we know the value of all the inputs, we can deduce everything.
-    if op.is_pure_function() {
-        let output_value = op.eval_pure(input_values)?.pop().unwrap();
+    if let Some(mut values) = op.eval_out_of_plan(input_values)? {
+        let output_value = values.pop().unwrap();
         return Ok(Some(tvec![output_value.into_arc_tensor().try_into()?]));
     }
 

--- a/hir/src/infer/model.rs
+++ b/hir/src/infer/model.rs
@@ -108,7 +108,11 @@ impl InferenceModelExt for InferenceModel {
                 target: &mut TypedModel,
                 mapping: &HashMap<OutletId, OutletId>,
             ) -> TractResult<TVec<OutletId>> {
-                if node.op.is_pure_function()
+                // Two kinds of node must survive translation even when inference
+                // knows their value: a source, which is the model's input, and one
+                // whose state would be dropped along with it.
+                if !InferenceModel::is_source(&node.op)
+                    && node.op.state(&EvalContext::pure())?.is_none()
                     && source.node_output_facts(node.id)?.iter().all(|f| f.value.is_concrete())
                 {
                     (0..node.outputs.len())

--- a/hir/src/infer/model.rs
+++ b/hir/src/infer/model.rs
@@ -112,7 +112,7 @@ impl InferenceModelExt for InferenceModel {
                 // knows their value: a source, which is the model's input, and one
                 // whose state would be dropped along with it.
                 if !InferenceModel::is_source(&node.op)
-                    && node.op.state(&EvalContext::pure())?.is_none()
+                    && node.op.state(&EvalContext::out_of_plan())?.is_none()
                     && source.node_output_facts(node.id)?.iter().all(|f| f.value.is_concrete())
                 {
                     (0..node.outputs.len())

--- a/hir/src/infer/ops.rs
+++ b/hir/src/infer/ops.rs
@@ -38,8 +38,7 @@ pub trait InferenceOp: Op {
         let (infered_inputs, infered_outputs, observed) =
             self.infer_facts(inputs, outputs, observed).context("Infering facts")?;
 
-        if self.is_pure_function()
-            && infered_inputs.len() > 0
+        if infered_inputs.len() > 0
             && let Some(input_values) = infered_inputs
                 .iter()
                 .map(|i| {
@@ -51,8 +50,9 @@ pub trait InferenceOp: Op {
                 .collect::<Option<TVec<_>>>()
         {
             let input_mem: u64 = input_values.iter().map(|t| tensor_mem(t)).sum();
-            match self.eval_pure(input_values) {
-                Ok(values) => {
+            match self.eval_out_of_plan(input_values) {
+                Ok(None) => (),
+                Ok(Some(values)) => {
                     let output_mem: u64 = values.iter().map(|t| tensor_mem(t)).sum();
                     if output_mem <= input_mem.max(CONST_FOLD_MEM_BUDGET) {
                         let output_values = values

--- a/hir/src/ops/array/constant_like.rs
+++ b/hir/src/ops/array/constant_like.rs
@@ -23,9 +23,7 @@ impl Op for ConstantLike {
 }
 
 impl EvalOp for ConstantLike {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
@@ -102,9 +100,7 @@ impl Op for EyeLike {
 }
 
 impl EvalOp for EyeLike {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/hir/src/ops/array/strided_slice.rs
+++ b/hir/src/ops/array/strided_slice.rs
@@ -126,7 +126,7 @@ mod tests {
         S: Into<Tensor>,
     {
         op.eval(
-            &EvalContext::pure(),
+            &EvalContext::out_of_plan(),
             tvec![
                 input.into().into(),
                 begin.into().into(),

--- a/hir/src/ops/binary.rs
+++ b/hir/src/ops/binary.rs
@@ -122,9 +122,7 @@ impl Op for Nary {
 }
 
 impl EvalOp for Nary {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let mut t = inputs[0].clone().into_tensor();

--- a/hir/src/ops/cnn/conv.rs
+++ b/hir/src/ops/cnn/conv.rs
@@ -315,7 +315,7 @@ mod test {
         setup_test_logger();
         let op = expand(Conv::default().nhwc().hwio().padding(PaddingSpec::SameUpper));
         let res = op.eval(
-            &EvalContext::pure(),
+            &EvalContext::out_of_plan(),
             tvec!(
                 Tensor::zero::<f32>(&[1, 2, 2, 2]).unwrap().into_tvalue(),
                 Tensor::zero::<f32>(&[2, 2, 2, 1]).unwrap().into_tvalue(),
@@ -342,7 +342,7 @@ mod test {
         let i = tensor4(&[[[[0.0f32, 0.0], [1.0, 0.0]]]]);
         let k = tensor4(&[[[[0.0f32], [0.0]], [[1.0], [0.0]]]]);
         let e = tensor4(&[[[[1.0f32], [0.0]]]]);
-        let res = op.eval(&EvalContext::pure(), tvec!(i.into(), k.into())).unwrap();
+        let res = op.eval(&EvalContext::out_of_plan(), tvec!(i.into(), k.into())).unwrap();
         res[0].close_enough(&e, Approximation::Approximate).unwrap();
     }
 
@@ -352,7 +352,7 @@ mod test {
         let op = expand(Conv::default().nhwc().hwio().padding(PaddingSpec::SameUpper));
         let i = tensor4(&[[[[0.0f32, 1.0], [2.0, 3.0]], [[10.0, 11.0], [12.0, 13.0]]]]);
         let k = tensor4(&[[[[1.0f32, 0.0], [0.0, 1.0]]]]);
-        let res = op.eval(&EvalContext::pure(), tvec!(i.clone().into(), k.into())).unwrap();
+        let res = op.eval(&EvalContext::out_of_plan(), tvec!(i.clone().into(), k.into())).unwrap();
         res[0].close_enough(&i, Approximation::Approximate).unwrap()
     }
 
@@ -362,7 +362,7 @@ mod test {
         let op = expand(Conv::default().nhwc().hwio().padding(PaddingSpec::SameUpper));
         let result = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec!(
                     tensor4(&[[[[2.0f32]]], [[[0.0f32]]]]).into(),
                     tensor4(&[[[[1.0f32]]]]).into()
@@ -389,7 +389,7 @@ mod test {
         let op = expand(Conv::default().nhwc().hwio().padding(PaddingSpec::SameUpper));
         let result = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec!(tensor3(&[[[2.0f32], [0.0f32]]]).into(), tensor3(&[[[1.0f32]]]).into()),
             )
             .unwrap();
@@ -413,7 +413,7 @@ mod test {
         let op = expand(Conv::default().nhwc().hwio().padding(PaddingSpec::SameUpper));
         let result = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec!(tensor3(&[[[2.0f32]], [[0.0f32]]]).into(), tensor3(&[[[1.0f32]]]).into()),
             )
             .unwrap();
@@ -437,7 +437,7 @@ mod test {
         let op = expand(Conv::default().nhwc().hwio().padding(PaddingSpec::SameUpper));
         let result = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec!(
                     tensor3(&[[[2.0f32, 0.0f32]]]).into(),
                     tensor3(&[[[1.0f32], [0.0f32]]]).into()

--- a/hir/src/ops/expandable.rs
+++ b/hir/src/ops/expandable.rs
@@ -54,7 +54,9 @@ pub trait Expansion:
         outputs: &'p [TensorProxy],
     ) -> InferenceResult;
 
-    fn is_pure_function(&self) -> bool {
+    /// Whether this expansion's ad-hoc model can be evaluated with no plan around
+    /// it. Consulted by `EvalOp for Box<dyn Expansion>` before it builds one.
+    fn runs_out_of_plan(&self) -> bool {
         true
     }
 }
@@ -85,8 +87,12 @@ impl Op for Box<dyn Expansion> {
 }
 
 impl EvalOp for Box<dyn Expansion> {
-    fn is_pure_function(&self) -> bool {
-        self.as_ref().is_pure_function()
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        if self.as_ref().runs_out_of_plan() {
+            Ok(Some(self.eval(&EvalContext::out_of_plan(), inputs)?))
+        } else {
+            Ok(None)
+        }
     }
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {

--- a/hir/src/ops/scan.rs
+++ b/hir/src/ops/scan.rs
@@ -41,9 +41,7 @@ impl Op for InferenceScan {
 }
 
 impl EvalOp for InferenceScan {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         self.to_mir_scan()?.state(ctx)

--- a/hir/src/ops/source.rs
+++ b/hir/src/ops/source.rs
@@ -15,9 +15,7 @@ impl Op for Source {
 }
 
 impl EvalOp for Source {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(!inputs.is_empty(), "Input for node {} is missing", ctx.node_id);
         Ok(inputs)

--- a/metal/src/kernels/array/diag_gather.rs
+++ b/metal/src/kernels/array/diag_gather.rs
@@ -148,7 +148,9 @@ mod tests {
             let metal_in = cpu_in.clone().into_device()?;
 
             let cpu_op = cpu_dg::DiagGather { offset: offset.to_dim(), out_len: out_len.to_dim() };
-            let cpu_out = cpu_op.eval_pure(tvec![cpu_in.into_tvalue()])?[0].clone().into_tensor();
+            let cpu_out = cpu_op.eval(&EvalContext::out_of_plan(), tvec![cpu_in.into_tvalue()])?[0]
+                .clone()
+                .into_tensor();
             let metal_out = DiagGather.eval(stream, &metal_in, offset, out_len)?;
             cpu_out
                 .close_enough(&metal_out.to_host()?.into_tensor(), Approximation::Exact)

--- a/metal/src/kernels/array/gather.rs
+++ b/metal/src/kernels/array/gather.rs
@@ -141,8 +141,10 @@ mod tests {
             let metal_indices = indices.clone().into_device()?;
 
             let cpu_op = CpuGather::new(axis);
-            let cpu_out = cpu_op
-                .eval(&EvalContext::pure(), tvec![data.into_tvalue(), indices.into_tvalue()])?[0]
+            let cpu_out = cpu_op.eval(
+                &EvalContext::out_of_plan(),
+                tvec![data.into_tvalue(), indices.into_tvalue()],
+            )?[0]
                 .clone()
                 .into_tensor();
             let metal_out = Gather.eval(stream, &metal_data, &metal_indices, axis)?;

--- a/metal/src/kernels/array/rotate_half.rs
+++ b/metal/src/kernels/array/rotate_half.rs
@@ -116,7 +116,7 @@ mod tests {
             let metal_a = a.clone().into_device()?;
 
             let cpu_output = apply_rope::RotateHalf
-                .eval(&EvalContext::pure(), tvec![a.clone().into()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.clone().into()])?[0]
                 .clone()
                 .into_tensor();
             let metal_output = RotateHalf.eval(stream, &metal_a)?;

--- a/metal/src/kernels/matmul/mfa/mod.rs
+++ b/metal/src/kernels/matmul/mfa/mod.rs
@@ -485,9 +485,7 @@ impl Op for MetalMfaSdpa {
 }
 
 impl EvalOp for MetalMfaSdpa {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         use tract_gpu::tensor::{DeviceTensorExt, IntoDevice};
         ensure!(inputs.len() == 3, "MetalMfaSdpa expects Q,K,V");
@@ -1312,11 +1310,14 @@ mod tests {
                 let kd = Tensor::from_shape(&[b, nh, sk, d], &kv)?.into_device()?;
                 let vd = Tensor::from_shape(&[b, nh, sk, d], &vv)?.into_device()?;
                 let op = MetalMfaSdpa { scale, is_causal };
-                let out = op.eval_pure(tvec![
-                    qd.into_tensor().into_tvalue(),
-                    kd.into_tensor().into_tvalue(),
-                    vd.into_tensor().into_tvalue()
-                ])?;
+                let out = op.eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        qd.into_tensor().into_tvalue(),
+                        kd.into_tensor().into_tvalue(),
+                        vd.into_tensor().into_tvalue()
+                    ],
+                )?;
                 let got = out[0].to_device_tensor()?.to_host()?.into_tensor();
                 let gv = unsafe { got.as_slice_unchecked::<f32>() };
                 Ok(gv.iter().zip(want.iter()).map(|(&g, &w)| (g - w).abs()).fold(0f32, f32::max))

--- a/metal/src/kernels/matmul/mlx_sdpa/mod.rs
+++ b/metal/src/kernels/matmul/mlx_sdpa/mod.rs
@@ -464,9 +464,7 @@ impl Op for MetalMlxSdpa {
 }
 
 impl EvalOp for MetalMlxSdpa {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         use tract_gpu::tensor::DeviceTensorExt;
         ensure!((3..=4).contains(&inputs.len()), "MetalMlxSdpa expects Q,K,V[,mask]");
@@ -595,7 +593,7 @@ mod tests {
             is_causal,
         };
         Ok(cpu.eval(
-            &EvalContext::pure(),
+            &EvalContext::out_of_plan(),
             tvec![q.clone().into_tvalue(), k.clone().into_tvalue(), v.clone().into_tvalue()],
         )?[0]
             .clone()
@@ -754,7 +752,7 @@ mod tests {
             is_causal: false,
         };
         let reference = cpu.eval(
-            &EvalContext::pure(),
+            &EvalContext::out_of_plan(),
             tvec![
                 q.clone().into_tvalue(),
                 k.clone().into_tvalue(),

--- a/metal/src/kernels/matmul/mod.rs
+++ b/metal/src/kernels/matmul/mod.rs
@@ -454,7 +454,8 @@ mod tests {
             }
 
             let output = args_1!(
-                matmul.eval(&EvalContext::pure(), tvec![a.into_tvalue(), b.into_tvalue()])?
+                matmul
+                    .eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue(), b.into_tvalue()])?
             );
             metal_output.to_host()?.close_enough(&output, Approximation::SuperApproximate)?;
             Ok(())
@@ -913,7 +914,7 @@ mod tests {
                 rhs_tensor = Q4_0.simulate_precision_loss(rhs_tensor, 2)?
             };
             let output = matmul.eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![lhs_tensor.into_tvalue(), rhs_tensor.into_tvalue()],
             )?;
 

--- a/metal/src/kernels/nn/apply_rope.rs
+++ b/metal/src/kernels/nn/apply_rope.rs
@@ -157,7 +157,7 @@ mod tests {
             let metal_cos = cos.clone().into_device()?;
 
             let cpu_output = apply_rope::ApplyRope.eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![a.clone().into(), cos.clone().into(), sin.clone().into(),],
             )?[0]
                 .clone()

--- a/metal/src/kernels/nn/gelu_approximate.rs
+++ b/metal/src/kernels/nn/gelu_approximate.rs
@@ -130,7 +130,7 @@ mod tests {
             .into_device()?;
 
             let cpu_output = gelu_approximate::gelu_approximate(false)
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_output = gelu_approx.eval(stream, &a)?;
@@ -275,7 +275,7 @@ mod tests {
             let a = Tensor::from_shape(self.shape.as_slice(), &self.input)?;
 
             let cpu_output = gelu_approximate::gelu_approximate(false)
-                .eval(&EvalContext::pure(), tvec![a.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
 

--- a/metal/src/kernels/nn/rms_norm.rs
+++ b/metal/src/kernels/nn/rms_norm.rs
@@ -187,7 +187,7 @@ mod tests {
             let cpu_rms = rms_norm::RmsNorm { axis, eps: Arc::clone(&eps) };
 
             let cpu_output = cpu_rms
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_output = RmsNorm.eval(stream, &a, axis, &eps)?;
@@ -294,7 +294,7 @@ mod tests {
 
             let cpu_rms = rms_norm::RmsNorm { axis: self.axis, eps: Arc::clone(&self.eps) };
 
-            let cpu_output = cpu_rms.eval(&EvalContext::pure(), tvec![a.into_tvalue()])?[0]
+            let cpu_output = cpu_rms.eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
 

--- a/metal/src/kernels/nn/scaled_masked_softmax.rs
+++ b/metal/src/kernels/nn/scaled_masked_softmax.rs
@@ -197,7 +197,7 @@ mod tests {
             };
 
             let cpu_output = cpu.eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![a.to_host()?.into_tvalue(), mask.to_host()?.into_tvalue()],
             )?[0]
                 .clone()
@@ -229,7 +229,7 @@ mod tests {
             };
 
             let cpu_output = cpu.eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec![a.to_host()?.into_tvalue(), mask.to_host()?.into_tvalue()],
             )?[0]
                 .clone()
@@ -272,7 +272,7 @@ mod tests {
                     post_softmax_mask: post,
                 };
                 let cpu_out = cpu.eval(
-                    &EvalContext::pure(),
+                    &EvalContext::out_of_plan(),
                     tvec![a.to_host()?.into_tvalue(), mask.to_host()?.into_tvalue()],
                 )?[0]
                     .clone()
@@ -373,7 +373,10 @@ mod tests {
 
             let cpu_output =
                 scaled_masked_softmax::ScaledMaskedSoftmax { scale, post_softmax_mask: false }
-                    .eval(&EvalContext::pure(), tvec![a.into_tvalue(), mask.into_tvalue()])?[0]
+                    .eval(
+                        &EvalContext::out_of_plan(),
+                        tvec![a.into_tvalue(), mask.into_tvalue()],
+                    )?[0]
                     .clone()
                     .into_tensor();
             Ok(cpu_output)

--- a/metal/src/kernels/nn/silu.rs
+++ b/metal/src/kernels/nn/silu.rs
@@ -101,7 +101,7 @@ mod tests {
             .into_device()?;
 
             let cpu_output = tract_core::ops::nn::silu::silu()
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_output = Silu.eval(stream, &a)?;
@@ -201,8 +201,9 @@ mod tests {
         pub fn reference(&self) -> TractResult<Tensor> {
             let a = Tensor::from_shape(self.shape.as_slice(), &self.input)?;
             let silu = tract_core::ops::nn::silu::silu();
-            let cpu_output =
-                silu.eval(&EvalContext::pure(), tvec![a.into_tvalue()])?[0].clone().into_tensor();
+            let cpu_output = silu.eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue()])?[0]
+                .clone()
+                .into_tensor();
 
             Ok(cpu_output)
         }

--- a/metal/src/kernels/nn/softmax.rs
+++ b/metal/src/kernels/nn/softmax.rs
@@ -127,7 +127,7 @@ mod tests {
             };
 
             let cpu_output = cpu_softmax
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_output = Softmax.eval(stream, &a, axis)?;
@@ -157,7 +157,7 @@ mod tests {
             };
 
             let cpu_output = cpu_softmax
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_output = Softmax.eval(stream, &a, axis)?;
@@ -187,7 +187,7 @@ mod tests {
             };
 
             let cpu_output = cpu_softmax
-                .eval(&EvalContext::pure(), tvec![a.to_host()?.into_tvalue()])?[0]
+                .eval(&EvalContext::out_of_plan(), tvec![a.to_host()?.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             let metal_output = Softmax.eval(stream, &a, axis)?;
@@ -274,7 +274,8 @@ mod tests {
                 quant_output_dt: None,
                 kind: SoftmaxKind::Softmax,
             };
-            let cpu_output = cpu_softmax.eval(&EvalContext::pure(), tvec![a.into_tvalue()])?[0]
+            let cpu_output = cpu_softmax
+                .eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue()])?[0]
                 .clone()
                 .into_tensor();
             Ok(cpu_output)

--- a/metal/src/ops/conv.rs
+++ b/metal/src/ops/conv.rs
@@ -57,9 +57,7 @@ impl Op for MetalConv {
 }
 
 impl EvalOp for MetalConv {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let inputs =

--- a/metal/src/ops/fused_axis_op.rs
+++ b/metal/src/ops/fused_axis_op.rs
@@ -139,8 +139,10 @@ impl Op for MetalFusedAxisOp {
 }
 
 impl EvalOp for MetalFusedAxisOp {
-    fn is_pure_function(&self) -> bool {
-        self.op.is_pure_function()
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        let ctx = EvalContext::out_of_plan();
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, &ctx)?;
+        self.op.eval_out_of_plan(inputs)
     }
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {

--- a/metal/src/ops/gemm.rs
+++ b/metal/src/ops/gemm.rs
@@ -67,9 +67,7 @@ impl<K: GemmKernel> MetalGemm<K> {
     }
 }
 impl<K: GemmKernel + 'static> EvalOp for MetalGemm<K> {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (a_raw, b_raw) = args_2!(inputs);

--- a/metal/src/ops/pool.rs
+++ b/metal/src/ops/pool.rs
@@ -44,9 +44,7 @@ impl Op for MetalPool {
 }
 
 impl EvalOp for MetalPool {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = inputs[0].to_device_tensor()?;

--- a/onnx-opl/src/lrn.rs
+++ b/onnx-opl/src/lrn.rs
@@ -45,9 +45,7 @@ impl Op for Lrn {
 }
 
 impl EvalOp for Lrn {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/onnx-opl/src/ml/category_mapper.rs
+++ b/onnx-opl/src/ml/category_mapper.rs
@@ -50,9 +50,7 @@ impl Op for DirectLookup {
 }
 
 impl EvalOp for DirectLookup {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
@@ -167,9 +165,7 @@ impl Op for ReverseLookup {
 }
 
 impl EvalOp for ReverseLookup {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/onnx-opl/src/ml/tree_ensemble_classifier.rs
+++ b/onnx-opl/src/ml/tree_ensemble_classifier.rs
@@ -35,9 +35,7 @@ impl Op for TreeEnsembleClassifier {
 }
 
 impl EvalOp for TreeEnsembleClassifier {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/onnx-opl/src/multinomial.rs
+++ b/onnx-opl/src/multinomial.rs
@@ -103,9 +103,7 @@ impl Op for Multinomial {
 }
 
 impl EvalOp for Multinomial {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/onnx-opl/src/non_max_suppression.rs
+++ b/onnx-opl/src/non_max_suppression.rs
@@ -207,9 +207,7 @@ impl Op for NonMaxSuppression {
 }
 
 impl EvalOp for NonMaxSuppression {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let dt = inputs[0].datum_type();

--- a/onnx-opl/src/non_zero.rs
+++ b/onnx-opl/src/non_zero.rs
@@ -59,9 +59,7 @@ impl Op for NonZero {
 }
 
 impl EvalOp for NonZero {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/onnx-opl/src/random.rs
+++ b/onnx-opl/src/random.rs
@@ -103,9 +103,7 @@ impl TypedOp for Random {
 }
 
 impl EvalOp for Random {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         let rng = self.seed.map(SmallRng::seed_from_u64).unwrap_or_else(rand::make_rng);

--- a/onnx-opl/src/resize.rs
+++ b/onnx-opl/src/resize.rs
@@ -362,9 +362,7 @@ impl Op for Resize {
 }
 
 impl EvalOp for Resize {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, mut inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_dt = inputs[0].datum_type();

--- a/onnx/src/ops/array/compress.rs
+++ b/onnx/src/ops/array/compress.rs
@@ -56,9 +56,7 @@ impl Op for Compress {
 }
 
 impl EvalOp for Compress {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, conds) = args_2!(inputs);

--- a/onnx/src/ops/array/nonzero.rs
+++ b/onnx/src/ops/array/nonzero.rs
@@ -32,9 +32,7 @@ impl Op for NonZero {
 }
 
 impl EvalOp for NonZero {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         self.typed().eval(_ctx, inputs)

--- a/onnx/src/ops/cast.rs
+++ b/onnx/src/ops/cast.rs
@@ -51,7 +51,7 @@ impl ElementWiseMiniOp for Cast {
             }
         } else {
             tract_hir::ops::cast::cast(self.to)
-                .eval_pure(tvec!(t.clone().into_tvalue()))
+                .eval(&EvalContext::out_of_plan(), tvec!(t.clone().into_tvalue()))
                 .map(|mut t| t.remove(0).into_tensor())
         }
     }

--- a/onnx/src/ops/logic.rs
+++ b/onnx/src/ops/logic.rs
@@ -78,9 +78,7 @@ impl Op for If {
 }
 
 impl EvalOp for If {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let cond = inputs[0].cast_to_scalar::<bool>()?;

--- a/onnx/src/ops/nn/dropout.rs
+++ b/onnx/src/ops/nn/dropout.rs
@@ -23,9 +23,7 @@ impl Op for Dropout {
 }
 
 impl EvalOp for Dropout {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         if self.output_mask {

--- a/onnx/src/ops/quant.rs
+++ b/onnx/src/ops/quant.rs
@@ -273,9 +273,7 @@ impl Op for DynamicQuantizeLinearU8 {
 }
 
 impl EvalOp for DynamicQuantizeLinearU8 {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = &inputs[0];
         let input = input.cast_to::<f32>()?;

--- a/onnx/src/ops/random.rs
+++ b/onnx/src/ops/random.rs
@@ -55,7 +55,7 @@ impl Expansion for Random {
         Validation::Random
     }
 
-    fn is_pure_function(&self) -> bool {
+    fn runs_out_of_plan(&self) -> bool {
         false
     }
 
@@ -107,7 +107,7 @@ impl Expansion for RandomLike {
         Validation::Random
     }
 
-    fn is_pure_function(&self) -> bool {
+    fn runs_out_of_plan(&self) -> bool {
         false
     }
 

--- a/pulse-opl/src/affine_trim.rs
+++ b/pulse-opl/src/affine_trim.rs
@@ -36,9 +36,7 @@ impl Op for AffineChunkTrim {
 }
 
 impl EvalOp for AffineChunkTrim {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/pulse-opl/src/concat.rs
+++ b/pulse-opl/src/concat.rs
@@ -20,9 +20,7 @@ impl Op for PulsedSameAxisConcat {
 }
 
 impl EvalOp for PulsedSameAxisConcat {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulsedSameAxisConcatState>::default()))

--- a/pulse-opl/src/deconv_delay.rs
+++ b/pulse-opl/src/deconv_delay.rs
@@ -24,9 +24,7 @@ impl Op for DeconvDelay {
 }
 
 impl EvalOp for DeconvDelay {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, _inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         unreachable!()

--- a/pulse-opl/src/delay.rs
+++ b/pulse-opl/src/delay.rs
@@ -140,9 +140,7 @@ impl Op for Delay {
 }
 
 impl EvalOp for Delay {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(DelayState { buffer: None })))

--- a/pulse-opl/src/mask.rs
+++ b/pulse-opl/src/mask.rs
@@ -122,9 +122,7 @@ impl Op for PulseMask {
 }
 
 impl EvalOp for PulseMask {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulseMaskOpState>::default()))

--- a/pulse-opl/src/pad.rs
+++ b/pulse-opl/src/pad.rs
@@ -271,9 +271,7 @@ impl Op for PulsePad {
 }
 
 impl EvalOp for PulsePad {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulsePadOpState>::default()))

--- a/pulse-opl/src/range.rs
+++ b/pulse-opl/src/range.rs
@@ -40,9 +40,7 @@ impl Op for PulsedRange {
 }
 
 impl EvalOp for PulsedRange {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::<PulsedRangeState>::default()))

--- a/pulse-opl/src/slice.rs
+++ b/pulse-opl/src/slice.rs
@@ -28,9 +28,7 @@ impl TypedOp for PulsedAxisSlice {
 }
 
 impl EvalOp for PulsedAxisSlice {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(inputs)

--- a/pulse-opl/src/window.rs
+++ b/pulse-opl/src/window.rs
@@ -97,9 +97,7 @@ impl Op for WindowOnAxis {
 }
 
 impl EvalOp for WindowOnAxis {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/pulse/src/model.rs
+++ b/pulse/src/model.rs
@@ -371,12 +371,12 @@ impl Op for PulseWrappingOp {
 }
 
 impl EvalOp for PulseWrappingOp {
-    fn is_pure_function(&self) -> bool {
-        self.0.is_pure_function()
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        self.0.eval_out_of_plan(inputs)
     }
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        self.0.eval_pure(inputs)
+        self.0.eval(&EvalContext::out_of_plan(), inputs)
     }
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
@@ -461,12 +461,12 @@ impl Op for NonPulsingWrappingOp {
 }
 
 impl EvalOp for NonPulsingWrappingOp {
-    fn is_pure_function(&self) -> bool {
-        self.0.is_pure_function()
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        self.0.eval_out_of_plan(inputs)
     }
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        self.0.eval_pure(inputs)
+        self.0.eval(&EvalContext::out_of_plan(), inputs)
     }
 
     fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {

--- a/pulse/src/ops/array/broadcast.rs
+++ b/pulse/src/ops/array/broadcast.rs
@@ -108,11 +108,9 @@ impl TypedOp for PulsedMultibroadcastTo {
 }
 
 impl EvalOp for PulsedMultibroadcastTo {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        self.to_typed().eval_pure(inputs)
+        self.to_typed().eval(&EvalContext::out_of_plan(), inputs)
     }
 }
 

--- a/pulse/src/ops/array/reshape.rs
+++ b/pulse/src/ops/array/reshape.rs
@@ -96,12 +96,10 @@ impl Op for PulsedReshape {
 }
 
 impl EvalOp for PulsedReshape {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        self.op.eval_pure(inputs)
+        self.op.eval(&EvalContext::out_of_plan(), inputs)
     }
 }
 

--- a/pulse/src/ops/array/slice.rs
+++ b/pulse/src/ops/array/slice.rs
@@ -61,9 +61,7 @@ impl Op for PulsedAxisSlice {
 }
 
 impl EvalOp for PulsedAxisSlice {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(inputs)

--- a/pulse/src/ops/source.rs
+++ b/pulse/src/ops/source.rs
@@ -43,9 +43,7 @@ impl Op for PulsedSource {
 }
 
 impl EvalOp for PulsedSource {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(!inputs.is_empty(), "Input for node {} is missing", ctx.node_id);

--- a/pulse/src/ops/window.rs
+++ b/pulse/src/ops/window.rs
@@ -127,9 +127,7 @@ impl Op for PulsedExposeWindow {
 }
 
 impl EvalOp for PulsedExposeWindow {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs).into_tensor();
@@ -196,8 +194,9 @@ mod tests {
         let op = WindowOnAxis::future(0, 2, f32::datum_type()).unwrap();
         let input =
             tract_core::ndarray::Array2::<f32>::from_shape_fn((4, 2), |(i, j)| (i * 10 + j) as f32);
-        let result =
-            op.eval(&EvalContext::pure(), tvec!(input.clone().into_dyn().into_tvalue())).unwrap();
+        let result = op
+            .eval(&EvalContext::out_of_plan(), tvec!(input.clone().into_dyn().into_tvalue()))
+            .unwrap();
         let out = result[0].to_plain_array_view::<f32>().unwrap().to_owned();
         assert_eq!(out.shape(), &[4, 2, 2]);
         // Slot w=0: copy of input.

--- a/tensorflow/src/ops/array/fill.rs
+++ b/tensorflow/src/ops/array/fill.rs
@@ -35,9 +35,7 @@ impl Op for Fill {
 }
 
 impl EvalOp for Fill {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         dispatch_datum!(Self::eval_t(self.dt)(self, inputs))

--- a/tensorflow/src/ops/array/gather_nd.rs
+++ b/tensorflow/src/ops/array/gather_nd.rs
@@ -19,10 +19,10 @@ mod tests {
     fn simple_indexing() {
         let g = GatherNd::new(0);
         assert_eq!(
-            g.eval_pure(tvec!(
-                tensor2(&[[1, 2], [3, 4]]).into(),
-                tensor2(&[[0, 0], [1, 1]]).into()
-            ))
+            g.eval(
+                &EvalContext::out_of_plan(),
+                tvec!(tensor2(&[[1, 2], [3, 4]]).into(), tensor2(&[[0, 0], [1, 1]]).into())
+            )
             .unwrap(),
             tvec!(tensor1(&[1, 4]).into())
         );
@@ -32,8 +32,11 @@ mod tests {
     fn slice_indexing() {
         let g = GatherNd::new(0);
         assert_eq!(
-            g.eval_pure(tvec!(tensor2(&[[1, 2], [3, 4]]).into(), tensor2(&[[1], [0]]).into()))
-                .unwrap(),
+            g.eval(
+                &EvalContext::out_of_plan(),
+                tvec!(tensor2(&[[1, 2], [3, 4]]).into(), tensor2(&[[1], [0]]).into())
+            )
+            .unwrap(),
             tvec!(tensor2(&[[3, 4], [1, 2]]).into())
         );
     }
@@ -43,7 +46,7 @@ mod tests {
         let g = GatherNd::new(0);
         let t = tensor3(&[[[10, 20], [30, 40]], [[11, 21], [31, 41]]]);
         assert_eq!(
-            g.eval_pure(tvec!(t.into(), tensor2(&[[1]]).into())).unwrap(),
+            g.eval(&EvalContext::out_of_plan(), tvec!(t.into(), tensor2(&[[1]]).into())).unwrap(),
             tvec!(tensor3(&[[[11, 21], [31, 41]]]).into())
         );
     }
@@ -53,7 +56,8 @@ mod tests {
         let g = GatherNd::new(0);
         let t = tensor3(&[[[10, 20], [30, 40]], [[11, 21], [31, 41]]]);
         assert_eq!(
-            g.eval_pure(tvec!(t.into(), tensor2(&[[0, 1], [1, 0]]).into())).unwrap(),
+            g.eval(&EvalContext::out_of_plan(), tvec!(t.into(), tensor2(&[[0, 1], [1, 0]]).into()))
+                .unwrap(),
             tvec!(tensor2(&[[30, 40], [11, 21]]).into())
         );
     }
@@ -63,7 +67,11 @@ mod tests {
         let g = GatherNd::new(0);
         let t = tensor3(&[[[10, 20], [30, 40]], [[11, 21], [31, 41]]]);
         assert_eq!(
-            g.eval_pure(tvec!(t.into(), tensor2(&[[0, 0, 1], [1, 0, 1]]).into())).unwrap(),
+            g.eval(
+                &EvalContext::out_of_plan(),
+                tvec!(t.into(), tensor2(&[[0, 0, 1], [1, 0, 1]]).into())
+            )
+            .unwrap(),
             tvec!(tensor1(&[20, 21]).into())
         );
     }
@@ -73,7 +81,8 @@ mod tests {
         let g = GatherNd::new(1);
         let t = tensor3(&[[[10, 20], [30, 40]], [[11, 21], [31, 41]]]);
         assert_eq!(
-            g.eval_pure(tvec!(t.into(), tensor2(&[[1], [0]]).into())).unwrap(),
+            g.eval(&EvalContext::out_of_plan(), tvec!(t.into(), tensor2(&[[1], [0]]).into()))
+                .unwrap(),
             tvec!(tensor2(&[[30, 40], [11, 21]]).into())
         );
     }
@@ -83,7 +92,8 @@ mod tests {
         let g = GatherNd::new(1);
         let t = tensor3(&[[[10, 20], [30, 40]], [[11, 21], [31, 41]]]);
         assert_eq!(
-            g.eval_pure(tvec!(t.into(), tensor3(&[[[1]], [[0]]]).into())).unwrap(),
+            g.eval(&EvalContext::out_of_plan(), tvec!(t.into(), tensor3(&[[[1]], [[0]]]).into()))
+                .unwrap(),
             tvec!(tensor3(&[[[30, 40]], [[11, 21]]]).into())
         );
     }
@@ -93,7 +103,11 @@ mod tests {
         let g = GatherNd::new(1);
         let t = tensor3(&[[[10, 20], [30, 40]], [[11, 21], [31, 41]]]);
         assert_eq!(
-            g.eval_pure(tvec!(t.into(), tensor3(&[[[1, 0]], [[0, 1]]]).into())).unwrap(),
+            g.eval(
+                &EvalContext::out_of_plan(),
+                tvec!(t.into(), tensor3(&[[[1, 0]], [[0, 1]]]).into())
+            )
+            .unwrap(),
             tvec!(tensor2(&[[30], [21]]).into())
         );
     }

--- a/tensorflow/src/ops/array/pad.rs
+++ b/tensorflow/src/ops/array/pad.rs
@@ -56,9 +56,7 @@ impl Op for Pad {
 }
 
 impl EvalOp for Pad {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, paddings) = args_2!(inputs);
@@ -120,6 +118,6 @@ mod tests {
             .into()
         );
 
-        assert_eq!(Pad::new().eval_pure(inputs).unwrap(), expected);
+        assert_eq!(Pad::new().eval(&EvalContext::out_of_plan(), inputs).unwrap(), expected);
     }
 }

--- a/tensorflow/src/ops/array/squeeze.rs
+++ b/tensorflow/src/ops/array/squeeze.rs
@@ -24,7 +24,12 @@ mod tests {
     where
         I: Into<Tensor>,
     {
-        expand(op).eval_pure(tvec![input.into().into()]).unwrap().pop().unwrap().into_tensor()
+        expand(op)
+            .eval(&EvalContext::out_of_plan(), tvec![input.into().into()])
+            .unwrap()
+            .pop()
+            .unwrap()
+            .into_tensor()
     }
 
     #[test]

--- a/tensorflow/src/ops/control_flow.rs
+++ b/tensorflow/src/ops/control_flow.rs
@@ -29,9 +29,7 @@ impl Op for LoopGate {
 }
 
 impl EvalOp for LoopGate {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(inputs)
@@ -76,9 +74,7 @@ impl Op for NextIteration {
 }
 
 impl EvalOp for NextIteration {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         unimplemented!();

--- a/tensorflow/src/ops/logic.rs
+++ b/tensorflow/src/ops/logic.rs
@@ -32,9 +32,7 @@ impl Op for Switch {
 }
 
 impl EvalOp for Switch {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)
@@ -123,9 +121,7 @@ impl Op for Merge {
 }
 
 impl EvalOp for Merge {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(None)

--- a/tensorflow/src/ops/math/reduce.rs
+++ b/tensorflow/src/ops/math/reduce.rs
@@ -48,15 +48,13 @@ impl Op for Reduce {
 }
 
 impl EvalOp for Reduce {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, axes) = args_2!(inputs);
         let axes: Vec<i64> = axes.cast_to::<i64>()?.try_as_plain()?.as_slice::<i64>()?.to_vec();
         let op = nn::Reduce::new(Some(axes), self.keep_dims, self.reducer);
-        expand(op).eval_pure(tvec!(input))
+        expand(op).eval(&EvalContext::out_of_plan(), tvec!(input))
     }
 }
 

--- a/tensorflow/src/ops/mod.rs
+++ b/tensorflow/src/ops/mod.rs
@@ -59,9 +59,7 @@ impl Op for Noop {
 }
 
 impl EvalOp for Noop {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, _inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         Ok(tvec!(Tensor::from(false).into()))

--- a/tensorflow/src/ops/nn/conv2d.rs
+++ b/tensorflow/src/ops/nn/conv2d.rs
@@ -35,7 +35,7 @@ mod tests {
 
     fn verify(input: Tensor, filter: Tensor, stride: usize, padding: PaddingSpec, expect: &[f32]) {
         let result = make_conv(stride, stride, padding)
-            .eval_pure(tvec![input.into(), filter.into()])
+            .eval(&EvalContext::out_of_plan(), tvec![input.into(), filter.into()])
             .unwrap()
             .remove(0);
         assert_eq!(expect.len(), result.shape().iter().product::<usize>());
@@ -136,7 +136,8 @@ mod tests {
         let filter = tensor4(&[[[[0.0f32]]], [[[1.0]]], [[[0.0]]]]);
         let exp = tensor4(&[[[[1f32]]]]);
 
-        let result = conv.eval_pure(tvec![data.into(), filter.into()]).unwrap();
+        let result =
+            conv.eval(&EvalContext::out_of_plan(), tvec![data.into(), filter.into()]).unwrap();
         result[0].close_enough(&exp, Approximation::Approximate).unwrap()
     }
 
@@ -146,7 +147,8 @@ mod tests {
         let data = tensor4(&[[[[142.3088f32], [48.891083]], [[208.3187], [-11.274994]]]]);
         let filter = tensor4(&[[[[160.72833f32]], [[107.84076]]], [[[247.50552]], [[-38.738464]]]]);
         let exp = tensor4(&[[[[80142.31f32], [5067.5586]], [[32266.81], [-1812.2109]]]]);
-        let got = &conv.eval_pure(tvec![data.into(), filter.into()]).unwrap()[0];
+        let got =
+            &conv.eval(&EvalContext::out_of_plan(), tvec![data.into(), filter.into()]).unwrap()[0];
         exp.close_enough(got, true).unwrap()
     }
 

--- a/tensorflow/src/ops/nn/s2b/mod.rs
+++ b/tensorflow/src/ops/nn/s2b/mod.rs
@@ -117,11 +117,14 @@ mod tests {
     fn space_to_batch_nd_1() {
         assert_eq!(
             SpaceToBatch::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[[[[1i32], [2]], [[3], [4]]]]).into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [0, 0]]).into(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[[[[1i32], [2]], [[3], [4]]]]).into(),
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [0, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![tensor4(&[[[[1i32]]], [[[2]]], [[[3]]], [[[4]]]]).into()],
         )
@@ -131,11 +134,14 @@ mod tests {
     fn space_to_batch_nd_2() {
         assert_eq!(
             SpaceToBatch::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]]).into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [0, 0]]).into(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[[[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]]).into(),
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [0, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![
                 tensor4(&[[[[1i32, 2, 3]]], [[[4, 5, 6]]], [[[7, 8, 9]]], [[[10, 11, 12]]],])
@@ -148,17 +154,20 @@ mod tests {
     fn space_to_batch_nd_3() {
         assert_eq!(
             SpaceToBatch::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[[
-                        [[1], [2], [3], [4]],
-                        [[5], [6], [7], [8]],
-                        [[9], [10], [11], [12]],
-                        [[13], [14], [15], [16]],
-                    ]])
-                    .into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [0, 0]]).into(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[[
+                            [[1], [2], [3], [4]],
+                            [[5], [6], [7], [8]],
+                            [[9], [10], [11], [12]],
+                            [[13], [14], [15], [16]],
+                        ]])
+                        .into(),
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [0, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![
                 tensor4(&[
@@ -176,15 +185,18 @@ mod tests {
     fn space_to_batch_nd_4() {
         assert_eq!(
             SpaceToBatch::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[
-                        [[[1], [2], [3], [4]], [[5], [6], [7], [8]]],
-                        [[[9], [10], [11], [12]], [[13], [14], [15], [16]]],
-                    ])
-                    .into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [2, 0]]).into(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[
+                            [[[1], [2], [3], [4]], [[5], [6], [7], [8]]],
+                            [[[9], [10], [11], [12]], [[13], [14], [15], [16]]],
+                        ])
+                        .into(),
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [2, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![
                 tensor4(&[
@@ -238,11 +250,14 @@ mod tests {
     fn batch_to_space_nd_1() {
         assert_eq!(
             BatchToSpace::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[[[[1]]], [[[2]]], [[[3]]], [[[4]]]]).into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [0, 0]]).into(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[[[[1]]], [[[2]]], [[[3]]], [[[4]]]]).into(),
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [0, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![tensor4(&[[[[1], [2]], [[3], [4]]]]).into()]
         )
@@ -252,12 +267,20 @@ mod tests {
     fn batch_to_space_nd_2() {
         assert_eq!(
             BatchToSpace::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[[[[1i32, 2, 3]]], [[[4, 5, 6]]], [[[7, 8, 9]]], [[[10, 11, 12]]],])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[
+                            [[[1i32, 2, 3]]],
+                            [[[4, 5, 6]]],
+                            [[[7, 8, 9]]],
+                            [[[10, 11, 12]]],
+                        ])
                         .into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [0, 0]]).into(),
-                ])
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [0, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![tensor4(&[[[[1i32, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]]).into()]
         )
@@ -267,17 +290,20 @@ mod tests {
     fn batch_to_space_nd_3() {
         assert_eq!(
             BatchToSpace::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[
-                        [[[1i32], [3]], [[9], [11]]],
-                        [[[2], [4]], [[10], [12]]],
-                        [[[5], [7]], [[13], [15]]],
-                        [[[6], [8]], [[14], [16]]],
-                    ])
-                    .into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [0, 0]]).into(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[
+                            [[[1i32], [3]], [[9], [11]]],
+                            [[[2], [4]], [[10], [12]]],
+                            [[[5], [7]], [[13], [15]]],
+                            [[[6], [8]], [[14], [16]]],
+                        ])
+                        .into(),
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [0, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![
                 tensor4(&[[
@@ -295,21 +321,24 @@ mod tests {
     fn batch_to_space_nd_4() {
         assert_eq!(
             BatchToSpace::new(i32::datum_type())
-                .eval_pure(tvec![
-                    tensor4(&[
-                        [[[0i32], [1], [3]]],
-                        [[[0], [9], [11]]],
-                        [[[0], [2], [4]]],
-                        [[[0], [10], [12]]],
-                        [[[0], [5], [7]]],
-                        [[[0], [13], [15]]],
-                        [[[0], [6], [8]]],
-                        [[[0], [14], [16]]],
-                    ])
-                    .into(),
-                    tensor1(&[2, 2]).into(),
-                    tensor2(&[[0, 0], [2, 0]]).into(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        tensor4(&[
+                            [[[0i32], [1], [3]]],
+                            [[[0], [9], [11]]],
+                            [[[0], [2], [4]]],
+                            [[[0], [10], [12]]],
+                            [[[0], [5], [7]]],
+                            [[[0], [13], [15]]],
+                            [[[0], [6], [8]]],
+                            [[[0], [14], [16]]],
+                        ])
+                        .into(),
+                        tensor1(&[2, 2]).into(),
+                        tensor2(&[[0, 0], [2, 0]]).into(),
+                    ]
+                )
                 .unwrap(),
             tvec![
                 tensor4(&[

--- a/tensorflow/src/ops/nn/s2b/raw.rs
+++ b/tensorflow/src/ops/nn/s2b/raw.rs
@@ -15,9 +15,7 @@ impl Op for SpaceToBatch {
 }
 
 impl EvalOp for SpaceToBatch {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, block_shape, paddings) = args_3!(inputs);
@@ -108,9 +106,7 @@ impl Op for BatchToSpace {
 }
 
 impl EvalOp for BatchToSpace {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, block_shape, crops) = args_3!(inputs);

--- a/tensorflow/src/ops/nn/s2b/unary.rs
+++ b/tensorflow/src/ops/nn/s2b/unary.rs
@@ -28,9 +28,7 @@ impl Op for SpaceToBatchUnary {
 }
 
 impl EvalOp for SpaceToBatchUnary {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
@@ -116,9 +114,7 @@ impl Op for BatchToSpaceUnary {
 }
 
 impl EvalOp for BatchToSpaceUnary {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/tensorflow/src/ops/random/random_uniform.rs
+++ b/tensorflow/src/ops/random/random_uniform.rs
@@ -41,9 +41,7 @@ impl Op for RandomUniform {
 }
 
 impl EvalOp for RandomUniform {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let shape: TVec<usize> = inputs[0]
@@ -129,9 +127,7 @@ impl Op for TypedRandomUniform {
 }
 
 impl EvalOp for TypedRandomUniform {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, _inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let shape = self.shape.iter().map(|d| d.to_usize()).collect::<Result<TVec<_>, _>>()?;
@@ -200,9 +196,7 @@ impl Op for RandomUniformInt {
 }
 
 impl EvalOp for RandomUniformInt {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let shape: TVec<usize> = inputs[0]

--- a/test-rt/suite-unit/src/q_binary.rs
+++ b/test-rt/suite-unit/src/q_binary.rs
@@ -29,7 +29,7 @@ impl QOpProblem for QBinaryOpProblem {
         let b = self.tensor_b.cast_to::<f32>()?.clone().into_owned();
         Ok(self
             .operator
-            .eval_pure(tvec![a.into_tvalue(), b.into_tvalue()])?
+            .eval(&EvalContext::out_of_plan(), tvec![a.into_tvalue(), b.into_tvalue()])?
             .remove(0)
             .into_tensor())
     }

--- a/test-rt/suite-unit/src/q_elmwise.rs
+++ b/test-rt/suite-unit/src/q_elmwise.rs
@@ -14,7 +14,11 @@ struct QElmWiseOpProblem {
 impl QOpProblem for QElmWiseOpProblem {
     fn reference_float_ops(&self) -> TractResult<Tensor> {
         let inp = self.tensor_input.cast_to::<f32>()?.clone().into_owned();
-        Ok(self.operator.eval_pure(tvec![inp.into_tvalue()])?.remove(0).into_tensor())
+        Ok(self
+            .operator
+            .eval(&EvalContext::out_of_plan(), tvec![inp.into_tvalue()])?
+            .remove(0)
+            .into_tensor())
     }
 }
 

--- a/transformers/src/lib.rs
+++ b/transformers/src/lib.rs
@@ -87,8 +87,10 @@ pub fn figure_out_causal_llm_b_s_p(
         // Look for KVCache Op
         let mut symbols = HashSet::new();
         for node in &model.nodes {
-            if let Some((_, fact)) =
-                node.op.state(&EvalContext::pure())?.and_then(|state| state.init_tensor_fact())
+            if let Some((_, fact)) = node
+                .op
+                .state(&EvalContext::out_of_plan())?
+                .and_then(|state| state.init_tensor_fact())
             {
                 symbols = fact.shape.volume().symbols();
                 break;

--- a/transformers/src/ops/apply_rope.rs
+++ b/transformers/src/ops/apply_rope.rs
@@ -51,9 +51,7 @@ impl Op for RotateHalf {
 }
 
 impl EvalOp for RotateHalf {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);
@@ -162,13 +160,12 @@ impl Op for ApplyRope {
 }
 
 impl EvalOp for ApplyRope {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, cos, sin) = args_3!(inputs);
-        let rotated_input = args_1!(RotateHalf.eval(&EvalContext::pure(), tvec![input.clone()])?);
+        let rotated_input =
+            args_1!(RotateHalf.eval(&EvalContext::out_of_plan(), tvec![input.clone()])?);
         let mul_with_cos = Mul.eval(input.clone(), cos, input.datum_type())?;
         let mul_with_sin = Mul.eval(rotated_input, sin, input.datum_type())?;
         let output = Add.eval(mul_with_cos.into(), mul_with_sin.into(), input.datum_type())?;
@@ -260,8 +257,9 @@ mod tests {
     {
         let a_len = a_shape.iter().product::<usize>();
         let input = Tensor::from_shape(a_shape, &(0..a_len).map(|f| f.as_()).collect::<Vec<F>>())?;
-        let rotated = RotateHalf.eval(&EvalContext::pure(), tvec![input.clone().into()])?;
-        let mut back = args_1!(RotateHalf.eval_pure(rotated)?).into_tensor();
+        let rotated = RotateHalf.eval(&EvalContext::out_of_plan(), tvec![input.clone().into()])?;
+        let mut back =
+            args_1!(RotateHalf.eval(&EvalContext::out_of_plan(), rotated)?).into_tensor();
         Neg {}.eval_in_place(&mut back, None)?;
         back.close_enough(&input, Approximation::Close)?;
         Ok(())

--- a/transformers/src/ops/causal_conv1d_update.rs
+++ b/transformers/src/ops/causal_conv1d_update.rs
@@ -36,9 +36,7 @@ impl Op for CausalConv1dUpdate {
 }
 
 impl EvalOp for CausalConv1dUpdate {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, weight, state) = args_3!(inputs);

--- a/transformers/src/ops/diag_gather.rs
+++ b/transformers/src/ops/diag_gather.rs
@@ -39,9 +39,7 @@ impl Op for DiagGather {
 }
 
 impl EvalOp for DiagGather {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input = args_1!(inputs);

--- a/transformers/src/ops/dyn_kv_cache.rs
+++ b/transformers/src/ops/dyn_kv_cache.rs
@@ -164,7 +164,7 @@ impl OpState for DynKeyValueCacheState {
         // build output
         let output = if let Some(curr) = self.kv_cache.take() {
             TypedConcat { axis: self.axis }
-                .eval(&EvalContext::pure(), tvec![curr, input])?
+                .eval(&EvalContext::out_of_plan(), tvec![curr, input])?
                 .remove(0)
         } else {
             input
@@ -196,9 +196,7 @@ impl Op for DynKeyValueCache {
 }
 
 impl EvalOp for DynKeyValueCache {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
 
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(DynKeyValueCacheState {
@@ -426,7 +424,7 @@ mod tests {
         };
 
         let mut turn = TurnState::default();
-        let mut state = op.state(&EvalContext::pure())?.unwrap();
+        let mut state = op.state(&EvalContext::out_of_plan())?.unwrap();
 
         let mut inputs = tvec![];
 
@@ -444,7 +442,7 @@ mod tests {
             let len = shape.iter().product::<usize>();
             let input = Tensor::from_shape(shape, &(0..len).map(|f| f.as_()).collect::<Vec<F>>())?;
             inputs.push(input.clone().into_tvalue());
-            state.eval(&EvalContext::pure(), &op, tvec!(input.clone().into()))?[0]
+            state.eval(&EvalContext::out_of_plan(), &op, tvec!(input.clone().into()))?[0]
                 .clone()
                 .into_tensor();
         }
@@ -453,7 +451,7 @@ mod tests {
         state.save_to(&mut curr_states)?;
         let output = curr_states.remove(0);
 
-        let reference = &TypedConcat { axis }.eval_pure(inputs)?[0];
+        let reference = &TypedConcat { axis }.eval(&EvalContext::out_of_plan(), inputs)?[0];
         output.close_enough(&reference.clone().into_tensor(), Approximation::Close)?;
         Ok(())
     }
@@ -482,7 +480,7 @@ mod tests {
             input_sequence_fact: f32::fact(&input),
         };
         let _turn = TurnState::default();
-        let state = op.state(&EvalContext::pure())?.unwrap();
+        let state = op.state(&EvalContext::out_of_plan())?.unwrap();
         assert!(state.has_init_tensor_fact());
         assert_eq!(state.has_init_tensor_fact(), state.init_tensor_fact().is_some());
         Ok(())

--- a/transformers/src/ops/flash_sdpa.rs
+++ b/transformers/src/ops/flash_sdpa.rs
@@ -96,9 +96,7 @@ impl TypedOp for FlashSdpaOp {
 }
 
 impl EvalOp for FlashSdpaOp {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 3 || inputs.len() == 4);
@@ -416,7 +414,7 @@ mod tests {
         let op = FlashSdpaOp { causal: true, scale: None };
         let f32_out = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec!(q.clone().into_tvalue(), k.clone().into_tvalue(), v.clone().into_tvalue()),
             )?
             .remove(0);
@@ -427,7 +425,7 @@ mod tests {
         );
         let f16_out = op
             .eval(
-                &EvalContext::pure(),
+                &EvalContext::out_of_plan(),
                 tvec!(q16.into_tvalue(), k16.into_tvalue(), v16.into_tvalue()),
             )?
             .remove(0);

--- a/transformers/src/ops/gdn_recurrent.rs
+++ b/transformers/src/ops/gdn_recurrent.rs
@@ -39,9 +39,7 @@ impl Op for GatedDeltaNetRecurrent {
 }
 
 impl EvalOp for GatedDeltaNetRecurrent {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 6, "GDN expects q, k, v, log_decay, beta, state");

--- a/transformers/src/ops/inplace_kv_cache.rs
+++ b/transformers/src/ops/inplace_kv_cache.rs
@@ -150,9 +150,7 @@ impl Op for InPlaceKvSdpa {
 }
 
 impl EvalOp for InPlaceKvSdpa {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(InPlaceKvSdpaState {
             axis: self.axis,
@@ -338,7 +336,7 @@ mod tests {
             concat = Some(match concat.take() {
                 None => chunk,
                 Some(c) => TypedConcat { axis }
-                    .eval(&EvalContext::pure(), tvec![c.into(), chunk.into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), chunk.into()])?
                     .remove(0)
                     .into_tensor(),
             });
@@ -431,7 +429,7 @@ mod tests {
             concat = Some(match concat.take() {
                 None => kv.clone(),
                 Some(c) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![c.into(), kv.clone().into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), kv.clone().into()])?
                     .remove(0)
                     .into_tensor(),
             });
@@ -477,7 +475,10 @@ mod tests {
                     concat = Some(match concat.take() {
                         None => step.clone(),
                         Some(c) => TypedConcat { axis: 2 }
-                            .eval(&EvalContext::pure(), tvec![c.into(), step.clone().into()])?
+                            .eval(
+                                &EvalContext::out_of_plan(),
+                                tvec![c.into(), step.clone().into()],
+                            )?
                             .remove(0)
                             .into_tensor(),
                     });
@@ -524,7 +525,10 @@ mod tests {
                     concat = Some(match concat.take() {
                         None => step.clone(),
                         Some(c) => TypedConcat { axis: 2 }
-                            .eval(&EvalContext::pure(), tvec![c.into(), step.clone().into()])?
+                            .eval(
+                                &EvalContext::out_of_plan(),
+                                tvec![c.into(), step.clone().into()],
+                            )?
                             .remove(0)
                             .into_tensor(),
                     });
@@ -562,7 +566,7 @@ mod tests {
         let (bsz, hq, hkv, d) = (1usize, 4usize, 2usize, 16usize); // GQA: 4 q-heads / 2 kv-heads
         let op = InPlaceKvSdpa { axis: 2, causal, scale: None };
         let turn = TurnState::default();
-        let mut state = op.state(&EvalContext::pure())?.unwrap();
+        let mut state = op.state(&EvalContext::out_of_plan())?.unwrap();
         let _turn = turn;
         let flash = FlashSdpaOp { causal, scale: None };
 
@@ -580,7 +584,7 @@ mod tests {
 
             let o_fused = state
                 .eval(
-                    &EvalContext::pure(),
+                    &EvalContext::out_of_plan(),
                     &op,
                     tvec![q.clone().into(), knew.clone().into(), vnew.clone().into()],
                 )?
@@ -590,20 +594,20 @@ mod tests {
             kc = Some(match kc.take() {
                 None => knew.clone(),
                 Some(c) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![c.into(), knew.clone().into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), knew.clone().into()])?
                     .remove(0)
                     .into_tensor(),
             });
             vc = Some(match vc.take() {
                 None => vnew.clone(),
                 Some(c) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![c.into(), vnew.clone().into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), vnew.clone().into()])?
                     .remove(0)
                     .into_tensor(),
             });
             let o_base = flash
                 .eval(
-                    &EvalContext::pure(),
+                    &EvalContext::out_of_plan(),
                     tvec![q.into(), kc.clone().unwrap().into(), vc.clone().unwrap().into()],
                 )?
                 .remove(0)
@@ -669,20 +673,20 @@ mod tests {
             kc = Some(match kc.take() {
                 None => knew.clone(),
                 Some(c) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![c.into(), knew.clone().into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), knew.clone().into()])?
                     .remove(0)
                     .into_tensor(),
             });
             vc = Some(match vc.take() {
                 None => vnew.clone(),
                 Some(c) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![c.into(), vnew.clone().into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), vnew.clone().into()])?
                     .remove(0)
                     .into_tensor(),
             });
             let o_base = flash
                 .eval(
-                    &EvalContext::pure(),
+                    &EvalContext::out_of_plan(),
                     tvec![q.into(), kc.clone().unwrap().into(), vc.clone().unwrap().into()],
                 )?
                 .remove(0)
@@ -760,20 +764,20 @@ mod tests {
             kacc = Some(match kacc.take() {
                 None => ki.clone(),
                 Some(c) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![c.into(), ki.clone().into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), ki.clone().into()])?
                     .remove(0)
                     .into_tensor(),
             });
             vacc = Some(match vacc.take() {
                 None => vi.clone(),
                 Some(c) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![c.into(), vi.clone().into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![c.into(), vi.clone().into()])?
                     .remove(0)
                     .into_tensor(),
             });
             let o_base = flash
                 .eval(
-                    &EvalContext::pure(),
+                    &EvalContext::out_of_plan(),
                     tvec![qi.into(), kacc.clone().unwrap().into(), vacc.clone().unwrap().into()],
                 )?
                 .remove(0)
@@ -803,13 +807,13 @@ mod tests {
         for &steps in &[256usize, 512, 1024, 2048] {
             let op = InPlaceKvSdpa { axis: 2, causal: false, scale: None };
             let turn = TurnState::default();
-            let mut state = op.state(&EvalContext::pure())?.unwrap();
+            let mut state = op.state(&EvalContext::out_of_plan())?.unwrap();
             let _turn = turn;
             let t_fused = {
                 let start = Instant::now();
                 for _ in 0..steps {
                     std::hint::black_box(state.eval(
-                        &EvalContext::pure(),
+                        &EvalContext::out_of_plan(),
                         &op,
                         tvec![q.clone().into(), knew.clone().into(), vnew.clone().into()],
                     )?);
@@ -826,19 +830,25 @@ mod tests {
                     kc = Some(match kc.take() {
                         None => knew.clone(),
                         Some(c) => TypedConcat { axis: 2 }
-                            .eval(&EvalContext::pure(), tvec![c.into(), knew.clone().into()])?
+                            .eval(
+                                &EvalContext::out_of_plan(),
+                                tvec![c.into(), knew.clone().into()],
+                            )?
                             .remove(0)
                             .into_tensor(),
                     });
                     vc = Some(match vc.take() {
                         None => vnew.clone(),
                         Some(c) => TypedConcat { axis: 2 }
-                            .eval(&EvalContext::pure(), tvec![c.into(), vnew.clone().into()])?
+                            .eval(
+                                &EvalContext::out_of_plan(),
+                                tvec![c.into(), vnew.clone().into()],
+                            )?
                             .remove(0)
                             .into_tensor(),
                     });
                     std::hint::black_box(flash.eval(
-                        &EvalContext::pure(),
+                        &EvalContext::out_of_plan(),
                         tvec![
                             q.clone().into(),
                             kc.clone().unwrap().into(),
@@ -877,15 +887,18 @@ mod tests {
     fn resume_via_clone() -> TractResult<()> {
         let op = InPlaceKvSdpa { axis: 2, causal: true, scale: None };
         let _turn = TurnState::default();
-        let mut straight = op.state(&EvalContext::pure())?.unwrap();
-        let mut split = op.state(&EvalContext::pure())?.unwrap();
+        let mut straight = op.state(&EvalContext::out_of_plan())?.unwrap();
+        let mut split = op.state(&EvalContext::out_of_plan())?.unwrap();
         for (t, (q, k, v)) in decode_inputs(9).into_iter().enumerate() {
             let ins = tvec![q.into(), k.into(), v.into()];
-            let os = straight.eval(&EvalContext::pure(), &op, ins.clone())?.remove(0).into_tensor();
+            let os = straight
+                .eval(&EvalContext::out_of_plan(), &op, ins.clone())?
+                .remove(0)
+                .into_tensor();
             if t == 5 {
                 split = split.clone();
             }
-            let op2 = split.eval(&EvalContext::pure(), &op, ins)?.remove(0).into_tensor();
+            let op2 = split.eval(&EvalContext::out_of_plan(), &op, ins)?.remove(0).into_tensor();
             os.close_enough(&op2, Approximation::Exact)
                 .with_context(|| format!("clone resume mismatch at step {t}"))?;
         }
@@ -898,20 +911,23 @@ mod tests {
     fn resume_via_save_load() -> TractResult<()> {
         let op = InPlaceKvSdpa { axis: 2, causal: true, scale: None };
         let mut turn = TurnState::default();
-        let mut straight = op.state(&EvalContext::pure())?.unwrap();
-        let mut split = op.state(&EvalContext::pure())?.unwrap();
+        let mut straight = op.state(&EvalContext::out_of_plan())?.unwrap();
+        let mut split = op.state(&EvalContext::out_of_plan())?.unwrap();
         for (t, (q, k, v)) in decode_inputs(9).into_iter().enumerate() {
             let ins = tvec![q.into(), k.into(), v.into()];
-            let os = straight.eval(&EvalContext::pure(), &op, ins.clone())?.remove(0).into_tensor();
+            let os = straight
+                .eval(&EvalContext::out_of_plan(), &op, ins.clone())?
+                .remove(0)
+                .into_tensor();
             if t == 5 {
                 let mut saved = vec![];
                 split.save_to(&mut saved)?;
                 ensure!(saved.len() == 2, "save_to should emit [K, V]");
-                let mut fresh = op.state(&EvalContext::pure())?.unwrap();
+                let mut fresh = op.state(&EvalContext::out_of_plan())?.unwrap();
                 fresh.load_from(&mut turn, &mut saved.into_iter())?;
                 split = fresh;
             }
-            let op2 = split.eval(&EvalContext::pure(), &op, ins)?.remove(0).into_tensor();
+            let op2 = split.eval(&EvalContext::out_of_plan(), &op, ins)?.remove(0).into_tensor();
             os.close_enough(&op2, Approximation::Exact)
                 .with_context(|| format!("save/load resume mismatch at step {t}"))?;
         }
@@ -933,10 +949,10 @@ mod tests {
         println!("   len    save_to(ms)");
         for &len in &[256usize, 1024, 4096] {
             let _sess = TurnState::default();
-            let mut state = op.state(&EvalContext::pure())?.unwrap();
+            let mut state = op.state(&EvalContext::out_of_plan())?.unwrap();
             for _ in 0..len {
                 state.eval(
-                    &EvalContext::pure(),
+                    &EvalContext::out_of_plan(),
                     &op,
                     tvec![q.clone().into(), kv.clone().into(), kv.clone().into()],
                 )?;

--- a/transformers/src/ops/kv_quant.rs
+++ b/transformers/src/ops/kv_quant.rs
@@ -259,9 +259,7 @@ impl Op for QuantizedKvSdpa {
 }
 
 impl EvalOp for QuantizedKvSdpa {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(QuantizedKvSdpaState {
             scale: self.scale,
@@ -557,7 +555,7 @@ mod tests {
             Ok(match acc {
                 None => x,
                 Some(a) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![a.into(), x.into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![a.into(), x.into()])?
                     .remove(0)
                     .into_tensor(),
             })

--- a/transformers/src/ops/quant_dyn_kv_cache.rs
+++ b/transformers/src/ops/quant_dyn_kv_cache.rs
@@ -306,9 +306,7 @@ impl Op for QuantizedDynKeyValueCache {
 }
 
 impl EvalOp for QuantizedDynKeyValueCache {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(QuantizedDynKvCacheState {
             name: self.name.clone(),
@@ -699,7 +697,7 @@ mod tests {
                 acc = Some(match acc.take() {
                     None => step,
                     Some(a) => TypedConcat { axis: 2 }
-                        .eval(&EvalContext::pure(), tvec![a.into(), step.into()])?
+                        .eval(&EvalContext::out_of_plan(), tvec![a.into(), step.into()])?
                         .remove(0)
                         .into_tensor(),
                 });

--- a/transformers/src/ops/scaled_masked_softmax.rs
+++ b/transformers/src/ops/scaled_masked_softmax.rs
@@ -79,9 +79,7 @@ impl Op for ScaledMaskedSoftmax {
 }
 
 impl EvalOp for ScaledMaskedSoftmax {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let (input, mask) = args_2!(inputs);
@@ -93,20 +91,24 @@ impl EvalOp for ScaledMaskedSoftmax {
         let pre_softmax: TValue = if mask.datum_type() == bool::datum_type() {
             // Boolean mask: keep score where mask=true, replace with -inf where mask=false.
             let fill = tensor0(-f32::INFINITY).cast_to_dt(dt)?.into_owned();
-            Iff.eval(&EvalContext::pure(), tvec![mask.clone(), scaled.into(), fill.into_tvalue()])?
-                .remove(0)
+            Iff.eval(
+                &EvalContext::out_of_plan(),
+                tvec![mask.clone(), scaled.into(), fill.into_tvalue()],
+            )?
+            .remove(0)
         } else {
             Add.eval(scaled.into(), mask.clone(), dt)?.into()
         };
 
         let softmax_out = Softmax::new(softmax_axis, None, SoftmaxKind::Softmax)
-            .eval(&EvalContext::pure(), tvec![pre_softmax])?[0]
+            .eval(&EvalContext::out_of_plan(), tvec![pre_softmax])?[0]
             .clone();
 
         if self.post_softmax_mask {
             // Zero out positions where the bool mask is false.
             let zero = tensor0(0f32).cast_to_dt(dt)?.into_owned();
-            Ok(Iff.eval(&EvalContext::pure(), tvec![mask, softmax_out, zero.into_tvalue()])?)
+            Ok(Iff
+                .eval(&EvalContext::out_of_plan(), tvec![mask, softmax_out, zero.into_tvalue()])?)
         } else {
             Ok(tvec![softmax_out])
         }

--- a/transformers/src/ops/sdpa.rs
+++ b/transformers/src/ops/sdpa.rs
@@ -275,9 +275,7 @@ impl Op for Sdpa {
 }
 
 impl EvalOp for Sdpa {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_facts: TVec<TypedFact> = inputs

--- a/transformers/src/ops/streamed_sdpa.rs
+++ b/transformers/src/ops/streamed_sdpa.rs
@@ -93,9 +93,7 @@ impl TypedOp for StreamedSdpaOp {
 }
 
 impl EvalOp for StreamedSdpaOp {
-    fn is_pure_function(&self) -> bool {
-        true
-    }
+    op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 3 || inputs.len() == 4);

--- a/transformers/src/ops/window_kv_cache.rs
+++ b/transformers/src/ops/window_kv_cache.rs
@@ -175,9 +175,7 @@ impl Op for WindowKvSdpa {
 }
 
 impl EvalOp for WindowKvSdpa {
-    fn is_pure_function(&self) -> bool {
-        false
-    }
+    not_out_of_plan!();
     fn state(&self, _ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
         Ok(Some(Box::new(WindowKvSdpaState {
             scale: self.scale,
@@ -398,7 +396,7 @@ mod tests {
                 Ok(match acc {
                     None => x,
                     Some(a) => TypedConcat { axis: 2 }
-                        .eval(&EvalContext::pure(), tvec![a.into(), x.into()])?
+                        .eval(&EvalContext::out_of_plan(), tvec![a.into(), x.into()])?
                         .remove(0)
                         .into_tensor(),
                 })
@@ -464,7 +462,7 @@ mod tests {
             Ok(match acc {
                 None => x,
                 Some(a) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![a.into(), x.into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![a.into(), x.into()])?
                     .remove(0)
                     .into_tensor(),
             })
@@ -554,7 +552,7 @@ mod tests {
             Ok(match acc {
                 None => x,
                 Some(a) => TypedConcat { axis: 2 }
-                    .eval(&EvalContext::pure(), tvec![a.into(), x.into()])?
+                    .eval(&EvalContext::out_of_plan(), tvec![a.into(), x.into()])?
                     .remove(0)
                     .into_tensor(),
             })


### PR DESCRIPTION
is_pure_function, eval_pure and EvalContext::pure named a property and left the reader to work out what it bought, while what they gate is running a node with no plan around it -- const folding, shape inference, tests. Rename to runs_out_of_plan, eval_out_of_plan and EvalContext::out_of_plan.