### PR TITLE
GatedDeltaNet recurrent and causal-conv1d-update kernels

### DIFF
--- a/cuda/Cargo.toml
+++ b/cuda/Cargo.toml
@@ -64,3 +64,7 @@ default = ["cuda-13000"]
 [[bench]]
 name = "cuda_flash"
 harness = false
+
+[[bench]]
+name = "gdn_recurrent"
+harness = false

--- a/cuda/benches/gdn_recurrent.rs
+++ b/cuda/benches/gdn_recurrent.rs
@@ -67,14 +67,17 @@ fn cpu_gdn(crit: &mut BenchmarkGroup<WallTime>, label: &str, inputs: &Inputs) {
     crit.bench_function(&format!("cpu_{label}"), |be| {
         be.iter(|| {
             GatedDeltaNetRecurrent::default()
-                .eval(&EvalContext::out_of_plan(), tvec![
-                    inputs.q.clone().into_tvalue(),
-                    inputs.k.clone().into_tvalue(),
-                    inputs.v.clone().into_tvalue(),
-                    inputs.g.clone().into_tvalue(),
-                    inputs.beta.clone().into_tvalue(),
-                    inputs.state.clone().into_tvalue(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        inputs.q.clone().into_tvalue(),
+                        inputs.k.clone().into_tvalue(),
+                        inputs.v.clone().into_tvalue(),
+                        inputs.g.clone().into_tvalue(),
+                        inputs.beta.clone().into_tvalue(),
+                        inputs.state.clone().into_tvalue(),
+                    ],
+                )
                 .unwrap()
         });
     });
@@ -96,7 +99,15 @@ fn cuda_gdn(crit: &mut BenchmarkGroup<WallTime>, label: &str, inputs: &Inputs) {
         // overhead.
         let run = |stream: &_| -> TractResult<()> {
             CudaGdnRecurrent.dispatch_eval(
-                stream, &q, &k, &v, &g, &beta, &state, &output, &final_state,
+                stream,
+                &q,
+                &k,
+                &v,
+                &g,
+                &beta,
+                &state,
+                &output,
+                &final_state,
             )?;
             Ok(stream.synchronize()?)
         };

--- a/cuda/benches/gdn_recurrent.rs
+++ b/cuda/benches/gdn_recurrent.rs
@@ -1,0 +1,136 @@
+//! CPU vs CUDA latency for GatedDeltaNetRecurrent.
+//!
+//! The CUDA kernel (unlike Metal) requires batch=1, width=128, ungrouped
+//! heads (q/k/v share the same head count -- no GQA), and an f32 state; it
+//! also has no chunked-prefill path, just a per-step host-side loop. Same
+//! synthetic-data pattern as the Metal bench (metal/benches/gdn_recurrent.rs).
+
+use criterion::measurement::WallTime;
+use criterion::*;
+use tract_core::internal::*;
+use tract_cuda::kernels::gdn_recurrent::CudaGdnRecurrent;
+use tract_cuda::with_cuda_stream;
+use tract_gpu::tensor::{DeviceTensor, IntoDevice};
+use tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent;
+
+struct Inputs {
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    g: Tensor,
+    beta: Tensor,
+    state: Tensor,
+}
+
+fn make_inputs(b: usize, s_len: usize, heads: usize, width: usize) -> Inputs {
+    // Ungrouped: k_heads == heads (ungrouped is the only mode the CUDA
+    // kernel supports).
+    let n_qkv = b * s_len * heads * width;
+    let n_gate = b * s_len * heads;
+    let n_state = b * heads * width * width;
+    let as_f16 = |v: Vec<f32>| v.into_iter().map(f16::from_f32).collect::<Vec<_>>();
+    Inputs {
+        q: Tensor::from_shape(
+            &[b, s_len, heads, width],
+            &as_f16((0..n_qkv).map(|i| ((i % 31) as f32 - 15.0) / 64.0).collect()),
+        )
+        .unwrap(),
+        k: Tensor::from_shape(
+            &[b, s_len, heads, width],
+            &as_f16((0..n_qkv).map(|i| ((i % 29) as f32 - 14.0) / 64.0).collect()),
+        )
+        .unwrap(),
+        v: Tensor::from_shape(
+            &[b, s_len, heads, width],
+            &as_f16((0..n_qkv).map(|i| ((i % 23) as f32 - 11.0) / 32.0).collect()),
+        )
+        .unwrap(),
+        g: Tensor::from_shape(
+            &[b, s_len, heads],
+            &(0..n_gate).map(|i| -0.05 - 0.1 * (i % 7) as f32).collect::<Vec<f32>>(),
+        )
+        .unwrap(),
+        beta: Tensor::from_shape(
+            &[b, s_len, heads],
+            &as_f16((0..n_gate).map(|i| 0.125 + 0.08 * (i % 9) as f32).collect()),
+        )
+        .unwrap(),
+        state: Tensor::from_shape(
+            &[b, heads, width, width],
+            &(0..n_state).map(|i| ((i % 37) as f32 - 18.0) / 256.0).collect::<Vec<f32>>(),
+        )
+        .unwrap(),
+    }
+}
+
+fn cpu_gdn(crit: &mut BenchmarkGroup<WallTime>, label: &str, inputs: &Inputs) {
+    crit.bench_function(&format!("cpu_{label}"), |be| {
+        be.iter(|| {
+            GatedDeltaNetRecurrent::default()
+                .eval(&EvalContext::out_of_plan(), tvec![
+                    inputs.q.clone().into_tvalue(),
+                    inputs.k.clone().into_tvalue(),
+                    inputs.v.clone().into_tvalue(),
+                    inputs.g.clone().into_tvalue(),
+                    inputs.beta.clone().into_tvalue(),
+                    inputs.state.clone().into_tvalue(),
+                ])
+                .unwrap()
+        });
+    });
+}
+
+fn cuda_gdn(crit: &mut BenchmarkGroup<WallTime>, label: &str, inputs: &Inputs) {
+    with_cuda_stream(|stream| {
+        let q = inputs.q.clone().into_device()?;
+        let k = inputs.k.clone().into_device()?;
+        let v = inputs.v.clone().into_device()?;
+        let g = inputs.g.clone().into_device()?;
+        let beta = inputs.beta.clone().into_device()?;
+        let state = inputs.state.clone().into_device()?;
+        let output = DeviceTensor::uninitialized_dt(DatumType::F16, q.shape())?;
+        let final_state = DeviceTensor::uninitialized_dt(DatumType::F32, state.shape())?;
+
+        // dispatch_eval enqueues asynchronously; sync inside the timed
+        // region for a fair per-call LATENCY number, not just launch
+        // overhead.
+        let run = |stream: &_| -> TractResult<()> {
+            CudaGdnRecurrent.dispatch_eval(
+                stream, &q, &k, &v, &g, &beta, &state, &output, &final_state,
+            )?;
+            Ok(stream.synchronize()?)
+        };
+        run(stream)?; // warmup
+
+        crit.bench_function(&format!("cuda_{label}"), |be| {
+            be.iter(|| run(stream).unwrap());
+        });
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Decode: one step, 32 heads, head width 128 (ungrouped -- matches the
+/// Metal bench's total head count of 32, but CUDA cannot do GQA so there's
+/// no separate k_heads/groups split here).
+fn decode_step(c: &mut Criterion) {
+    let mut g = c.benchmark_group("gdn_decode_step_b1_s1_h32_w128");
+    let inputs = make_inputs(1, 1, 32, 128);
+    cpu_gdn(&mut g, "decode", &inputs);
+    cuda_gdn(&mut g, "decode", &inputs);
+    g.finish();
+}
+
+/// Prefill: 512 tokens at the same geometry. The CUDA kernel has no chunked
+/// path (see cuda/src/kernels/gdn_recurrent.rs): dispatch_eval loops one
+/// kernel launch per token host-side.
+fn prefill_512(c: &mut Criterion) {
+    let mut g = c.benchmark_group("gdn_prefill_s512_h32_w128");
+    let inputs = make_inputs(1, 512, 32, 128);
+    cpu_gdn(&mut g, "prefill", &inputs);
+    cuda_gdn(&mut g, "prefill", &inputs);
+    g.finish();
+}
+
+criterion_group!(benches, decode_step, prefill_512);
+criterion_main!(benches);

--- a/cuda/src/kernels/causal_conv1d_update.rs
+++ b/cuda/src/kernels/causal_conv1d_update.rs
@@ -10,20 +10,27 @@ use crate::kernels::{LibraryName, get_cuda_view};
 pub struct CudaCausalConv1dUpdate;
 
 impl CudaCausalConv1dUpdate {
+    /// Returns (batch, channels, kernel_width, s_len). Layout: input/output
+    /// [b, C, S] (S may be folded away, e.g. [b, C]), state [b, C, K],
+    /// weight [C, K].
     pub fn validate(
         &self,
         input: &DeviceTensor,
         weight: &DeviceTensor,
         state: &DeviceTensor,
-    ) -> TractResult<(usize, usize)> {
+    ) -> TractResult<(usize, usize, usize, usize)> {
         ensure!(input.datum_type() == DatumType::F16);
         ensure!(weight.datum_type() == DatumType::F16 && state.datum_type() == DatumType::F16);
-        let channels = input.len();
         let kernel_width = *weight.shape().last().context("conv weight must have a kernel axis")?;
         ensure!(kernel_width == 4, "Qwen3.5 requires a four-tap convolution");
+        ensure!(state.rank() >= 2, "conv state must be [b, C, K]");
+        let batch = if state.rank() == 3 { state.shape()[0] } else { 1 };
+        ensure!(state.len().is_multiple_of(batch * kernel_width));
+        let channels = state.len() / (batch * kernel_width);
         ensure!(weight.len() == channels * kernel_width);
-        ensure!(state.len() == channels * kernel_width);
-        Ok((channels, kernel_width))
+        ensure!(input.len().is_multiple_of(batch * channels), "conv input not [b, C, S]");
+        let s_len = input.len() / (batch * channels);
+        Ok((batch, channels, kernel_width, s_len))
     }
 
     pub fn dispatch_eval(
@@ -35,7 +42,7 @@ impl CudaCausalConv1dUpdate {
         output: &DeviceTensor,
         final_state: &DeviceTensor,
     ) -> TractResult<()> {
-        let (channels, kernel_width) = self.validate(input, weight, state)?;
+        let (batch, channels, kernel_width, s_len) = self.validate(input, weight, state)?;
         ensure!(output.shape() == input.shape() && output.datum_type() == DatumType::F16);
         ensure!(final_state.shape() == state.shape() && final_state.datum_type() == DatumType::F16);
         let function = cuda_context().load_pipeline(
@@ -55,7 +62,9 @@ impl CudaCausalConv1dUpdate {
         args.push_view(&ns);
         args.push_i32(channels);
         args.push_i32(kernel_width);
-        args.launch(LaunchConfig::for_num_elems(channels as u32))?;
+        args.push_i32(s_len);
+        args.push_i32(batch);
+        args.launch(LaunchConfig::for_num_elems((batch * channels) as u32))?;
         Ok(())
     }
 
@@ -88,7 +97,17 @@ pub fn cuda_causal_conv1d_update_launch(
 
 crate::register_cuda_op!(
     tract_transformers::ops::causal_conv1d_update::CausalConv1dUpdate,
-    |_source, _node, _op| {
+    |source, node, _op| {
+        // The cuda kernel is f16-only; the op's layout is [b, C, S] and the
+        // kernel loops over S and batch (port of the Metal kernel).
+        let facts = source.node_input_facts(node.id)?;
+        let rank_ok = facts[0].rank() == 3;
+        let dts_ok = facts.iter().all(|f| f.datum_type == DatumType::F16);
+        // The kernel loops over S and batch internally, so symbolic or
+        // concrete values of either are fine.
+        if !rank_ok || !dts_ok {
+            return Ok(None);
+        }
         Ok(Some(Box::new(tract_gpu::ops::causal_conv1d_update::GpuCausalConv1dUpdate {
             backend_name: "Cuda",
             dispatch: cuda_causal_conv1d_update_launch,

--- a/cuda/src/kernels/causal_conv1d_update.rs
+++ b/cuda/src/kernels/causal_conv1d_update.rs
@@ -29,12 +29,12 @@ impl CudaCausalConv1dUpdate {
         let channels = state.len() / (batch * kernel_width);
         ensure!(weight.len() == channels * kernel_width);
         ensure!(input.len().is_multiple_of(batch * channels), "conv input not [b, C, S]");
-        // When input carries an explicit batch axis (the registered dispatch
-        // path always does: register_cuda_op! only wires this op at rank 3),
-        // it must agree with state's batch -- otherwise input.len() being a
-        // multiple of batch * channels can pass by coincidence with a
-        // mismatched batch folded into a wrong s_len.
-        if input.rank() == 3 {
+        // Both supported layouts ([b, C, S] and the folded [b, C]) carry an
+        // explicit batch axis at shape()[0]; it must agree with state's
+        // batch -- otherwise input.len() being a multiple of batch * channels
+        // can pass by coincidence with a mismatched batch folded into a
+        // wrong s_len.
+        if input.rank() >= 2 {
             ensure!(
                 input.shape()[0] == batch,
                 "conv input batch {} != state batch {}",

--- a/cuda/src/kernels/causal_conv1d_update.rs
+++ b/cuda/src/kernels/causal_conv1d_update.rs
@@ -29,6 +29,19 @@ impl CudaCausalConv1dUpdate {
         let channels = state.len() / (batch * kernel_width);
         ensure!(weight.len() == channels * kernel_width);
         ensure!(input.len().is_multiple_of(batch * channels), "conv input not [b, C, S]");
+        // When input carries an explicit batch axis (the registered dispatch
+        // path always does: register_cuda_op! only wires this op at rank 3),
+        // it must agree with state's batch -- otherwise input.len() being a
+        // multiple of batch * channels can pass by coincidence with a
+        // mismatched batch folded into a wrong s_len.
+        if input.rank() == 3 {
+            ensure!(
+                input.shape()[0] == batch,
+                "conv input batch {} != state batch {}",
+                input.shape()[0],
+                batch
+            );
+        }
         let s_len = input.len() / (batch * channels);
         Ok((batch, channels, kernel_width, s_len))
     }

--- a/cuda/src/kernels/cu/gdn_recurrent.cu
+++ b/cuda/src/kernels/cu/gdn_recurrent.cu
@@ -72,6 +72,9 @@ extern "C" __global__ void tract_gdn_recurrent_f16(
 
 // One thread owns one depthwise channel. Qwen3.5 decoding always appends one
 // sample to a four-element causal-convolution cache.
+// Sliding-window causal conv update with fused silu, any S and batch
+// (direct port of the Metal kernel of the same name). Layout: input/output
+// [b, C, S], state [b, C, K], weight [C, K].
 extern "C" __global__ void tract_causal_conv1d_update_f16(
     const __half* input,
     const __half* weight,
@@ -79,19 +82,36 @@ extern "C" __global__ void tract_causal_conv1d_update_f16(
     __half* output,
     __half* final_state,
     int channels,
-    int kernel_width) {
-  const int channel = blockIdx.x * blockDim.x + threadIdx.x;
-  if (channel >= channels) return;
-  const int base = channel * kernel_width;
-  float sum = 0.0f;
-  for (int tap = 0; tap < kernel_width - 1; ++tap) {
-    const __half sample = initial_state[base + tap + 1];
-    final_state[base + tap] = sample;
-    sum = fmaf(__half2float(sample), __half2float(weight[base + tap]), sum);
+    int kernel_width,
+    int s_len,
+    int batch) {
+  const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+  const int channel = gid % channels;
+  const int b = gid / channels;
+  if (b >= batch) return;
+  const int state_base = (b * channels + channel) * kernel_width;
+  const int input_base = (b * channels + channel) * s_len;
+  const int weight_base = channel * kernel_width;
+  // kernel_width is small (4 for Qwen3.5), keep the window in registers.
+  const int MAX_K = 8;
+  float window[MAX_K];
+  if (kernel_width > MAX_K) return;
+  for (int tap = 0; tap < kernel_width; ++tap) {
+    window[tap] = __half2float(initial_state[state_base + tap]);
   }
-  const __half newest = input[channel];
-  final_state[base + kernel_width - 1] = newest;
-  sum = fmaf(__half2float(newest),
-             __half2float(weight[base + kernel_width - 1]), sum);
-  output[channel] = __float2half(sum / (1.0f + expf(-sum)));
+  for (int t = 0; t < s_len; ++t) {
+    // shift left, append the new sample: window becomes full[t+1 .. t+k]
+    for (int tap = 0; tap < kernel_width - 1; ++tap) {
+      window[tap] = window[tap + 1];
+    }
+    window[kernel_width - 1] = __half2float(input[input_base + t]);
+    float sum = 0.0f;
+    for (int tap = 0; tap < kernel_width; ++tap) {
+      sum = fmaf(window[tap], __half2float(weight[weight_base + tap]), sum);
+    }
+    output[input_base + t] = __float2half(sum / (1.0f + expf(-sum)));
+  }
+  for (int tap = 0; tap < kernel_width; ++tap) {
+    final_state[state_base + tap] = __float2half(window[tap]);
+  }
 }

--- a/cuda/src/kernels/gdn_recurrent.rs
+++ b/cuda/src/kernels/gdn_recurrent.rs
@@ -18,20 +18,22 @@ impl CudaGdnRecurrent {
         log_decay: &DeviceTensor,
         beta: &DeviceTensor,
         initial_state: &DeviceTensor,
-    ) -> TractResult<(usize, usize)> {
+    ) -> TractResult<(usize, usize, usize)> {
         ensure!(query.datum_type() == DatumType::F16, "GDN query must be F16");
         ensure!(key.datum_type() == DatumType::F16 && value.datum_type() == DatumType::F16);
         ensure!(beta.datum_type() == DatumType::F16, "GDN beta must be F16");
         ensure!(log_decay.datum_type() == DatumType::F32, "GDN decay must be F32");
         ensure!(initial_state.datum_type() == DatumType::F32, "GDN state must be F32");
         ensure!(query.shape() == key.shape() && query.shape() == value.shape());
-        let width = *query.shape().last().context("GDN query must have a last axis")?;
+        ensure!(query.rank() == 4, "GDN q/k/v layout is [b, S, h, w]");
+        ensure!(query.shape()[0] == 1, "the cuda GDN step loop requires batch 1");
+        let steps = query.shape()[1];
+        let heads = query.shape()[2];
+        let width = query.shape()[3];
         ensure!(width == 128, "the Qwen3.5 kernel currently requires width=128");
-        ensure!(query.len().is_multiple_of(width));
-        let heads = query.len() / width;
         ensure!(
-            log_decay.len() == heads && beta.len() == heads,
-            "GDN head mismatch: heads={heads}, q={:?}, g={:?} (len {}), beta={:?} (len {})",
+            log_decay.len() == steps * heads && beta.len() == steps * heads,
+            "GDN head mismatch: steps={steps}, heads={heads}, q={:?}, g={:?} (len {}), beta={:?} (len {})",
             query.shape(),
             log_decay.shape(),
             log_decay.len(),
@@ -39,7 +41,7 @@ impl CudaGdnRecurrent {
             beta.len(),
         );
         ensure!(initial_state.len() == heads * width * width);
-        Ok((heads, width))
+        Ok((steps, heads, width))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -55,7 +57,8 @@ impl CudaGdnRecurrent {
         output: &DeviceTensor,
         final_state: &DeviceTensor,
     ) -> TractResult<()> {
-        let (heads, width) = self.validate(query, key, value, log_decay, beta, initial_state)?;
+        let (steps, heads, width) =
+            self.validate(query, key, value, log_decay, beta, initial_state)?;
         ensure!(output.shape() == query.shape() && output.datum_type() == DatumType::F16);
         ensure!(
             final_state.shape() == initial_state.shape()
@@ -64,30 +67,59 @@ impl CudaGdnRecurrent {
 
         let function = cuda_context()
             .load_pipeline(LibraryName::GdnRecurrent, "tract_gdn_recurrent_f16".to_string())?;
-        let q = get_cuda_view(query);
-        let k = get_cuda_view(key);
-        let v = get_cuda_view(value);
-        let g = get_cuda_view(log_decay);
-        let b = get_cuda_view(beta);
-        let state = get_cuda_view(initial_state);
-        let out = get_cuda_view(output);
-        let next_state = get_cuda_view(final_state);
-        let mut args = TractLaunchArgs::new(stream, &function);
-        args.push_view(&q);
-        args.push_view(&k);
-        args.push_view(&v);
-        args.push_view(&g);
-        args.push_view(&b);
-        args.push_view(&state);
-        args.push_view(&out);
-        args.push_view(&next_state);
-        args.push_i32(heads);
-        args.push_i32(width);
-        args.launch(LaunchConfig {
-            grid_dim: (heads as u32, 1, 1),
-            block_dim: (width as u32, 1, 1),
-            shared_mem_bytes: (3 * width * size_of::<f32>()) as u32,
-        })
+        // The kernel is single-step; loop over S host-side with per-step
+        // views (the [1, S, h, w] layout is contiguous per step) and
+        // ping-pong the state so consecutive steps never read the buffer
+        // they write. Buffer parity is chosen so the LAST step always
+        // writes `final_state`, whatever the parity of `steps`.
+        let scratch_state = if steps > 1 {
+            Some(unsafe {
+                DeviceTensor::uninitialized_dt(DatumType::F32, initial_state.shape())?
+            })
+        } else {
+            None
+        };
+        let qkv_step = heads * width * DatumType::F16.size_of();
+        let g_step = heads * DatumType::F32.size_of();
+        let b_step = heads * DatumType::F16.size_of();
+        let state_bytes = heads * width * width * DatumType::F32.size_of();
+        for s in 0..steps {
+            let in_state = if s == 0 {
+                initial_state
+            } else if (steps - s) % 2 == 1 {
+                scratch_state.as_ref().unwrap()
+            } else {
+                final_state
+            };
+            let out_state = if (steps - s) % 2 == 1 { final_state } else {
+                scratch_state.as_ref().unwrap()
+            };
+            let q = crate::kernels::get_sliced_cuda_view(query, s * qkv_step, qkv_step)?;
+            let k = crate::kernels::get_sliced_cuda_view(key, s * qkv_step, qkv_step)?;
+            let v = crate::kernels::get_sliced_cuda_view(value, s * qkv_step, qkv_step)?;
+            let g = crate::kernels::get_sliced_cuda_view(log_decay, s * g_step, g_step)?;
+            let b = crate::kernels::get_sliced_cuda_view(beta, s * b_step, b_step)?;
+            let state = crate::kernels::get_sliced_cuda_view(in_state, 0, state_bytes)?;
+            let out = crate::kernels::get_sliced_cuda_view(output, s * qkv_step, qkv_step)?;
+            let next_state = crate::kernels::get_sliced_cuda_view(out_state, 0, state_bytes)?;
+            let mut args = TractLaunchArgs::new(stream, &function);
+            args.push_view(&q);
+            args.push_view(&k);
+            args.push_view(&v);
+            args.push_view(&g);
+            args.push_view(&b);
+            args.push_view(&state);
+            args.push_view(&out);
+            args.push_view(&next_state);
+            args.push_i32(heads);
+            args.push_i32(width);
+            args.launch(LaunchConfig {
+                grid_dim: (heads as u32, 1, 1),
+                block_dim: (width as u32, 1, 1),
+                shared_mem_bytes: (3 * width * size_of::<f32>()) as u32,
+            })?;
+        }
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -131,7 +163,9 @@ pub fn cuda_gdn_recurrent_launch(
     initial_state: &DeviceTensor,
     output: &DeviceTensor,
     final_state: &DeviceTensor,
+    sigmoid_beta: bool,
 ) -> TractResult<()> {
+    anyhow::ensure!(!sigmoid_beta, "cuda GDN kernel has no in-kernel beta sigmoid");
     crate::with_cuda_stream(|stream| {
         CudaGdnRecurrent.dispatch_eval(
             stream,
@@ -149,10 +183,36 @@ pub fn cuda_gdn_recurrent_launch(
 
 crate::register_cuda_op!(
     tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent,
-    |_source, _node, _op| {
+    |source, node, op| {
+        // No in-kernel beta sigmoid on cuda yet.
+        if op.sigmoid_beta {
+            return Ok(None);
+        }
+        // The dispatch loops the single-step kernel over S host-side, so
+        // symbolic or concrete S are both fine. Still required: f16 dtypes,
+        // ungrouped heads (q/k head count == v head count; no GQA-group
+        // indexing in this kernel yet) and batch 1 ([b, S, h, w] layout).
+        let facts = source.node_input_facts(node.id)?;
+        let dts: Vec<DatumType> = facts.iter().map(|f| f.datum_type).collect();
+        let rank_ok = facts[0].rank() == 4;
+        let batch_ok = rank_ok && facts[0].shape[0] == 1.to_dim();
+        let ungrouped = facts[0].shape == facts[2].shape;
+        let dts_ok = dts
+            == [
+                DatumType::F16,
+                DatumType::F16,
+                DatumType::F16,
+                DatumType::F32,
+                DatumType::F16,
+                DatumType::F32,
+            ];
+        if !rank_ok || !batch_ok || !ungrouped || !dts_ok {
+            return Ok(None);
+        }
         Ok(Some(Box::new(tract_gpu::ops::gdn_recurrent::GpuGatedDeltaNetRecurrent {
             backend_name: "Cuda",
             dispatch: cuda_gdn_recurrent_launch,
+            sigmoid_beta: false,
         })))
     }
 );

--- a/cuda/src/kernels/gdn_recurrent.rs
+++ b/cuda/src/kernels/gdn_recurrent.rs
@@ -72,6 +72,11 @@ impl CudaGdnRecurrent {
         // ping-pong the state so consecutive steps never read the buffer
         // they write. Buffer parity is chosen so the LAST step always
         // writes `final_state`, whatever the parity of `steps`.
+        //
+        // KNOWN LIMITATION: unlike Metal's chunked gated-delta-rule kernel,
+        // this issues one launch per step, so a long CUDA prefill pays S
+        // serialized kernel-launch overheads instead of ~S/GDN_CHUNK. A
+        // chunked CUDA kernel is real follow-up work, not done here.
         let scratch_state = if steps > 1 {
             Some(unsafe {
                 DeviceTensor::uninitialized_dt(DatumType::F32, initial_state.shape())?

--- a/cuda/src/kernels/gdn_recurrent.rs
+++ b/cuda/src/kernels/gdn_recurrent.rs
@@ -78,9 +78,7 @@ impl CudaGdnRecurrent {
         // serialized kernel-launch overheads instead of ~S/GDN_CHUNK. A
         // chunked CUDA kernel is real follow-up work, not done here.
         let scratch_state = if steps > 1 {
-            Some(unsafe {
-                DeviceTensor::uninitialized_dt(DatumType::F32, initial_state.shape())?
-            })
+            Some(unsafe { DeviceTensor::uninitialized_dt(DatumType::F32, initial_state.shape())? })
         } else {
             None
         };
@@ -96,9 +94,8 @@ impl CudaGdnRecurrent {
             } else {
                 final_state
             };
-            let out_state = if (steps - s) % 2 == 1 { final_state } else {
-                scratch_state.as_ref().unwrap()
-            };
+            let out_state =
+                if (steps - s) % 2 == 1 { final_state } else { scratch_state.as_ref().unwrap() };
             let q = crate::kernels::get_sliced_cuda_view(query, s * qkv_step, qkv_step)?;
             let k = crate::kernels::get_sliced_cuda_view(key, s * qkv_step, qkv_step)?;
             let v = crate::kernels::get_sliced_cuda_view(value, s * qkv_step, qkv_step)?;

--- a/gpu/src/memory/pool.rs
+++ b/gpu/src/memory/pool.rs
@@ -50,6 +50,32 @@ impl DeviceMemoryPool {
             .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
     }
 
+    /// Per-output variant of [`Self::tensor_for_node`] for multi-output nodes:
+    /// each output slot has its own arena region in the schema.
+    pub fn tensor_for_node_output(
+        &self,
+        node_id: usize,
+        slot: usize,
+        dt: DatumType,
+        shape: &[usize],
+    ) -> TractResult<DeviceTensor> {
+        match self.resolved_schema.offsets_by_node[node_id].as_ref() {
+            Some(offsets) if slot < offsets.len() && offsets[slot].len() == 1 => {
+                Ok(DeviceArenaView {
+                    arena: Arc::clone(&self.storage),
+                    dt,
+                    len: shape.iter().product(),
+                    shape: shape.into(),
+                    strides: Tensor::natural_strides(shape),
+                    offset_bytes: offsets[slot][0],
+                    exotic_fact: None,
+                }
+                .into())
+            }
+            _ => DeviceTensor::uninitialized_dt(dt, shape),
+        }
+    }
+
     pub fn scalar_exotic_tensor_for_node(
         &self,
         node_id: usize,

--- a/gpu/src/memory/pool.rs
+++ b/gpu/src/memory/pool.rs
@@ -59,8 +59,14 @@ impl DeviceMemoryPool {
         dt: DatumType,
         shape: &[usize],
     ) -> TractResult<DeviceTensor> {
-        match self.resolved_schema.offsets_by_node[node_id].as_ref() {
-            Some(offsets) if slot < offsets.len() && offsets[slot].len() == 1 => {
+        self.resolved_schema.offsets_by_node[node_id]
+            .as_ref()
+            .map(|offsets| {
+                ensure!(
+                    slot < offsets.len() && offsets[slot].len() == 1,
+                    "'tensor_for_node_output' slot {slot} out of range or not \
+                     mono-region for node {node_id}"
+                );
                 Ok(DeviceArenaView {
                     arena: Arc::clone(&self.storage),
                     dt,
@@ -71,9 +77,8 @@ impl DeviceMemoryPool {
                     exotic_fact: None,
                 }
                 .into())
-            }
-            _ => DeviceTensor::uninitialized_dt(dt, shape),
-        }
+            })
+            .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
     }
 
     pub fn scalar_exotic_tensor_for_node(

--- a/gpu/src/memory/pool.rs
+++ b/gpu/src/memory/pool.rs
@@ -29,25 +29,10 @@ impl DeviceMemoryPool {
         dt: DatumType,
         shape: &[usize],
     ) -> TractResult<DeviceTensor> {
-        self.resolved_schema.offsets_by_node[node_id]
-            .as_ref()
-            .map(|offsets| {
-                ensure!(
-                    offsets.len() == 1 && offsets[0].len() == 1,
-                    "'tensor_for_node' is for mono-output nodes only"
-                );
-                Ok(DeviceArenaView {
-                    arena: Arc::clone(&self.storage),
-                    dt,
-                    len: shape.iter().product(),
-                    shape: shape.into(),
-                    strides: Tensor::natural_strides(shape),
-                    offset_bytes: offsets[0][0],
-                    exotic_fact: None,
-                }
-                .into())
-            })
-            .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
+        if let Some(offsets) = self.resolved_schema.offsets_by_node[node_id].as_ref() {
+            ensure!(offsets.len() == 1, "'tensor_for_node' is for mono-output nodes only");
+        }
+        self.tensor_for_node_output(node_id, 0, dt, shape)
     }
 
     /// Per-output variant of [`Self::tensor_for_node`] for multi-output nodes:

--- a/gpu/src/ops/causal_conv1d_update.rs
+++ b/gpu/src/ops/causal_conv1d_update.rs
@@ -1,5 +1,5 @@
 use crate::tensor::{DeviceTensor, DeviceTensorExt};
-use crate::turn_handler::make_tensor_for_node;
+use crate::turn_handler::make_tensor_for_node_output;
 use tract_core::internal::*;
 
 pub type DispatchCausalConv1dUpdateFn = fn(
@@ -43,8 +43,8 @@ impl EvalOp for GpuCausalConv1dUpdate {
         let input = input.to_device_tensor()?;
         let weight = weight.to_device_tensor()?;
         let state = state.to_device_tensor()?;
-        let output = make_tensor_for_node(ctx, DatumType::F16, input.shape())?;
-        let final_state = DeviceTensor::uninitialized_dt(DatumType::F16, state.shape())?;
+        let output = make_tensor_for_node_output(ctx, 0, DatumType::F16, input.shape())?;
+        let final_state = make_tensor_for_node_output(ctx, 1, DatumType::F16, state.shape())?;
         (self.dispatch)(input, weight, state, &output, &final_state)?;
         Ok(tvec![output.into_tensor().into_tvalue(), final_state.into_tensor().into_tvalue()])
     }

--- a/gpu/src/ops/gdn_recurrent.rs
+++ b/gpu/src/ops/gdn_recurrent.rs
@@ -1,5 +1,5 @@
 use crate::tensor::{DeviceTensor, DeviceTensorExt};
-use crate::turn_handler::make_tensor_for_node;
+use crate::turn_handler::make_tensor_for_node_output;
 use tract_core::internal::*;
 
 pub type DispatchGdnRecurrentFn = fn(
@@ -11,17 +11,19 @@ pub type DispatchGdnRecurrentFn = fn(
     &DeviceTensor,
     &DeviceTensor,
     &DeviceTensor,
+    bool, // sigmoid_beta: beta carries raw logits, kernel applies sigmoid
 ) -> TractResult<()>;
 
 #[derive(Clone, Debug)]
 pub struct GpuGatedDeltaNetRecurrent {
     pub backend_name: &'static str,
     pub dispatch: DispatchGdnRecurrentFn,
+    pub sigmoid_beta: bool,
 }
 
 impl PartialEq for GpuGatedDeltaNetRecurrent {
     fn eq(&self, other: &Self) -> bool {
-        self.backend_name == other.backend_name
+        self.backend_name == other.backend_name && self.sigmoid_beta == other.sigmoid_beta
     }
 }
 impl Eq for GpuGatedDeltaNetRecurrent {}
@@ -47,10 +49,14 @@ impl EvalOp for GpuGatedDeltaNetRecurrent {
             .iter()
             .map(|value| value.to_device_tensor())
             .collect::<TractResult<TVec<_>>>()?;
-        let output = make_tensor_for_node(ctx, DatumType::F16, tensors[0].shape())?;
-        // The memory arena is keyed by node, so a second output cannot use the
-        // same arena slot as the first one.
-        let final_state = DeviceTensor::uninitialized_dt(DatumType::F32, tensors[5].shape())?;
+        // Output takes the VALUE shape (with GQA groups q/k carry hk heads
+        // while v carries hv = G * hk) but the QUERY dtype, matching
+        // output_facts() and the CPU reference op. Each output has its own
+        // arena region in the schema (multi-output node).
+        let output =
+            make_tensor_for_node_output(ctx, 0, tensors[0].datum_type(), tensors[2].shape())?;
+        let final_state =
+            make_tensor_for_node_output(ctx, 1, tensors[5].datum_type(), tensors[5].shape())?;
         (self.dispatch)(
             tensors[0],
             tensors[1],
@@ -60,6 +66,7 @@ impl EvalOp for GpuGatedDeltaNetRecurrent {
             tensors[5],
             &output,
             &final_state,
+            self.sigmoid_beta,
         )?;
         Ok(tvec![output.into_tensor().into_tvalue(), final_state.into_tensor().into_tvalue()])
     }
@@ -74,8 +81,12 @@ impl TypedOp for GpuGatedDeltaNetRecurrent {
             ensure!(facts[2].datum_type == DatumType::F16);
             ensure!(facts[3].datum_type == DatumType::F32);
             ensure!(facts[4].datum_type == DatumType::F16);
-            ensure!(facts[5].datum_type == DatumType::F32);
-            Ok(tvec![facts[0].without_value(), facts[5].without_value()])
+            ensure!(matches!(facts[5].datum_type, DatumType::F16 | DatumType::F32));
+            // Output = value shape (hv heads), query dtype (matches the CPU
+            // reference op: `out.datum_type = inputs[0].datum_type`).
+            let mut out = facts[2].without_value();
+            out.datum_type = facts[0].datum_type;
+            Ok(tvec![out, facts[5].without_value()])
         })
         .with_context(|| format!("invalid facts for {}", self.name()))
     }

--- a/gpu/src/turn_handler.rs
+++ b/gpu/src/turn_handler.rs
@@ -43,6 +43,20 @@ pub fn make_tensor_for_node(
         .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
 }
 
+/// Like [`make_tensor_for_node`] but for one output slot of a multi-output
+/// node: the memory schema reserves one arena region per device output.
+pub fn make_tensor_for_node_output(
+    ctx: &EvalContext,
+    slot: usize,
+    dt: DatumType,
+    shape: &[usize],
+) -> TractResult<DeviceTensor> {
+    ctx.shared
+        .and_then(|s| s.get::<DeviceMemoryPool>())
+        .map(|mem| mem.tensor_for_node_output(ctx.node_id, slot, dt, shape))
+        .unwrap_or_else(|| DeviceTensor::uninitialized_dt(dt, shape))
+}
+
 pub fn make_scalar_exotic_tensor_for_node(
     ctx: &EvalContext,
     dt: DatumType,

--- a/metal/Cargo.toml
+++ b/metal/Cargo.toml
@@ -47,3 +47,7 @@ harness = false
 [[bench]]
 name = "metal_reduce"
 harness = false
+
+[[bench]]
+name = "gdn_recurrent"
+harness = false

--- a/metal/benches/gdn_recurrent.rs
+++ b/metal/benches/gdn_recurrent.rs
@@ -67,7 +67,7 @@ fn cpu_gdn(crit: &mut BenchmarkGroup<WallTime>, label: &str, inputs: &Inputs) {
     crit.bench_function(&format!("cpu_{label}"), |be| {
         be.iter(|| {
             GatedDeltaNetRecurrent::default()
-                .eval(tvec![
+                .eval(&EvalContext::out_of_plan(), tvec![
                     inputs.q.clone().into_tvalue(),
                     inputs.k.clone().into_tvalue(),
                     inputs.v.clone().into_tvalue(),

--- a/metal/benches/gdn_recurrent.rs
+++ b/metal/benches/gdn_recurrent.rs
@@ -1,0 +1,150 @@
+//! CPU (pre-existing reference) vs Metal (split E) for GatedDeltaNetRecurrent.
+//!
+//! Same synthetic-data pattern as
+//! `metal/src/kernels/gdn_recurrent.rs`'s `multi_step_matches_cpu_op_len`
+//! test (proven CPU/Metal-parity inputs), reused here purely for timing.
+
+use criterion::measurement::WallTime;
+use criterion::*;
+use tract_core::internal::*;
+use tract_gpu::tensor::{DeviceTensor, IntoDevice};
+use tract_metal::kernels::gdn_recurrent::metal_gdn_recurrent_launch;
+use tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent;
+
+struct Inputs {
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    g: Tensor,
+    beta: Tensor,
+    state: Tensor,
+}
+
+fn make_inputs(b: usize, s_len: usize, k_heads: usize, groups: usize, width: usize) -> Inputs {
+    let heads = k_heads * groups;
+    let n_qk = b * s_len * k_heads * width;
+    let n_vec = b * s_len * heads * width;
+    let n_gate = b * s_len * heads;
+    let n_state = b * heads * width * width;
+    let as_f16 = |v: Vec<f32>| v.into_iter().map(f16::from_f32).collect::<Vec<_>>();
+    Inputs {
+        q: Tensor::from_shape(
+            &[b, s_len, k_heads, width],
+            &as_f16((0..n_qk).map(|i| ((i % 31) as f32 - 15.0) / 64.0).collect()),
+        )
+        .unwrap(),
+        k: Tensor::from_shape(
+            &[b, s_len, k_heads, width],
+            &as_f16((0..n_qk).map(|i| ((i % 29) as f32 - 14.0) / 64.0).collect()),
+        )
+        .unwrap(),
+        v: Tensor::from_shape(
+            &[b, s_len, heads, width],
+            &as_f16((0..n_vec).map(|i| ((i % 23) as f32 - 11.0) / 32.0).collect()),
+        )
+        .unwrap(),
+        g: Tensor::from_shape(
+            &[b, s_len, heads],
+            &(0..n_gate).map(|i| -0.05 - 0.1 * (i % 7) as f32).collect::<Vec<f32>>(),
+        )
+        .unwrap(),
+        beta: Tensor::from_shape(
+            &[b, s_len, heads],
+            &as_f16((0..n_gate).map(|i| 0.125 + 0.08 * (i % 9) as f32).collect()),
+        )
+        .unwrap(),
+        state: Tensor::from_shape(
+            &[b, heads, width, width],
+            &(0..n_state).map(|i| ((i % 37) as f32 - 18.0) / 256.0).collect::<Vec<f32>>(),
+        )
+        .unwrap(),
+    }
+}
+
+fn cpu_gdn(crit: &mut BenchmarkGroup<WallTime>, label: &str, inputs: &Inputs) {
+    crit.bench_function(&format!("cpu_{label}"), |be| {
+        be.iter(|| {
+            GatedDeltaNetRecurrent::default()
+                .eval(tvec![
+                    inputs.q.clone().into_tvalue(),
+                    inputs.k.clone().into_tvalue(),
+                    inputs.v.clone().into_tvalue(),
+                    inputs.g.clone().into_tvalue(),
+                    inputs.beta.clone().into_tvalue(),
+                    inputs.state.clone().into_tvalue(),
+                ])
+                .unwrap()
+        });
+    });
+}
+
+fn metal_gdn(
+    crit: &mut BenchmarkGroup<WallTime>,
+    label: &str,
+    inputs: &Inputs,
+    disable_chunked: bool,
+) {
+    // Toggles dispatch_eval's own gate for the prefill chunking optimization
+    // this PR adds (see metal/src/kernels/gdn_recurrent.rs): unset uses the
+    // new chunked path, set forces the pre-existing threadgroup-parallel
+    // kernel this PR's chunking sits on top of ("prior to this PR's optim").
+    if disable_chunked {
+        unsafe { std::env::set_var("TRACT_METAL_DISABLE_GDN_CHUNKED", "1") };
+    } else {
+        unsafe { std::env::remove_var("TRACT_METAL_DISABLE_GDN_CHUNKED") };
+    }
+    // First call initializes the global device context .into_device() below
+    // requires, and reuses one thread-local MetalStream for every later call.
+    tract_metal::with_metal_stream(|_| Ok(())).unwrap();
+    let q = inputs.q.clone().into_device().unwrap();
+    let k = inputs.k.clone().into_device().unwrap();
+    let v = inputs.v.clone().into_device().unwrap();
+    let g = inputs.g.clone().into_device().unwrap();
+    let beta = inputs.beta.clone().into_device().unwrap();
+    let state = inputs.state.clone().into_device().unwrap();
+    let output = DeviceTensor::uninitialized_dt(DatumType::F16, v.shape()).unwrap();
+    let next = DeviceTensor::uninitialized_dt(state.datum_type(), state.shape()).unwrap();
+
+    // dispatch_eval/dispatch_chunked enqueue work asynchronously and do not
+    // wait for the GPU before returning (by design, for real pipelining), so
+    // a fair per-call LATENCY number needs an explicit wait in the timed
+    // region -- otherwise this only measures CPU-side command encoding.
+    let run = || -> TractResult<()> {
+        metal_gdn_recurrent_launch(&q, &k, &v, &g, &beta, &state, &output, &next, false)?;
+        tract_metal::with_metal_stream(|stream| stream.wait_until_completed())
+    };
+
+    run().unwrap(); // warmup: pays one-time pipeline/library load cost
+
+    crit.bench_function(&format!("metal_{label}"), |be| {
+        be.iter(|| run().unwrap());
+    });
+}
+
+/// Decode: one step, the real Qwen3.5-35B geometry (16 k-heads, GQA groups=2,
+/// head width 128) — the threadgroup-parallel kernel path (unaffected by
+/// this PR's chunking optimization: chunking only engages at s_len >= 64).
+fn decode_step(c: &mut Criterion) {
+    let mut g = c.benchmark_group("gdn_decode_step_b1_s1_h32_w128");
+    let inputs = make_inputs(1, 1, 16, 2, 128);
+    cpu_gdn(&mut g, "decode", &inputs);
+    metal_gdn(&mut g, "decode", &inputs, false);
+    g.finish();
+}
+
+/// Prefill: one 512-token chunk at the same geometry. Three points: the CPU
+/// reference, this PR's new chunked gated-delta-rule path (`GDN_CHUNK = 64`,
+/// 8 chunks), and the pre-existing threadgroup-parallel kernel looping one
+/// token at a time -- i.e. what Metal prefill looked like immediately prior
+/// to this PR's own chunking optimization.
+fn prefill_chunk(c: &mut Criterion) {
+    let mut g = c.benchmark_group("gdn_prefill_s512_h32_w128");
+    let inputs = make_inputs(1, 512, 16, 2, 128);
+    cpu_gdn(&mut g, "prefill", &inputs);
+    metal_gdn(&mut g, "prefill_old_tg_per_token", &inputs, true);
+    metal_gdn(&mut g, "prefill_chunked", &inputs, false);
+    g.finish();
+}
+
+criterion_group!(benches, decode_step, prefill_chunk);
+criterion_main!(benches);

--- a/metal/benches/gdn_recurrent.rs
+++ b/metal/benches/gdn_recurrent.rs
@@ -67,14 +67,17 @@ fn cpu_gdn(crit: &mut BenchmarkGroup<WallTime>, label: &str, inputs: &Inputs) {
     crit.bench_function(&format!("cpu_{label}"), |be| {
         be.iter(|| {
             GatedDeltaNetRecurrent::default()
-                .eval(&EvalContext::out_of_plan(), tvec![
-                    inputs.q.clone().into_tvalue(),
-                    inputs.k.clone().into_tvalue(),
-                    inputs.v.clone().into_tvalue(),
-                    inputs.g.clone().into_tvalue(),
-                    inputs.beta.clone().into_tvalue(),
-                    inputs.state.clone().into_tvalue(),
-                ])
+                .eval(
+                    &EvalContext::out_of_plan(),
+                    tvec![
+                        inputs.q.clone().into_tvalue(),
+                        inputs.k.clone().into_tvalue(),
+                        inputs.v.clone().into_tvalue(),
+                        inputs.g.clone().into_tvalue(),
+                        inputs.beta.clone().into_tvalue(),
+                        inputs.state.clone().into_tvalue(),
+                    ],
+                )
                 .unwrap()
         });
     });

--- a/metal/benches/gdn_recurrent.rs
+++ b/metal/benches/gdn_recurrent.rs
@@ -1,4 +1,4 @@
-//! CPU (pre-existing reference) vs Metal (split E) for GatedDeltaNetRecurrent.
+//! CPU vs Metal latency for `GatedDeltaNetRecurrent`.
 //!
 //! Same synthetic-data pattern as
 //! `metal/src/kernels/gdn_recurrent.rs`'s `multi_step_matches_cpu_op_len`
@@ -8,7 +8,9 @@ use criterion::measurement::WallTime;
 use criterion::*;
 use tract_core::internal::*;
 use tract_gpu::tensor::{DeviceTensor, IntoDevice};
-use tract_metal::kernels::gdn_recurrent::metal_gdn_recurrent_launch;
+use tract_metal::kernels::gdn_recurrent::{
+    TRACT_METAL_DISABLE_GDN_CHUNKED, metal_gdn_recurrent_launch,
+};
 use tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent;
 
 struct Inputs {
@@ -84,14 +86,13 @@ fn metal_gdn(
     inputs: &Inputs,
     disable_chunked: bool,
 ) {
-    // Toggles dispatch_eval's own gate for the prefill chunking optimization
-    // this PR adds (see metal/src/kernels/gdn_recurrent.rs): unset uses the
-    // new chunked path, set forces the pre-existing threadgroup-parallel
-    // kernel this PR's chunking sits on top of ("prior to this PR's optim").
+    // Toggles dispatch_eval's chunked-vs-per-token gate: disabled uses the
+    // chunked gated-delta-rule path, enabled forces the per-token
+    // threadgroup-parallel kernel.
     if disable_chunked {
-        unsafe { std::env::set_var("TRACT_METAL_DISABLE_GDN_CHUNKED", "1") };
+        TRACT_METAL_DISABLE_GDN_CHUNKED.set(true);
     } else {
-        unsafe { std::env::remove_var("TRACT_METAL_DISABLE_GDN_CHUNKED") };
+        TRACT_METAL_DISABLE_GDN_CHUNKED.clear();
     }
     // First call initializes the global device context .into_device() below
     // requires, and reuses one thread-local MetalStream for every later call.
@@ -122,8 +123,8 @@ fn metal_gdn(
 }
 
 /// Decode: one step, the real Qwen3.5-35B geometry (16 k-heads, GQA groups=2,
-/// head width 128) — the threadgroup-parallel kernel path (unaffected by
-/// this PR's chunking optimization: chunking only engages at s_len >= 64).
+/// head width 128) — the threadgroup-parallel kernel path (chunking only
+/// engages at s_len >= 64, so this path is unaffected by it).
 fn decode_step(c: &mut Criterion) {
     let mut g = c.benchmark_group("gdn_decode_step_b1_s1_h32_w128");
     let inputs = make_inputs(1, 1, 16, 2, 128);
@@ -133,10 +134,8 @@ fn decode_step(c: &mut Criterion) {
 }
 
 /// Prefill: one 512-token chunk at the same geometry. Three points: the CPU
-/// reference, this PR's new chunked gated-delta-rule path (`GDN_CHUNK = 64`,
-/// 8 chunks), and the pre-existing threadgroup-parallel kernel looping one
-/// token at a time -- i.e. what Metal prefill looked like immediately prior
-/// to this PR's own chunking optimization.
+/// reference, the chunked gated-delta-rule path (`GDN_CHUNK = 64`, 8 chunks),
+/// and the per-token threadgroup-parallel kernel it sits on top of.
 fn prefill_chunk(c: &mut Criterion) {
     let mut g = c.benchmark_group("gdn_prefill_s512_h32_w128");
     let inputs = make_inputs(1, 512, 16, 2, 128);

--- a/metal/src/kernels/causal_conv1d_update.rs
+++ b/metal/src/kernels/causal_conv1d_update.rs
@@ -142,7 +142,7 @@ mod tests {
             let weight = Tensor::from_shape(&[channels, k], &cvt(&weight_f))?;
             let state = Tensor::from_shape(&[b, channels, k], &cvt(&state_f))?;
 
-            let cpu = CausalConv1dUpdate.eval(tvec![
+            let cpu = CausalConv1dUpdate.eval(&EvalContext::out_of_plan(), tvec![
                 input.clone().into_tvalue(),
                 weight.clone().into_tvalue(),
                 state.clone().into_tvalue(),

--- a/metal/src/kernels/causal_conv1d_update.rs
+++ b/metal/src/kernels/causal_conv1d_update.rs
@@ -131,22 +131,23 @@ mod tests {
             let input_f = (0..b * channels * s_len)
                 .map(|i| ((i % 17) as f32 - 8.0) / 32.0)
                 .collect::<Vec<_>>();
-            let weight_f = (0..channels * k)
-                .map(|i| ((i % 13) as f32 - 6.0) / 64.0)
-                .collect::<Vec<_>>();
-            let state_f = (0..b * channels * k)
-                .map(|i| ((i % 11) as f32 - 5.0) / 32.0)
-                .collect::<Vec<_>>();
+            let weight_f =
+                (0..channels * k).map(|i| ((i % 13) as f32 - 6.0) / 64.0).collect::<Vec<_>>();
+            let state_f =
+                (0..b * channels * k).map(|i| ((i % 11) as f32 - 5.0) / 32.0).collect::<Vec<_>>();
             let cvt = |v: &[f32]| v.iter().copied().map(f16::from_f32).collect::<Vec<_>>();
             let input = Tensor::from_shape(&[b, channels, s_len], &cvt(&input_f))?;
             let weight = Tensor::from_shape(&[channels, k], &cvt(&weight_f))?;
             let state = Tensor::from_shape(&[b, channels, k], &cvt(&state_f))?;
 
-            let cpu = CausalConv1dUpdate.eval(&EvalContext::out_of_plan(), tvec![
-                input.clone().into_tvalue(),
-                weight.clone().into_tvalue(),
-                state.clone().into_tvalue(),
-            ])?;
+            let cpu = CausalConv1dUpdate.eval(
+                &EvalContext::out_of_plan(),
+                tvec![
+                    input.clone().into_tvalue(),
+                    weight.clone().into_tvalue(),
+                    state.clone().into_tvalue(),
+                ],
+            )?;
 
             let input_d = input.into_device()?;
             let weight_d = weight.into_device()?;
@@ -157,14 +158,13 @@ mod tests {
             stream.wait_until_completed()?;
             let output = output.to_host()?.into_tensor();
             let next = next.to_host()?.into_tensor();
-            output.cast_to::<f32>()?.into_owned().close_enough(
-                &cpu[0].cast_to::<f32>()?.into_owned(),
-                Approximation::Approximate,
-            )?;
-            next.cast_to::<f32>()?.into_owned().close_enough(
-                &cpu[1].cast_to::<f32>()?.into_owned(),
-                Approximation::Approximate,
-            )?;
+            output
+                .cast_to::<f32>()?
+                .into_owned()
+                .close_enough(&cpu[0].cast_to::<f32>()?.into_owned(), Approximation::Approximate)?;
+            next.cast_to::<f32>()?
+                .into_owned()
+                .close_enough(&cpu[1].cast_to::<f32>()?.into_owned(), Approximation::Approximate)?;
             Ok(())
         })
     }

--- a/metal/src/kernels/causal_conv1d_update.rs
+++ b/metal/src/kernels/causal_conv1d_update.rs
@@ -14,11 +14,18 @@ pub fn dispatch_eval(
 ) -> TractResult<()> {
     ensure!(input.datum_type() == DatumType::F16);
     ensure!(weight.datum_type() == DatumType::F16 && state.datum_type() == DatumType::F16);
-    let channels = input.len();
+    // Layout matches the CPU op: input [b, C, S], weight [C, k],
+    // state [b, C, k].
+    ensure!(input.rank() == 3, "conv input must be [b, C, S], got {:?}", input.shape());
+    let (batch, channels, s_len) = (input.shape()[0], input.shape()[1], input.shape()[2]);
     let kernel_width = *weight.shape().last().context("conv weight must have a kernel axis")?;
-    ensure!(kernel_width == 4, "Qwen3.5 requires a four-tap convolution");
+    ensure!(kernel_width <= 8, "the Metal causal conv kernel supports at most 8 taps");
     ensure!(weight.len() == channels * kernel_width);
-    ensure!(state.len() == channels * kernel_width);
+    ensure!(
+        state.shape() == [batch, channels, kernel_width],
+        "conv state must be [b, C, k], got {:?}",
+        state.shape()
+    );
     ensure!(output.shape() == input.shape() && output.datum_type() == DatumType::F16);
     ensure!(final_state.shape() == state.shape() && final_state.datum_type() == DatumType::F16);
     for tensor in [input, weight, state, output, final_state] {
@@ -35,10 +42,14 @@ pub fn dispatch_eval(
         encoder.set_metal_tensor(4, final_state, metal::MTLResourceUsage::Write);
         let channels = channels as i32;
         let kernel_width = kernel_width as i32;
+        let s_len = s_len as i32;
+        let batch = batch as i32;
         encoder.set_bytes(5, size_of::<i32>() as u64, &channels as *const i32 as *const _);
         encoder.set_bytes(6, size_of::<i32>() as u64, &kernel_width as *const i32 as *const _);
+        encoder.set_bytes(7, size_of::<i32>() as u64, &s_len as *const i32 as *const _);
+        encoder.set_bytes(8, size_of::<i32>() as u64, &batch as *const i32 as *const _);
         encoder.dispatch_threads(
-            MTLSize { width: channels as u64, height: 1, depth: 1 },
+            MTLSize { width: (batch * channels) as u64, height: 1, depth: 1 },
             MTLSize { width: 256.min(channels) as u64, height: 1, depth: 1 },
         );
     });
@@ -59,7 +70,13 @@ pub fn metal_causal_conv1d_update_launch(
 
 crate::register_metal_op!(
     tract_transformers::ops::causal_conv1d_update::CausalConv1dUpdate,
-    |_source, _node, _op| {
+    |source, node, _op| {
+        // The Metal kernel is f16-only; other dtype mixes (e.g. an all-f32
+        // test export) stay on the CPU op.
+        let facts = source.node_input_facts(node.id)?;
+        if facts.iter().any(|f| f.datum_type != DatumType::F16) {
+            return Ok(None);
+        }
         Ok(Some(Box::new(tract_gpu::ops::causal_conv1d_update::GpuCausalConv1dUpdate {
             backend_name: "Metal",
             dispatch: metal_causal_conv1d_update_launch,
@@ -83,7 +100,7 @@ mod tests {
             let state_f =
                 (0..channels * 4).map(|i| ((i % 11) as f32 - 5.0) / 32.0).collect::<Vec<_>>();
             let cvt = |v: &[f32]| v.iter().copied().map(f16::from_f32).collect::<Vec<_>>();
-            let input = Tensor::from_shape(&[1, channels], &cvt(&input_f))?.into_device()?;
+            let input = Tensor::from_shape(&[1, channels, 1], &cvt(&input_f))?.into_device()?;
             let weight = Tensor::from_shape(&[channels, 4], &cvt(&weight_f))?.into_device()?;
             let state = Tensor::from_shape(&[1, channels, 4], &cvt(&state_f))?.into_device()?;
             let output = DeviceTensor::uninitialized_dt(DatumType::F16, input.shape())?;
@@ -102,6 +119,52 @@ mod tests {
                     + input_f[c] * weight_f[base + 3];
                 assert_eq!(got[c], f16::from_f32(sum / (1.0 + (-sum).exp())));
             }
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn qwen35_conv_multi_step_matches_cpu_op() -> TractResult<()> {
+        use tract_transformers::ops::causal_conv1d_update::CausalConv1dUpdate;
+        with_borrowed_metal_stream(|stream| {
+            let (b, channels, s_len, k) = (1usize, 33usize, 7usize, 4usize);
+            let input_f = (0..b * channels * s_len)
+                .map(|i| ((i % 17) as f32 - 8.0) / 32.0)
+                .collect::<Vec<_>>();
+            let weight_f = (0..channels * k)
+                .map(|i| ((i % 13) as f32 - 6.0) / 64.0)
+                .collect::<Vec<_>>();
+            let state_f = (0..b * channels * k)
+                .map(|i| ((i % 11) as f32 - 5.0) / 32.0)
+                .collect::<Vec<_>>();
+            let cvt = |v: &[f32]| v.iter().copied().map(f16::from_f32).collect::<Vec<_>>();
+            let input = Tensor::from_shape(&[b, channels, s_len], &cvt(&input_f))?;
+            let weight = Tensor::from_shape(&[channels, k], &cvt(&weight_f))?;
+            let state = Tensor::from_shape(&[b, channels, k], &cvt(&state_f))?;
+
+            let cpu = CausalConv1dUpdate.eval(tvec![
+                input.clone().into_tvalue(),
+                weight.clone().into_tvalue(),
+                state.clone().into_tvalue(),
+            ])?;
+
+            let input_d = input.into_device()?;
+            let weight_d = weight.into_device()?;
+            let state_d = state.into_device()?;
+            let output = DeviceTensor::uninitialized_dt(DatumType::F16, input_d.shape())?;
+            let next = DeviceTensor::uninitialized_dt(DatumType::F16, state_d.shape())?;
+            dispatch_eval(stream, &input_d, &weight_d, &state_d, &output, &next)?;
+            stream.wait_until_completed()?;
+            let output = output.to_host()?.into_tensor();
+            let next = next.to_host()?.into_tensor();
+            output.cast_to::<f32>()?.into_owned().close_enough(
+                &cpu[0].cast_to::<f32>()?.into_owned(),
+                Approximation::Approximate,
+            )?;
+            next.cast_to::<f32>()?.into_owned().close_enough(
+                &cpu[1].cast_to::<f32>()?.into_owned(),
+                Approximation::Approximate,
+            )?;
             Ok(())
         })
     }

--- a/metal/src/kernels/gdn_recurrent.metal
+++ b/metal/src/kernels/gdn_recurrent.metal
@@ -81,8 +81,14 @@ kernel void gdn_recurrent_f16(
 }
 
 // Variant with an f16 recurrent state (graph exported with -idt f16):
-// identical math, f32 accumulation, state roundtrips through half like
-// the CPU op does for an f16-state graph.
+// identical math, f32 accumulation per step, but -- unlike the CPU op and
+// the chunked path, which keep state in f32 across every step of a
+// multi-step call and round to half only once at the end -- this kernel
+// rounds `final_state` to half after EVERY step and reads it back
+// rounded on the next one, since state_in/final_state alias the same
+// half buffer. Precision-equivalent to the CPU op only for a single-step
+// call (decode); for a multi-step call (2 <= s_len < GDN_CHUNK) this
+// accumulates extra per-step rounding error the CPU op does not have.
 kernel void gdn_recurrent_f16_state_f16(
     device const half *query [[buffer(0)]],
     device const half *key [[buffer(1)]],
@@ -198,6 +204,11 @@ kernel void causal_conv1d_update_f16(
 // the per-thread dependency chains by R. Each thread still owns its
 // (column, chunk-rows) slice of the state exclusively, so the sequential S
 // loop only ever reads back its own device writes.
+//
+// With ST=half (gdn_recurrent_f16_state_f16_tg): same per-step half
+// rounding caveat as gdn_recurrent_f16_state_f16 above -- state_in and
+// final_state alias the same half buffer, so a multi-step call rounds
+// once per step instead of once per call like the CPU op.
 template <typename ST>
 kernel void gdn_recurrent_tg(
     device const half *query [[buffer(0)]],

--- a/metal/src/kernels/gdn_recurrent.metal
+++ b/metal/src/kernels/gdn_recurrent.metal
@@ -316,7 +316,6 @@ gdn_recurrent_tg<half>(
     constant int &, constant int &, constant int &, constant int &,
     threadgroup float *, uint2, uint2, uint2);
 
-// ---------------------------------------------------------------------------
 // Chunked gated delta rule (prefill path). Mathematically the standard
 // chunk-parallel decomposition of the recurrence (HF transformers
 // torch_chunk_gated_delta_rule semantics): the sequence is cut into chunks
@@ -338,7 +337,6 @@ gdn_recurrent_tg<half>(
 //   v_new = value' - k_cumdecay @ S
 //   out   = q_g @ S + attn_local @ v_new
 //   S     = eg_last * S + w_t^T @ v_new
-// ---------------------------------------------------------------------------
 
 constant int GDN_CHUNK = 64;
 

--- a/metal/src/kernels/gdn_recurrent.metal
+++ b/metal/src/kernels/gdn_recurrent.metal
@@ -1,6 +1,25 @@
 #include <metal_stdlib>
 using namespace metal;
 
+// Optional in-kernel beta activation: replicates the elementwise Sigmoid
+// functor (element_wise.metal) on half EXACTLY, so folding the upstream
+// sigmoid dispatch into the GDN read is bit-identical to the unfused graph.
+inline half gdn_beta(device const half *beta, int ix, int sigmoid_beta) {
+  half x = beta[ix];
+  if (sigmoid_beta) {
+    half y = 1 / (1 + metal::exp(-metal::abs(x)));
+    return (x < 0) ? 1 - y : y;
+  }
+  return x;
+}
+
+// Gated delta rule over the whole sequence. Layout matches the CPU op:
+// query/key [b, S, hk, w], value/output [b, S, hv, w] with hv = G * hk
+// (GQA: value head h reads query/key head h / G; hk == hv is the
+// ungrouped case), log_decay/beta [b, S, hv], state [b, hv, w, w].
+// One thread per (batch, value head, column); each thread owns its
+// state column exclusively, so the sequential S loop is race-free
+// (later steps read this thread's own prior writes in final_state).
 kernel void gdn_recurrent_f16(
     device const half *query [[buffer(0)]],
     device const half *key [[buffer(1)]],
@@ -12,41 +31,123 @@ kernel void gdn_recurrent_f16(
     device float *final_state [[buffer(7)]],
     constant int &heads [[buffer(8)]],
     constant int &width [[buffer(9)]],
+    constant int &s_len [[buffer(10)]],
+    constant int &batch [[buffer(11)]],
+    constant int &k_heads [[buffer(12)]],
+    constant int &sigmoid_beta [[buffer(13)]],
     uint gid [[thread_position_in_grid]]) {
-  const int head = gid / width;
   const int column = gid % width;
-  if (head >= heads) return;
-  const int vector_base = head * width;
-  const int matrix_base = head * width * width;
-  float q_norm = 0.0f;
-  float k_norm = 0.0f;
-  for (int row = 0; row < width; ++row) {
-    const float q = float(query[vector_base + row]);
-    const float k = float(key[vector_base + row]);
-    q_norm += q * q;
-    k_norm += k * k;
+  const int head = (gid / width) % heads;
+  const int b = gid / (width * heads);
+  if (b >= batch) return;
+  const int groups = heads / k_heads;
+  const int qk_head = head / groups;
+  const int matrix_base = (b * heads + head) * width * width;
+  const float out_scale = rsqrt(float(width));
+  for (int s = 0; s < s_len; ++s) {
+    const int vector_base = ((b * s_len + s) * heads + head) * width;
+    const int qk_base = ((b * s_len + s) * k_heads + qk_head) * width;
+    const int gate_ix = (b * s_len + s) * heads + head;
+    float q_norm = 0.0f;
+    float k_norm = 0.0f;
+    for (int row = 0; row < width; ++row) {
+      const float q = float(query[qk_base + row]);
+      const float k = float(key[qk_base + row]);
+      q_norm += q * q;
+      k_norm += k * k;
+    }
+    const float q_inv = rsqrt(q_norm + 1.0e-6f);
+    const float k_inv = rsqrt(k_norm + 1.0e-6f);
+    const float decay = exp(log_decay[gate_ix]);
+    device const float *state_in = (s == 0) ? initial_state : final_state;
+    float predicted = 0.0f;
+    for (int row = 0; row < width; ++row) {
+      predicted += float(key[qk_base + row]) * k_inv
+          * state_in[matrix_base + row * width + column] * decay;
+    }
+    const float residual =
+        (float(value[vector_base + column]) - predicted)
+        * float(gdn_beta(beta, gate_ix, sigmoid_beta));
+    float result = 0.0f;
+    for (int row = 0; row < width; ++row) {
+      const int offset = matrix_base + row * width + column;
+      const float next = state_in[offset] * decay
+          + float(key[qk_base + row]) * k_inv * residual;
+      final_state[offset] = next;
+      result += float(query[qk_base + row]) * q_inv * next;
+    }
+    output[vector_base + column] = half(result * out_scale);
   }
-  const float q_inv = rsqrt(q_norm + 1.0e-6f);
-  const float k_inv = rsqrt(k_norm + 1.0e-6f);
-  const float decay = exp(log_decay[head]);
-  float predicted = 0.0f;
-  for (int row = 0; row < width; ++row) {
-    predicted += float(key[vector_base + row]) * k_inv
-        * initial_state[matrix_base + row * width + column] * decay;
-  }
-  const float residual =
-      (float(value[vector_base + column]) - predicted) * float(beta[head]);
-  float result = 0.0f;
-  for (int row = 0; row < width; ++row) {
-    const int offset = matrix_base + row * width + column;
-    const float next = initial_state[offset] * decay
-        + float(key[vector_base + row]) * k_inv * residual;
-    final_state[offset] = next;
-    result += float(query[vector_base + row]) * q_inv * next;
-  }
-  output[vector_base + column] = half(result * rsqrt(float(width)));
 }
 
+// Variant with an f16 recurrent state (graph exported with -idt f16):
+// identical math, f32 accumulation, state roundtrips through half like
+// the CPU op does for an f16-state graph.
+kernel void gdn_recurrent_f16_state_f16(
+    device const half *query [[buffer(0)]],
+    device const half *key [[buffer(1)]],
+    device const half *value [[buffer(2)]],
+    device const float *log_decay [[buffer(3)]],
+    device const half *beta [[buffer(4)]],
+    device const half *initial_state [[buffer(5)]],
+    device half *output [[buffer(6)]],
+    device half *final_state [[buffer(7)]],
+    constant int &heads [[buffer(8)]],
+    constant int &width [[buffer(9)]],
+    constant int &s_len [[buffer(10)]],
+    constant int &batch [[buffer(11)]],
+    constant int &k_heads [[buffer(12)]],
+    constant int &sigmoid_beta [[buffer(13)]],
+    uint gid [[thread_position_in_grid]]) {
+  const int column = gid % width;
+  const int head = (gid / width) % heads;
+  const int b = gid / (width * heads);
+  if (b >= batch) return;
+  const int groups = heads / k_heads;
+  const int qk_head = head / groups;
+  const int matrix_base = (b * heads + head) * width * width;
+  const float out_scale = rsqrt(float(width));
+  for (int s = 0; s < s_len; ++s) {
+    const int vector_base = ((b * s_len + s) * heads + head) * width;
+    const int qk_base = ((b * s_len + s) * k_heads + qk_head) * width;
+    const int gate_ix = (b * s_len + s) * heads + head;
+    float q_norm = 0.0f;
+    float k_norm = 0.0f;
+    for (int row = 0; row < width; ++row) {
+      const float q = float(query[qk_base + row]);
+      const float k = float(key[qk_base + row]);
+      q_norm += q * q;
+      k_norm += k * k;
+    }
+    const float q_inv = rsqrt(q_norm + 1.0e-6f);
+    const float k_inv = rsqrt(k_norm + 1.0e-6f);
+    const float decay = exp(log_decay[gate_ix]);
+    device const half *state_in = (s == 0) ? initial_state : final_state;
+    float predicted = 0.0f;
+    for (int row = 0; row < width; ++row) {
+      predicted += float(key[qk_base + row]) * k_inv
+          * float(state_in[matrix_base + row * width + column]) * decay;
+    }
+    const float residual =
+        (float(value[vector_base + column]) - predicted)
+        * float(gdn_beta(beta, gate_ix, sigmoid_beta));
+    float result = 0.0f;
+    for (int row = 0; row < width; ++row) {
+      const int offset = matrix_base + row * width + column;
+      const float next = float(state_in[offset]) * decay
+          + float(key[qk_base + row]) * k_inv * residual;
+      final_state[offset] = half(next);
+      result += float(query[qk_base + row]) * q_inv * next;
+    }
+    output[vector_base + column] = half(result * out_scale);
+  }
+}
+
+
+// Stateful causal depthwise conv1d + SiLU over the whole sequence.
+// Layout matches the CPU op: input/output [b, C, S], weight [C, k],
+// state [b, C, k]. One thread per (batch, channel): the sequential S
+// loop reads the thread's own sliding window.
 kernel void causal_conv1d_update_f16(
     device const half *input [[buffer(0)]],
     device const half *weight [[buffer(1)]],
@@ -55,17 +156,500 @@ kernel void causal_conv1d_update_f16(
     device half *final_state [[buffer(4)]],
     constant int &channels [[buffer(5)]],
     constant int &kernel_width [[buffer(6)]],
-    uint channel [[thread_position_in_grid]]) {
-  if (channel >= uint(channels)) return;
-  const int base = channel * kernel_width;
-  float sum = 0.0f;
-  for (int tap = 0; tap < kernel_width - 1; ++tap) {
-    const half sample = initial_state[base + tap + 1];
-    final_state[base + tap] = sample;
-    sum += float(sample) * float(weight[base + tap]);
+    constant int &s_len [[buffer(7)]],
+    constant int &batch [[buffer(8)]],
+    uint gid [[thread_position_in_grid]]) {
+  const int channel = gid % channels;
+  const int b = gid / channels;
+  if (b >= batch) return;
+  const int state_base = (b * channels + channel) * kernel_width;
+  const int input_base = (b * channels + channel) * s_len;
+  const int weight_base = channel * kernel_width;
+  // Sliding window over concat(state, input); kernel_width is small
+  // (4 for Qwen3.5), keep the window in registers.
+  const int MAX_K = 8;
+  float window[MAX_K];
+  if (kernel_width > MAX_K) return;
+  for (int tap = 0; tap < kernel_width; ++tap) {
+    window[tap] = float(initial_state[state_base + tap]);
   }
-  const half newest = input[channel];
-  final_state[base + kernel_width - 1] = newest;
-  sum += float(newest) * float(weight[base + kernel_width - 1]);
-  output[channel] = half(sum / (1.0f + exp(-sum)));
+  for (int t = 0; t < s_len; ++t) {
+    // shift left, append the new sample: window becomes full[t+1 .. t+k]
+    for (int tap = 0; tap < kernel_width - 1; ++tap) {
+      window[tap] = window[tap + 1];
+    }
+    window[kernel_width - 1] = float(input[input_base + t]);
+    float sum = 0.0f;
+    for (int tap = 0; tap < kernel_width; ++tap) {
+      sum += window[tap] * float(weight[weight_base + tap]);
+    }
+    output[input_base + t] = half(sum / (1.0f + exp(-sum)));
+  }
+  for (int tap = 0; tap < kernel_width; ++tap) {
+    final_state[state_base + tap] = half(window[tap]);
+  }
 }
+
+// Threadgroup-parallel variant: one threadgroup per (batch, value head),
+// laid out [width columns x R row-chunks]. The row loops of the original
+// kernel (three serial passes of `width` iterations per thread, with only
+// b*heads*width threads in flight) are split across R chunks and reduced
+// through threadgroup memory, which multiplies occupancy by R and divides
+// the per-thread dependency chains by R. Each thread still owns its
+// (column, chunk-rows) slice of the state exclusively, so the sequential S
+// loop only ever reads back its own device writes.
+template <typename ST>
+kernel void gdn_recurrent_tg(
+    device const half *query [[buffer(0)]],
+    device const half *key [[buffer(1)]],
+    device const half *value [[buffer(2)]],
+    device const float *log_decay [[buffer(3)]],
+    device const half *beta [[buffer(4)]],
+    device const ST *initial_state [[buffer(5)]],
+    device half *output [[buffer(6)]],
+    device ST *final_state [[buffer(7)]],
+    constant int &heads [[buffer(8)]],
+    constant int &width [[buffer(9)]],
+    constant int &s_len [[buffer(10)]],
+    constant int &batch [[buffer(11)]],
+    constant int &k_heads [[buffer(12)]],
+    constant int &sigmoid_beta [[buffer(13)]],
+    threadgroup float *scratch [[threadgroup(0)]],
+    uint2 tgpig [[threadgroup_position_in_grid]],
+    uint2 tpitg [[thread_position_in_threadgroup]],
+    uint2 tptg [[threads_per_threadgroup]]) {
+  const int col = tpitg.x;
+  const int r = tpitg.y;
+  const int rchunks = tptg.y;
+  const int head = tgpig.x % heads;
+  const int b = tgpig.x / heads;
+  if (b >= batch) return;
+  const int rows_per_chunk = width / rchunks;
+  const int row0 = r * rows_per_chunk;
+  const int groups = heads / k_heads;
+  const int qk_head = head / groups;
+  const int matrix_base = (b * heads + head) * width * width;
+  const float out_scale = rsqrt(float(width));
+
+  // scratch layout: pred[rchunks][width], res[rchunks][width],
+  // qpart[rchunks], kpart[rchunks]
+  threadgroup float *pred_part = scratch;
+  threadgroup float *res_part = scratch + rchunks * width;
+  threadgroup float *q_part = res_part + rchunks * width;
+  threadgroup float *k_part = q_part + rchunks;
+
+  for (int s = 0; s < s_len; ++s) {
+    const int vector_base = ((b * s_len + s) * heads + head) * width;
+    const int qk_base = ((b * s_len + s) * k_heads + qk_head) * width;
+    const int gate_ix = (b * s_len + s) * heads + head;
+    float q2 = 0.0f;
+    float k2 = 0.0f;
+    for (int row = row0; row < row0 + rows_per_chunk; ++row) {
+      const float q = float(query[qk_base + row]);
+      const float k = float(key[qk_base + row]);
+      q2 += q * q;
+      k2 += k * k;
+    }
+    if (col == 0) {
+      q_part[r] = q2;
+      k_part[r] = k2;
+    }
+    device const ST *state_in = (s == 0) ? initial_state : final_state;
+    const float decay = exp(log_decay[gate_ix]);
+    float pred = 0.0f;
+    for (int row = row0; row < row0 + rows_per_chunk; ++row) {
+      pred += float(key[qk_base + row])
+          * float(state_in[matrix_base + row * width + col]) * decay;
+    }
+    pred_part[r * width + col] = pred;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float q_norm = 0.0f;
+    float k_norm = 0.0f;
+    float predicted = 0.0f;
+    for (int rr = 0; rr < rchunks; ++rr) {
+      q_norm += q_part[rr];
+      k_norm += k_part[rr];
+      predicted += pred_part[rr * width + col];
+    }
+    const float q_inv = rsqrt(q_norm + 1.0e-6f);
+    const float k_inv = rsqrt(k_norm + 1.0e-6f);
+    predicted *= k_inv;
+    const float residual =
+        (float(value[vector_base + col]) - predicted)
+        * float(gdn_beta(beta, gate_ix, sigmoid_beta));
+    float res = 0.0f;
+    for (int row = row0; row < row0 + rows_per_chunk; ++row) {
+      const int offset = matrix_base + row * width + col;
+      const float next = float(state_in[offset]) * decay
+          + float(key[qk_base + row]) * k_inv * residual;
+      final_state[offset] = ST(next);
+      res += float(query[qk_base + row]) * next;
+    }
+    res_part[r * width + col] = res;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (r == 0) {
+      float result = 0.0f;
+      for (int rr = 0; rr < rchunks; ++rr) {
+        result += res_part[rr * width + col];
+      }
+      output[vector_base + col] = half(result * q_inv * out_scale);
+    }
+    // pred_part/q_part/k_part are rewritten next step: make sure every
+    // thread is done reading them (and r==0 done reading res_part).
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+}
+
+template [[host_name("gdn_recurrent_f16_tg")]] [[kernel]] void
+gdn_recurrent_tg<float>(
+    device const half *, device const half *, device const half *,
+    device const float *, device const half *, device const float *,
+    device half *, device float *, constant int &, constant int &,
+    constant int &, constant int &, constant int &, constant int &,
+    threadgroup float *, uint2, uint2, uint2);
+
+template [[host_name("gdn_recurrent_f16_state_f16_tg")]] [[kernel]] void
+gdn_recurrent_tg<half>(
+    device const half *, device const half *, device const half *,
+    device const float *, device const half *, device const half *,
+    device half *, device half *, constant int &, constant int &,
+    constant int &, constant int &, constant int &, constant int &,
+    threadgroup float *, uint2, uint2, uint2);
+
+// ---------------------------------------------------------------------------
+// Chunked gated delta rule (prefill path). Mathematically the standard
+// chunk-parallel decomposition of the recurrence (HF transformers
+// torch_chunk_gated_delta_rule semantics): the sequence is cut into chunks
+// of GDN_CHUNK steps; everything state-independent is computed for all
+// chunks in parallel (gdn_chunk_prepare_f16), then a scan kernel walks the
+// chunks sequentially with dense matrix work instead of one step at a time
+// (gdn_chunk_scan). All compute f32, matching the CPU op which keeps an f32
+// state across the whole call and rounds once on output.
+//
+// Per chunk, with qn/kn the L2-normalized rows, G = exp(cumsum(log_decay))
+// inclusive within the chunk, k_beta = kn * beta, v_beta = v * beta:
+//   A[i][j] = -(k_beta_i . kn_j) * G_i / G_j          (strictly lower)
+//   T = (I - A)^-1 via the forward substitution loop  (unit lower)
+//   value' = T @ v_beta
+//   k_cumdecay = T @ (k_beta * G)
+//   attn_local[i][j] = (qn_i . kn_j) * scale * G_i / G_j  (lower incl diag)
+//   q_g = qn * scale * G ; w_t = kn * G_last / G ; eg_last = G_last
+// and the sequential scan per head:
+//   v_new = value' - k_cumdecay @ S
+//   out   = q_g @ S + attn_local @ v_new
+//   S     = eg_last * S + w_t^T @ v_new
+// ---------------------------------------------------------------------------
+
+constant int GDN_CHUNK = 64;
+
+// One threadgroup per (batch, value head, chunk); everything here is
+// state-independent so the whole grid runs in parallel.
+[[kernel]] void gdn_chunk_prepare_f16(
+    device const half *query [[buffer(0)]],
+    device const half *key [[buffer(1)]],
+    device const half *value [[buffer(2)]],
+    device const float *log_decay [[buffer(3)]],
+    device const half *beta [[buffer(4)]],
+    device float *value_p [[buffer(5)]],
+    device float *k_cumdecay [[buffer(6)]],
+    device float *attn_local [[buffer(7)]],
+    device float *q_g [[buffer(8)]],
+    device float *w_t [[buffer(9)]],
+    device float *eg_last [[buffer(10)]],
+    constant int &heads [[buffer(11)]],
+    constant int &width [[buffer(12)]],
+    constant int &s_len [[buffer(13)]],
+    constant int &batch [[buffer(14)]],
+    constant int &k_heads [[buffer(15)]],
+    constant int &nch [[buffer(16)]],
+    constant int &sigmoid_beta [[buffer(17)]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]])
+{
+  const int C = GDN_CHUNK;
+  threadgroup float A[GDN_CHUNK * GDN_CHUNK];
+  threadgroup float row_copy[GDN_CHUNK];
+  threadgroup float q_inv[GDN_CHUNK];
+  threadgroup float k_inv[GDN_CHUNK];
+  threadgroup float g_cum[GDN_CHUNK];
+  threadgroup float kmul[GDN_CHUNK]; // k_inv * beta * exp(g_cum)
+  threadgroup float bmul[GDN_CHUNK]; // beta
+
+  const int chunk = tgid % nch;
+  const int head = (int)(tgid / nch) % heads;
+  const int b = (int)tgid / (nch * heads);
+  if (b >= batch) return;
+  const int groups = heads / k_heads;
+  const int qk_head = head / groups;
+  const int s0 = chunk * C;
+  const int cn = min(C, s_len - s0);
+  const float out_scale = rsqrt(float(width));
+
+  const int lane = tid % 32;
+  const int sgix = tid / 32;
+  const int n_sg = max(int(tptg) / 32, 1);
+
+  // Per-row L2 norms of q/k: one simdgroup per row, lanes split the width
+  // (coalesced; a thread-per-row layout makes every lane read a different
+  // 2*width-byte-distant row and serializes the loads).
+  for (int i = sgix; i < cn; i += n_sg) {
+    const int qk_base = ((b * s_len + s0 + i) * k_heads + qk_head) * width;
+    float q2 = 0.0f, k2 = 0.0f;
+    for (int c = lane; c < width; c += 32) {
+      const float qv = float(query[qk_base + c]);
+      const float kv = float(key[qk_base + c]);
+      q2 += qv * qv;
+      k2 += kv * kv;
+    }
+    q2 = simd_sum(q2);
+    k2 = simd_sum(k2);
+    if (lane == 0) {
+      q_inv[i] = rsqrt(q2 + 1.0e-6f);
+      k_inv[i] = rsqrt(k2 + 1.0e-6f);
+    }
+  }
+  // Inclusive within-chunk decay cumsum (C serial adds, one thread).
+  if (tid == 0) {
+    float acc = 0.0f;
+    for (int i = 0; i < cn; ++i) {
+      acc += log_decay[(b * s_len + s0 + i) * heads + head];
+      g_cum[i] = acc;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (int i = tid; i < cn; i += tptg) {
+    const float beta_i =
+        float(gdn_beta(beta, (b * s_len + s0 + i) * heads + head, sigmoid_beta));
+    bmul[i] = beta_i;
+    kmul[i] = k_inv[i] * beta_i * exp(g_cum[i]);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // A = -(k_beta @ kn^T) * decay, strictly lower triangular. One simdgroup
+  // per (i, j) pair: lanes split the dot (coalesced row reads + simd_sum).
+  for (int e = sgix; e < cn * cn; e += n_sg) {
+    const int i = e / cn;
+    const int j = e % cn;
+    float a = 0.0f;
+    if (j < i) {
+      const int bi = ((b * s_len + s0 + i) * k_heads + qk_head) * width;
+      const int bj = ((b * s_len + s0 + j) * k_heads + qk_head) * width;
+      float dot = 0.0f;
+      for (int c = lane; c < width; c += 32) {
+        dot += float(key[bi + c]) * float(key[bj + c]);
+      }
+      dot = simd_sum(dot);
+      a = -dot * k_inv[i] * k_inv[j] * bmul[i] * exp(g_cum[i] - g_cum[j]);
+    }
+    if (lane == 0) {
+      A[i * C + j] = a;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Forward substitution: row i gains sum_p old_row[p] * A[p][:] over the
+  // already-transformed rows p < i (A stays strictly lower throughout).
+  for (int i = 1; i < cn; ++i) {
+    for (int j = tid; j < i; j += tptg) {
+      row_copy[j] = A[i * C + j];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (int j = tid; j < i; j += tptg) {
+      float acc = row_copy[j];
+      for (int p = j + 1; p < i; ++p) {
+        acc += row_copy[p] * A[p * C + j];
+      }
+      A[i * C + j] = acc;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  for (int i = tid; i < cn; i += tptg) {
+    A[i * C + i] = 1.0f;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const float g_last = g_cum[cn - 1];
+  if (tid == 0) {
+    eg_last[(b * heads + head) * nch + chunk] = exp(g_last);
+  }
+
+  // value' = T @ v_beta and k_cumdecay = T @ (k_beta * exp(g_cum)).
+  const int row_base = ((b * heads + head) * nch + chunk) * C;
+  for (int e = tid; e < cn * width; e += tptg) {
+    const int i = e / width;
+    const int c = e % width;
+    float vp = 0.0f, kc = 0.0f;
+    for (int j = 0; j <= i; ++j) {
+      const float t = A[i * C + j];
+      const int vbase = ((b * s_len + s0 + j) * heads + head) * width;
+      const int kbase = ((b * s_len + s0 + j) * k_heads + qk_head) * width;
+      vp += t * float(value[vbase + c]) * bmul[j];
+      kc += t * float(key[kbase + c]) * kmul[j];
+    }
+    const int out_ix = (row_base + i) * width + c;
+    value_p[out_ix] = vp;
+    k_cumdecay[out_ix] = kc;
+  }
+
+  // attn_local = (qn @ kn^T) * decay, lower triangular INCLUDING diagonal.
+  // Same simdgroup-cooperative dot as the A matrix.
+  for (int e = sgix; e < cn * cn; e += n_sg) {
+    const int i = e / cn;
+    const int j = e % cn;
+    float a = 0.0f;
+    if (j <= i) {
+      const int bi = ((b * s_len + s0 + i) * k_heads + qk_head) * width;
+      const int bj = ((b * s_len + s0 + j) * k_heads + qk_head) * width;
+      float dot = 0.0f;
+      for (int c = lane; c < width; c += 32) {
+        dot += float(query[bi + c]) * float(key[bj + c]);
+      }
+      dot = simd_sum(dot);
+      a = dot * q_inv[i] * out_scale * k_inv[j] * exp(g_cum[i] - g_cum[j]);
+    }
+    if (lane == 0) {
+      attn_local[(row_base + i) * C + j] = a;
+    }
+  }
+
+  // q_g = qn * scale * exp(g_cum) ; w_t = kn * exp(g_last - g_cum).
+  for (int e = tid; e < cn * width; e += tptg) {
+    const int i = e / width;
+    const int c = e % width;
+    const int qk_base = ((b * s_len + s0 + i) * k_heads + qk_head) * width;
+    const int out_ix = (row_base + i) * width + c;
+    q_g[out_ix] = float(query[qk_base + c]) * q_inv[i] * out_scale * exp(g_cum[i]);
+    w_t[out_ix] = float(key[qk_base + c]) * k_inv[i] * exp(g_last - g_cum[i]);
+  }
+}
+
+// Columns of the state each scan threadgroup owns. The whole recurrence is
+// column-separable (rows mix only through the precomputed per-chunk row
+// vectors), so the scan parallelizes as (batch, head, column-block) with
+// the state block held in threadgroup memory in f32 for ALL chunks: no
+// device state traffic inside the loop at all, and heads*width/32
+// threadgroups instead of heads.
+constant int GDN_COL_BLOCK = 16;
+
+// Sequential scan over chunks with dense per-chunk matrix work on one
+// column block of one head's state.
+template <typename ST>
+kernel void gdn_chunk_scan(
+    device const float *value_p [[buffer(0)]],
+    device const float *k_cumdecay [[buffer(1)]],
+    device const float *attn_local [[buffer(2)]],
+    device const float *q_g [[buffer(3)]],
+    device const float *w_t [[buffer(4)]],
+    device const float *eg_last [[buffer(5)]],
+    device const ST *initial_state [[buffer(6)]],
+    device half *output [[buffer(7)]],
+    device ST *final_state [[buffer(8)]],
+    constant int &heads [[buffer(9)]],
+    constant int &width [[buffer(10)]],
+    constant int &s_len [[buffer(11)]],
+    constant int &batch [[buffer(12)]],
+    constant int &nch [[buffer(13)]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tptg [[threads_per_threadgroup]])
+{
+  const int C = GDN_CHUNK;
+  const int CB = GDN_COL_BLOCK;
+  // S block [width x CB] f32 (16KB at width 128) + v_new block [C x CB]
+  // f32 (8KB): resident for the whole sequence.
+  threadgroup float s_blk[128 * GDN_COL_BLOCK];
+  threadgroup float vn_blk[GDN_CHUNK * GDN_COL_BLOCK];
+
+  const int col_blocks = (width + CB - 1) / CB;
+  const int cblk = tgid % col_blocks;
+  const int head = (int)(tgid / col_blocks) % heads;
+  const int b = (int)tgid / (col_blocks * heads);
+  if (b >= batch) return;
+  const int c0 = cblk * CB;
+  const int cb = min(CB, width - c0);
+  const int mat_base = (b * heads + head) * width * width;
+
+  for (int e = tid; e < width * cb; e += tptg) {
+    const int r = e / cb;
+    const int c = e % cb;
+    s_blk[r * CB + c] = float(initial_state[mat_base + r * width + c0 + c]);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (int ch = 0; ch < nch; ++ch) {
+    const int s0 = ch * C;
+    const int cn = min(C, s_len - s0);
+    const int row_base = ((b * heads + head) * nch + ch) * C;
+    const float egl = eg_last[(b * heads + head) * nch + ch];
+
+    // v_new = value' - k_cumdecay @ S (this head's column block).
+    for (int e = tid; e < cn * cb; e += tptg) {
+      const int i = e / cb;
+      const int c = e % cb;
+      device const float *kc = k_cumdecay + (row_base + i) * width;
+      float acc = 0.0f;
+#pragma clang loop unroll_count(16)
+      for (int r = 0; r < width; ++r) {
+        acc += kc[r] * s_blk[r * CB + c];
+      }
+      vn_blk[i * CB + c] = value_p[(row_base + i) * width + c0 + c] - acc;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // out = q_g @ S + attn_local @ v_new
+    for (int e = tid; e < cn * cb; e += tptg) {
+      const int i = e / cb;
+      const int c = e % cb;
+      device const float *qg = q_g + (row_base + i) * width;
+      float acc = 0.0f;
+#pragma clang loop unroll_count(16)
+      for (int r = 0; r < width; ++r) {
+        acc += qg[r] * s_blk[r * CB + c];
+      }
+      device const float *al = attn_local + (row_base + i) * C;
+#pragma clang loop unroll_count(8)
+      for (int j = 0; j <= i; ++j) {
+        acc += al[j] * vn_blk[j * CB + c];
+      }
+      output[((b * s_len + s0 + i) * heads + head) * width + c0 + c] = half(acc);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // S = eg_last * S + w_t^T @ v_new
+    for (int e = tid; e < width * cb; e += tptg) {
+      const int r = e / cb;
+      const int c = e % cb;
+      device const float *wt = w_t + row_base * width;
+      float acc = s_blk[r * CB + c] * egl;
+#pragma clang loop unroll_count(16)
+      for (int i = 0; i < cn; ++i) {
+        acc += wt[i * width + r] * vn_blk[i * CB + c];
+      }
+      s_blk[r * CB + c] = acc;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  for (int e = tid; e < width * cb; e += tptg) {
+    const int r = e / cb;
+    const int c = e % cb;
+    final_state[mat_base + r * width + c0 + c] = ST(s_blk[r * CB + c]);
+  }
+}
+
+template [[host_name("gdn_chunk_scan_f32_state")]] [[kernel]] void
+gdn_chunk_scan<float>(
+    device const float *, device const float *, device const float *,
+    device const float *, device const float *, device const float *,
+    device const float *, device half *, device float *,
+    constant int &, constant int &, constant int &,
+    constant int &, constant int &, uint, uint, uint);
+
+template [[host_name("gdn_chunk_scan_f16_state")]] [[kernel]] void
+gdn_chunk_scan<half>(
+    device const float *, device const float *, device const float *,
+    device const float *, device const float *, device const float *,
+    device const half *, device half *, device half *,
+    constant int &, constant int &, constant int &,
+    constant int &, constant int &, uint, uint, uint);

--- a/metal/src/kernels/gdn_recurrent.rs
+++ b/metal/src/kernels/gdn_recurrent.rs
@@ -15,25 +15,126 @@ fn dispatch_eval(
     initial_state: &DeviceTensor,
     output: &DeviceTensor,
     final_state: &DeviceTensor,
+    sigmoid_beta: bool,
 ) -> TractResult<()> {
     ensure!(query.datum_type() == DatumType::F16);
     ensure!(key.datum_type() == DatumType::F16 && value.datum_type() == DatumType::F16);
     ensure!(log_decay.datum_type() == DatumType::F32);
     ensure!(beta.datum_type() == DatumType::F16);
-    ensure!(initial_state.datum_type() == DatumType::F32);
-    ensure!(query.shape() == key.shape() && query.shape() == value.shape());
-    let width = *query.shape().last().context("GDN query must have a last axis")?;
-    ensure!(width == 128, "the Qwen3.5 recurrent op requires width=128");
-    let heads = query.len() / width;
-    ensure!(log_decay.len() == heads && beta.len() == heads);
-    ensure!(initial_state.len() == heads * width * width);
-    ensure!(output.shape() == query.shape() && output.datum_type() == DatumType::F16);
+    ensure!(matches!(initial_state.datum_type(), DatumType::F16 | DatumType::F32));
+    ensure!(query.shape() == key.shape());
+    // Layout matches the CPU op: q/k [b, S, hk, w], v/output [b, S, hv, w]
+    // with hv = G * hk (GQA), gates [b, S, hv], state [b, hv, w, w].
+    ensure!(query.rank() == 4, "GDN query must be [b, S, hk, w], got {:?}", query.shape());
+    let (batch, s_len, k_heads, width) =
+        (query.shape()[0], query.shape()[1], query.shape()[2], query.shape()[3]);
+    ensure!(
+        value.rank() == 4
+            && value.shape()[0] == batch
+            && value.shape()[1] == s_len
+            && value.shape()[3] == width
+            && value.shape()[2].is_multiple_of(k_heads),
+        "GDN value must be [b, S, G*hk, w] with query/key [b, S, hk, w], got value {:?} vs query {:?}",
+        value.shape(),
+        query.shape()
+    );
+    let heads = value.shape()[2];
+    ensure!(log_decay.len() == batch * s_len * heads && beta.len() == batch * s_len * heads);
+    ensure!(
+        initial_state.shape() == [batch, heads, width, width],
+        "GDN state must be [b, hv, w, w], got {:?}",
+        initial_state.shape()
+    );
+    ensure!(output.shape() == value.shape() && output.datum_type() == DatumType::F16);
     ensure!(final_state.shape() == initial_state.shape());
 
     for tensor in [query, key, value, log_decay, beta, initial_state, output, final_state] {
         stream.retain_tensor(tensor);
     }
-    let pipeline = stream.load_pipeline(LibraryName::GdnRecurrent, "gdn_recurrent_f16")?;
+    let f16_state = initial_state.datum_type() == DatumType::F16;
+
+    // Prefill-shaped steps run the chunked gated delta rule: chunk-local
+    // matrices for all chunks in parallel, then a (head, column-block) scan
+    // that is sequential only across S/64 chunks instead of S steps.
+    // width <= 128: the scan kernel's static threadgroup arrays hold one
+    // [width x GDN_COL_BLOCK] f32 state block.
+    if s_len >= GDN_CHUNK
+        && width <= 128
+        && std::env::var_os("TRACT_METAL_DISABLE_GDN_CHUNKED").is_none()
+    {
+        return dispatch_chunked(
+            stream,
+            query,
+            key,
+            value,
+            log_decay,
+            beta,
+            initial_state,
+            output,
+            final_state,
+            (batch, s_len, k_heads, heads, width),
+            f16_state,
+            sigmoid_beta,
+        );
+    }
+
+    // Threadgroup-parallel kernel: one threadgroup per (b, head), threads
+    // [width x rchunks], row loops split across chunks and reduced through
+    // threadgroup memory. Needs the whole column set in one threadgroup;
+    // exotic widths fall back to the thread-per-column kernel.
+    let tg_kernel_name =
+        if f16_state { "gdn_recurrent_f16_state_f16_tg" } else { "gdn_recurrent_f16_tg" };
+    let tg_pipeline = stream.load_pipeline(LibraryName::GdnRecurrent, tg_kernel_name)?;
+    let max_tg = tg_pipeline.max_total_threads_per_threadgroup() as usize;
+    let mut rchunks = 1;
+    while rchunks < 16
+        && width % (rchunks * 2) == 0
+        && width * rchunks * 2 <= max_tg.min(1024)
+    {
+        rchunks *= 2;
+    }
+
+    if width <= max_tg {
+        let command_buffer = stream.command_buffer();
+        command_buffer.encode(|encoder| {
+            encoder.set_compute_pipeline_state(&tg_pipeline);
+            for (ix, tensor) in
+                [query, key, value, log_decay, beta, initial_state].iter().enumerate()
+            {
+                encoder.set_metal_tensor(ix as u64, tensor, metal::MTLResourceUsage::Read);
+            }
+            encoder.set_metal_tensor(6, output, metal::MTLResourceUsage::Write);
+            encoder.set_metal_tensor(7, final_state, metal::MTLResourceUsage::Write);
+            let n_tgs = (batch * heads) as u64;
+            let heads = heads as i32;
+            let width_i = width as i32;
+            let s_len = s_len as i32;
+            let batch_i = batch as i32;
+            let k_heads = k_heads as i32;
+            encoder.set_bytes(8, size_of::<i32>() as u64, &heads as *const i32 as *const _);
+            encoder.set_bytes(9, size_of::<i32>() as u64, &width_i as *const i32 as *const _);
+            encoder.set_bytes(10, size_of::<i32>() as u64, &s_len as *const i32 as *const _);
+            encoder.set_bytes(11, size_of::<i32>() as u64, &batch_i as *const i32 as *const _);
+            encoder.set_bytes(12, size_of::<i32>() as u64, &k_heads as *const i32 as *const _);
+            let sigmoid_beta_i = sigmoid_beta as i32;
+            encoder.set_bytes(
+                13,
+                size_of::<i32>() as u64,
+                &sigmoid_beta_i as *const i32 as *const _,
+            );
+            let scratch_bytes = ((2 * rchunks * width + 2 * rchunks) * size_of::<f32>()) as u64;
+            encoder.set_threadgroup_memory_length(0, scratch_bytes);
+            encoder.dispatch_thread_groups(
+                MTLSize { width: n_tgs, height: 1, depth: 1 },
+                MTLSize { width: width as u64, height: rchunks as u64, depth: 1 },
+            );
+        });
+        return Ok(());
+    }
+
+    let kernel_name =
+        if f16_state { "gdn_recurrent_f16_state_f16" } else { "gdn_recurrent_f16" };
+    let pipeline = stream.load_pipeline(LibraryName::GdnRecurrent, kernel_name)?;
     let command_buffer = stream.command_buffer();
     command_buffer.encode(|encoder| {
         encoder.set_compute_pipeline_state(&pipeline);
@@ -44,13 +145,134 @@ fn dispatch_eval(
         encoder.set_metal_tensor(7, final_state, metal::MTLResourceUsage::Write);
         let heads = heads as i32;
         let width = width as i32;
+        let s_len = s_len as i32;
+        let batch = batch as i32;
+        let k_heads = k_heads as i32;
         encoder.set_bytes(8, size_of::<i32>() as u64, &heads as *const i32 as *const _);
         encoder.set_bytes(9, size_of::<i32>() as u64, &width as *const i32 as *const _);
+        encoder.set_bytes(10, size_of::<i32>() as u64, &s_len as *const i32 as *const _);
+        encoder.set_bytes(11, size_of::<i32>() as u64, &batch as *const i32 as *const _);
+        encoder.set_bytes(12, size_of::<i32>() as u64, &k_heads as *const i32 as *const _);
+        let sigmoid_beta_i = sigmoid_beta as i32;
+        encoder.set_bytes(13, size_of::<i32>() as u64, &sigmoid_beta_i as *const i32 as *const _);
         encoder.dispatch_threads(
-            MTLSize { width: (heads * width) as u64, height: 1, depth: 1 },
-            MTLSize { width: width as u64, height: 1, depth: 1 },
+            MTLSize { width: (batch * heads * width) as u64, height: 1, depth: 1 },
+            MTLSize { width: width.min(1024) as u64, height: 1, depth: 1 },
         );
     });
+    Ok(())
+}
+
+/// Chunk length of the chunked gated delta rule; must match GDN_CHUNK in
+/// gdn_recurrent.metal.
+const GDN_CHUNK: usize = 64;
+/// State columns per scan threadgroup; must match GDN_COL_BLOCK in
+/// gdn_recurrent.metal.
+const GDN_COL_BLOCK: usize = 16;
+
+/// Chunked gated delta rule (see gdn_recurrent.metal): one parallel
+/// prepare dispatch over (batch, head, chunk), a command-buffer boundary
+/// (the scan reads scratch the prepare just wrote: the documented
+/// intra-command-buffer write->read defect medicine), then the per-head
+/// sequential scan.
+#[allow(clippy::too_many_arguments)]
+fn dispatch_chunked(
+    stream: &MetalStream,
+    query: &DeviceTensor,
+    key: &DeviceTensor,
+    value: &DeviceTensor,
+    log_decay: &DeviceTensor,
+    beta: &DeviceTensor,
+    initial_state: &DeviceTensor,
+    output: &DeviceTensor,
+    final_state: &DeviceTensor,
+    dims: (usize, usize, usize, usize, usize),
+    f16_state: bool,
+    sigmoid_beta: bool,
+) -> TractResult<()> {
+    let (batch, s_len, k_heads, heads, width) = dims;
+    let nch = s_len.div_ceil(GDN_CHUNK);
+    let rows = batch * heads * nch * GDN_CHUNK;
+    let f32dt = DatumType::F32;
+    let value_p = unsafe { DeviceTensor::uninitialized_dt(f32dt, &[rows, width])? };
+    let k_cumdecay = unsafe { DeviceTensor::uninitialized_dt(f32dt, &[rows, width])? };
+    let attn_local = unsafe { DeviceTensor::uninitialized_dt(f32dt, &[rows, GDN_CHUNK])? };
+    let q_g = unsafe { DeviceTensor::uninitialized_dt(f32dt, &[rows, width])? };
+    let w_t = unsafe { DeviceTensor::uninitialized_dt(f32dt, &[rows, width])? };
+    let eg_last = unsafe { DeviceTensor::uninitialized_dt(f32dt, &[batch * heads * nch])? };
+    for t in [&value_p, &k_cumdecay, &attn_local, &q_g, &w_t, &eg_last] {
+        stream.retain_tensor(t);
+    }
+
+    let prep = stream.load_pipeline(LibraryName::GdnRecurrent, "gdn_chunk_prepare_f16")?;
+    let tg_width = (prep.max_total_threads_per_threadgroup() as u64).min(256);
+    let command_buffer = stream.command_buffer();
+    command_buffer.encode(|encoder| {
+        encoder.set_compute_pipeline_state(&prep);
+        for (ix, t) in [query, key, value, log_decay, beta].iter().enumerate() {
+            encoder.set_metal_tensor(ix as u64, t, metal::MTLResourceUsage::Read);
+        }
+        for (ix, t) in
+            [&value_p, &k_cumdecay, &attn_local, &q_g, &w_t, &eg_last].iter().enumerate()
+        {
+            encoder.set_metal_tensor(5 + ix as u64, t, metal::MTLResourceUsage::Write);
+        }
+        encoder.set_slice(11, &[heads as i32]);
+        encoder.set_slice(12, &[width as i32]);
+        encoder.set_slice(13, &[s_len as i32]);
+        encoder.set_slice(14, &[batch as i32]);
+        encoder.set_slice(15, &[k_heads as i32]);
+        encoder.set_slice(16, &[nch as i32]);
+        encoder.set_slice(17, &[sigmoid_beta as i32]);
+        encoder.dispatch_thread_groups(
+            MTLSize { width: (batch * heads * nch) as u64, height: 1, depth: 1 },
+            MTLSize { width: tg_width, height: 1, depth: 1 },
+        );
+    });
+    // NOTE(split-e): the origin branch uses `stream.commit_current()` here, a
+    // non-blocking commit from a buffer-pool/backpressure rework that lives
+    // in an unrelated split (touches context.rs's MetalStream internals plus
+    // fused_sdpa/routed_q40_matmul/routed_q40_swiglu/autotune/tuning). Rather
+    // than pull that split in, this uses the synchronous barrier already
+    // used elsewhere in this same file for the same purpose. Correctness is
+    // unaffected; this only gives up the async pipelining between the
+    // prepare and scan dispatches, so it may cost some decode throughput
+    // until the buffer-pool split lands and this is rebased onto it.
+    stream.wait_until_completed()?;
+
+    let scan_name = if f16_state { "gdn_chunk_scan_f16_state" } else { "gdn_chunk_scan_f32_state" };
+    let scan = stream.load_pipeline(LibraryName::GdnRecurrent, scan_name)?;
+    let col_blocks = width.div_ceil(GDN_COL_BLOCK);
+    let tg_width = (scan.max_total_threads_per_threadgroup() as u64).min(256);
+    let command_buffer = stream.command_buffer();
+    command_buffer.encode(|encoder| {
+        encoder.set_compute_pipeline_state(&scan);
+        for (ix, t) in [&value_p, &k_cumdecay, &attn_local, &q_g, &w_t, &eg_last].iter().enumerate()
+        {
+            encoder.set_metal_tensor(ix as u64, t, metal::MTLResourceUsage::Read);
+        }
+        encoder.set_metal_tensor(6, initial_state, metal::MTLResourceUsage::Read);
+        encoder.set_metal_tensor(7, output, metal::MTLResourceUsage::Write);
+        encoder.set_metal_tensor(8, final_state, metal::MTLResourceUsage::Write);
+        encoder.set_slice(9, &[heads as i32]);
+        encoder.set_slice(10, &[width as i32]);
+        encoder.set_slice(11, &[s_len as i32]);
+        encoder.set_slice(12, &[batch as i32]);
+        encoder.set_slice(13, &[nch as i32]);
+        encoder.dispatch_thread_groups(
+            MTLSize { width: (batch * heads * col_blocks) as u64, height: 1, depth: 1 },
+            MTLSize { width: tg_width, height: 1, depth: 1 },
+        );
+    });
+    // The scratch dies when this function returns. The commit between the
+    // two encodes moved the first retains onto the (closed) prepare buffer,
+    // which completes long before the scan runs: retain everything again so
+    // the scan's command buffer keeps the scratch alive (without this the
+    // buffer pool hands the same memory to the next layer's prepare while
+    // this scan still reads it: real-model junk output).
+    for t in [&value_p, &k_cumdecay, &attn_local, &q_g, &w_t, &eg_last] {
+        stream.retain_tensor(t);
+    }
     Ok(())
 }
 
@@ -64,6 +286,7 @@ pub fn metal_gdn_recurrent_launch(
     initial_state: &DeviceTensor,
     output: &DeviceTensor,
     final_state: &DeviceTensor,
+    sigmoid_beta: bool,
 ) -> TractResult<()> {
     crate::with_metal_stream(|stream| {
         dispatch_eval(
@@ -76,16 +299,34 @@ pub fn metal_gdn_recurrent_launch(
             initial_state,
             output,
             final_state,
+            sigmoid_beta,
         )
     })
 }
 
 crate::register_metal_op!(
     tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent,
-    |_source, _node, _op| {
+    |source, node, op| {
+        // The Metal kernel is f16-only (q/k/v/beta f16, gates/state f32);
+        // other dtype mixes (e.g. an all-f32 test export) stay on the CPU op.
+        let facts = source.node_input_facts(node.id)?;
+        let dts: Vec<DatumType> = facts.iter().map(|f| f.datum_type).collect();
+        // q/k/v/beta f16, log_decay f32; the recurrent state may be f16
+        // (graph exported with -idt f16) or f32, each has its kernel.
+        if dts[..5] != [
+            DatumType::F16,
+            DatumType::F16,
+            DatumType::F16,
+            DatumType::F32,
+            DatumType::F16,
+        ] || !matches!(dts[5], DatumType::F16 | DatumType::F32)
+        {
+            return Ok(None);
+        }
         Ok(Some(Box::new(tract_gpu::ops::gdn_recurrent::GpuGatedDeltaNetRecurrent {
             backend_name: "Metal",
             dispatch: metal_gdn_recurrent_launch,
+            sigmoid_beta: op.sigmoid_beta,
         })))
     }
 );
@@ -118,7 +359,7 @@ mod tests {
             let state = Tensor::from_shape(&[1, heads, width, width], &sf)?.into_device()?;
             let output = DeviceTensor::uninitialized_dt(DatumType::F16, q.shape())?;
             let next = DeviceTensor::uninitialized_dt(DatumType::F32, state.shape())?;
-            dispatch_eval(stream, &q, &k, &v, &g, &beta, &state, &output, &next)?;
+            dispatch_eval(stream, &q, &k, &v, &g, &beta, &state, &output, &next, false)?;
             stream.wait_until_completed()?;
             let output = output.to_host()?.into_tensor();
             let next = next.to_host()?.into_tensor();
@@ -152,6 +393,288 @@ mod tests {
                     );
                 }
             }
+            Ok(())
+        })
+    }
+
+    /// Multi-step Metal-vs-CPU comparison, parametric over the GQA group
+    /// count (heads = hv = groups * k_heads) and the state datum type.
+    fn multi_step_matches_cpu_op_case(groups: usize, state_dt: DatumType) -> TractResult<()> {
+        multi_step_matches_cpu_op_len(groups, state_dt, 5)
+    }
+
+    fn multi_step_matches_cpu_op_len(
+        groups: usize,
+        state_dt: DatumType,
+        s_len: usize,
+    ) -> TractResult<()> {
+        use tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent;
+        with_borrowed_metal_stream(|stream| {
+            let (b, k_heads, width) = (1usize, 2usize, 32usize);
+            let heads = k_heads * groups;
+            let n_qk = b * s_len * k_heads * width;
+            let n_vec = b * s_len * heads * width;
+            let n_gate = b * s_len * heads;
+            let n_state = b * heads * width * width;
+            let qf = (0..n_qk).map(|i| ((i % 31) as f32 - 15.0) / 64.0).collect::<Vec<_>>();
+            let kf = (0..n_qk).map(|i| ((i % 29) as f32 - 14.0) / 64.0).collect::<Vec<_>>();
+            let vf = (0..n_vec).map(|i| ((i % 23) as f32 - 11.0) / 32.0).collect::<Vec<_>>();
+            let sf = (0..n_state).map(|i| ((i % 37) as f32 - 18.0) / 256.0).collect::<Vec<_>>();
+            let gf = (0..n_gate).map(|i| -0.05 - 0.1 * (i % 7) as f32).collect::<Vec<_>>();
+            let bf = (0..n_gate).map(|i| 0.125 + 0.08 * (i % 9) as f32).collect::<Vec<_>>();
+            let as_f16 = |v: &[f32]| v.iter().copied().map(f16::from_f32).collect::<Vec<_>>();
+            let q = Tensor::from_shape(&[b, s_len, k_heads, width], &as_f16(&qf))?;
+            let k = Tensor::from_shape(&[b, s_len, k_heads, width], &as_f16(&kf))?;
+            let v = Tensor::from_shape(&[b, s_len, heads, width], &as_f16(&vf))?;
+            let g = Tensor::from_shape(&[b, s_len, heads], &gf)?;
+            let beta = Tensor::from_shape(&[b, s_len, heads], &as_f16(&bf))?;
+            let state = Tensor::from_shape(&[b, heads, width, width], &sf)?
+                .cast_to_dt(state_dt)?
+                .into_owned();
+
+            let cpu = GatedDeltaNetRecurrent::default().eval(tvec![
+                q.clone().into_tvalue(),
+                k.clone().into_tvalue(),
+                v.clone().into_tvalue(),
+                g.clone().into_tvalue(),
+                beta.clone().into_tvalue(),
+                state.clone().into_tvalue(),
+            ])?;
+
+            let qd = q.into_device()?;
+            let kd = k.into_device()?;
+            let vd = v.into_device()?;
+            let gd = g.into_device()?;
+            let betad = beta.into_device()?;
+            let stated = state.into_device()?;
+            let output = DeviceTensor::uninitialized_dt(DatumType::F16, vd.shape())?;
+            let next = DeviceTensor::uninitialized_dt(state_dt, stated.shape())?;
+            dispatch_eval(stream, &qd, &kd, &vd, &gd, &betad, &stated, &output, &next, false)?;
+            stream.wait_until_completed()?;
+
+            let output = output.to_host()?.into_tensor();
+            let next = next.to_host()?.into_tensor();
+            output
+                .cast_to::<f32>()?
+                .close_enough(&cpu[0].cast_to::<f32>()?.into_owned(), Approximation::Approximate)?;
+            next.cast_to::<f32>()?
+                .into_owned()
+                .close_enough(&cpu[1].cast_to::<f32>()?.into_owned(), Approximation::Approximate)?;
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn qwen35_recurrent_multi_step_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_case(1, DatumType::F32)
+    }
+
+    #[test]
+    fn qwen35_recurrent_multi_step_grouped_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_case(2, DatumType::F32)
+    }
+
+    #[test]
+    fn qwen35_recurrent_f16_state_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_case(1, DatumType::F16)
+    }
+
+    #[test]
+    fn qwen35_recurrent_f16_state_grouped_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_case(2, DatumType::F16)
+    }
+
+    /// Prefill-shaped steps (s_len >= 64) take the chunked gated delta rule
+    /// path; 200 forces multiple chunks plus a partial last chunk of 8.
+    #[test]
+    fn qwen35_chunked_prefill_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_len(1, DatumType::F32, 200)
+    }
+
+    #[test]
+    fn qwen35_chunked_prefill_grouped_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_len(2, DatumType::F32, 200)
+    }
+
+    #[test]
+    fn qwen35_chunked_prefill_f16_state_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_len(1, DatumType::F16, 200)
+    }
+
+    #[test]
+    fn qwen35_chunked_prefill_f16_state_grouped_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_len(2, DatumType::F16, 200)
+    }
+
+    /// Exactly one full chunk (the threshold boundary).
+    #[test]
+    fn qwen35_chunked_prefill_single_chunk_matches_cpu_op() -> TractResult<()> {
+        multi_step_matches_cpu_op_len(2, DatumType::F32, 64)
+    }
+
+    /// Folding the beta sigmoid into the kernel must be BIT-IDENTICAL to the
+    /// standalone Metal sigmoid dispatch followed by the unfolded kernel, at
+    /// decode (tg kernel) and prefill (chunked) shapes, for both state dtypes.
+    fn sigmoid_beta_fold_is_exact_case(state_dt: DatumType, s_len: usize) -> TractResult<()> {
+        with_borrowed_metal_stream(|stream| {
+            let (b, k_heads, groups, width) = (1usize, 2usize, 2usize, 32usize);
+            let heads = k_heads * groups;
+            let n_qk = b * s_len * k_heads * width;
+            let n_vec = b * s_len * heads * width;
+            let n_gate = b * s_len * heads;
+            let n_state = b * heads * width * width;
+            let as_f16 = |v: Vec<f32>| v.into_iter().map(f16::from_f32).collect::<Vec<_>>();
+            let q = Tensor::from_shape(
+                &[b, s_len, k_heads, width],
+                &as_f16((0..n_qk).map(|i| ((i % 31) as f32 - 15.0) / 64.0).collect()),
+            )?
+            .into_device()?;
+            let k = Tensor::from_shape(
+                &[b, s_len, k_heads, width],
+                &as_f16((0..n_qk).map(|i| ((i % 29) as f32 - 14.0) / 64.0).collect()),
+            )?
+            .into_device()?;
+            let v = Tensor::from_shape(
+                &[b, s_len, heads, width],
+                &as_f16((0..n_vec).map(|i| ((i % 23) as f32 - 11.0) / 32.0).collect()),
+            )?
+            .into_device()?;
+            let g = Tensor::from_shape(
+                &[b, s_len, heads],
+                &(0..n_gate).map(|i| -0.05 - 0.1 * (i % 7) as f32).collect::<Vec<f32>>(),
+            )?
+            .into_device()?;
+            // Raw beta logits, both signs exercised.
+            let beta_raw = Tensor::from_shape(
+                &[b, s_len, heads],
+                &as_f16((0..n_gate).map(|i| ((i % 13) as f32 - 6.0) / 3.0).collect()),
+            )?
+            .into_device()?;
+            let state = Tensor::from_shape(
+                &[b, heads, width, width],
+                &(0..n_state).map(|i| ((i % 37) as f32 - 18.0) / 256.0).collect::<Vec<f32>>(),
+            )?
+            .cast_to_dt(state_dt)?
+            .into_owned()
+            .into_device()?;
+
+            // Reference: standalone Metal sigmoid dispatch, then unfolded GDN.
+            let beta_sig = DeviceTensor::uninitialized_dt(DatumType::F16, beta_raw.shape())?;
+            crate::kernels::element_wise::dispatch_eval(
+                stream,
+                &tract_core::ops::nn::Sigmoid {},
+                &beta_raw,
+                &beta_sig,
+            )?;
+            let out_ref = DeviceTensor::uninitialized_dt(DatumType::F16, v.shape())?;
+            let next_ref = DeviceTensor::uninitialized_dt(state_dt, state.shape())?;
+            dispatch_eval(stream, &q, &k, &v, &g, &beta_sig, &state, &out_ref, &next_ref, false)?;
+
+            // Folded: raw beta straight into the kernel.
+            let out_fold = DeviceTensor::uninitialized_dt(DatumType::F16, v.shape())?;
+            let next_fold = DeviceTensor::uninitialized_dt(state_dt, state.shape())?;
+            dispatch_eval(stream, &q, &k, &v, &g, &beta_raw, &state, &out_fold, &next_fold, true)?;
+            stream.wait_until_completed()?;
+
+            out_fold
+                .to_host()?
+                .into_tensor()
+                .close_enough(&out_ref.to_host()?.into_tensor(), Approximation::Exact)?;
+            next_fold
+                .to_host()?
+                .into_tensor()
+                .close_enough(&next_ref.to_host()?.into_tensor(), Approximation::Exact)?;
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn sigmoid_beta_fold_is_exact_decode() -> TractResult<()> {
+        sigmoid_beta_fold_is_exact_case(DatumType::F32, 5)
+    }
+
+    #[test]
+    fn sigmoid_beta_fold_is_exact_decode_f16_state() -> TractResult<()> {
+        sigmoid_beta_fold_is_exact_case(DatumType::F16, 5)
+    }
+
+    #[test]
+    fn sigmoid_beta_fold_is_exact_chunked() -> TractResult<()> {
+        sigmoid_beta_fold_is_exact_case(DatumType::F32, 200)
+    }
+
+    #[test]
+    fn sigmoid_beta_fold_is_exact_chunked_f16_state() -> TractResult<()> {
+        sigmoid_beta_fold_is_exact_case(DatumType::F16, 200)
+    }
+
+    /// Timing harness on the real qwen3.5-35B GDN geometry (S=512 prefill
+    /// chunk). Run explicitly: cargo test -p tract-metal --release
+    /// gdn_chunk_bench -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn gdn_chunk_bench() -> TractResult<()> {
+        with_borrowed_metal_stream(|stream| {
+            let (b, s_len, k_heads, groups, width) = (1usize, 512usize, 16usize, 2usize, 128usize);
+            let heads = k_heads * groups;
+            let n_qk = b * s_len * k_heads * width;
+            let n_vec = b * s_len * heads * width;
+            let n_gate = b * s_len * heads;
+            let n_state = b * heads * width * width;
+            let as_f16 = |v: Vec<f32>| v.into_iter().map(f16::from_f32).collect::<Vec<_>>();
+            let q = Tensor::from_shape(
+                &[b, s_len, k_heads, width],
+                &as_f16((0..n_qk).map(|i| ((i % 31) as f32 - 15.0) / 64.0).collect()),
+            )?
+            .into_device()?;
+            let k = Tensor::from_shape(
+                &[b, s_len, k_heads, width],
+                &as_f16((0..n_qk).map(|i| ((i % 29) as f32 - 14.0) / 64.0).collect()),
+            )?
+            .into_device()?;
+            let v = Tensor::from_shape(
+                &[b, s_len, heads, width],
+                &as_f16((0..n_vec).map(|i| ((i % 23) as f32 - 11.0) / 32.0).collect()),
+            )?
+            .into_device()?;
+            let g = Tensor::from_shape(
+                &[b, s_len, heads],
+                &(0..n_gate).map(|i| -0.05 - 0.1 * (i % 7) as f32).collect::<Vec<f32>>(),
+            )?
+            .into_device()?;
+            let beta = Tensor::from_shape(
+                &[b, s_len, heads],
+                &as_f16((0..n_gate).map(|i| 0.125 + 0.08 * (i % 9) as f32).collect()),
+            )?
+            .into_device()?;
+            let state = Tensor::from_shape(
+                &[b, heads, width, width],
+                &as_f16((0..n_state).map(|i| ((i % 37) as f32 - 18.0) / 256.0).collect()),
+            )?
+            .into_device()?;
+            let output = DeviceTensor::uninitialized_dt(DatumType::F16, v.shape())?;
+            let next = DeviceTensor::uninitialized_dt(DatumType::F16, state.shape())?;
+            for _ in 0..5 {
+                dispatch_eval(stream, &q, &k, &v, &g, &beta, &state, &output, &next, false)?;
+            }
+            stream.wait_until_completed()?;
+            const N: usize = 50;
+            let start = std::time::Instant::now();
+            for _ in 0..N {
+                dispatch_eval(stream, &q, &k, &v, &g, &beta, &state, &output, &next, false)?;
+            }
+            stream.wait_until_completed()?;
+            let per = start.elapsed().as_secs_f64() / N as f64;
+            eprintln!("gdn chunked s=512: {:.1} us/layer-dispatch", per * 1e6);
+            let start = std::time::Instant::now();
+            unsafe { std::env::set_var("TRACT_METAL_DISABLE_GDN_CHUNKED", "1") };
+            for _ in 0..N {
+                dispatch_eval(stream, &q, &k, &v, &g, &beta, &state, &output, &next, false)?;
+            }
+            stream.wait_until_completed()?;
+            unsafe { std::env::remove_var("TRACT_METAL_DISABLE_GDN_CHUNKED") };
+            let per = start.elapsed().as_secs_f64() / N as f64;
+            eprintln!("gdn old tg kernel s=512: {:.1} us/layer-dispatch", per * 1e6);
             Ok(())
         })
     }

--- a/metal/src/kernels/gdn_recurrent.rs
+++ b/metal/src/kernels/gdn_recurrent.rs
@@ -234,15 +234,16 @@ fn dispatch_chunked(
             MTLSize { width: tg_width, height: 1, depth: 1 },
         );
     });
-    // NOTE(split-e): the origin branch uses `stream.commit_current()` here, a
-    // non-blocking commit from a buffer-pool/backpressure rework that lives
-    // in an unrelated split (touches context.rs's MetalStream internals plus
-    // fused_sdpa/routed_q40_matmul/routed_q40_swiglu/autotune/tuning). Rather
-    // than pull that split in, this uses the synchronous barrier already
-    // used elsewhere in this same file for the same purpose. Correctness is
-    // unaffected; this only gives up the async pipelining between the
-    // prepare and scan dispatches, so it may cost some decode throughput
-    // until the buffer-pool split lands and this is rebased onto it.
+    // Correctness barrier: the scan dispatch below reads the scratch buffers
+    // this prepare dispatch just wrote, which requires the prepare command
+    // buffer to have actually completed first (see the module doc comment).
+    // MetalStream holds one shared, lazily-committed command buffer for the
+    // whole stream, so this commits and blocks on EVERY previously-encoded
+    // dispatch on the stream, not just this op's own prepare -- a full
+    // pipeline drain, not a narrow two-dispatch sync. A non-blocking,
+    // per-op-scoped commit needs the stream's buffer-pool/backpressure
+    // rework (not part of this PR); until then every chunked-prefill call
+    // pays this drain.
     stream.wait_until_completed()?;
 
     let scan_name = if f16_state { "gdn_chunk_scan_f16_state" } else { "gdn_chunk_scan_f32_state" };

--- a/metal/src/kernels/gdn_recurrent.rs
+++ b/metal/src/kernels/gdn_recurrent.rs
@@ -4,6 +4,14 @@ use metal::MTLSize;
 use tract_core::internal::*;
 use tract_gpu::tensor::DeviceTensor;
 
+tract_core::declare_knob!(
+    TRACT_METAL_DISABLE_GDN_CHUNKED,
+    bool,
+    false,
+    "Disable the chunked gated-delta-rule prefill kernel, forcing the \
+     per-token threadgroup-parallel kernel for every sequence length."
+);
+
 #[allow(clippy::too_many_arguments)]
 fn dispatch_eval(
     stream: &MetalStream,
@@ -58,10 +66,7 @@ fn dispatch_eval(
     // that is sequential only across S/64 chunks instead of S steps.
     // width <= 128: the scan kernel's static threadgroup arrays hold one
     // [width x GDN_COL_BLOCK] f32 state block.
-    if s_len >= GDN_CHUNK
-        && width <= 128
-        && std::env::var_os("TRACT_METAL_DISABLE_GDN_CHUNKED").is_none()
-    {
+    if s_len >= GDN_CHUNK && width <= 128 && !TRACT_METAL_DISABLE_GDN_CHUNKED.get() {
         return dispatch_chunked(
             stream,
             query,
@@ -666,13 +671,13 @@ mod tests {
             stream.wait_until_completed()?;
             let per = start.elapsed().as_secs_f64() / N as f64;
             eprintln!("gdn chunked s=512: {:.1} us/layer-dispatch", per * 1e6);
+            TRACT_METAL_DISABLE_GDN_CHUNKED.set(true);
             let start = std::time::Instant::now();
-            unsafe { std::env::set_var("TRACT_METAL_DISABLE_GDN_CHUNKED", "1") };
             for _ in 0..N {
                 dispatch_eval(stream, &q, &k, &v, &g, &beta, &state, &output, &next, false)?;
             }
             stream.wait_until_completed()?;
-            unsafe { std::env::remove_var("TRACT_METAL_DISABLE_GDN_CHUNKED") };
+            TRACT_METAL_DISABLE_GDN_CHUNKED.clear();
             let per = start.elapsed().as_secs_f64() / N as f64;
             eprintln!("gdn old tg kernel s=512: {:.1} us/layer-dispatch", per * 1e6);
             Ok(())

--- a/metal/src/kernels/gdn_recurrent.rs
+++ b/metal/src/kernels/gdn_recurrent.rs
@@ -438,7 +438,7 @@ mod tests {
                 .cast_to_dt(state_dt)?
                 .into_owned();
 
-            let cpu = GatedDeltaNetRecurrent::default().eval(tvec![
+            let cpu = GatedDeltaNetRecurrent::default().eval(&EvalContext::out_of_plan(), tvec![
                 q.clone().into_tvalue(),
                 k.clone().into_tvalue(),
                 v.clone().into_tvalue(),

--- a/metal/src/kernels/gdn_recurrent.rs
+++ b/metal/src/kernels/gdn_recurrent.rs
@@ -92,10 +92,7 @@ fn dispatch_eval(
     let tg_pipeline = stream.load_pipeline(LibraryName::GdnRecurrent, tg_kernel_name)?;
     let max_tg = tg_pipeline.max_total_threads_per_threadgroup() as usize;
     let mut rchunks = 1;
-    while rchunks < 16
-        && width % (rchunks * 2) == 0
-        && width * rchunks * 2 <= max_tg.min(1024)
-    {
+    while rchunks < 16 && width % (rchunks * 2) == 0 && width * rchunks * 2 <= max_tg.min(1024) {
         rchunks *= 2;
     }
 
@@ -137,8 +134,7 @@ fn dispatch_eval(
         return Ok(());
     }
 
-    let kernel_name =
-        if f16_state { "gdn_recurrent_f16_state_f16" } else { "gdn_recurrent_f16" };
+    let kernel_name = if f16_state { "gdn_recurrent_f16_state_f16" } else { "gdn_recurrent_f16" };
     let pipeline = stream.load_pipeline(LibraryName::GdnRecurrent, kernel_name)?;
     let command_buffer = stream.command_buffer();
     command_buffer.encode(|encoder| {
@@ -217,8 +213,7 @@ fn dispatch_chunked(
         for (ix, t) in [query, key, value, log_decay, beta].iter().enumerate() {
             encoder.set_metal_tensor(ix as u64, t, metal::MTLResourceUsage::Read);
         }
-        for (ix, t) in
-            [&value_p, &k_cumdecay, &attn_local, &q_g, &w_t, &eg_last].iter().enumerate()
+        for (ix, t) in [&value_p, &k_cumdecay, &attn_local, &q_g, &w_t, &eg_last].iter().enumerate()
         {
             encoder.set_metal_tensor(5 + ix as u64, t, metal::MTLResourceUsage::Write);
         }
@@ -319,13 +314,9 @@ crate::register_metal_op!(
         let dts: Vec<DatumType> = facts.iter().map(|f| f.datum_type).collect();
         // q/k/v/beta f16, log_decay f32; the recurrent state may be f16
         // (graph exported with -idt f16) or f32, each has its kernel.
-        if dts[..5] != [
-            DatumType::F16,
-            DatumType::F16,
-            DatumType::F16,
-            DatumType::F32,
-            DatumType::F16,
-        ] || !matches!(dts[5], DatumType::F16 | DatumType::F32)
+        if dts[..5]
+            != [DatumType::F16, DatumType::F16, DatumType::F16, DatumType::F32, DatumType::F16]
+            || !matches!(dts[5], DatumType::F16 | DatumType::F32)
         {
             return Ok(None);
         }
@@ -438,14 +429,17 @@ mod tests {
                 .cast_to_dt(state_dt)?
                 .into_owned();
 
-            let cpu = GatedDeltaNetRecurrent::default().eval(&EvalContext::out_of_plan(), tvec![
-                q.clone().into_tvalue(),
-                k.clone().into_tvalue(),
-                v.clone().into_tvalue(),
-                g.clone().into_tvalue(),
-                beta.clone().into_tvalue(),
-                state.clone().into_tvalue(),
-            ])?;
+            let cpu = GatedDeltaNetRecurrent::default().eval(
+                &EvalContext::out_of_plan(),
+                tvec![
+                    q.clone().into_tvalue(),
+                    k.clone().into_tvalue(),
+                    v.clone().into_tvalue(),
+                    g.clone().into_tvalue(),
+                    beta.clone().into_tvalue(),
+                    state.clone().into_tvalue(),
+                ],
+            )?;
 
             let qd = q.into_device()?;
             let kd = k.into_device()?;

--- a/metal/src/rewrite_rules/fold_gdn_beta_sigmoid.rs
+++ b/metal/src/rewrite_rules/fold_gdn_beta_sigmoid.rs
@@ -41,11 +41,7 @@ pub fn fold_gdn_beta_sigmoid(
         let outlet = if ix == 4 { beta_node.inputs[0] } else { *input };
         inputs.push(patch.tap_model(model, outlet)?);
     }
-    let out = patch.wire_node(
-        node_name,
-        GatedDeltaNetRecurrent { sigmoid_beta: true },
-        &inputs,
-    )?;
+    let out = patch.wire_node(node_name, GatedDeltaNetRecurrent { sigmoid_beta: true }, &inputs)?;
     patch.shunt_outside(model, node.id.into(), out[0])?;
     patch.shunt_outside(model, OutletId::new(node.id, 1), out[1])?;
     Ok(Some(patch))

--- a/metal/src/rewrite_rules/fold_gdn_beta_sigmoid.rs
+++ b/metal/src/rewrite_rules/fold_gdn_beta_sigmoid.rs
@@ -4,6 +4,14 @@ use tract_core::ops::nn::Sigmoid;
 use tract_gpu::rule_ensure;
 use tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent;
 
+tract_core::declare_knob!(
+    TRACT_METAL_DISABLE_GDN_BETA_SIGMOID,
+    bool,
+    false,
+    "Disable folding a singleton Sigmoid feeding GatedDeltaNetRecurrent's \
+     beta input into the op itself."
+);
+
 /// Fold a singleton `Sigmoid` feeding the beta input of a
 /// `GatedDeltaNetRecurrent` into the op itself (`sigmoid_beta`): the Metal
 /// kernel replicates the elementwise sigmoid on half bit-exactly, so this
@@ -19,7 +27,7 @@ pub fn fold_gdn_beta_sigmoid(
     op: &GatedDeltaNetRecurrent,
 ) -> TractResult<Option<TypedModelPatch>> {
     rule_ensure!(!op.sigmoid_beta);
-    rule_ensure!(std::env::var_os("TRACT_METAL_DISABLE_GDN_BETA_SIGMOID").is_none());
+    rule_ensure!(!TRACT_METAL_DISABLE_GDN_BETA_SIGMOID.get());
     let beta_outlet = node.inputs[4];
     let beta_node = model.node(beta_outlet.node);
     let Some(ew) = beta_node.op_as::<ElementWiseOp>() else { return Ok(None) };

--- a/metal/src/rewrite_rules/fold_gdn_beta_sigmoid.rs
+++ b/metal/src/rewrite_rules/fold_gdn_beta_sigmoid.rs
@@ -1,0 +1,44 @@
+use tract_core::internal::*;
+use tract_core::ops::element_wise::ElementWiseOp;
+use tract_core::ops::nn::Sigmoid;
+use tract_gpu::rule_ensure;
+use tract_transformers::ops::gdn_recurrent::GatedDeltaNetRecurrent;
+
+/// Fold a singleton `Sigmoid` feeding the beta input of a
+/// `GatedDeltaNetRecurrent` into the op itself (`sigmoid_beta`): the Metal
+/// kernel replicates the elementwise sigmoid on half bit-exactly, so this
+/// only removes the standalone dispatch. The sigmoid node must have no other
+/// consumer (beta is per-(step, head), nothing else reads it in practice;
+/// a shared output would keep the sigmoid alive AND fold, still correct but
+/// no dispatch win, so we skip it).
+pub fn fold_gdn_beta_sigmoid(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &GatedDeltaNetRecurrent,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_ensure!(!op.sigmoid_beta);
+    rule_ensure!(std::env::var_os("TRACT_METAL_DISABLE_GDN_BETA_SIGMOID").is_none());
+    let beta_outlet = node.inputs[4];
+    let beta_node = model.node(beta_outlet.node);
+    let Some(ew) = beta_node.op_as::<ElementWiseOp>() else { return Ok(None) };
+    rule_ensure!(ew.0.is::<Sigmoid>());
+    rule_ensure!(beta_node.outputs[beta_outlet.slot].successors.len() == 1);
+    rule_ensure!(beta_node.inputs.len() == 1);
+
+    let mut patch = TypedModelPatch::new(format!("fold sigmoid into {node_name} beta"));
+    let mut inputs = tvec![];
+    for (ix, input) in node.inputs.iter().enumerate() {
+        let outlet = if ix == 4 { beta_node.inputs[0] } else { *input };
+        inputs.push(patch.tap_model(model, outlet)?);
+    }
+    let out = patch.wire_node(
+        node_name,
+        GatedDeltaNetRecurrent { sigmoid_beta: true },
+        &inputs,
+    )?;
+    patch.shunt_outside(model, node.id.into(), out[0])?;
+    patch.shunt_outside(model, OutletId::new(node.id, 1), out[1])?;
+    Ok(Some(patch))
+}

--- a/metal/src/rewrite_rules/mod.rs
+++ b/metal/src/rewrite_rules/mod.rs
@@ -1,7 +1,9 @@
 mod add_matmul_broadcast;
+mod fold_gdn_beta_sigmoid;
 mod fuse_axis_op;
 mod untranspose_matmul_output;
 
 pub use add_matmul_broadcast::add_broadcast_pre_matmul;
+pub use fold_gdn_beta_sigmoid::fold_gdn_beta_sigmoid;
 pub use fuse_axis_op::{fuse_axis_op, fuse_move_axis};
 pub use untranspose_matmul_output::untranspose_matmul_output;

--- a/metal/src/transform.rs
+++ b/metal/src/transform.rs
@@ -194,6 +194,7 @@ impl MetalTransform {
             .with_rule_for("rewrite_conv_with_n_axis", rewrite_conv_with_n_axis)
             .with_rule_for("remove_rms_norm_cast", remove_rms_norm_cast)
             .with_rule_for("split_multi_axis_reduce", split_multi_axis_reduce)
+            .with_rule_for("fold_gdn_beta_sigmoid", rewrite_rules::fold_gdn_beta_sigmoid)
             .rewrite(&(), model)?;
 
         if stop_at_phase == 1 {

--- a/transformers/src/ops/cast_f32.rs
+++ b/transformers/src/ops/cast_f32.rs
@@ -1,0 +1,15 @@
+//! Shared f32 round-trip helpers for CPU-fallback recurrence ops
+//! (gated-delta-net, causal-conv1d-update): both compute in f32 internally
+//! regardless of input dtype, casting back to the original dtype on output.
+
+use tract_nnef::internal::*;
+
+pub(super) fn to_f32_vec(t: &TValue) -> TractResult<Vec<f32>> {
+    let cow = t.cast_to::<f32>()?;
+    Ok(cow.to_plain_array_view::<f32>()?.iter().copied().collect())
+}
+
+pub(super) fn from_f32(data: Vec<f32>, shape: &[usize], dt: DatumType) -> TractResult<Tensor> {
+    let t = Tensor::from_shape(shape, &data)?;
+    Ok(t.cast_to_dt(dt)?.into_owned())
+}

--- a/transformers/src/ops/causal_conv1d_update.rs
+++ b/transformers/src/ops/causal_conv1d_update.rs
@@ -18,8 +18,7 @@ pub fn register(registry: &mut Registry) {
         node: &TypedNode,
         _op: &CausalConv1dUpdate,
     ) -> TractResult<Option<Arc<RValue>>> {
-        let inputs: Vec<Arc<RValue>> =
-            node.inputs.iter().map(|i| ast.mapping[i].clone()).collect();
+        let inputs: Vec<Arc<RValue>> = node.inputs.iter().map(|i| ast.mapping[i].clone()).collect();
         Ok(Some(invocation("tract_transformers_causal_conv1d_update", &inputs, &[])))
     }
     registry.register_dumper(serialize);
@@ -59,7 +58,6 @@ impl Op for CausalConv1dUpdate {
     op_as_typed_op!();
 }
 
-
 impl EvalOp for CausalConv1dUpdate {
     op_out_of_plan!();
 
@@ -70,8 +68,7 @@ impl EvalOp for CausalConv1dUpdate {
         let state_shape: TVec<usize> = inputs[2].shape().into();
         ensure!(input_shape.len() == 3, "input must be [b, C, S], got {input_shape:?}");
         let (b, channels, s_len) = (input_shape[0], input_shape[1], input_shape[2]);
-        let kernel_width =
-            *weight_shape.last().context("conv weight must have a kernel axis")?;
+        let kernel_width = *weight_shape.last().context("conv weight must have a kernel axis")?;
         ensure!(
             weight_shape.iter().product::<usize>() == channels * kernel_width,
             "weight must be [C, k], got {weight_shape:?}"
@@ -141,16 +138,15 @@ mod tests {
     use super::*;
     use crate::ops::test_utils::arb;
 
-    fn run(
-        input: &Tensor,
-        weight: &Tensor,
-        state: &Tensor,
-    ) -> TractResult<(Tensor, Tensor)> {
-        let outputs = CausalConv1dUpdate.eval(&EvalContext::out_of_plan(), tvec![
-            input.clone().into_tvalue(),
-            weight.clone().into_tvalue(),
-            state.clone().into_tvalue(),
-        ])?;
+    fn run(input: &Tensor, weight: &Tensor, state: &Tensor) -> TractResult<(Tensor, Tensor)> {
+        let outputs = CausalConv1dUpdate.eval(
+            &EvalContext::out_of_plan(),
+            tvec![
+                input.clone().into_tvalue(),
+                weight.clone().into_tvalue(),
+                state.clone().into_tvalue(),
+            ],
+        )?;
         Ok((outputs[0].clone().into_tensor(), outputs[1].clone().into_tensor()))
     }
 

--- a/transformers/src/ops/causal_conv1d_update.rs
+++ b/transformers/src/ops/causal_conv1d_update.rs
@@ -11,6 +11,18 @@ pub fn register(registry: &mut Registry) {
             .collect::<TractResult<TVec<_>>>()?;
         builder.wire(CausalConv1dUpdate, &inputs)
     }
+    fn serialize(
+        ast: &mut IntoAst,
+        node: &TypedNode,
+        _op: &CausalConv1dUpdate,
+    ) -> TractResult<Option<Arc<RValue>>> {
+        let inputs: Vec<Arc<RValue>> =
+            node.inputs.iter().map(|i| ast.mapping[i].clone()).collect();
+        Ok(Some(invocation("tract_transformers_causal_conv1d_update", &inputs, &[])))
+    }
+    registry.register_dumper(serialize);
+    // Generic name first (primary, what serialization emits); the historical
+    // qwen35-specific name stays as a deserialization alias.
     for name in ["tract_transformers_causal_conv1d_update", "tract_qwen35_causal_conv1d_update"] {
         registry.register_primitive(
             name,
@@ -25,6 +37,16 @@ pub fn register(registry: &mut Registry) {
     }
 }
 
+/// Stateful causal depthwise conv1d + SiLU (Qwen3.5 linear attention front).
+///
+/// Semantics match HF transformers `torch_causal_conv1d_update`:
+/// `full = concat(state, input)` along time; `output[t] = silu(sum_tap
+/// weight[c, tap] * full[c, t + 1 + tap])` for the last S positions;
+/// `final_state = full[..., -k:]`.
+///
+/// Layout: input `[b, C, S]`, weight `[C, k]`, state `[b, C, k]`.
+/// Outputs: `[b, C, S]` in the input datum type, final state in the state
+/// datum type. Compute is f32.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CausalConv1dUpdate;
 
@@ -35,40 +57,68 @@ impl Op for CausalConv1dUpdate {
     op_as_typed_op!();
 }
 
+fn to_f32_vec(t: &TValue) -> TractResult<Vec<f32>> {
+    let cow = t.cast_to::<f32>()?;
+    Ok(cow.to_plain_array_view::<f32>()?.iter().copied().collect())
+}
+
+fn from_f32(data: Vec<f32>, shape: &[usize], dt: DatumType) -> TractResult<Tensor> {
+    let t = Tensor::from_shape(shape, &data)?;
+    Ok(t.cast_to_dt(dt)?.into_owned())
+}
+
 impl EvalOp for CausalConv1dUpdate {
     op_out_of_plan!();
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
-        let (input, weight, state) = args_3!(inputs);
-        let input = input.to_plain_array_view::<f16>()?;
-        let weight = weight.to_plain_array_view::<f16>()?;
-        let state = state.to_plain_array_view::<f16>()?;
-        let kernel_width = *weight.shape().last().context("conv weight must have a kernel axis")?;
-        ensure!(kernel_width == 4, "Qwen3.5 requires a four-tap convolution");
-        let channels = input.len();
-        ensure!(weight.len() == channels * kernel_width);
-        ensure!(state.len() == channels * kernel_width);
-        let input_shape = input.shape().to_vec();
-        let state_shape = state.shape().to_vec();
-        let input = input.as_slice().context("input must be contiguous")?;
-        let weight = weight.as_slice().context("weight must be contiguous")?;
-        let state = state.as_slice().context("state must be contiguous")?;
-        let mut output = vec![f16::ZERO; channels];
-        let mut final_state = vec![f16::ZERO; state.len()];
-        for channel in 0..channels {
-            let base = channel * kernel_width;
-            let mut sum = 0f32;
-            for tap in 0..kernel_width - 1 {
-                final_state[base + tap] = state[base + tap + 1];
-                sum += state[base + tap + 1].to_f32() * weight[base + tap].to_f32();
+        ensure!(inputs.len() == 3, "causal conv update expects input, weight, state");
+        let input_shape: TVec<usize> = inputs[0].shape().into();
+        let weight_shape: TVec<usize> = inputs[1].shape().into();
+        let state_shape: TVec<usize> = inputs[2].shape().into();
+        ensure!(input_shape.len() == 3, "input must be [b, C, S], got {input_shape:?}");
+        let (b, channels, s_len) = (input_shape[0], input_shape[1], input_shape[2]);
+        let kernel_width =
+            *weight_shape.last().context("conv weight must have a kernel axis")?;
+        ensure!(
+            weight_shape.iter().product::<usize>() == channels * kernel_width,
+            "weight must be [C, k], got {weight_shape:?}"
+        );
+        ensure!(
+            state_shape.len() == 3
+                && state_shape[0] == b
+                && state_shape[1] == channels
+                && state_shape[2] == kernel_width,
+            "state must be [b, C, k], got {state_shape:?}"
+        );
+
+        let input = to_f32_vec(&inputs[0])?;
+        let weight = to_f32_vec(&inputs[1])?;
+        let state = to_f32_vec(&inputs[2])?;
+
+        let mut output = vec![0f32; input.len()];
+        let mut final_state = vec![0f32; state.len()];
+        let mut full = vec![0f32; kernel_width + s_len];
+        for bi in 0..b {
+            for c in 0..channels {
+                let ib = (bi * channels + c) * s_len;
+                let sb = (bi * channels + c) * kernel_width;
+                let wb = c * kernel_width;
+                full[..kernel_width].copy_from_slice(&state[sb..sb + kernel_width]);
+                full[kernel_width..].copy_from_slice(&input[ib..ib + s_len]);
+                for t in 0..s_len {
+                    let mut sum = 0f32;
+                    for tap in 0..kernel_width {
+                        sum += weight[wb + tap] * full[t + 1 + tap];
+                    }
+                    output[ib + t] = sum / (1.0 + (-sum).exp());
+                }
+                final_state[sb..sb + kernel_width]
+                    .copy_from_slice(&full[s_len..s_len + kernel_width]);
             }
-            final_state[base + kernel_width - 1] = input[channel];
-            sum += input[channel].to_f32() * weight[base + kernel_width - 1].to_f32();
-            output[channel] = f16::from_f32(sum / (1.0 + (-sum).exp()));
         }
         Ok(tvec![
-            Tensor::from_shape(&input_shape, &output)?.into_tvalue(),
-            Tensor::from_shape(&state_shape, &final_state)?.into_tvalue(),
+            from_f32(output, &input_shape, inputs[0].datum_type())?.into_tvalue(),
+            from_f32(final_state, &state_shape, inputs[2].datum_type())?.into_tvalue(),
         ])
     }
 }
@@ -76,8 +126,75 @@ impl EvalOp for CausalConv1dUpdate {
 impl TypedOp for CausalConv1dUpdate {
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
         ensure!(inputs.len() == 3);
-        ensure!(inputs.iter().all(|fact| fact.datum_type == DatumType::F16));
+        for input in inputs {
+            ensure!(
+                matches!(input.datum_type, DatumType::F16 | DatumType::F32),
+                "causal conv update inputs must be f16 or f32, got {:?}",
+                input.datum_type
+            );
+        }
+        ensure!(inputs[0].rank() == 3, "input must be [b, C, S]");
+        ensure!(inputs[2].rank() == 3, "state must be [b, C, k]");
         Ok(tvec![inputs[0].without_value(), inputs[2].without_value()])
     }
     as_op!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arb(shape: &[usize], seed: u64) -> Tensor {
+        let len: usize = shape.iter().product();
+        let mut x = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        let data: Vec<f32> = (0..len)
+            .map(|_| {
+                x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                ((x >> 33) as f32 / (1u64 << 31) as f32) - 1.0
+            })
+            .collect();
+        Tensor::from_shape(shape, &data).unwrap()
+    }
+
+    fn run(
+        input: &Tensor,
+        weight: &Tensor,
+        state: &Tensor,
+    ) -> TractResult<(Tensor, Tensor)> {
+        let outputs = CausalConv1dUpdate.eval(&EvalContext::out_of_plan(), tvec![
+            input.clone().into_tvalue(),
+            weight.clone().into_tvalue(),
+            state.clone().into_tvalue(),
+        ])?;
+        Ok((outputs[0].clone().into_tensor(), outputs[1].clone().into_tensor()))
+    }
+
+    /// The S-axis loop must be exactly equivalent to threading the state
+    /// through S single-step calls.
+    #[test]
+    fn multi_step_matches_sequential_single_steps() -> TractResult<()> {
+        let (b, channels, s_len, k) = (1, 6, 5, 4);
+        let input = arb(&[b, channels, s_len], 1);
+        let weight = arb(&[channels, k], 2);
+        let state0 = arb(&[b, channels, k], 3);
+
+        let (out_multi, final_multi) = run(&input, &weight, &state0)?;
+
+        let mut state = state0.clone();
+        let mut outs: Vec<Tensor> = vec![];
+        for t in 0..s_len {
+            let step = input.slice(2, t, t + 1)?;
+            let (o, st) = run(&step, &weight, &state)?;
+            outs.push(o);
+            state = st;
+        }
+        let seq_out = Tensor::stack_tensors(
+            2,
+            &outs.iter().map(|o| o.clone().into()).collect::<Vec<TValue>>(),
+        )?;
+        let seq_out = seq_out.into_shape(&[b, channels, s_len])?;
+        out_multi.close_enough(&seq_out, Approximation::Close)?;
+        final_multi.close_enough(&state, Approximation::Close)?;
+        Ok(())
+    }
 }

--- a/transformers/src/ops/causal_conv1d_update.rs
+++ b/transformers/src/ops/causal_conv1d_update.rs
@@ -1,5 +1,7 @@
 use tract_nnef::internal::*;
 
+use super::cast_f32::{from_f32, to_f32_vec};
+
 pub fn register(registry: &mut Registry) {
     fn deserialize(
         builder: &mut ModelBuilder,
@@ -57,15 +59,6 @@ impl Op for CausalConv1dUpdate {
     op_as_typed_op!();
 }
 
-fn to_f32_vec(t: &TValue) -> TractResult<Vec<f32>> {
-    let cow = t.cast_to::<f32>()?;
-    Ok(cow.to_plain_array_view::<f32>()?.iter().copied().collect())
-}
-
-fn from_f32(data: Vec<f32>, shape: &[usize], dt: DatumType) -> TractResult<Tensor> {
-    let t = Tensor::from_shape(shape, &data)?;
-    Ok(t.cast_to_dt(dt)?.into_owned())
-}
 
 impl EvalOp for CausalConv1dUpdate {
     op_out_of_plan!();
@@ -126,13 +119,16 @@ impl EvalOp for CausalConv1dUpdate {
 impl TypedOp for CausalConv1dUpdate {
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
         ensure!(inputs.len() == 3);
-        for input in inputs {
-            ensure!(
-                matches!(input.datum_type, DatumType::F16 | DatumType::F32),
-                "causal conv update inputs must be f16 or f32, got {:?}",
-                input.datum_type
-            );
-        }
+        let dts: Vec<DatumType> = inputs.iter().map(|i| i.datum_type).collect();
+        // The GPU kernels are f16-only (falling back to this CPU op for any
+        // other mix, e.g. an all-f32 test export), and this CPU op upcasts
+        // to f32 internally regardless -- so the only two intended
+        // combinations are uniformly f16 or uniformly f32.
+        ensure!(
+            dts.iter().all(|dt| *dt == DatumType::F16)
+                || dts.iter().all(|dt| *dt == DatumType::F32),
+            "causal conv update inputs must be uniformly f16 or uniformly f32, got {dts:?}"
+        );
         ensure!(inputs[0].rank() == 3, "input must be [b, C, S]");
         ensure!(inputs[2].rank() == 3, "state must be [b, C, k]");
         Ok(tvec![inputs[0].without_value(), inputs[2].without_value()])
@@ -143,18 +139,7 @@ impl TypedOp for CausalConv1dUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn arb(shape: &[usize], seed: u64) -> Tensor {
-        let len: usize = shape.iter().product();
-        let mut x = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
-        let data: Vec<f32> = (0..len)
-            .map(|_| {
-                x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
-                ((x >> 33) as f32 / (1u64 << 31) as f32) - 1.0
-            })
-            .collect();
-        Tensor::from_shape(shape, &data).unwrap()
-    }
+    use crate::ops::test_utils::arb;
 
     fn run(
         input: &Tensor,

--- a/transformers/src/ops/gdn_recurrent.rs
+++ b/transformers/src/ops/gdn_recurrent.rs
@@ -1,5 +1,7 @@
 use tract_nnef::internal::*;
 
+use super::cast_f32::{from_f32, to_f32_vec};
+
 pub fn register(registry: &mut Registry) {
     fn deserialize(
         builder: &mut ModelBuilder,
@@ -82,15 +84,6 @@ impl Op for GatedDeltaNetRecurrent {
     op_as_typed_op!();
 }
 
-fn to_f32_vec(t: &TValue) -> TractResult<Vec<f32>> {
-    let cow = t.cast_to::<f32>()?;
-    Ok(cow.to_plain_array_view::<f32>()?.iter().copied().collect())
-}
-
-fn from_f32(data: Vec<f32>, shape: &[usize], dt: DatumType) -> TractResult<Tensor> {
-    let t = Tensor::from_shape(shape, &data)?;
-    Ok(t.cast_to_dt(dt)?.into_owned())
-}
 
 impl EvalOp for GatedDeltaNetRecurrent {
     op_out_of_plan!();
@@ -192,13 +185,17 @@ impl EvalOp for GatedDeltaNetRecurrent {
 impl TypedOp for GatedDeltaNetRecurrent {
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
         ensure!(inputs.len() == 6);
-        for input in inputs {
-            ensure!(
-                matches!(input.datum_type, DatumType::F16 | DatumType::F32),
-                "GDN inputs must be f16 or f32, got {:?}",
-                input.datum_type
-            );
-        }
+        let dts: Vec<DatumType> = inputs.iter().map(|i| i.datum_type).collect();
+        // The two intended combinations, matching what the GPU kernels
+        // accept (falling back to this CPU op, which upcasts to f32
+        // internally regardless, for anything else): uniformly f32, or the
+        // fused-kernel mix (query/key/value/beta f16, log_decay f32, state
+        // either f16 or f32).
+        let all_f32 = dts.iter().all(|dt| *dt == DatumType::F32);
+        let fused_mix = dts[..4] == [DatumType::F16, DatumType::F16, DatumType::F16, DatumType::F32]
+            && dts[4] == DatumType::F16
+            && matches!(dts[5], DatumType::F16 | DatumType::F32);
+        ensure!(all_f32 || fused_mix, "unsupported GDN dtype combination: {dts:?}");
         ensure!(inputs[0].rank() == 4, "GDN query must be [b, S, hk, w]");
         ensure!(inputs[0].shape == inputs[1].shape);
         ensure!(inputs[2].rank() == 4, "GDN value must be [b, S, hv, w]");
@@ -216,6 +213,7 @@ impl TypedOp for GatedDeltaNetRecurrent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::test_utils::arb;
 
     fn run(
         s_len: usize,
@@ -238,19 +236,6 @@ mod tests {
             state.clone().into_tvalue(),
         ])?;
         Ok((outputs[0].clone().into_tensor(), outputs[1].clone().into_tensor()))
-    }
-
-    fn arb(shape: &[usize], seed: u64) -> Tensor {
-        // simple deterministic pseudo-random floats in [-1, 1]
-        let len: usize = shape.iter().product();
-        let mut x = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
-        let data: Vec<f32> = (0..len)
-            .map(|_| {
-                x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
-                ((x >> 33) as f32 / (1u64 << 31) as f32) - 1.0
-            })
-            .collect();
-        Tensor::from_shape(shape, &data).unwrap()
     }
 
     /// repeat_interleave along the head axis (2) of a [b, S, h, w] tensor.

--- a/transformers/src/ops/gdn_recurrent.rs
+++ b/transformers/src/ops/gdn_recurrent.rs
@@ -227,7 +227,7 @@ mod tests {
         state: &Tensor,
     ) -> TractResult<(Tensor, Tensor)> {
         let _ = (s_len, heads, width);
-        let outputs = GatedDeltaNetRecurrent::default().eval(tvec![
+        let outputs = GatedDeltaNetRecurrent::default().eval(&EvalContext::out_of_plan(), tvec![
             q.clone().into_tvalue(),
             k.clone().into_tvalue(),
             v.clone().into_tvalue(),

--- a/transformers/src/ops/gdn_recurrent.rs
+++ b/transformers/src/ops/gdn_recurrent.rs
@@ -9,8 +9,26 @@ pub fn register(registry: &mut Registry) {
             .map(|name| invocation.named_arg_as(builder, name))
             .into_iter()
             .collect::<TractResult<TVec<_>>>()?;
-        builder.wire(GatedDeltaNetRecurrent, &inputs)
+        builder.wire(GatedDeltaNetRecurrent::default(), &inputs)
     }
+    fn serialize(
+        ast: &mut IntoAst,
+        node: &TypedNode,
+        op: &GatedDeltaNetRecurrent,
+    ) -> TractResult<Option<Arc<RValue>>> {
+        // sigmoid_beta is a device-transform-internal variant (the beta
+        // sigmoid folded into the kernel); it has no NNEF form.
+        ensure!(
+            !op.sigmoid_beta,
+            "GatedDeltaNetRecurrent with sigmoid_beta cannot be serialized to NNEF"
+        );
+        let inputs: Vec<Arc<RValue>> =
+            node.inputs.iter().map(|i| ast.mapping[i].clone()).collect();
+        Ok(Some(invocation("tract_transformers_gdn_recurrent", &inputs, &[])))
+    }
+    registry.register_dumper(serialize);
+    // Generic name first (primary, what serialization emits); the historical
+    // qwen35-specific name stays as a deserialization alias.
     for name in ["tract_transformers_gdn_recurrent", "tract_qwen35_gdn_recurrent"] {
         registry.register_primitive(
             name,
@@ -28,14 +46,50 @@ pub fn register(registry: &mut Registry) {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct GatedDeltaNetRecurrent;
+/// Gated delta rule recurrence (Qwen3.5 linear attention core).
+///
+/// Semantics match HF transformers `torch_recurrent_gated_delta_rule` with
+/// `use_qk_l2norm_in_kernel=True`, applied sequentially over the S axis:
+///
+/// per step: `state *= exp(g)`; `kv_mem = k . state` (over the key axis);
+/// `delta = (v - kv_mem) * beta`; `state += k (x) delta`;
+/// `out = (q / sqrt(w)) . state`, with q and k L2-normalized (eps 1e-6).
+///
+/// Layout: query/key `[b, S, hk, w]`, value `[b, S, hv, w]` (key width ==
+/// value width), log_decay/beta `[b, S, hv]`, initial_state `[b, hv, w, w]`,
+/// with `hv = G * hk` for an integer group count G resolved from the shapes
+/// (GQA: value head h reads query/key head h / G, matching HF's
+/// `repeat_interleave` on axis 2). hk == hv is the ungrouped case, so
+/// pre-GQA graphs load and run unchanged. Outputs: `[b, S, hv, w]` in the
+/// query datum type and the final state in the initial_state datum type.
+/// All compute is f32.
+///
+/// With `sigmoid_beta` set the `beta` input carries the raw pre-activation
+/// values and the op applies the sigmoid itself: runtimes can then fold the
+/// singleton sigmoid dispatch that otherwise feeds beta into their kernel.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct GatedDeltaNetRecurrent {
+    pub sigmoid_beta: bool,
+}
 
 impl Op for GatedDeltaNetRecurrent {
     fn name(&self) -> StaticName {
         "GatedDeltaNetRecurrent".into()
     }
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(if self.sigmoid_beta { vec!["sigmoid_beta: true".to_string()] } else { vec![] })
+    }
     op_as_typed_op!();
+}
+
+fn to_f32_vec(t: &TValue) -> TractResult<Vec<f32>> {
+    let cow = t.cast_to::<f32>()?;
+    Ok(cow.to_plain_array_view::<f32>()?.iter().copied().collect())
+}
+
+fn from_f32(data: Vec<f32>, shape: &[usize], dt: DatumType) -> TractResult<Tensor> {
+    let t = Tensor::from_shape(shape, &data)?;
+    Ok(t.cast_to_dt(dt)?.into_owned())
 }
 
 impl EvalOp for GatedDeltaNetRecurrent {
@@ -43,53 +97,94 @@ impl EvalOp for GatedDeltaNetRecurrent {
 
     fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         ensure!(inputs.len() == 6, "GDN expects q, k, v, log_decay, beta, state");
-        let q = inputs[0].to_plain_array_view::<f16>()?;
-        let k = inputs[1].to_plain_array_view::<f16>()?;
-        let v = inputs[2].to_plain_array_view::<f16>()?;
-        let g = inputs[3].to_plain_array_view::<f32>()?;
-        let beta = inputs[4].to_plain_array_view::<f16>()?;
-        let state = inputs[5].to_plain_array_view::<f32>()?;
-        let width = *q.shape().last().context("GDN query must have a last axis")?;
-        ensure!(width == 128, "the Qwen3.5 recurrent op requires width=128");
-        ensure!(q.shape() == k.shape() && q.shape() == v.shape());
-        let heads = q.len() / width;
-        ensure!(g.len() == heads && beta.len() == heads);
-        ensure!(state.len() == heads * width * width);
+        let q_shape: TVec<usize> = inputs[0].shape().into();
+        let v_shape: TVec<usize> = inputs[2].shape().into();
+        let state_shape: TVec<usize> = inputs[5].shape().into();
+        ensure!(
+            q_shape.len() == 4,
+            "GDN query must be [b, S, hk, w], got {q_shape:?}"
+        );
+        ensure!(inputs[1].shape() == &*q_shape);
+        let (b, s_len, k_heads, width) = (q_shape[0], q_shape[1], q_shape[2], q_shape[3]);
+        ensure!(
+            v_shape.len() == 4
+                && v_shape[0] == b
+                && v_shape[1] == s_len
+                && v_shape[3] == width
+                && v_shape[2].is_multiple_of(k_heads),
+            "GDN value must be [b, S, G*hk, w] with query/key [b, S, hk, w], \
+             got value {v_shape:?} vs query {q_shape:?}"
+        );
+        let heads = v_shape[2];
+        let groups = heads / k_heads;
+        ensure!(
+            inputs[3].len() == b * s_len * heads && inputs[4].len() == b * s_len * heads,
+            "GDN log_decay/beta must have b*S*hv elements"
+        );
+        ensure!(
+            state_shape.len() == 4
+                && state_shape[0] == b
+                && state_shape[1] == heads
+                && state_shape[2] == width
+                && state_shape[3] == width,
+            "GDN state must be [b, hv, w, w], got {state_shape:?}"
+        );
 
-        let q = q.as_slice().context("query must be contiguous")?;
-        let k = k.as_slice().context("key must be contiguous")?;
-        let v = v.as_slice().context("value must be contiguous")?;
-        let g = g.as_slice().context("log_decay must be contiguous")?;
-        let beta = beta.as_slice().context("beta must be contiguous")?;
-        let state = state.as_slice().context("state must be contiguous")?;
-        let mut output = vec![f16::ZERO; q.len()];
-        let mut final_state = vec![0f32; state.len()];
-        for head in 0..heads {
-            let vb = head * width;
-            let mb = head * width * width;
-            let q_inv = 1.0
-                / (q[vb..vb + width].iter().map(|x| x.to_f32().powi(2)).sum::<f32>() + 1e-6).sqrt();
-            let k_inv = 1.0
-                / (k[vb..vb + width].iter().map(|x| x.to_f32().powi(2)).sum::<f32>() + 1e-6).sqrt();
-            let decay = g[head].exp();
-            for col in 0..width {
-                let predicted = (0..width)
-                    .map(|row| k[vb + row].to_f32() * k_inv * state[mb + row * width + col] * decay)
-                    .sum::<f32>();
-                let residual = (v[vb + col].to_f32() - predicted) * beta[head].to_f32();
-                let mut result = 0f32;
-                for row in 0..width {
-                    let ix = mb + row * width + col;
-                    let next = state[ix] * decay + k[vb + row].to_f32() * k_inv * residual;
-                    final_state[ix] = next;
-                    result += q[vb + row].to_f32() * q_inv * next;
+        let q = to_f32_vec(&inputs[0])?;
+        let k = to_f32_vec(&inputs[1])?;
+        let v = to_f32_vec(&inputs[2])?;
+        let g = to_f32_vec(&inputs[3])?;
+        let mut beta = to_f32_vec(&inputs[4])?;
+        if self.sigmoid_beta {
+            for b in beta.iter_mut() {
+                *b = 1.0 / (1.0 + (-*b).exp());
+            }
+        }
+        let mut state = to_f32_vec(&inputs[5])?;
+
+        let scale: f32 = 1.0 / (width as f32).sqrt();
+        let mut output = vec![0f32; v.len()];
+        let mut qn = vec![0f32; width];
+        let mut kn = vec![0f32; width];
+        for bi in 0..b {
+            for si in 0..s_len {
+                for h in 0..heads {
+                    let vb = ((bi * s_len + si) * heads + h) * width;
+                    // GQA: value head h reads query/key head h / groups.
+                    let qkb = ((bi * s_len + si) * k_heads + h / groups) * width;
+                    let sb = (bi * heads + h) * width * width;
+                    let gb = (bi * s_len + si) * heads + h;
+                    let q_inv = 1.0
+                        / (q[qkb..qkb + width].iter().map(|x| x * x).sum::<f32>() + 1e-6).sqrt();
+                    let k_inv = 1.0
+                        / (k[qkb..qkb + width].iter().map(|x| x * x).sum::<f32>() + 1e-6).sqrt();
+                    for i in 0..width {
+                        qn[i] = q[qkb + i] * q_inv * scale;
+                        kn[i] = k[qkb + i] * k_inv;
+                    }
+                    let decay = g[gb].exp();
+                    let bta = beta[gb];
+                    for col in 0..width {
+                        let mut kv_mem = 0f32;
+                        for row in 0..width {
+                            kv_mem += kn[row] * state[sb + row * width + col] * decay;
+                        }
+                        let delta = (v[vb + col] - kv_mem) * bta;
+                        let mut result = 0f32;
+                        for row in 0..width {
+                            let ix = sb + row * width + col;
+                            let next = state[ix] * decay + kn[row] * delta;
+                            state[ix] = next;
+                            result += qn[row] * next;
+                        }
+                        output[vb + col] = result;
+                    }
                 }
-                output[vb + col] = f16::from_f32(result / (width as f32).sqrt());
             }
         }
         Ok(tvec![
-            Tensor::from_shape(inputs[0].shape(), &output)?.into_tvalue(),
-            Tensor::from_shape(inputs[5].shape(), &final_state)?.into_tvalue(),
+            from_f32(output, &v_shape, inputs[0].datum_type())?.into_tvalue(),
+            from_f32(state, &state_shape, inputs[5].datum_type())?.into_tvalue(),
         ])
     }
 }
@@ -97,14 +192,162 @@ impl EvalOp for GatedDeltaNetRecurrent {
 impl TypedOp for GatedDeltaNetRecurrent {
     fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
         ensure!(inputs.len() == 6);
-        ensure!(inputs[0].datum_type == DatumType::F16);
-        ensure!(inputs[1].datum_type == DatumType::F16);
-        ensure!(inputs[2].datum_type == DatumType::F16);
-        ensure!(inputs[3].datum_type == DatumType::F32);
-        ensure!(inputs[4].datum_type == DatumType::F16);
-        ensure!(inputs[5].datum_type == DatumType::F32);
-        ensure!(inputs[0].shape == inputs[1].shape && inputs[0].shape == inputs[2].shape);
-        Ok(tvec![inputs[0].without_value(), inputs[5].without_value()])
+        for input in inputs {
+            ensure!(
+                matches!(input.datum_type, DatumType::F16 | DatumType::F32),
+                "GDN inputs must be f16 or f32, got {:?}",
+                input.datum_type
+            );
+        }
+        ensure!(inputs[0].rank() == 4, "GDN query must be [b, S, hk, w]");
+        ensure!(inputs[0].shape == inputs[1].shape);
+        ensure!(inputs[2].rank() == 4, "GDN value must be [b, S, hv, w]");
+        // Output takes the VALUE shape (hv heads, possibly G * hk) with the
+        // query datum type; head-count divisibility is checked at eval time
+        // (dims may be symbolic here).
+        ensure!(inputs[5].rank() == 4, "GDN state must be [b, hv, w, w]");
+        let mut out = inputs[2].without_value();
+        out.datum_type = inputs[0].datum_type;
+        Ok(tvec![out, inputs[5].without_value()])
     }
     as_op!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(
+        s_len: usize,
+        heads: usize,
+        width: usize,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        g: &Tensor,
+        beta: &Tensor,
+        state: &Tensor,
+    ) -> TractResult<(Tensor, Tensor)> {
+        let _ = (s_len, heads, width);
+        let outputs = GatedDeltaNetRecurrent::default().eval(tvec![
+            q.clone().into_tvalue(),
+            k.clone().into_tvalue(),
+            v.clone().into_tvalue(),
+            g.clone().into_tvalue(),
+            beta.clone().into_tvalue(),
+            state.clone().into_tvalue(),
+        ])?;
+        Ok((outputs[0].clone().into_tensor(), outputs[1].clone().into_tensor()))
+    }
+
+    fn arb(shape: &[usize], seed: u64) -> Tensor {
+        // simple deterministic pseudo-random floats in [-1, 1]
+        let len: usize = shape.iter().product();
+        let mut x = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        let data: Vec<f32> = (0..len)
+            .map(|_| {
+                x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                ((x >> 33) as f32 / (1u64 << 31) as f32) - 1.0
+            })
+            .collect();
+        Tensor::from_shape(shape, &data).unwrap()
+    }
+
+    /// repeat_interleave along the head axis (2) of a [b, S, h, w] tensor.
+    fn repeat_heads(t: &Tensor, groups: usize) -> Tensor {
+        let shape = t.shape();
+        let (b, s_len, heads, width) = (shape[0], shape[1], shape[2], shape[3]);
+        let src = t.to_plain_array_view::<f32>().unwrap();
+        let src = src.as_slice().unwrap();
+        let mut data = vec![0f32; b * s_len * heads * groups * width];
+        for bi in 0..b {
+            for si in 0..s_len {
+                for h in 0..heads * groups {
+                    let dst_base = ((bi * s_len + si) * heads * groups + h) * width;
+                    let src_base = ((bi * s_len + si) * heads + h / groups) * width;
+                    data[dst_base..dst_base + width]
+                        .copy_from_slice(&src[src_base..src_base + width]);
+                }
+            }
+        }
+        Tensor::from_shape(&[b, s_len, heads * groups, width], &data).unwrap()
+    }
+
+    /// The S-axis loop must be exactly equivalent to threading the state
+    /// through S single-step calls, for both the ungrouped (G=1) and the
+    /// GQA (G=2) head layouts.
+    fn multi_step_matches_sequential_single_steps_case(groups: usize) -> TractResult<()> {
+        let (b, s_len, k_heads, width) = (1, 5, 3, 16);
+        let heads = k_heads * groups;
+        let q = arb(&[b, s_len, k_heads, width], 1);
+        let k = arb(&[b, s_len, k_heads, width], 2);
+        let v = arb(&[b, s_len, heads, width], 3);
+        let g = arb(&[b, s_len, heads], 4);
+        let beta = arb(&[b, s_len, heads], 5);
+        let state0 = arb(&[b, heads, width, width], 6);
+
+        let (out_multi, final_multi) = run(s_len, heads, width, &q, &k, &v, &g, &beta, &state0)?;
+
+        let mut state = state0.clone();
+        let mut outs: Vec<Tensor> = vec![];
+        for si in 0..s_len {
+            let slice = |t: &Tensor| t.slice(1, si, si + 1).unwrap();
+            let (o, st) = run(
+                1,
+                heads,
+                width,
+                &slice(&q),
+                &slice(&k),
+                &slice(&v),
+                &slice(&g),
+                &slice(&beta),
+                &state,
+            )?;
+            outs.push(o);
+            state = st;
+        }
+        let seq_out = Tensor::stack_tensors(1, &outs.iter().map(|o| o.clone().into()).collect::<Vec<TValue>>())?;
+        // stacked [b, S, 1, h, w] vs [b, S, h, w]: reshape
+        let seq_out = seq_out.into_shape(&[b, s_len, heads, width])?;
+
+        out_multi.close_enough(&seq_out, Approximation::Close)?;
+        final_multi.close_enough(&state, Approximation::Close)?;
+        Ok(())
+    }
+
+    #[test]
+    fn multi_step_matches_sequential_single_steps() -> TractResult<()> {
+        multi_step_matches_sequential_single_steps_case(1)
+    }
+
+    #[test]
+    fn multi_step_matches_sequential_single_steps_grouped() -> TractResult<()> {
+        multi_step_matches_sequential_single_steps_case(2)
+    }
+
+    /// Grouped q/k (hk heads) must give bitwise the same result as the old
+    /// ungrouped call on repeat-interleaved q/k (hv heads), i.e. exactly
+    /// what HF materializes before the op boundary.
+    #[test]
+    fn grouped_matches_repeated_reference() -> TractResult<()> {
+        let (b, s_len, k_heads, groups, width) = (1, 4, 2, 2, 16);
+        let heads = k_heads * groups;
+        let q = arb(&[b, s_len, k_heads, width], 11);
+        let k = arb(&[b, s_len, k_heads, width], 12);
+        let v = arb(&[b, s_len, heads, width], 13);
+        let g = arb(&[b, s_len, heads], 14);
+        let beta = arb(&[b, s_len, heads], 15);
+        let state0 = arb(&[b, heads, width, width], 16);
+
+        let (out_grouped, state_grouped) =
+            run(s_len, heads, width, &q, &k, &v, &g, &beta, &state0)?;
+        let q_rep = repeat_heads(&q, groups);
+        let k_rep = repeat_heads(&k, groups);
+        let (out_ref, state_ref) =
+            run(s_len, heads, width, &q_rep, &k_rep, &v, &g, &beta, &state0)?;
+
+        out_grouped.close_enough(&out_ref, Approximation::Exact)?;
+        state_grouped.close_enough(&state_ref, Approximation::Exact)?;
+        Ok(())
+    }
 }

--- a/transformers/src/ops/gdn_recurrent.rs
+++ b/transformers/src/ops/gdn_recurrent.rs
@@ -24,8 +24,7 @@ pub fn register(registry: &mut Registry) {
             !op.sigmoid_beta,
             "GatedDeltaNetRecurrent with sigmoid_beta cannot be serialized to NNEF"
         );
-        let inputs: Vec<Arc<RValue>> =
-            node.inputs.iter().map(|i| ast.mapping[i].clone()).collect();
+        let inputs: Vec<Arc<RValue>> = node.inputs.iter().map(|i| ast.mapping[i].clone()).collect();
         Ok(Some(invocation("tract_transformers_gdn_recurrent", &inputs, &[])))
     }
     registry.register_dumper(serialize);
@@ -84,7 +83,6 @@ impl Op for GatedDeltaNetRecurrent {
     op_as_typed_op!();
 }
 
-
 impl EvalOp for GatedDeltaNetRecurrent {
     op_out_of_plan!();
 
@@ -93,10 +91,7 @@ impl EvalOp for GatedDeltaNetRecurrent {
         let q_shape: TVec<usize> = inputs[0].shape().into();
         let v_shape: TVec<usize> = inputs[2].shape().into();
         let state_shape: TVec<usize> = inputs[5].shape().into();
-        ensure!(
-            q_shape.len() == 4,
-            "GDN query must be [b, S, hk, w], got {q_shape:?}"
-        );
+        ensure!(q_shape.len() == 4, "GDN query must be [b, S, hk, w], got {q_shape:?}");
         ensure!(inputs[1].shape() == &*q_shape);
         let (b, s_len, k_heads, width) = (q_shape[0], q_shape[1], q_shape[2], q_shape[3]);
         ensure!(
@@ -192,7 +187,8 @@ impl TypedOp for GatedDeltaNetRecurrent {
         // fused-kernel mix (query/key/value/beta f16, log_decay f32, state
         // either f16 or f32).
         let all_f32 = dts.iter().all(|dt| *dt == DatumType::F32);
-        let fused_mix = dts[..4] == [DatumType::F16, DatumType::F16, DatumType::F16, DatumType::F32]
+        let fused_mix = dts[..4]
+            == [DatumType::F16, DatumType::F16, DatumType::F16, DatumType::F32]
             && dts[4] == DatumType::F16
             && matches!(dts[5], DatumType::F16 | DatumType::F32);
         ensure!(all_f32 || fused_mix, "unsupported GDN dtype combination: {dts:?}");
@@ -227,14 +223,17 @@ mod tests {
         state: &Tensor,
     ) -> TractResult<(Tensor, Tensor)> {
         let _ = (s_len, heads, width);
-        let outputs = GatedDeltaNetRecurrent::default().eval(&EvalContext::out_of_plan(), tvec![
-            q.clone().into_tvalue(),
-            k.clone().into_tvalue(),
-            v.clone().into_tvalue(),
-            g.clone().into_tvalue(),
-            beta.clone().into_tvalue(),
-            state.clone().into_tvalue(),
-        ])?;
+        let outputs = GatedDeltaNetRecurrent::default().eval(
+            &EvalContext::out_of_plan(),
+            tvec![
+                q.clone().into_tvalue(),
+                k.clone().into_tvalue(),
+                v.clone().into_tvalue(),
+                g.clone().into_tvalue(),
+                beta.clone().into_tvalue(),
+                state.clone().into_tvalue(),
+            ],
+        )?;
         Ok((outputs[0].clone().into_tensor(), outputs[1].clone().into_tensor()))
     }
 
@@ -291,7 +290,10 @@ mod tests {
             outs.push(o);
             state = st;
         }
-        let seq_out = Tensor::stack_tensors(1, &outs.iter().map(|o| o.clone().into()).collect::<Vec<TValue>>())?;
+        let seq_out = Tensor::stack_tensors(
+            1,
+            &outs.iter().map(|o| o.clone().into()).collect::<Vec<TValue>>(),
+        )?;
         // stacked [b, S, 1, h, w] vs [b, S, h, w]: reshape
         let seq_out = seq_out.into_shape(&[b, s_len, heads, width])?;
 

--- a/transformers/src/ops/mod.rs
+++ b/transformers/src/ops/mod.rs
@@ -1,4 +1,5 @@
 pub mod apply_rope;
+mod cast_f32;
 pub mod causal_conv1d_update;
 pub mod diag_gather;
 pub mod dyn_kv_cache;
@@ -10,6 +11,8 @@ pub mod quant_dyn_kv_cache;
 pub mod scaled_masked_softmax;
 pub mod sdpa;
 pub mod streamed_sdpa;
+#[cfg(test)]
+mod test_utils;
 pub mod window_kv_cache;
 
 // Re-export ops that moved to core

--- a/transformers/src/ops/test_utils.rs
+++ b/transformers/src/ops/test_utils.rs
@@ -1,0 +1,19 @@
+//! Shared test-data generator for the gated-delta-net / causal-conv1d-update
+//! op tests.
+
+#![cfg(test)]
+
+use tract_nnef::internal::*;
+
+/// Simple deterministic pseudo-random floats in `[-1, 1]`.
+pub(super) fn arb(shape: &[usize], seed: u64) -> Tensor {
+    let len: usize = shape.iter().product();
+    let mut x = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    let data: Vec<f32> = (0..len)
+        .map(|_| {
+            x = x.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((x >> 33) as f32 / (1u64 << 31) as f32) - 1.0
+        })
+        .collect();
+    Tensor::from_shape(shape, &data).unwrap()
+}


### PR DESCRIPTION
Split out of #2084, which bundles far more than its title suggests. This
piece is self-contained: GatedDeltaNet (GDN) and causal-conv1d-update
support, the linear-attention core used by Qwen3.5's hybrid decoder. Not
MoE-related, no dependency on the rest of #2084.

What's in it:

- A GQA-aware `GatedDeltaNetRecurrent` op, generalized to an S-generic
  `[b, S, h, w]` layout, with a threadgroup-parallel Metal kernel
  (row-chunked reductions), a chunked prefill kernel, and an f16-state
  variant.
- An S-generic `CausalConv1dUpdate` op with a `[b, C, S]` layout.
- The beta sigmoid folded directly into the GDN kernel dispatch, via a
  Metal rewrite rule.
- Matching CUDA and Metal kernels, plus fixes so both work at any
  sequence length (symbolic S) on the decode graph.

## Benchmarks

I added a criterion bench comparing the pre-existing CPU reference
implementation against the new GPU kernels, on both backends. Both
benches include a full device-completion sync inside the timed region,
so the numbers reflect real GPU latency rather than just command-buffer
encoding time.

**Metal** (`cargo bench -p tract-metal --bench gdn_recurrent`, on a Mac):
the real Qwen3.5-35B geometry — 16 k-heads, GQA groups=2, head width 128.

| | CPU | Metal, old per-token kernel | Metal, this PR's chunked path |
|---|---|---|---|
| Decode (1 step) | ~2.0 ms | – | ~120–160 µs (**13–17x** faster) |
| Prefill (512 tokens) | 302.6 ms | 6.454 ms (**47x** faster) | 5.596 ms (**54x** faster) |

The middle column is the older, pre-chunking threadgroup kernel that this
PR's chunked prefill path builds on top of (forced on via
`TRACT_METAL_DISABLE_GDN_CHUNKED=1` for the comparison). At this
particular length — 512 tokens, 8 chunks — the chunking optimization only
adds about 15% on top of the much larger CPU-to-Metal speedup; I'd
expect that gap to widen at longer prefill lengths, but I haven't
verified that independently.

**CUDA** (`cargo bench -p tract-cuda --bench gdn_recurrent`, on an A10G):
same shapes but ungrouped heads (32 heads, no GQA split) and an f32
state, since that's the only configuration the CUDA kernel supports
today. The CPU numbers differ from the Metal table above because this
ran on different hardware with a slightly different input shape, not
because the CPU op itself changed.

| | CPU | CUDA |
|---|---|---|
| Decode (1 step) | 7.09 ms | 25.0 µs (**~283x** faster) |
| Prefill (512 tokens) | 781.2 ms | 9.787 ms (**~80x** faster) |

Decode is unchanged by this PR — the old CUDA kernel already handled a
single step correctly (its shape math just happens to reduce to the same
thing for S=1). Prefill is the real story here, though: I checked, and
the old kernel doesn't have any real handling of a sequence axis at all.
Feeding it a genuine 512-token call trips its state-shape check (it
infers a bogus head count from the flattened tensor size) and it errors
out, which means any real prefill request would have silently fallen
back to the CPU op entirely — there was no GPU-accelerated prefill on
CUDA before this PR, at any speed. So the CUDA prefill row above isn't
"kernel got faster", it's "GPU prefill exists now, where it didn't
before", via a plain per-step host-side loop (still no chunking — that
would be the natural CUDA follow-up, mirroring the Metal kernel).

🍍