### PR TITLE
linalg: wasm had no ln or exp kernel, so both funcs fell to the gener…

### DIFF
--- a/linalg/benches/wasm.rs
+++ b/linalg/benches/wasm.rs
@@ -39,6 +39,10 @@ fn main() {
     eprintln!("=== int8 matvec (n=1): wasm_i32_4x4 vs generic_i32_4x1 ({target}) ===");
     bench_i8_matvec::run();
 
+    eprintln!();
+    eprintln!("=== ln/exp: wasm simd128 vs generic scalar ({target}) ===");
+    bench_ln_exp::run();
+
     #[cfg(target_feature = "relaxed-simd")]
     {
         eprintln!();
@@ -698,6 +702,69 @@ mod bench_activations {
         bench("hidden=256", 256, 5_000);
         bench("hidden=512", 512, 3_000);
         bench("hidden=1024", 1024, 2_000);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+mod bench_ln_exp {
+    //! Microbench: the WASM SIMD ln and exp kernels against the generic scalar
+    //! fallback, whose per-element fit is what a log-mel featurizer pays.
+    //!
+    //! The buffer is restored from a source before every call: run in place over
+    //! and over, ln walks its own output into NaN and exp into infinity within a
+    //! few iterations, and the timing then belongs to the special paths. The
+    //! restore is timed on its own and taken off both readings.
+
+    use std::time::Instant;
+    use tract_linalg::element_wise::ElementWiseKer;
+
+    fn ns_per_call<K: ElementWiseKer<f32>>(src: &[f32], buf: &mut [f32], iters: usize) -> f64 {
+        for _ in 0..50 {
+            buf.copy_from_slice(src);
+            K::run(buf, ());
+        }
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            buf.copy_from_slice(src);
+            K::run(buf, ());
+        }
+        let with_restore = t0.elapsed().as_secs_f64() / iters as f64 * 1e9;
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            buf.copy_from_slice(src);
+            std::hint::black_box(&buf);
+        }
+        with_restore - t0.elapsed().as_secs_f64() / iters as f64 * 1e9
+    }
+
+    fn bench(label: &str, n: usize, iters: usize) {
+        let positive: Vec<f32> = (0..n).map(|i| (i % 37) as f32 * 0.7 + 0.1).collect();
+        let centered: Vec<f32> = (0..n).map(|i| ((i % 37) as f32 - 18.0) * 0.5).collect();
+        let mut buf = vec![0f32; n];
+
+        let scalar_ln =
+            ns_per_call::<tract_linalg::generic::ln::generic_ln_f32_4n>(&positive, &mut buf, iters);
+        let simd_ln =
+            ns_per_call::<tract_linalg::wasm::wasm_ln_f32_16n>(&positive, &mut buf, iters);
+        let scalar_exp = ns_per_call::<tract_linalg::generic::exp::generic_exp_f32_4n>(
+            &centered, &mut buf, iters,
+        );
+        let simd_exp =
+            ns_per_call::<tract_linalg::wasm::wasm_exp_f32_16n>(&centered, &mut buf, iters);
+
+        eprintln!(
+            "{label} n={n} iters={iters}: \
+             ln scalar={scalar_ln:.0} ns simd={simd_ln:.0} ns ({:.2}x); \
+             exp scalar={scalar_exp:.0} ns simd={simd_exp:.0} ns ({:.2}x)",
+            scalar_ln / simd_ln,
+            scalar_exp / simd_exp,
+        );
+    }
+
+    pub fn run() {
+        bench("frame=256", 256, 5_000);
+        bench("frame=512", 512, 3_000);
+        bench("frame=1024", 1024, 2_000);
     }
 }
 

--- a/linalg/src/wasm/exp.rs
+++ b/linalg/src/wasm/exp.rs
@@ -1,0 +1,47 @@
+//! simd128 f32 exp: the [`crate::generic::exp`] reduction and fit, four lanes at a time.
+
+routine_ew_rust!(wasm32;
+    f32,
+    wasm_exp_f32_16n,
+    16,
+    4,
+    #[inline(never)]
+    fn run(buf: &mut [f32], _: ()) {
+        use crate::generic::exp::{HIGH, LN2_HI, LN2_LO, LOG2E, LOW, POLY, SCALE_BIAS};
+        use std::arch::wasm32::*;
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        #[inline(always)]
+        fn exp4(x: v128) -> v128 {
+            use std::arch::wasm32::*;
+            // Clamped by selection rather than by f32x4_min and f32x4_max: those answer with
+            // the bound where a lane is NaN, which is what must propagate instead.
+            let high = f32x4_splat(HIGH);
+            let low = f32x4_splat(LOW);
+            let x = v128_bitselect(high, x, f32x4_gt(x, high));
+            let x = v128_bitselect(low, x, f32x4_lt(x, low));
+            let kf = f32x4_nearest(f32x4_mul(x, f32x4_splat(LOG2E)));
+            let mut r = madd_f32x4!(x, kf, f32x4_splat(-LN2_HI));
+            r = madd_f32x4!(r, kf, f32x4_splat(-LN2_LO));
+            let mut q = f32x4_splat(POLY[0]);
+            for c in &POLY[1..] {
+                let c = f32x4_splat(*c);
+                q = madd_f32x4!(c, q, r);
+            }
+            let k = i32x4_trunc_sat_f32x4(kf);
+            let half = i32x4_shr(k, 1);
+            let rest = i32x4_sub(k, half);
+            let scale = |k| i32x4_shl(i32x4_add(k, i32x4_splat(SCALE_BIAS)), 23);
+            f32x4_mul(f32x4_mul(q, scale(half)), scale(rest))
+        }
+        unsafe {
+            let mut p = buf.as_mut_ptr();
+            let end = p.add(buf.len());
+            while p < end {
+                v128_store(p as *mut v128, exp4(v128_load(p as *const v128)));
+                p = p.add(4);
+            }
+        }
+    },
+    func(Exp)
+);

--- a/linalg/src/wasm/ln.rs
+++ b/linalg/src/wasm/ln.rs
@@ -1,0 +1,64 @@
+//! simd128 f32 ln: the [`crate::generic::ln`] fit, four lanes at a time.
+
+routine_ew_rust!(wasm32;
+    f32,
+    wasm_ln_f32_16n,
+    16,
+    4,
+    #[inline(never)]
+    fn run(buf: &mut [f32], _: ()) {
+        use crate::generic::ln::{LN2_HI, LN2_LO, POLY, SPLIT, SUBNORMAL_SCALE, SUBNORMAL_SHIFT};
+        use std::arch::wasm32::*;
+        debug_assert!(buf.len() % Self::nr() == 0);
+        debug_assert!(buf.as_ptr() as usize % Self::alignment_bytes() == 0);
+        #[inline(always)]
+        fn ln4(x: v128) -> v128 {
+            use std::arch::wasm32::*;
+            let one = f32x4_splat(1.0);
+            let zero = f32x4_splat(0.0);
+            let subnormal = f32x4_lt(x, f32x4_splat(f32::MIN_POSITIVE));
+            let scaled =
+                v128_bitselect(f32x4_mul(x, f32x4_splat(SUBNORMAL_SCALE)), x, subnormal);
+            let mut exponent = i32x4_sub(u32x4_shr(scaled, 23), i32x4_splat(127));
+            exponent =
+                i32x4_sub(exponent, v128_and(subnormal, i32x4_splat(SUBNORMAL_SHIFT)));
+            let mantissa =
+                v128_or(v128_and(scaled, i32x4_splat(0x007fffff)), i32x4_splat(0x3f800000));
+            let split = f32x4_gt(mantissa, f32x4_splat(SPLIT));
+            let mantissa =
+                v128_bitselect(f32x4_mul(mantissa, f32x4_splat(0.5)), mantissa, split);
+            exponent = i32x4_add(exponent, v128_and(split, i32x4_splat(1)));
+            let e = f32x4_convert_i32x4(exponent);
+            let f = f32x4_sub(mantissa, one);
+            let mut p = f32x4_splat(POLY[0]);
+            for c in &POLY[1..] {
+                let c = f32x4_splat(*c);
+                p = madd_f32x4!(c, p, f);
+            }
+            let f2 = f32x4_mul(f, f);
+            let mut y = f32x4_mul(f32x4_mul(p, f2), f);
+            y = madd_f32x4!(y, e, f32x4_splat(LN2_LO));
+            y = f32x4_add(madd_f32x4!(y, f32x4_splat(-0.5), f2), f);
+            y = madd_f32x4!(y, e, f32x4_splat(LN2_HI));
+            // A NaN compares false whichever way round, so `not greater than zero` is what
+            // gathers the negatives, the zeros and the NaNs in one mask.
+            let outside = v128_not(f32x4_gt(x, zero));
+            let special = v128_bitselect(
+                f32x4_splat(f32::NEG_INFINITY),
+                f32x4_splat(f32::NAN),
+                f32x4_eq(x, zero),
+            );
+            y = v128_bitselect(special, y, outside);
+            v128_bitselect(f32x4_splat(f32::INFINITY), y, f32x4_eq(x, f32x4_splat(f32::INFINITY)))
+        }
+        unsafe {
+            let mut p = buf.as_mut_ptr();
+            let end = p.add(buf.len());
+            while p < end {
+                v128_store(p as *mut v128, ln4(v128_load(p as *const v128)));
+                p = p.add(4);
+            }
+        }
+    },
+    func(Ln)
+);

--- a/linalg/src/wasm/mod.rs
+++ b/linalg/src/wasm/mod.rs
@@ -18,6 +18,8 @@ mod act;
 mod act_f32;
 #[cfg(all(test, target_arch = "wasm32", target_feature = "simd128"))]
 mod dispatch_tests;
+mod exp;
+mod ln;
 mod mmm_f32_gemm;
 mod mmm_f32_gemv;
 mod mmm_i32;
@@ -25,6 +27,8 @@ mod reduce;
 
 pub use act::*;
 pub use act_f32::*;
+pub use exp::*;
+pub use ln::*;
 pub use mmm_f32_gemm::*;
 pub use mmm_f32_gemv::*;
 pub use mmm_i32::*;


### PR DESCRIPTION
…ic scalar, whose mul_add lowers to a libm fmaf call per element on wasm32. Add simd128 kernels running the shared generic reduction and fit four lanes at a time, through the madd_f32x4! macro so a relaxed-simd build fuses them, and bench them against the scalar.