### PR TITLE
test-llm.sh only understood cpu, cuda and metal, so the gpu token the…

### DIFF
--- a/.github/workflows/large_models.yml
+++ b/.github/workflows/large_models.yml
@@ -143,14 +143,7 @@ jobs:
       run: |
         chmod +x "tract-cli-${UNAME}/tract"
         export TRACT_RUN="$GITHUB_WORKSPACE/tract-cli-${UNAME}/tract"
-        if [ "$RT_MATRIX" = "gpu" ]
-        then
-          case $(uname) in
-            Darwin) RT=metal;;
-            Linux) RT=cuda;;
-          esac
-        fi
-        .travis/test-llm.sh "$MODEL" "$Q" "$RT"
+        .travis/test-llm.sh "$MODEL" "$Q" "$RT_MATRIX"
 
   parakeet-tdt-600m-v3:
     name: ${{matrix.os}} / Parakeet TDT 600m v3

--- a/.travis/test-llm.sh
+++ b/.travis/test-llm.sh
@@ -15,6 +15,16 @@ if [ -z "$device" ]
 then
     device=cpu
 fi
+# "gpu" is the platform-agnostic token used by the CI matrix: resolve it to the
+# actual accelerator available here.
+if [ "$device" = "gpu" ]
+then
+    case $(uname) in
+        Darwin) device=metal;;
+        Linux) device=cuda;;
+        *) echo "No known GPU runtime for $(uname)"; exit 1;;
+    esac
+fi
 generation=541
 manifest=$ROOT/.travis/llm-models.tsv
 


### PR DESCRIPTION
… CI matrix uses fell through to the cpu branch: a manual run passing gpu silently tested the CPU and recorded the result under an x86_64.gpu key. Resolve gpu to cuda or metal in the script itself, and let the workflow pass the matrix value straight through instead of mapping it inline, which also drops a branch that left RT unset on the cpu leg.