### PR TITLE
cli: glibc adapts its mmap threshold at run time, so a plan whose per…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,6 +4765,7 @@ dependencies = [
  "idna_adapter",
  "inventory",
  "lazy_static",
+ "libc",
  "litemap",
  "log",
  "minijinja",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -97,6 +97,9 @@ tract-cuda = { workspace = true, optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix = { version = "1", features = ["fs"] }
 
+[target.'cfg(all(target_os = "linux", target_env = "gnu"))'.dependencies]
+libc.workspace = true
+
 [features]
 default = [
   "onnx",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -97,8 +97,27 @@ pub const STAGES: &[&str] = &[
     "optimize",
 ];
 
+/// Pins glibc's mmap and trim thresholds.
+///
+/// Left to itself glibc adapts the mmap threshold at run time, and a plan whose
+/// per-eval intermediates straddle the current value maps and unmaps them on
+/// every pass. Whether a process settles above or below that line depends on
+/// how its heap happens to start, so the same binary can run either way.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+fn pin_malloc_thresholds() {
+    const PIN: libc::c_int = 64 * 1024 * 1024;
+    unsafe {
+        libc::mallopt(libc::M_MMAP_THRESHOLD, PIN);
+        libc::mallopt(libc::M_TRIM_THRESHOLD, PIN);
+    }
+}
+
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+fn pin_malloc_thresholds() {}
+
 /// Entrypoint for the command-line interface.
 fn main() -> TractResult<()> {
+    pin_malloc_thresholds();
     use clap::*;
     let mut app = command!()
         .arg(arg!(--readings "Start readings instrumentation"))


### PR DESCRIPTION
…-eval intermediates straddle the current value maps and unmaps them on every pass, and which side of the line a process lands on depends on how its heap happened to start -- the same binary runs either way, one mode paying millions of minor faults. Pin the mmap and trim thresholds at startup so the adaptation is off and the CLI cannot fall into that regime.