### PR TITLE
pulse-opl: cast the pad constant to the datum type it fills

### DIFF
--- a/core/src/floats.rs
+++ b/core/src/floats.rs
@@ -1,6 +1,5 @@
 use crate::internal::translator::Translate;
 use crate::internal::*;
-use crate::ops::array::{Pad, PadMode};
 use crate::ops::binary::TypedBinOp;
 use crate::ops::cast::{Cast, cast};
 use crate::ops::einsum::EinSum;
@@ -179,17 +178,6 @@ impl Translate<TypedFact, Box<dyn TypedOp>, TypedFact, Box<dyn TypedOp>>
                 let operating_dt =
                     if op.operating_dt == self.from_dt { self.to_dt } else { op.operating_dt };
                 Box::new(EinSum { operating_dt, ..op.clone() })
-            } else if let Some(op) = node.op_as::<Pad>() {
-                if let PadMode::Constant(t) = &op.mode {
-                    let new_t = if t.datum_type() == self.from_dt {
-                        t.cast_to_dt(self.to_dt)?.into_owned().into_arc_tensor()
-                    } else {
-                        Arc::clone(t)
-                    };
-                    Box::new(Pad { mode: PadMode::Constant(new_t), ..op.clone() })
-                } else {
-                    Box::new(op.clone())
-                }
             } else {
                 node.op.clone()
             };

--- a/core/src/ops/array/pad.rs
+++ b/core/src/ops/array/pad.rs
@@ -1,5 +1,8 @@
 use crate::internal::*;
 
+/// How a padded region is filled. A `Constant` value carries a single element
+/// in the datum type the model builder gave it, f32 for a float graph, and no
+/// pass retypes it: a consumer casts it to the datum type of the tensor it pads.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PadMode {
     Constant(Arc<Tensor>),

--- a/gpu/src/ops/copy_based.rs
+++ b/gpu/src/ops/copy_based.rs
@@ -36,7 +36,8 @@ pub fn try_make_copy_based_op(
         return Ok(Some(Box::new(super::pulse::GpuDelay::new(op))));
     }
     if let Some(op) = node.op_as::<PulsePad>() {
-        return Ok(Some(Box::new(super::pulse::GpuPulsePad::new(op)?)));
+        let dt = source.node_input_facts(node.id)?[0].datum_type;
+        return Ok(Some(Box::new(super::pulse::GpuPulsePad::new(op, dt)?)));
     }
     if let Some(op) = node.op_as::<AffineChunkTrim>() {
         return Ok(Some(Box::new(super::pulse::GpuAffineChunkTrim::new(op))));

--- a/gpu/src/ops/pulse.rs
+++ b/gpu/src/ops/pulse.rs
@@ -269,9 +269,12 @@ pub struct GpuPulsePad {
 }
 
 impl GpuPulsePad {
-    pub fn new(op: &PulsePad) -> TractResult<Self> {
-        let device_cst =
-            if let PadMode::Constant(c) = &op.mode { Some(c.clone().into_device()?) } else { None };
+    pub fn new(op: &PulsePad, dt: DatumType) -> TractResult<Self> {
+        let device_cst = if let PadMode::Constant(c) = &op.mode {
+            Some(c.cast_to_dt(dt)?.into_owned().into_device()?)
+        } else {
+            None
+        };
         Ok(Self { op: op.clone(), device_cst })
     }
 }

--- a/harness/nnef-test-cases/conv-then-shape-of-mask/runme.sh
+++ b/harness/nnef-test-cases/conv-then-shape-of-mask/runme.sh
@@ -19,3 +19,10 @@ do
     $TRACT_RUN --nnef-tract-core . --pulse 4 $rt compare \
         --stream --allow-random-input -q
 done
+
+# Same graph in f16.  The `pulse` stage runs before `-t`, so the f32 pad
+# constant is still carried by a PulsePad when the cast lands, and the op has
+# to cast it to the datum type it fills.  `run`, not `compare --stream`: the
+# reference model stays f32, so its inputs no longer match the pulsed facts.
+$TRACT_RUN --nnef-tract-core . --pulse 4 -t f32_to_f16 \
+    run --allow-random-input -q

--- a/pulse-opl/src/mask.rs
+++ b/pulse-opl/src/mask.rs
@@ -74,13 +74,14 @@ impl PulseMaskOpState {
             return Ok(input);
         }
 
+        let value = op.value.cast_to_dt(input.datum_type())?;
         if pulse_begin < op.begin {
             let fill_up_to = (op.begin - pulse_begin).min(pulse);
-            input.fill_slice(0..fill_up_to, &op.value, op.axis)?;
+            input.fill_slice(0..fill_up_to, &value, op.axis)?;
         }
         if pulse_end > end {
             let fill_from = pulse - (pulse_end - end).min(pulse);
-            input.fill_slice(fill_from..pulse, &op.value, op.axis)?;
+            input.fill_slice(fill_from..pulse, &value, op.axis)?;
         }
 
         Ok(input)

--- a/pulse-opl/src/pad.rs
+++ b/pulse-opl/src/pad.rs
@@ -275,9 +275,12 @@ impl PulsePadOpState {
             if pulse_begin < op.begin_input {
                 let fill_up_to = (op.begin_input - pulse_begin).min(pulse);
                 match &op.mode {
-                    PadMode::Constant(c) => {
-                        output.fill_slice_at_prefix(seat.as_slice(), 0..fill_up_to, c, op.axis)?
-                    }
+                    PadMode::Constant(c) => output.fill_slice_at_prefix(
+                        seat.as_slice(),
+                        0..fill_up_to,
+                        &*c.cast_to_dt(dt)?,
+                        op.axis,
+                    )?,
                     PadMode::Edge => {
                         fill_from_own_frame(&mut output, seat, op.axis, 0..fill_up_to, fill_up_to)
                     }
@@ -290,7 +293,7 @@ impl PulsePadOpState {
                     PadMode::Constant(c) => output.fill_slice_at_prefix(
                         seat.as_slice(),
                         fill_from..pulse,
-                        c,
+                        &*c.cast_to_dt(dt)?,
                         op.axis,
                     )?,
                     PadMode::Edge => {
@@ -353,4 +356,47 @@ impl TypedOp for PulsePad {
     }
 
     as_op!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An f16 pulse padded by the f32 constant a model builder leaves in
+    /// `PadMode`, on both the leading and the trailing pad.
+    #[test]
+    fn constant_is_cast_to_the_pulse_datum_type() -> TractResult<()> {
+        let mut model = TypedModel::default();
+        let source = model.add_source("source", f16::fact([2]))?;
+        let pad = model.wire_node(
+            "pad",
+            PulsePad {
+                axis: 0,
+                before: 2,
+                after: 2.to_dim(),
+                begin_input: 2,
+                end_input: 6.to_dim(),
+                mode: PadMode::Constant(rctensor0(-1f32)),
+                overlap: 0,
+            },
+            &[source],
+        )?;
+        model.select_output_outlets(&pad)?;
+
+        let mut state = model.into_runnable()?.spawn()?;
+        let minus_one = f16::from_f32(-1.0);
+        let mut got = vec![];
+        for pulse in 0..4 {
+            let input = tensor1(&[f16::from_f32(pulse as f32), f16::from_f32(pulse as f32)]);
+            let output = state.run(tvec!(input.into_tvalue()))?;
+            got.extend_from_slice(output[0].try_as_plain()?.as_slice::<f16>()?);
+        }
+        assert_eq!(got[0..2], [minus_one; 2]);
+        assert_eq!(
+            got[2..6],
+            [f16::from_f32(1.0), f16::from_f32(1.0), f16::from_f32(2.0), f16::from_f32(2.0)]
+        );
+        assert_eq!(got[6..8], [minus_one; 2]);
+        Ok(())
+    }
 }

--- a/tflite/src/ops/cnn.rs
+++ b/tflite/src/ops/cnn.rs
@@ -313,7 +313,7 @@ fn de_dw_conv2d(op: &mut DeserOp) -> TractResult<TVec<OutletId>> {
 
 fn ser_pad(
     builder: &mut SubgraphBuilder,
-    _model: &TypedModel,
+    model: &TypedModel,
     node: &TypedNode,
     pad: &Pad,
 ) -> TractResult<()> {
@@ -332,12 +332,12 @@ fn ser_pad(
     let PadMode::Constant(pad_value) = &pad.mode else {
         bail!("Only constant padding is supported by tflite");
     };
-    inputs.push(
-        builder.write_fact(
-            format!("{node_name}.pad_value"),
-            TypedFact::try_from(pad_value.clone())?,
-        )?,
-    );
+    // PADV2 takes constant_values in the type of the tensor it pads.
+    let dt = model.outlet_fact(node.inputs[0])?.datum_type;
+    inputs.push(builder.write_fact(
+        format!("{node_name}.pad_value"),
+        TypedFact::try_from(pad_value.cast_to_dt(dt)?.into_owned())?,
+    )?);
     let options = PadOptions::create(builder.fb(), &PadOptionsArgs {});
     builder.write_op_with_options(
         &inputs,


### PR DESCRIPTION
PulsePad, PulseMask and GpuPulsePad handed the tensor PadMode carries straight to a fill that takes its value in the datum type it fills, so an f16 pulse padded by the f32 constant the NNEF deserializer builds could not run. Cast at use, as Pad and GpuPad already do, and drop the Pad case from the float precision translator: a constant keeps the datum type its builder gave it, and the tflite writer, which hands the value to PADV2 in the type of the padded tensor, casts on the way out.