### PR TITLE
cross-platform.yml pinned dtolnay/rust-toolchain to a commit off the …

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -70,7 +70,7 @@ jobs:
         ref: ${{ needs.prepare.outputs.test_ref }}
         fetch-depth: 0
         persist-credentials: false
-    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: stable
     - name: Check tract-linalg

--- a/.github/workflows/pydoc.yml
+++ b/.github/workflows/pydoc.yml
@@ -25,7 +25,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable # zizmor: ignore[unpinned-uses]
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
…action's

force-pushed stable branch, which is now unreachable from any ref and trips zizmor's impostor-commit audit. Pin both call sites to the v1 tag commit with an explicit toolchain: stable input, which still resolves the current stable at run time.