### PR TITLE
AtomicUsize::fetch_update is deprecated on beta, and the closure here…

### DIFF
--- a/nnef/tests/nnef_string_len_alloc.rs
+++ b/nnef/tests/nnef_string_len_alloc.rs
@@ -21,8 +21,7 @@ static MAX_SINGLE_ALLOC: AtomicUsize = AtomicUsize::new(0);
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let size = layout.size();
-        let _ = MAX_SINGLE_ALLOC
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| Some(c.max(size)));
+        MAX_SINGLE_ALLOC.fetch_max(size, Ordering::Relaxed);
         unsafe { System.alloc(layout) }
     }
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {


### PR DESCRIPTION
… only kept the larger of the two values: use fetch_max.