### PR TITLE
fix(data): check tensor shape arithmetic before allocating (CWE-770, CWE-190)

### DIFF
--- a/data/src/tensor.rs
+++ b/data/src/tensor.rs
@@ -317,7 +317,15 @@ impl Tensor {
         shape: &[usize],
         alignment: usize,
     ) -> TractResult<Tensor> {
-        let bytes = shape.iter().cloned().product::<usize>() * dt.size_of();
+        // `shape` and `dt` come from the model file. Computing the byte count
+        // with a plain product used to wrap around on overflow, silently
+        // allocating a buffer much smaller than the tensor claims (or asking
+        // the allocator for an absurd one). Check instead.
+        let bytes = shape
+            .iter()
+            .try_fold(dt.size_of(), |acc, &d| acc.checked_mul(d))
+            .filter(|&b| b <= isize::MAX as usize)
+            .ok_or_else(|| format_err!("tensor shape {shape:?} of {dt:?} is too large"))?;
         let storage = StorageKind::Plain(PlainStorage::from(unsafe {
             Blob::new_for_size_and_align(bytes, alignment)
         }));
@@ -591,8 +599,17 @@ impl Tensor {
         content: &[u8],
         align: usize,
     ) -> TractResult<Tensor> {
-        let mut tensor = unsafe { Tensor::uninitialized_aligned_dt(dt, shape, align) }?;
-        let expected = tensor.as_bytes().len();
+        // Check the declared shape against the payload *before* allocating.
+        // The shape is attacker-controlled, so allocating first lets a
+        // malformed model request an allocation of any size it likes, even
+        // when the payload that follows is a few bytes long.
+        let len = shape
+            .iter()
+            .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+            .ok_or_else(|| format_err!("tensor shape {shape:?} overflows"))?;
+        let expected = len
+            .checked_mul(dt.size_of())
+            .ok_or_else(|| format_err!("tensor shape {shape:?} of {dt:?} is too large"))?;
         ensure!(
             content.len() == expected,
             "Raw tensor data length ({}) does not match shape {:?} of {:?} ({} bytes)",
@@ -601,6 +618,7 @@ impl Tensor {
             dt,
             expected
         );
+        let mut tensor = unsafe { Tensor::uninitialized_aligned_dt(dt, shape, align) }?;
         tensor.as_bytes_mut().copy_from_slice(content);
         Ok(tensor)
     }


### PR DESCRIPTION
I found an integer overflow in how a `Tensor` size gets computed.

The shape comes from the model file. `uninitialized_aligned_dt` turns it into a byte count with a plain product:

```rust
let bytes = shape.iter().cloned().product::<usize>() * dt.size_of();
```

That wraps around in release builds. Two things can happen.

1. It wraps to a huge number. `from_raw_dt_align` allocates first and checks the payload length afterwards, so a 4-byte payload can make tract ask the allocator for 16 EiB.
2. It wraps to a small number. Now the length check passes, and the tensor claims many more elements than it actually owns.

Measured on 0.23.6 with a counting allocator:

| dims in the file | payload | before | after |
|---|---|---|---|
| `[2]` (valid) | 8 B | 8 B allocated | 8 B allocated |
| `[-1]` | 4 B | 18,446,744,073,709,551,612 B requested (16 EiB) | rejected |
| `[4611686018427387906]` | 8 B | accepted, `len()` = 4,611,686,018,427,387,906, backed by 8 real bytes | rejected |

The last row is the one I worry about. `as_slice_unchecked()` then hands out a slice of 4.6e18 `f32` over an 8-byte buffer, so any index is out of bounds.

`dims = [-1]` is what ONNX writes for a dynamic dimension, so it is easy to put in a file.

The fix, in `data/src/tensor.rs`:

- `uninitialized_aligned_dt` computes the byte count with `checked_mul`, and rejects anything above `isize::MAX` (`Blob` hands the size to `Layout::from_size_align_unchecked`, which needs it).
- `from_raw_dt_align` checks the declared shape against the payload before allocating, not after.

Valid models are untouched. The first row above is unchanged.

The three loaders still cast dims straight to `usize` without a sign check — `onnx/src/tensor.rs:163`, `tflite/src/tensors.rs:116`, `tensorflow/src/tensor.rs:87`. I left them alone to keep this small. Want me to add those checks as well?
