### PR TITLE
data: copy every run in assign_slice, not just the leading-1 one

### DIFF
--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -791,7 +791,56 @@ impl Tensor {
     }
 
     pub fn broadcast_to_shape(&self, shape: &[usize]) -> TractResult<Tensor> {
-        dispatch_datum!(Self::broadcast_to_shape_t(self.dt)(self, shape))
+        if !self.dt.is_copy() {
+            return dispatch_datum!(Self::broadcast_to_shape_t(self.dt)(self, shape));
+        }
+        ensure!(
+            self.rank() <= shape.len(),
+            "Broadcasting {self:?} to {shape:?} would lose {} axes",
+            self.rank() - shape.len()
+        );
+        let offset = shape.len() - self.rank();
+        let mut src: TVec<usize> = tvec!(1; shape.len());
+        src[offset..].copy_from_slice(self.shape());
+        ensure!(
+            izip!(&src, shape).all(|(s, d)| *s == 1 || s == d),
+            "Broadcasting {self:?} to {shape:?}"
+        );
+        // The axes from the innermost one down to the first broadcast axis are
+        // one contiguous run of the source, so only the axes above it need a
+        // coordinate walk, with a null source stride wherever they broadcast.
+        let mut split = shape.len();
+        while split > 0 && src[split - 1] == shape[split - 1] {
+            split -= 1;
+        }
+        let dt_size = self.dt.size_of();
+        let run = shape[split..].iter().product::<usize>() * dt_size;
+        let outer: usize = shape[..split].iter().product();
+        let mut src_strides: TVec<usize> = tvec!(0; split);
+        let mut acc = run;
+        for ax in (0..split).rev() {
+            src_strides[ax] = if src[ax] == 1 { 0 } else { acc };
+            acc *= src[ax];
+        }
+        let mut output = unsafe { Tensor::uninitialized_dt(self.dt, shape)? };
+        if run == 0 || outer == 0 {
+            return Ok(output);
+        }
+        let source = self.as_bytes();
+        let dst = output.as_bytes_mut();
+        let mut coords: TVec<usize> = tvec!(0; split);
+        for block in 0..outer {
+            let from: usize = izip!(&coords, &src_strides).map(|(c, s)| c * s).sum();
+            dst[block * run..][..run].copy_from_slice(&source[from..][..run]);
+            for ax in (0..split).rev() {
+                coords[ax] += 1;
+                if coords[ax] < shape[ax] {
+                    break;
+                }
+                coords[ax] = 0;
+            }
+        }
+        Ok(output)
     }
 
     pub fn broadcast_vector_to_shape(&self, shape: &[usize], axis: usize) -> TractResult<Tensor> {
@@ -2399,6 +2448,38 @@ mod tests {
             .into_tensor();
         dst.assign_slice(1..2, &src, 0..1, 1).unwrap();
         assert_eq!(dst, strings(["a", "x", "c", "d", "y", "f"]));
+    }
+
+    // The run-based broadcast must agree with the ndarray view it replaced, over
+    // leading, middle and trailing broadcast axes and over ranks that grow.
+    #[test]
+    fn broadcast_to_shape_agrees_with_the_view() {
+        for (src, dst) in [
+            (tvec!(1usize, 8, 1, 7, 4), tvec!(1usize, 8, 4, 7, 4)),
+            (tvec!(1usize, 1, 1, 7), tvec!(2usize, 3, 5, 7)),
+            (tvec!(4usize), tvec!(2usize, 3, 5, 4)),
+            (tvec!(1usize, 5, 3), tvec!(6usize, 5, 3)),
+            (tvec!(2usize, 3), tvec!(2usize, 3)),
+            (tvec!(1usize), tvec!(3usize, 1, 2)),
+            (tvec!(3usize, 1), tvec!(3usize, 0)),
+        ] {
+            for dt in [f32::datum_type(), u8::datum_type(), i32::datum_type()] {
+                let t = Tensor::zero_dt(dt, &src).unwrap().cast_to_dt(dt).unwrap().into_owned();
+                let got = t.broadcast_to_shape(&dst).unwrap();
+                let want = dispatch_datum!(Tensor::broadcast_to_shape_t(dt)(&t, &dst)).unwrap();
+                assert_eq!(got.shape(), &*dst, "{src:?} -> {dst:?}");
+                assert_eq!(got, want, "{src:?} -> {dst:?} {dt:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn broadcast_to_shape_carries_values_and_rejects_mismatches() {
+        let t = tensor2(&[[1u8, 2, 3], [4, 5, 6]]);
+        let got = t.clone().into_shape(&[2, 1, 3]).unwrap().broadcast_to_shape(&[2, 2, 3]).unwrap();
+        assert_eq!(got, tensor3(&[[[1u8, 2, 3], [1, 2, 3]], [[4, 5, 6], [4, 5, 6]]]));
+        assert!(t.broadcast_to_shape(&[3, 3]).is_err());
+        assert!(t.broadcast_to_shape(&[3]).is_err());
     }
 
     #[test]

--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -1734,18 +1734,13 @@ impl Tensor {
         if start > self.shape[axis] || end > self.shape[axis] || start >= end {
             bail!("Invalid slicing range {start}..{end} on axis {axis} for {self:?}");
         }
-        fn slice_t<T: Datum>(
-            t: &Tensor,
-            axis: usize,
-            start: usize,
-            end: usize,
-        ) -> TractResult<Tensor> {
-            Ok(t.to_plain_array_view::<T>()?
-                .slice_axis(ndarray::Axis(axis), (start..end).into())
-                .into_owned()
-                .into_tensor())
+        let mut shape: TVec<usize> = self.shape().into();
+        shape[axis] = end - start;
+        unsafe {
+            let mut tensor = Tensor::uninitialized_dt(self.datum_type(), &shape)?;
+            tensor.assign_slice_from_resolved(0..end - start, self, start..end, axis);
+            Ok(tensor)
         }
-        dispatch_datum!(slice_t(self.datum_type())(self, axis, start, end))
     }
 
     #[inline]
@@ -2404,6 +2399,21 @@ mod tests {
             .into_tensor();
         dst.assign_slice(1..2, &src, 0..1, 1).unwrap();
         assert_eq!(dst, strings(["a", "x", "c", "d", "y", "f"]));
+    }
+
+    #[test]
+    fn slice_keeps_the_datum_type_and_the_values() {
+        let t = ramp::<u32>(&tvec!(2usize, 3, 4), 0);
+        let got = t.slice(1, 1, 3).unwrap();
+        let mut want = Tensor::zero::<u32>(&[2, 2, 4]).unwrap();
+        want.assign_slice(0..2, &t, 1..3, 1).unwrap();
+        assert_eq!(got, want);
+        let quantized = Tensor::zero_dt(
+            i8::datum_type().quantize(QParams::ZpScale { zero_point: 3, scale: 0.5 }),
+            &[2, 4],
+        )
+        .unwrap();
+        assert_eq!(quantized.slice(1, 0, 2).unwrap().datum_type(), quantized.datum_type());
     }
 
     #[test]

--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -923,24 +923,27 @@ impl Tensor {
                         )
                 }
             }
-            if self.datum_type().is_copy() && self.shape[..axis].iter().all(|d| *d == 1) {
-                let stride = self.strides[axis] as usize * self.datum_type().size_of();
-                let dst_start = (stride * range.start) as isize;
-                let src_start = (stride * src_range.start) as isize;
-                let len = stride * range.len();
+            if self.datum_type().is_copy() {
+                // Tensors carry natural strides, so a range along `axis` is one
+                // contiguous run per coordinate of the axes before it, and both
+                // sides share the run length and the trailing block.
+                let post = self.strides[axis] as usize * self.datum_type().size_of();
+                let len = post * range.len();
                 if len > 0 {
-                    if self.plain_storage().as_ptr() != src.plain_storage().as_ptr() {
-                        std::ptr::copy_nonoverlapping(
-                            src.plain_storage().as_ptr().offset(src_start),
-                            self.plain_storage_mut().as_mut_ptr().offset(dst_start),
-                            len,
-                        );
-                    } else {
-                        std::ptr::copy(
-                            src.plain_storage().as_ptr().offset(src_start),
-                            self.plain_storage_mut().as_mut_ptr().offset(dst_start),
-                            len,
-                        );
+                    let outer: usize = self.shape[..axis].iter().product();
+                    let dst_block = post * self.shape[axis];
+                    let src_block = post * src.shape[axis];
+                    let src_ptr = src.plain_storage().as_ptr().add(post * src_range.start);
+                    let aliasing = self.plain_storage().as_ptr() == src.plain_storage().as_ptr();
+                    let dst_ptr = self.plain_storage_mut().as_mut_ptr().add(post * range.start);
+                    for run in 0..outer {
+                        let from = src_ptr.add(run * src_block);
+                        let to = dst_ptr.add(run * dst_block);
+                        if aliasing {
+                            std::ptr::copy(from, to, len);
+                        } else {
+                            std::ptr::copy_nonoverlapping(from, to, len);
+                        }
                     }
                 }
             } else {
@@ -2314,6 +2317,93 @@ mod tests {
         let a = Tensor::zero::<f32>(&[0, 2, 3]).unwrap();
         let stacked = Tensor::stack_tensors(2, &[a.clone(), a.clone()]).unwrap();
         assert_eq!(stacked.shape(), &[0, 2, 6]);
+    }
+
+    // assign_slice copies one contiguous run per coordinate of the axes before
+    // `axis`; the runs must agree with plain index arithmetic for every axis,
+    // including the trailing one where each run is a single datum.
+    fn assign_slice_reference<T: Datum + Copy>(
+        dst: &Tensor,
+        dst_range: Range<usize>,
+        src: &Tensor,
+        src_range: Range<usize>,
+        axis: usize,
+    ) -> Tensor {
+        let mut out = dst.clone();
+        let outer: usize = dst.shape()[..axis].iter().product();
+        let inner: usize = dst.shape()[axis + 1..].iter().product();
+        let dst_mid = dst.shape()[axis];
+        let src_mid = src.shape()[axis];
+        let sv = unsafe { src.as_slice_unchecked::<T>() };
+        let ov = unsafe { out.as_slice_mut_unchecked::<T>() };
+        for o in 0..outer {
+            for j in 0..dst_range.len() {
+                for i in 0..inner {
+                    ov[(o * dst_mid + dst_range.start + j) * inner + i] =
+                        sv[(o * src_mid + src_range.start + j) * inner + i];
+                }
+            }
+        }
+        out
+    }
+
+    macro_rules! assign_slice_agrees_for {
+        ($name:ident, $t:ty) => {
+            #[test]
+            fn $name() {
+                for (shape, axis, dst_mid, src_mid, dst_start, len, src_start) in [
+                    (tvec!(1usize, 56, 24), 2, 24, 8, 16, 8, 0),
+                    (tvec!(1usize, 56, 24), 2, 24, 24, 0, 16, 8),
+                    (tvec!(1usize, 32, 4, 128), 3, 128, 128, 0, 64, 64),
+                    (tvec!(1usize, 8, 16, 64), 2, 16, 1, 3, 1, 0),
+                    (tvec!(3usize, 5), 0, 3, 7, 1, 2, 4),
+                    (tvec!(4usize, 3), 1, 3, 3, 0, 3, 0),
+                    (tvec!(7usize), 0, 7, 7, 2, 0, 5),
+                ] {
+                    let mut dst_shape = shape.clone();
+                    dst_shape[axis] = dst_mid;
+                    let mut src_shape = shape.clone();
+                    src_shape[axis] = src_mid;
+                    let mut got: Tensor = ramp::<$t>(&dst_shape, 1);
+                    let src: Tensor = ramp::<$t>(&src_shape, 100);
+                    let want = assign_slice_reference::<$t>(
+                        &got,
+                        dst_start..dst_start + len,
+                        &src,
+                        src_start..src_start + len,
+                        axis,
+                    );
+                    got.assign_slice(
+                        dst_start..dst_start + len,
+                        &src,
+                        src_start..src_start + len,
+                        axis,
+                    )
+                    .unwrap();
+                    assert_eq!(got, want, "shape {dst_shape:?} axis {axis}");
+                }
+            }
+        };
+    }
+
+    assign_slice_agrees_for!(assign_slice_agrees_u8, u8);
+    assign_slice_agrees_for!(assign_slice_agrees_u16, u16);
+    assign_slice_agrees_for!(assign_slice_agrees_u32, u32);
+    assign_slice_agrees_for!(assign_slice_agrees_u64, u64);
+
+    #[test]
+    fn assign_slice_carries_non_copy_data() {
+        let strings = |v: [&str; 6]| {
+            ndarray::Array2::from_shape_vec((2, 3), v.iter().map(|s| s.to_string()).collect())
+                .unwrap()
+                .into_tensor()
+        };
+        let mut dst = strings(["a", "b", "c", "d", "e", "f"]);
+        let src = ndarray::Array2::from_shape_vec((2, 1), vec!["x".to_string(), "y".to_string()])
+            .unwrap()
+            .into_tensor();
+        dst.assign_slice(1..2, &src, 0..1, 1).unwrap();
+        assert_eq!(dst, strings(["a", "x", "c", "d", "y", "f"]));
     }
 
     #[test]


### PR DESCRIPTION
assign_slice only reached its memcpy path when every axis before the sliced one had extent 1, so a slice on a trailing axis of a batched tensor fell back to ndarray's element-wise assign. Tensors carry natural strides, so the range is one contiguous run per coordinate of the preceding axes; copy those runs instead.