### PR TITLE
Add input validation to packing functions

### DIFF
--- a/linalg/src/frame/pack.rs
+++ b/linalg/src/frame/pack.rs
@@ -203,6 +203,7 @@ impl PackedFormat {
         k_axis: usize,
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
+        ensure!(k_axis != mn_axis, "k_axis and mn_axis must differ (both are {k_axis})");
         ensure!(
             t.datum_type().unquantized() == self.dt.unquantized(),
             "Attempting to pack for {self} tensor view {t:?}"
@@ -598,6 +599,12 @@ where
         mn: usize,
         k: usize,
     ) -> KInWriter<'p, T> {
+        assert!(panel_width > 0, "panel_width must be non-zero");
+        assert!(panel_len > 0 || (k == 0 && mn == 0), "panel_len must be non-zero when k or mn is non-zero");
+        assert!(
+            k.checked_mul(panel_width).is_some(),
+            "k * panel_width overflows"
+        );
         let panels = mn.divceil(panel_width);
         let last_panel_width = mn - (panels - 1) * panel_width;
         KInWriter {
@@ -1106,6 +1113,7 @@ impl PackedI8K4 {
         k_axis: usize,
         mn_axis: usize,
     ) -> TractResult<Box<dyn MMMInputValue>> {
+        ensure!(k_axis != mn_axis, "k_axis and mn_axis must differ (both are {k_axis})");
         let k = t.shape()[k_axis];
         let mn = t.shape()[mn_axis];
         let kp = k.div_ceil(4) * 4;

--- a/linalg/src/frame/pack.rs
+++ b/linalg/src/frame/pack.rs
@@ -600,11 +600,11 @@ where
         k: usize,
     ) -> KInWriter<'p, T> {
         assert!(panel_width > 0, "panel_width must be non-zero");
-        assert!(panel_len > 0 || (k == 0 && mn == 0), "panel_len must be non-zero when k or mn is non-zero");
         assert!(
-            k.checked_mul(panel_width).is_some(),
-            "k * panel_width overflows"
+            panel_len > 0 || (k == 0 && mn == 0),
+            "panel_len must be non-zero when k or mn is non-zero"
         );
+        assert!(k.checked_mul(panel_width).is_some(), "k * panel_width overflows");
         let panels = mn.divceil(panel_width);
         let last_panel_width = mn - (panels - 1) * panel_width;
         KInWriter {


### PR DESCRIPTION
- PackedFormat::pack_tensor_view: ensure k_axis != mn_axis
- PackedI8K4::pack_view: ensure k_axis != mn_axis
- KInWriter::new: assert panel_len > 0, panel_width > 0, no overflow

Fixes #2784