### PR TITLE
cli: bring a node's pulse output to host before slicing it

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -100,6 +100,33 @@ jobs:
     - name: Full test
       run: .travis/cli-tests.sh
 
+  cli-tests-cuda:
+    name: Device-capable CLI cases on cuda
+    runs-on: cuda-lovelace
+    needs: prepare
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ needs.prepare.outputs.test_ref }}
+        fetch-depth: 0
+        persist-credentials: false
+
+    # A case's device-capable steps are the ones naming TRACT_TEST_DEVICES, so the
+    # list maintains itself. cli-tests.sh reads the executable path back with jq,
+    # which this runner has not got, hence the fixed profile path here.
+    - name: Device-capable nnef-test-cases
+      run: |
+        ROOT=. ./.travis/ci-system-setup.sh
+        cargo build -p tract-cli --profile opt-no-lto --no-default-features --features pulse,pulse-opl,cuda-13000
+        export TRACT_RUN=$PWD/target/opt-no-lto/tract
+        export TRACT_TEST_DEVICES=--cuda
+        for t in $(grep -l TRACT_TEST_DEVICES harness/nnef-test-cases/*/runme.sh)
+        do
+            echo $t
+            $t
+        done
+
   onnx-tests:
     runs-on: ubuntu-latest
     needs: prepare
@@ -267,7 +294,7 @@ jobs:
 
   report:
     name: Report result to PR
-    needs: [ prepare, old-harness, cli-tests, onnx-tests, tflite, some-tests-with-paranoid-asserts, without-default-features, complexes, check-all-targets, C, python ]
+    needs: [ prepare, old-harness, cli-tests, cli-tests-cuda, onnx-tests, tflite, some-tests-with-paranoid-asserts, without-default-features, complexes, check-all-targets, C, python ]
     if: ${{ always() && needs.prepare.outputs.pr_number != '' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.travis/cli-tests.sh
+++ b/.travis/cli-tests.sh
@@ -16,6 +16,11 @@ TRACT_RUN=$(cargo build --message-format json -p tract-cli $CARGO_EXTRA --profil
 echo TRACT_RUN=$TRACT_RUN
 export TRACT_RUN
 
+# Device flags the device-capable runme.sh cases repeat their pulsed steps with:
+# empty on a runner with no accelerator, --cuda or --metal where there is one.
+: ${TRACT_TEST_DEVICES:=}
+export TRACT_TEST_DEVICES
+
 echo
 echo $WHITE • harness/nnef-test-cases $NC
 echo

--- a/cli/src/compare.rs
+++ b/cli/src/compare.rs
@@ -393,7 +393,8 @@ pub fn handle_stream(
                                 // Full pulse in valid region
                                 (0, info.output_pulse)
                             };
-                            let valid = result[0].slice(info.output_axis, p_o, p_o + count)?;
+                            let value = crate::utils::clarify_tvalue(&result[0])?;
+                            let valid = value.slice(info.output_axis, p_o, p_o + count)?;
                             node_slices
                                 .entry(node.name.clone())
                                 .or_default()
@@ -406,7 +407,7 @@ pub fn handle_stream(
                     node_slices
                         .entry(node.name.clone())
                         .or_default()
-                        .push(result[0].clone().into_tensor());
+                        .push(crate::utils::clarify_tvalue(&result[0])?.into_tensor());
                 }
 
                 Ok(result)

--- a/harness/nnef-test-cases/conv-then-shape-of-mask/runme.sh
+++ b/harness/nnef-test-cases/conv-then-shape-of-mask/runme.sh
@@ -14,5 +14,8 @@ $TRACT_RUN --nnef-tract-core . \
 # tract_core_broadcast (shape=[1,1,S/2+1]) must also produce 2 frames/step.
 # The MultiBroadcastTo pulsifier removes the constant boundary term so that
 # per-pulse size = substitute(S→P) - substitute(S→0) = (1+P/2) - 1 = P/2.
-$TRACT_RUN --nnef-tract-core . --pulse 4 compare \
-    --stream --allow-random-input -q
+for dev in "" $TRACT_TEST_DEVICES
+do
+    $TRACT_RUN --nnef-tract-core . --pulse 4 $dev compare \
+        --stream --allow-random-input -q
+done

--- a/harness/nnef-test-cases/pulse-sync-inputs-multi-delay/runme.sh
+++ b/harness/nnef-test-cases/pulse-sync-inputs-multi-delay/runme.sh
@@ -17,5 +17,8 @@ $TRACT_RUN --nnef-tract-core . \
 # at graph compaction with "duplicate name for node ... output.Delay". This
 # step pulsifies and compares against the batch run, so it fails without the
 # fix and passes with it.
-$TRACT_RUN --nnef-tract-core . --pulse 4 compare \
-    --stream --allow-random-input -q
+for dev in "" $TRACT_TEST_DEVICES
+do
+    $TRACT_RUN --nnef-tract-core . --pulse 4 $dev compare \
+        --stream --allow-random-input -q
+done

--- a/harness/nnef-test-cases/scan-body-stream-drift/runme.sh
+++ b/harness/nnef-test-cases/scan-body-stream-drift/runme.sh
@@ -11,8 +11,11 @@ $TRACT_RUN --nnef-tract-core . \
     -t 'set_symbols(values: {"S": 8})' \
     run --allow-random-input -q
 
-$TRACT_RUN --nnef-tract-core . --pulse 4 compare \
-    --stream --allow-random-input -q
+for dev in "" $TRACT_TEST_DEVICES
+do
+    $TRACT_RUN --nnef-tract-core . --pulse 4 $dev compare \
+        --stream --allow-random-input -q
+done
 
 # Body / outer fact consistency: the Pulsifier substitutes the stream
 # symbol S in the outer wire facts; it must do the same on the Scan

--- a/harness/nnef-test-cases/slice-of-static-with-streaming-size/runme.sh
+++ b/harness/nnef-test-cases/slice-of-static-with-streaming-size/runme.sh
@@ -13,5 +13,8 @@ $TRACT_RUN --nnef-tract-core . \
 # Streaming compare: pulse=4.  Each step slices pe_table[0:4, :] (constant
 # 0.0001) and adds it to the current input chunk.  Because pe_table is uniform,
 # the streaming output matches the batch output element-wise.
-$TRACT_RUN --nnef-tract-core . --pulse 4 compare \
-    --stream --allow-random-input -q
+for dev in "" $TRACT_TEST_DEVICES
+do
+    $TRACT_RUN --nnef-tract-core . --pulse 4 $dev compare \
+        --stream --allow-random-input -q
+done


### PR DESCRIPTION
compare --stream captures each node's valid output region per pulse, slicing the value the eval closure just produced. On a device runtime that value is device resident, whose storage is not plain, so slicing it failed and --cuda could not run a pulsed comparison at all -- only the per-node capture was affected, a plain pulsed run on cuda was already fine. Clarify the value first, as the non-stream path does around its own comparison, keeping the device value itself flowing on to the next node.