### PR TITLE
bench: let a bench ask for median-of-N on the PR path

### DIFF
--- a/.travis/benches.toml
+++ b/.travis/benches.toml
@@ -4,6 +4,9 @@
 # `threads = [n, ...]` adds cpu-only runs with `--threads n` (0 = physical cores),
 # labelled `<variant>_t{n}` (or `_mt` for 0); the base single-thread series is
 # always kept. Threaded runs need a `multithread-mm` build (else skipped).
+# `samples = n` runs a bench n times and keeps the per-metric median on the PR path
+# too, for the few benches whose single shot sits off the nightly median often enough
+# to flag on its own.
 
 base_url = "https://tract-test-assets.tract.rs"
 
@@ -15,6 +18,7 @@ name = "arm_ml_kws_cnn_m"
 variant = "pass"
 model = "ARM-ML-KWS-CNN-M.pb"
 args = "-i 49,10,f32 --partial --input-node Mfcc"
+samples = 5
 
 [[bench]]
 kind = "net"
@@ -36,6 +40,7 @@ name = "hey_snips_v4_model17"
 variant = "2sec"
 model = "hey_snips_v4_model17.pb"
 args = "-i 200,20,f32"
+samples = 5
 
 [[bench]]
 kind = "net"
@@ -43,6 +48,7 @@ name = "hey_snips_v4_model17"
 variant = "pulse8"
 model = "hey_snips_v4_model17.pb"
 args = "-i S,20,f32 --pulse 8"
+samples = 5
 
 [[bench]]
 kind = "net"
@@ -50,6 +56,7 @@ name = "hey_snips_v4_model17_nnef"
 variant = "pulse8"
 model = "hey_snips_v4_model17.alpha1.tar"
 args = "--nnef-tract-pulse"
+samples = 5
 
 [[bench]]
 kind = "net"
@@ -252,6 +259,7 @@ name = "parakeet-tdt-600m-v3-f32f32-preprocessor_1s"
 model = "asr/608/nvidia--parakeet-tdt-0.6b-v3-f32f32/nvidia--parakeet-tdt-0.6b-v3-f32f32.preprocessor.nnef.tgz"
 args = "-t transformers_detect_all --nnef-tract-transformers --set B=1 --set A=16000"
 runtimes = ["cpu", "metal", "cuda"]
+samples = 3
 
 [[bench]]
 kind = "net"
@@ -281,6 +289,7 @@ name = "nemotron-3_5-asr-streaming-0_6b-f32f32-preprocessor_1s"
 model = "asr/634/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32/nvidia--nemotron-3.5-asr-streaming-0.6b-f32f32.preprocessor.nnef.tgz"
 args = "-t transformers_detect_all --nnef-tract-transformers --set BATCH=1 --set INPUT_SIGNAL__TIME=16000"
 runtimes = ["cpu", "metal", "cuda"]
+samples = 3
 
 [[bench]]
 kind = "net"
@@ -304,6 +313,7 @@ args = [
     "-t", 'pulse(symbol: Some("INPUT_SIGNAL__TIME"), pulse: "1600")',
 ]
 runtimes = ["cpu", "metal", "cuda"]
+samples = 3
 
 [[bench]]
 kind = "net"

--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -53,6 +53,13 @@ struct Bench {
     /// Requires a `multithread-mm` build; skipped with a warning otherwise.
     #[serde(default)]
     threads: Vec<usize>,
+    /// Median-of-N on the PR path, for a bench whose single shot lands off the
+    /// nightly reference's own median often enough to flag on its own. Raises the
+    /// suite's `--samples` for this bench alone; the nightly reference, already
+    /// sampling more than this, is unaffected. A bench listed here is also left out
+    /// of the second pass, whose keep-best would undo the median.
+    #[serde(default)]
+    samples: Option<usize>,
 }
 
 #[derive(Deserialize, Clone, Copy, PartialEq)]
@@ -388,10 +395,11 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
             let run = || {
                 run_one(&exe, &staged.arg, staged.format, bench, runtime, &variant, threads, smoke)
             };
+            let bench_samples = bench.samples.unwrap_or(1).max(samples);
             let outcome = if smoke {
                 run()
-            } else if samples > 1 {
-                bench_median(run, samples)
+            } else if bench_samples > 1 {
+                bench_median(run, bench_samples)
             } else {
                 bench_run(run, &expectations, retry_max)
             };
@@ -643,6 +651,7 @@ fn second_pass(
     let red: Vec<usize> = results
         .iter()
         .enumerate()
+        .filter(|(_, r)| manifest.benches[r.bench_idx].samples.unwrap_or(1) <= 1)
         .filter(|(_, r)| {
             let m: BTreeMap<String, f64> = r.metrics.iter().cloned().collect();
             out_of_threshold(&m, expectations)
@@ -692,8 +701,9 @@ fn second_pass(
 /// Reference statistics: run the bench `samples` times (a fresh child each) and record
 /// the per-metric median. A median drops a lone clock-glitch outlier (spuriously fast /
 /// sub-floor time) that `bench_run`'s keep-best would instead latch onto — so the stored
-/// nightly reference can't be poisoned by a single bad draw. Used for the reference run;
-/// PR runs stay on `bench_run` (retry-until-good-enough).
+/// nightly reference can't be poisoned by a single bad draw. Used for the reference run,
+/// and on the PR path for the benches carrying a per-bench `samples`; every other PR
+/// bench stays on `bench_run` (retry-until-good-enough).
 fn bench_median(
     run: impl Fn() -> TractResult<Vec<(String, f64)>>,
     samples: usize,


### PR DESCRIPTION
A PR run takes one shot per bench while the nightly reference stores the median of five, so on the boards where a run's timing is right-skewed the single shot lands above the reference every time and flags a regression that is not one. Add a per-bench `samples` key that switches those benches to the same median-of-N on the PR path, and keep them out of the second pass, whose keep-best would undo the median.