### PR TITLE
core/fft: Stft::eval_t walked contiguous tensors one element at a tim…

### DIFF
--- a/core/src/ops/fft.rs
+++ b/core/src/ops/fft.rs
@@ -3,7 +3,6 @@ use num_complex::Complex;
 use rustfft::num_traits::{Float, FromPrimitive};
 use rustfft::{FftDirection, FftNum};
 use tract_data::itertools::Itertools;
-use tract_ndarray::Axis as NdAxis;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Fft {
@@ -140,68 +139,102 @@ pub struct Stft {
 }
 
 impl Stft {
+    /// The window zero-padded to `frame` and centered, ready to scale a whole frame in one
+    /// pass; `None` when the op carries no window.
+    fn padded_window<T: Datum + Float>(&self) -> TractResult<Option<Vec<T>>> {
+        let Some(window) = &self.window else { return Ok(None) };
+        let window = window.try_as_plain()?.as_slice::<T>()?;
+        ensure!(
+            window.len() <= self.frame,
+            "Stft window ({}) is longer than the frame ({})",
+            window.len(),
+            self.frame
+        );
+        let pad_left = (self.frame - window.len()) / 2;
+        let mut padded = vec![T::zero(); self.frame];
+        padded[pad_left..pad_left + window.len()].copy_from_slice(window);
+        Ok(Some(padded))
+    }
+
     fn eval_t<T: Datum + FftNum + FromPrimitive + Float>(
         &self,
         input: &Tensor,
     ) -> TractResult<Tensor> {
-        let mut iterator_shape: TVec<usize> = input.shape().into();
-        iterator_shape.pop(); // [re,im]
-        iterator_shape[self.axis] = 1;
-        let mut output_shape: TVec<usize> = input.shape().into();
+        let rank = input.rank();
         let frames = (input.shape()[self.axis] - self.frame) / self.stride + 1;
-        output_shape.insert(self.axis, frames);
-        output_shape[self.axis + 1] = self.frame;
+        let mut output_shape: TVec<usize> = input.shape().into();
+        output_shape[self.axis] = frames;
+        output_shape.insert(self.axis + 1, self.frame);
         let mut output = unsafe { Tensor::uninitialized::<T>(&output_shape)? };
+
+        let mut iterator_shape: TVec<usize> = input.shape().into();
+        iterator_shape.pop(); // last dim is [re, im]
+        iterator_shape[self.axis] = 1;
+
+        let in_strides: TVec<usize> = input.strides().iter().map(|s| *s as usize).collect();
+        let out_strides: TVec<usize> = output.strides().iter().map(|s| *s as usize).collect();
+        let time_stride = in_strides[self.axis];
+        let frame_stride = out_strides[self.axis];
+        let bin_stride = out_strides[self.axis + 1];
+
+        let window = self.padded_window::<T>()?;
         let fft = rustfft::FftPlanner::new().plan_fft_forward(self.frame);
-        let input = input.to_plain_array_view::<T>()?;
+
+        let input_plain = input.try_as_plain()?;
+        let data = input_plain.as_slice::<T>()?;
         let mut output_plain = output.try_as_plain_mut()?;
-        let mut oview = output_plain.to_array_view_mut::<T>()?;
+        let out = output_plain.as_slice_mut::<T>()?;
+
         let mut v = Vec::with_capacity(self.frame);
         for coords in tract_ndarray::indices(&*iterator_shape) {
-            let islice = input.slice_each_axis(|ax| {
-                if ax.axis.index() == self.axis || ax.stride == 1 {
-                    (..).into()
-                } else {
-                    let c = coords[ax.axis.index()] as isize;
-                    (c..=c).into()
-                }
-            });
-            let mut oslice = oview.slice_each_axis_mut(|ax| {
-                if ax.stride == 1 {
-                    (..).into()
-                } else if ax.axis.index() < self.axis {
-                    let c = coords[ax.axis.index()] as isize;
-                    (c..=c).into()
-                } else if ax.axis.index() == self.axis || ax.axis.index() == self.axis + 1 {
-                    (..).into()
-                } else {
-                    let c = coords[ax.axis.index() - 1] as isize;
-                    (c..=c).into()
-                }
-            });
-            let signal: Vec<Complex<T>> =
-                islice.iter().tuples().map(|(re, im)| Complex::new(*re, *im)).collect();
+            let mut in_base = 0;
+            let mut out_base = 0;
+            for i in (0..rank - 1).filter(|i| *i != self.axis) {
+                in_base += coords[i] * in_strides[i];
+                out_base += coords[i] * out_strides[i + usize::from(i > self.axis)];
+            }
             for f in 0..frames {
+                let src = in_base + f * self.stride * time_stride;
                 v.clear();
-                v.extend_from_slice(&signal[self.stride * f..self.stride * f + self.frame]);
-                if let Some(win) = &self.window {
-                    let win = win.try_as_plain()?.as_slice::<T>()?;
-                    // symmetric padding in case window is smaller than frames (aka n fft)
-                    let pad_left = (self.frame - win.len()) / 2;
-                    v.iter_mut().enumerate().for_each(|(ix, v)| {
-                        *v = if ix < pad_left || ix >= pad_left + win.len() {
-                            Complex::new(T::zero(), T::zero())
-                        } else {
-                            *v * Complex::new(win[ix - pad_left], T::zero())
-                        }
+                if time_stride == 2 {
+                    v.extend(
+                        data[src..src + 2 * self.frame]
+                            .as_chunks::<2>()
+                            .0
+                            .iter()
+                            .map(|c| Complex::new(c[0], c[1])),
+                    );
+                } else {
+                    v.extend((0..self.frame).map(|k| {
+                        let o = src + k * time_stride;
+                        Complex::new(data[o], data[o + 1])
+                    }));
+                }
+                if let Some(window) = &window {
+                    v.iter_mut().zip(window).for_each(|(v, w)| {
+                        v.re = v.re * *w;
+                        v.im = v.im * *w;
                     });
                 }
                 fft.process(&mut v);
-                oslice
-                    .index_axis_mut(NdAxis(self.axis), f)
-                    .iter_mut()
-                    .zip(v.iter().flat_map(|cmpl| [cmpl.re, cmpl.im].into_iter()))
-                    .for_each(|(s, v)| *s = v);
+                let dst = out_base + f * frame_stride;
+                if bin_stride == 2 {
+                    out[dst..dst + 2 * self.frame]
+                        .as_chunks_mut::<2>()
+                        .0
+                        .iter_mut()
+                        .zip(&v)
+                        .for_each(|(o, c)| {
+                            o[0] = c.re;
+                            o[1] = c.im;
+                        });
+                } else {
+                    for (k, c) in v.iter().enumerate() {
+                        let o = dst + k * bin_stride;
+                        out[o] = c.re;
+                        out[o + 1] = c.im;
+                    }
+                }
             }
         }
         Ok(output)

--- a/harness/nnef-test-cases/stft-strided-axis/graph.nnef
+++ b/harness/nnef-test-cases/stft-strided-axis/graph.nnef
@@ -1,0 +1,27 @@
+version 1.0;
+
+extension tract_registry tract_core;
+
+# Two spellings of the same STFT, so `mismatch` is 0 only if they agree.
+#
+# `fast` runs the STFT on the axis right before the [re, im] pair, so a frame is
+# a contiguous run and the op gathers and stores it as one. `slow` transposes so
+# the STFT axis is 0, leaving the batch between the time axis and the pair: the
+# frame is then strided and the op falls back to element-wise indexing.
+#   slow_t[f, k, b, c] = fast[b, f, k, c]
+# The window is shorter than the frame, so both legs also exercise the centered
+# zero-padding.
+graph stft_strided_axis(data) -> (mismatch)
+{
+    data = external<scalar>(shape = [2, 12, 2]);
+
+    window = [0.25, 0.5, 0.75, 1.0];
+
+    fast = tract_core_stft(data, axis = 1, frame = 8, stride = 2, window = window);
+
+    data_t = transpose(data, axes = [1, 0, 2]);
+    slow_t = tract_core_stft(data_t, axis = 0, frame = 8, stride = 2, window = window);
+    slow = transpose(slow_t, axes = [2, 0, 1, 3]);
+
+    mismatch = sum_reduce(abs(sub(fast, slow)), axes = [0, 1, 2, 3]);
+}

--- a/harness/nnef-test-cases/stft-strided-axis/runme.sh
+++ b/harness/nnef-test-cases/stft-strided-axis/runme.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# --allow-random-input is seeded from a fixed constant, so `data` is the same
+# every run. The graph runs the same STFT twice, once with the frame contiguous
+# and once with the batch axis between the time axis and the [re, im] pair, and
+# outputs the summed absolute difference: any divergence between the contiguous
+# and the strided path makes it non-zero. The reference here is the op's own
+# other code path, not a golden value, so the two legs live in one graph rather
+# than in an --assert-output-bundle pair.
+#
+# --assert-op-count pins that both STFTs survive as distinct nodes, so no pass
+# folded one leg into the other through the op's axes_mapping and left the
+# comparison trivially true.
+$TRACT_RUN . run --allow-random-input \
+    --assert-op-count STFT 2 \
+    --assert-output 'mismatch:1,1,1,1,f32=0'
+
+$TRACT_RUN . -O run --allow-random-input \
+    --assert-op-count STFT 2 \
+    --assert-output 'mismatch:1,1,1,1,f32=0'


### PR DESCRIPTION
…e through dynamic-rank ndarray views, gathering the signal with slice_each_axis and itertools tuples, re-resolving the window and branching on the pad offset once per sample, and storing the result scalar by scalar through index_axis_mut and a flat_map over [re, im]. Since a tract Tensor always carries natural strides, address the frames by offset instead: gather and store whole frames as slices when the frame is contiguous, keep an element-wise path for a time axis that is not adjacent to the complex pair, and precompute the zero-padded window once per eval.