### PR TITLE
cli: --override-fact only set the outlet fact, which a TypedSource si…

### DIFF
--- a/cli/src/params.rs
+++ b/cli/src/params.rs
@@ -8,7 +8,9 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use tract_core::internal::*;
 use tract_core::model::TypedModel;
+use tract_core::model::translator::Translate;
 use tract_core::ops::konst::Const;
+use tract_core::ops::source::TypedSource;
 #[allow(unused_imports)]
 use tract_core::transform::ModelTransform;
 use tract_hir::internal::*;
@@ -898,12 +900,25 @@ impl Parameters {
         if let Some(override_facts) = matches.get_many::<String>("override-fact") {
             for fact in override_facts {
                 let fact = fact.as_str();
-                let (name, fact) = tensor::for_string(&symbols, fact)?;
-                let node = raw_model.node_id_by_name(name.as_ref().unwrap())?;
+                // The symbols of the fact are the model's own, not the ones the
+                // command line built: a symbol of another scope names nothing
+                // here.
                 if let Some(inf) = raw_model.downcast_mut::<InferenceModel>() {
+                    let (name, fact) = tensor::for_string(&inf.symbols.clone(), fact)?;
+                    let node = inf.node_id_by_name(name.as_ref().unwrap())?;
                     inf.set_outlet_fact(OutletId::new(node, 0), fact)?;
                 } else if let Some(typ) = raw_model.downcast_mut::<TypedModel>() {
-                    typ.set_outlet_fact(OutletId::new(node, 0), (&fact).try_into()?)?;
+                    let (name, fact) = tensor::for_string(&typ.symbols.clone(), fact)?;
+                    let node = typ.node_id_by_name(name.as_ref().unwrap())?;
+                    let source = typ.node(node);
+                    ensure!(
+                        source.op_as::<TypedSource>().is_some(),
+                        "--override-fact overrides the fact of a source, and {} is a {}",
+                        source.name,
+                        source.op().name()
+                    );
+                    *typ = OverrideSourceFact { node, fact: (&fact).try_into()? }
+                        .translate_model(typ)?;
                 }
             }
         };
@@ -1252,4 +1267,33 @@ pub(crate) fn http_client() -> TractResult<reqwest::blocking::Client> {
             .with_no_client_auth();
 
     Ok(reqwest::blocking::Client::builder().use_preconfigured_tls(config).build()?)
+}
+
+/// Rewire a typed model from one of its sources holding `fact`.
+///
+/// A `TypedSource` carries its fact in the op, so overriding the outlet fact
+/// alone is undone by the next `output_facts` call. Rewiring re-derives every
+/// downstream fact from the new one, and fails on an op which cannot take it.
+#[derive(Debug)]
+struct OverrideSourceFact {
+    node: usize,
+    fact: TypedFact,
+}
+
+impl Translate<TypedFact, Box<dyn TypedOp>, TypedFact, Box<dyn TypedOp>> for OverrideSourceFact {
+    fn translate_node(
+        &self,
+        _source: &TypedModel,
+        node: &TypedNode,
+        target: &mut TypedModel,
+        mapping: &HashMap<OutletId, OutletId>,
+    ) -> TractResult<TVec<OutletId>> {
+        let op: Box<dyn TypedOp> = if node.id == self.node {
+            Box::new(TypedSource::new(self.fact.clone()))
+        } else {
+            node.op.clone()
+        };
+        let inputs: TVec<OutletId> = node.inputs.iter().map(|i| mapping[i]).collect();
+        target.wire_node(&node.name, op, &inputs)
+    }
 }

--- a/harness/nnef-test-cases/override-source-fact/graph.nnef
+++ b/harness/nnef-test-cases/override-source-fact/graph.nnef
@@ -1,0 +1,7 @@
+version 1.0;
+
+graph scaled_bias(bias) -> (output)
+{
+    bias = external<scalar>(shape = [1, 1]);
+    output = mul(bias, 2.0);
+}

--- a/harness/nnef-test-cases/override-source-fact/runme.sh
+++ b/harness/nnef-test-cases/override-source-fact/runme.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+cd `dirname $0`
+set -ex
+
+: ${TRACT_RUN:=cargo run -p tract-cli $CARGO_OPTS --}
+
+# The export pins the input to one row.
+$TRACT_RUN . dump -q --assert-output-fact 1,1,f32
+
+# --override-fact widens it, and the new fact reaches the ops downstream: a
+# source carries its fact in the op, so overriding the outlet fact alone would
+# leave the graph as it was.
+$TRACT_RUN . --override-fact 'bias:B,1,f32' dump -q --assert-output-fact B,1,f32
+
+# And the widened model runs.
+$TRACT_RUN . --override-fact 'bias:B,1,f32' --set B=3 run -q -R \
+    --assert-output-fact 3,1,f32
+
+# Only a source's fact can be overridden: every other op derives its own, so
+# the override is refused rather than ignored.
+if $TRACT_RUN . --override-fact 'output:B,1,f32' dump -q > /dev/null 2>&1
+then
+    echo "overriding the fact of a computed node should have failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
…lently puts back from the fact it holds in the op, so overriding an input of an nnef model reported success and changed nothing. Rewire the model from the new fact instead, which also re-derives the facts downstream and fails on an op which cannot take it, refuse a node which is not a source, and read the fact in the model's own symbol scope rather than the command line's.