### PR TITLE
RFC: a WebGPU backend (tract-wgpu)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +205,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -382,6 +400,15 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec 0.9.1",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d87354e4229f54a44f7bf2435906a4656dba36026ab6eaca629a2c436a691c"
@@ -394,6 +421,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit-vec"
@@ -515,6 +548,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder"
@@ -608,9 +655,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -700,6 +747,17 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "color_quant"
@@ -1187,6 +1245,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,10 +1727,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows",
+]
 
 [[package]]
 name = "half"
@@ -1688,6 +1810,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -2170,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
@@ -2198,6 +2323,23 @@ dependencies = [
  "ndarray-npy",
  "tract",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -2297,6 +2439,12 @@ name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2504,6 +2652,44 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bitflags 2.13.0",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "libm",
+ "log",
+ "naga-types",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2868,6 +3054,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,6 +3082,43 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2955,6 +3190,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "page_size"
@@ -3116,6 +3360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3403,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -3434,6 +3690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,6 +3743,24 @@ dependencies = [
  "rav1e",
  "rayon",
  "rgb",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -3581,6 +3861,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -4021,6 +4307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4329,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4243,6 +4547,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -5198,6 +5511,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tract-wgpu"
+version = "0.23.8-pre"
+dependencies = [
+ "anyhow",
+ "derive-new",
+ "downcast-rs",
+ "inventory",
+ "js-sys",
+ "log",
+ "num-traits",
+ "pollster",
+ "proptest",
+ "rand 0.10.2",
+ "tract-core",
+ "tract-gpu",
+ "tract-pulse-opl",
+ "tract-transformers",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu",
+]
+
+[[package]]
 name = "transpose"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5380,9 +5717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -5393,9 +5730,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5403,9 +5740,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5413,22 +5750,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -5443,10 +5780,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.102"
+name = "wayland-sys"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5485,6 +5834,179 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "naga",
+ "naga-types",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f3d319a40d39d00b1ecc2c33b89fe21d4e6fe01859df3500a3a8ecccd6b68"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98b86cf4abf524a902dd35f18ca6a3f08fc2ae9847c8f10b48e30491b1f0b86"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.10.0",
+ "bitflags 2.13.0",
+ "block2",
+ "bytemuck",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "hashbrown 0.17.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "naga-types",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "naga-types",
+ "raw-window-handle",
+ "static_assertions",
+ "web-sys",
+]
 
 [[package]]
 name = "which"
@@ -5766,6 +6288,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "cli",
     "gpu",
     "metal",
+    "wgpu",
     "extra",
     "transformers",
     "cuda",
@@ -221,6 +222,8 @@ toml = "1.1"
 unicode-normalization = "0.1.19"
 walkdir = "2.3.2"
 zerofrom = "0.1.5"
+wgpu = { version = "30.0.1", features = ["fragile-send-sync-non-atomic-wasm"] }
+pollster = "0.4"
 tract-api = { version = "0.23.8-pre", path = 'api' }
 tract-core = { version = "0.23.8-pre", path = 'core' }
 tract-cuda = { version = "0.23.8-pre", path = 'cuda', default-features = false }
@@ -231,6 +234,7 @@ tract-hir = { version = "0.23.8-pre", path = 'hir' }
 tract-libcli = { version = "0.23.8-pre", path = 'libcli' }
 tract-linalg = { version = "0.23.8-pre", path = 'linalg' }
 tract-metal = { version = "0.23.8-pre", path = 'metal' }
+tract-wgpu = { version = "0.23.8-pre", path = 'wgpu' }
 tract-nnef-resources = { version = "0.23.8-pre", path = 'nnef/nnef-resources' }
 tract-nnef = { version = "0.23.8-pre", path = 'nnef' }
 tract-onnx-opl = { version = "0.23.8-pre", path = 'onnx-opl' }

--- a/examples/tract-wgpu-web/pkg/tract_wgpu_web.d.ts
+++ b/examples/tract-wgpu-web/pkg/tract_wgpu_web.d.ts
@@ -1,0 +1,106 @@
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * RGBA8 packed pixels → NCHW f32 `[1, 3, H, W]` (alpha dropped), then readback.
+ */
+export function ingest_rgba8(width: number, height: number, rgba: Uint8Array): Promise<Float32Array>;
+
+export function run_hybrid_logsoftmax(_input: Float32Array): Float32Array;
+
+/**
+ * Mul-by-2 then sigmoid on a length-8 f32 vector, shape `[2, 4]`.
+ */
+export function run_two_op(input: Float32Array): Promise<Float32Array>;
+
+/**
+ * Runs the model on one RGBA frame and writes the mask into the texture above.
+ * Nothing is read back: the mask stays on the GPU for the compositor.
+ */
+export function segment_into_texture(width: number, height: number, rgba: Uint8Array): number;
+
+/**
+ * The `GPUDevice` the model runs on. A compositor built against this device
+ * can sample the mask where the model leaves it.
+ */
+export function segmentation_device(): any;
+
+/**
+ * The `GPUTexture` the mask is written into, created on first use.
+ */
+export function segmentation_mask_texture(): any;
+
+/**
+ * Whole selfie-segmentation model on the GPU: `iters` frames, each ending in
+ * the one readback the covered graph allows. Returns a one-line report.
+ */
+export function selfie_seg_bench(iters: number): Promise<string>;
+
+/**
+ * The comparator the GPU path has to beat: the same model on tract's CPU
+ * kernels, single-threaded, in the same browser.
+ */
+export function selfie_seg_bench_cpu(iters: number): Promise<string>;
+
+/**
+ * Splits a frame into the phases that make up its cost: recording the graph's
+ * dispatches, submitting them, and the readback's map and copy.
+ */
+export function selfie_seg_phases(iters: number): Promise<string>;
+
+/**
+ * `requestAdapter` / `requestDevice`. Call once before anything else.
+ */
+export function start(): Promise<void>;
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InitOutput {
+    readonly memory: WebAssembly.Memory;
+    readonly ingest_rgba8: (a: number, b: number, c: number, d: number) => any;
+    readonly run_hybrid_logsoftmax: (a: number, b: number) => [number, number, number, number];
+    readonly run_two_op: (a: number, b: number) => any;
+    readonly segment_into_texture: (a: number, b: number, c: number, d: number) => [number, number, number];
+    readonly segmentation_device: () => [number, number, number];
+    readonly segmentation_mask_texture: () => [number, number, number];
+    readonly selfie_seg_bench: (a: number) => any;
+    readonly selfie_seg_bench_cpu: (a: number) => any;
+    readonly selfie_seg_phases: (a: number) => any;
+    readonly start: () => any;
+    readonly wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined_______true_: (a: number, b: number, c: any, d: any) => void;
+    readonly wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___JsValue__core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_: (a: number, b: number, c: any) => [number, number];
+    readonly wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_: (a: number, b: number, c: any) => [number, number];
+    readonly wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__13: (a: number, b: number, c: any) => [number, number];
+    readonly wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__14: (a: number, b: number, c: any) => [number, number];
+    readonly __wbindgen_malloc_command_export: (a: number, b: number) => number;
+    readonly __wbindgen_realloc_command_export: (a: number, b: number, c: number, d: number) => number;
+    readonly __wbindgen_exn_store_command_export: (a: number) => void;
+    readonly __externref_table_alloc_command_export: () => number;
+    readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_free_command_export: (a: number, b: number, c: number) => void;
+    readonly __wbindgen_destroy_closure_command_export: (a: number, b: number) => void;
+    readonly __externref_table_dealloc_command_export: (a: number) => void;
+    readonly __wbindgen_start: () => void;
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+
+/**
+ * Instantiates the given `module`, which can either be bytes or
+ * a precompiled `WebAssembly.Module`.
+ *
+ * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+ *
+ * @returns {InitOutput}
+ */
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
+/**
+ * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+ * for everything else, calls `WebAssembly.instantiate` directly.
+ *
+ * @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+ *
+ * @returns {Promise<InitOutput>}
+ */
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/examples/tract-wgpu-web/pkg/tract_wgpu_web.js
+++ b/examples/tract-wgpu-web/pkg/tract_wgpu_web.js
@@ -1,0 +1,1353 @@
+/* @ts-self-types="./tract_wgpu_web.d.ts" */
+
+/**
+ * RGBA8 packed pixels → NCHW f32 `[1, 3, H, W]` (alpha dropped), then readback.
+ * @param {number} width
+ * @param {number} height
+ * @param {Uint8Array} rgba
+ * @returns {Promise<Float32Array>}
+ */
+export function ingest_rgba8(width, height, rgba) {
+    const ptr0 = passArray8ToWasm0(rgba, wasm.__wbindgen_malloc_command_export);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.ingest_rgba8(width, height, ptr0, len0);
+    return ret;
+}
+
+/**
+ * @param {Float32Array} _input
+ * @returns {Float32Array}
+ */
+export function run_hybrid_logsoftmax(_input) {
+    const ptr0 = passArrayF32ToWasm0(_input, wasm.__wbindgen_malloc_command_export);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.run_hybrid_logsoftmax(ptr0, len0);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v2 = getArrayF32FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free_command_export(ret[0], ret[1] * 4, 4);
+    return v2;
+}
+
+/**
+ * Mul-by-2 then sigmoid on a length-8 f32 vector, shape `[2, 4]`.
+ * @param {Float32Array} input
+ * @returns {Promise<Float32Array>}
+ */
+export function run_two_op(input) {
+    const ptr0 = passArrayF32ToWasm0(input, wasm.__wbindgen_malloc_command_export);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.run_two_op(ptr0, len0);
+    return ret;
+}
+
+/**
+ * Runs the model on one RGBA frame and writes the mask into the texture above.
+ * Nothing is read back: the mask stays on the GPU for the compositor.
+ * @param {number} width
+ * @param {number} height
+ * @param {Uint8Array} rgba
+ * @returns {number}
+ */
+export function segment_into_texture(width, height, rgba) {
+    const ptr0 = passArray8ToWasm0(rgba, wasm.__wbindgen_malloc_command_export);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.segment_into_texture(width, height, ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0];
+}
+
+/**
+ * The `GPUDevice` the model runs on. A compositor built against this device
+ * can sample the mask where the model leaves it.
+ * @returns {any}
+ */
+export function segmentation_device() {
+    const ret = wasm.segmentation_device();
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * The `GPUTexture` the mask is written into, created on first use.
+ * @returns {any}
+ */
+export function segmentation_mask_texture() {
+    const ret = wasm.segmentation_mask_texture();
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Whole selfie-segmentation model on the GPU: `iters` frames, each ending in
+ * the one readback the covered graph allows. Returns a one-line report.
+ * @param {number} iters
+ * @returns {Promise<string>}
+ */
+export function selfie_seg_bench(iters) {
+    const ret = wasm.selfie_seg_bench(iters);
+    return ret;
+}
+
+/**
+ * The comparator the GPU path has to beat: the same model on tract's CPU
+ * kernels, single-threaded, in the same browser.
+ * @param {number} iters
+ * @returns {Promise<string>}
+ */
+export function selfie_seg_bench_cpu(iters) {
+    const ret = wasm.selfie_seg_bench_cpu(iters);
+    return ret;
+}
+
+/**
+ * Splits a frame into the phases that make up its cost: recording the graph's
+ * dispatches, submitting them, and the readback's map and copy.
+ * @param {number} iters
+ * @returns {Promise<string>}
+ */
+export function selfie_seg_phases(iters) {
+    const ret = wasm.selfie_seg_phases(iters);
+    return ret;
+}
+
+/**
+ * `requestAdapter` / `requestDevice`. Call once before anything else.
+ * @returns {Promise<void>}
+ */
+export function start() {
+    const ret = wasm.start();
+    return ret;
+}
+function __wbg_get_imports() {
+    const import0 = {
+        __proto__: null,
+        __wbg_Window_a2a6c4d665047b14: function(arg0) {
+            const ret = arg0.Window;
+            return ret;
+        },
+        __wbg_WorkerGlobalScope_2664448a7c667d67: function(arg0) {
+            const ret = arg0.WorkerGlobalScope;
+            return ret;
+        },
+        __wbg___wbindgen_debug_string_0e68cf47c9cbd9b0: function(arg0, arg1) {
+            const ret = debugString(arg1);
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc_command_export, wasm.__wbindgen_realloc_command_export);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg___wbindgen_is_function_fcda5e3902d732fe: function(arg0) {
+            const ret = typeof(arg0) === 'function';
+            return ret;
+        },
+        __wbg___wbindgen_is_null_5160b3e381865372: function(arg0) {
+            const ret = arg0 === null;
+            return ret;
+        },
+        __wbg___wbindgen_is_string_c4f7cb494a2a21f1: function(arg0) {
+            const ret = typeof(arg0) === 'string';
+            return ret;
+        },
+        __wbg___wbindgen_is_undefined_8c687d0b90d5b524: function(arg0) {
+            const ret = arg0 === undefined;
+            return ret;
+        },
+        __wbg___wbindgen_number_get_1dc732b810cb937c: function(arg0, arg1) {
+            const obj = arg1;
+            const ret = typeof(obj) === 'number' ? obj : undefined;
+            getDataViewMemory0().setFloat64(arg0 + 8 * 1, isLikeNone(ret) ? 0 : ret, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, !isLikeNone(ret), true);
+        },
+        __wbg___wbindgen_string_get_92ab86bb19cbc12f: function(arg0, arg1) {
+            const obj = arg1;
+            const ret = typeof(obj) === 'string' ? obj : undefined;
+            var ptr1 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc_command_export, wasm.__wbindgen_realloc_command_export);
+            var len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg___wbindgen_throw_5d9e815e6fdf150f: function(arg0, arg1) {
+            throw new Error(getStringFromWasm0(arg0, arg1));
+        },
+        __wbg__wbg_cb_unref_997e73d32238e655: function(arg0) {
+            arg0._wbg_cb_unref();
+        },
+        __wbg_beginComputePass_b9a325184985e6ff: function(arg0, arg1) {
+            const ret = arg0.beginComputePass(arg1);
+            return ret;
+        },
+        __wbg_call_269c5566fbede3eb: function() { return handleError(function (arg0, arg1) {
+            const ret = arg0.call(arg1);
+            return ret;
+        }, arguments); },
+        __wbg_call_6bcf8d3e20937e46: function() { return handleError(function (arg0, arg1, arg2) {
+            const ret = arg0.call(arg1, arg2);
+            return ret;
+        }, arguments); },
+        __wbg_configure_1e2c1c9edad07d26: function() { return handleError(function (arg0, arg1) {
+            arg0.configure(arg1);
+        }, arguments); },
+        __wbg_copyBufferToBuffer_01766818654a9868: function() { return handleError(function (arg0, arg1, arg2, arg3, arg4) {
+            arg0.copyBufferToBuffer(arg1, arg2, arg3, arg4);
+        }, arguments); },
+        __wbg_copyBufferToBuffer_9c174b96fb08d551: function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5) {
+            arg0.copyBufferToBuffer(arg1, arg2, arg3, arg4, arg5);
+        }, arguments); },
+        __wbg_createBindGroupLayout_b1bd63b4e88459d8: function() { return handleError(function (arg0, arg1) {
+            const ret = arg0.createBindGroupLayout(arg1);
+            return ret;
+        }, arguments); },
+        __wbg_createBindGroup_f539b26ca341308f: function(arg0, arg1) {
+            const ret = arg0.createBindGroup(arg1);
+            return ret;
+        },
+        __wbg_createBuffer_d800e9b1d41b2ee5: function() { return handleError(function (arg0, arg1) {
+            const ret = arg0.createBuffer(arg1);
+            return ret;
+        }, arguments); },
+        __wbg_createCommandEncoder_3352d1ffc36c6fc0: function(arg0, arg1) {
+            const ret = arg0.createCommandEncoder(arg1);
+            return ret;
+        },
+        __wbg_createComputePipeline_224fa2618d9948a0: function(arg0, arg1) {
+            const ret = arg0.createComputePipeline(arg1);
+            return ret;
+        },
+        __wbg_createPipelineLayout_6eab52c327118937: function(arg0, arg1) {
+            const ret = arg0.createPipelineLayout(arg1);
+            return ret;
+        },
+        __wbg_createShaderModule_cefa51336cb288ae: function(arg0, arg1) {
+            const ret = arg0.createShaderModule(arg1);
+            return ret;
+        },
+        __wbg_createTexture_ed7e9fc04dd54d84: function() { return handleError(function (arg0, arg1) {
+            const ret = arg0.createTexture(arg1);
+            return ret;
+        }, arguments); },
+        __wbg_createView_da41c2d2cb212715: function() { return handleError(function (arg0, arg1) {
+            const ret = arg0.createView(arg1);
+            return ret;
+        }, arguments); },
+        __wbg_description_83b8a393160021b9: function(arg0, arg1) {
+            const ret = arg1.description;
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc_command_export, wasm.__wbindgen_realloc_command_export);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg_dispatchWorkgroups_56b943172790add0: function(arg0, arg1, arg2, arg3) {
+            arg0.dispatchWorkgroups(arg1 >>> 0, arg2 >>> 0, arg3 >>> 0);
+        },
+        __wbg_end_82fd0c12ba185009: function(arg0) {
+            arg0.end();
+        },
+        __wbg_error_757e9472f8410341: function(arg0, arg1) {
+            let deferred0_0;
+            let deferred0_1;
+            try {
+                deferred0_0 = arg0;
+                deferred0_1 = arg1;
+                console.error(getStringFromWasm0(arg0, arg1));
+            } finally {
+                wasm.__wbindgen_free_command_export(deferred0_0, deferred0_1, 1);
+            }
+        },
+        __wbg_features_dec7bd2fd3d91bd6: function(arg0) {
+            const ret = arg0.features;
+            return ret;
+        },
+        __wbg_finish_09ec094c10f41e7b: function(arg0) {
+            const ret = arg0.finish();
+            return ret;
+        },
+        __wbg_finish_ec1c191f66a895b1: function(arg0, arg1) {
+            const ret = arg0.finish(arg1);
+            return ret;
+        },
+        __wbg_getContext_5ff6bd600503b094: function() { return handleError(function (arg0, arg1, arg2) {
+            const ret = arg0.getContext(getStringFromWasm0(arg1, arg2));
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        }, arguments); },
+        __wbg_getMappedRange_fb54c6327b2d8d20: function() { return handleError(function (arg0, arg1, arg2) {
+            const ret = arg0.getMappedRange(arg1, arg2);
+            return ret;
+        }, arguments); },
+        __wbg_getRandomValues_436a51d0629d84e1: function() { return handleError(function (arg0, arg1) {
+            globalThis.crypto.getRandomValues(getArrayU8FromWasm0(arg0, arg1));
+        }, arguments); },
+        __wbg_get_989d0a1309644f2b: function() { return handleError(function (arg0, arg1) {
+            const ret = Reflect.get(arg0, arg1);
+            return ret;
+        }, arguments); },
+        __wbg_gpu_afdd4387c7afe5f9: function(arg0) {
+            const ret = arg0.gpu;
+            return ret;
+        },
+        __wbg_has_eafa12e457ea88fb: function(arg0, arg1, arg2) {
+            const ret = arg0.has(getStringFromWasm0(arg1, arg2));
+            return ret;
+        },
+        __wbg_info_971d8b9db3dae69f: function(arg0) {
+            const ret = arg0.info;
+            return ret;
+        },
+        __wbg_isFallbackAdapter_4c8cc3b18677460a: function(arg0) {
+            const ret = arg0.isFallbackAdapter;
+            return ret;
+        },
+        __wbg_label_7add8cb37a6ef98f: function(arg0, arg1) {
+            const ret = arg1.label;
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc_command_export, wasm.__wbindgen_realloc_command_export);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg_length_31bdaf014f5fbde2: function(arg0) {
+            const ret = arg0.length;
+            return ret;
+        },
+        __wbg_limits_601ad2e086ef8141: function(arg0) {
+            const ret = arg0.limits;
+            return ret;
+        },
+        __wbg_mapAsync_b0597127f5037286: function(arg0, arg1, arg2, arg3) {
+            const ret = arg0.mapAsync(arg1 >>> 0, arg2, arg3);
+            return ret;
+        },
+        __wbg_maxBindGroupsPlusVertexBuffers_52369f089736ef9d: function(arg0) {
+            const ret = arg0.maxBindGroupsPlusVertexBuffers;
+            return ret;
+        },
+        __wbg_maxBindGroups_4e424afe6ce86ca2: function(arg0) {
+            const ret = arg0.maxBindGroups;
+            return ret;
+        },
+        __wbg_maxBindingsPerBindGroup_7d035da36821c44f: function(arg0) {
+            const ret = arg0.maxBindingsPerBindGroup;
+            return ret;
+        },
+        __wbg_maxBufferSize_423f4a084e32a195: function(arg0) {
+            const ret = arg0.maxBufferSize;
+            return ret;
+        },
+        __wbg_maxColorAttachmentBytesPerSample_c4cd9126f6d287c6: function(arg0) {
+            const ret = arg0.maxColorAttachmentBytesPerSample;
+            return ret;
+        },
+        __wbg_maxColorAttachments_d924670762b9e250: function(arg0) {
+            const ret = arg0.maxColorAttachments;
+            return ret;
+        },
+        __wbg_maxComputeInvocationsPerWorkgroup_707a3868f7cebb59: function(arg0) {
+            const ret = arg0.maxComputeInvocationsPerWorkgroup;
+            return ret;
+        },
+        __wbg_maxComputeWorkgroupSizeX_0a4d99463cbd6e5e: function(arg0) {
+            const ret = arg0.maxComputeWorkgroupSizeX;
+            return ret;
+        },
+        __wbg_maxComputeWorkgroupSizeY_85123ea0587f7558: function(arg0) {
+            const ret = arg0.maxComputeWorkgroupSizeY;
+            return ret;
+        },
+        __wbg_maxComputeWorkgroupSizeZ_a3186b4c5267d44f: function(arg0) {
+            const ret = arg0.maxComputeWorkgroupSizeZ;
+            return ret;
+        },
+        __wbg_maxComputeWorkgroupStorageSize_57b297355cfb6204: function(arg0) {
+            const ret = arg0.maxComputeWorkgroupStorageSize;
+            return ret;
+        },
+        __wbg_maxComputeWorkgroupsPerDimension_4158f95e673d54c4: function(arg0) {
+            const ret = arg0.maxComputeWorkgroupsPerDimension;
+            return ret;
+        },
+        __wbg_maxDynamicStorageBuffersPerPipelineLayout_226b0b70910aa16c: function(arg0) {
+            const ret = arg0.maxDynamicStorageBuffersPerPipelineLayout;
+            return ret;
+        },
+        __wbg_maxDynamicUniformBuffersPerPipelineLayout_0e835fda711fc7e6: function(arg0) {
+            const ret = arg0.maxDynamicUniformBuffersPerPipelineLayout;
+            return ret;
+        },
+        __wbg_maxInterStageShaderVariables_8c4a1d727e2aa35a: function(arg0) {
+            const ret = arg0.maxInterStageShaderVariables;
+            return ret;
+        },
+        __wbg_maxSampledTexturesPerShaderStage_6675f5e91d9a728a: function(arg0) {
+            const ret = arg0.maxSampledTexturesPerShaderStage;
+            return ret;
+        },
+        __wbg_maxSamplersPerShaderStage_1910fa38a6ed1e1f: function(arg0) {
+            const ret = arg0.maxSamplersPerShaderStage;
+            return ret;
+        },
+        __wbg_maxStorageBufferBindingSize_2e244bded070b18d: function(arg0) {
+            const ret = arg0.maxStorageBufferBindingSize;
+            return ret;
+        },
+        __wbg_maxStorageBuffersPerShaderStage_a285f3ebca51ca0d: function(arg0) {
+            const ret = arg0.maxStorageBuffersPerShaderStage;
+            return ret;
+        },
+        __wbg_maxStorageTexturesPerShaderStage_7aa946f0fc322a2b: function(arg0) {
+            const ret = arg0.maxStorageTexturesPerShaderStage;
+            return ret;
+        },
+        __wbg_maxTextureArrayLayers_0e699147ad00502d: function(arg0) {
+            const ret = arg0.maxTextureArrayLayers;
+            return ret;
+        },
+        __wbg_maxTextureDimension1D_aabf6add54decfe2: function(arg0) {
+            const ret = arg0.maxTextureDimension1D;
+            return ret;
+        },
+        __wbg_maxTextureDimension2D_dd598b27e9c0c1c4: function(arg0) {
+            const ret = arg0.maxTextureDimension2D;
+            return ret;
+        },
+        __wbg_maxTextureDimension3D_f944266c65dfd1a9: function(arg0) {
+            const ret = arg0.maxTextureDimension3D;
+            return ret;
+        },
+        __wbg_maxUniformBufferBindingSize_59fa6be7cfbeeb53: function(arg0) {
+            const ret = arg0.maxUniformBufferBindingSize;
+            return ret;
+        },
+        __wbg_maxUniformBuffersPerShaderStage_bee5f00a4d706c7f: function(arg0) {
+            const ret = arg0.maxUniformBuffersPerShaderStage;
+            return ret;
+        },
+        __wbg_maxVertexAttributes_5cf6392c4e9033fe: function(arg0) {
+            const ret = arg0.maxVertexAttributes;
+            return ret;
+        },
+        __wbg_maxVertexBufferArrayStride_548baa887375d865: function(arg0) {
+            const ret = arg0.maxVertexBufferArrayStride;
+            return ret;
+        },
+        __wbg_maxVertexBuffers_75d881156591f5da: function(arg0) {
+            const ret = arg0.maxVertexBuffers;
+            return ret;
+        },
+        __wbg_minStorageBufferOffsetAlignment_5ba9b77792bdadb3: function(arg0) {
+            const ret = arg0.minStorageBufferOffsetAlignment;
+            return ret;
+        },
+        __wbg_minUniformBufferOffsetAlignment_ab7d52a5293b22bd: function(arg0) {
+            const ret = arg0.minUniformBufferOffsetAlignment;
+            return ret;
+        },
+        __wbg_navigator_d217ca64c4bbff48: function(arg0) {
+            const ret = arg0.navigator;
+            return ret;
+        },
+        __wbg_navigator_d25c0f071226f233: function(arg0) {
+            const ret = arg0.navigator;
+            return ret;
+        },
+        __wbg_new_12e5d807044fbfe3: function() { return handleError(function (arg0, arg1) {
+            const ret = new OffscreenCanvas(arg0 >>> 0, arg1 >>> 0);
+            return ret;
+        }, arguments); },
+        __wbg_new_227d7c05414eb861: function() {
+            const ret = new Error();
+            return ret;
+        },
+        __wbg_new_8f72ed7c652bf5a2: function(arg0, arg1) {
+            try {
+                var state0 = {a: arg0, b: arg1};
+                var cb0 = (arg0, arg1) => {
+                    const a = state0.a;
+                    state0.a = 0;
+                    try {
+                        return wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined_______true_(a, state0.b, arg0, arg1);
+                    } finally {
+                        state0.a = a;
+                    }
+                };
+                const ret = new Promise(cb0);
+                return ret;
+            } finally {
+                state0.a = 0;
+            }
+        },
+        __wbg_new_bebc3f4757acf305: function() {
+            const ret = new Object();
+            return ret;
+        },
+        __wbg_new_typed_6f8b0d724fe26c07: function(arg0, arg1) {
+            try {
+                var state0 = {a: arg0, b: arg1};
+                var cb0 = (arg0, arg1) => {
+                    const a = state0.a;
+                    state0.a = 0;
+                    try {
+                        return wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined_______true_(a, state0.b, arg0, arg1);
+                    } finally {
+                        state0.a = a;
+                    }
+                };
+                const ret = new Promise(cb0);
+                return ret;
+            } finally {
+                state0.a = 0;
+            }
+        },
+        __wbg_new_typed_7d4574ab4b8446c8: function() {
+            const ret = new Object();
+            return ret;
+        },
+        __wbg_new_with_byte_offset_and_length_492c969e8b5da8a4: function(arg0, arg1, arg2) {
+            const ret = new Uint8Array(arg0, arg1 >>> 0, arg2 >>> 0);
+            return ret;
+        },
+        __wbg_onSubmittedWorkDone_1190213cee1ecf7e: function(arg0) {
+            const ret = arg0.onSubmittedWorkDone();
+            return ret;
+        },
+        __wbg_prototypesetcall_ae9f5e7459250748: function(arg0, arg1, arg2) {
+            Uint8Array.prototype.set.call(getArrayU8FromWasm0(arg0, arg1), arg2);
+        },
+        __wbg_queueMicrotask_85c90f6987555d65: function(arg0) {
+            const ret = arg0.queueMicrotask;
+            return ret;
+        },
+        __wbg_queueMicrotask_f6a1fa10b81d1fc0: function(arg0) {
+            queueMicrotask(arg0);
+        },
+        __wbg_queue_7b62c28143d44293: function(arg0) {
+            const ret = arg0.queue;
+            return ret;
+        },
+        __wbg_requestAdapter_a539af006419f2e9: function(arg0, arg1) {
+            const ret = arg0.requestAdapter(arg1);
+            return ret;
+        },
+        __wbg_requestDevice_5cb8a582e55d08cb: function(arg0, arg1) {
+            const ret = arg0.requestDevice(arg1);
+            return ret;
+        },
+        __wbg_resolve_35ec7e0c6af4c82c: function(arg0) {
+            const ret = Promise.resolve(arg0);
+            return ret;
+        },
+        __wbg_setBindGroup_0b7c2a055ef1f314: function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5, arg6) {
+            arg0.setBindGroup(arg1 >>> 0, arg2, getArrayU32FromWasm0(arg3, arg4), arg5, arg6 >>> 0);
+        }, arguments); },
+        __wbg_setBindGroup_c83391351ce68826: function(arg0, arg1, arg2) {
+            arg0.setBindGroup(arg1 >>> 0, arg2);
+        },
+        __wbg_setPipeline_5146f7b8d2b4af5c: function(arg0, arg1) {
+            arg0.setPipeline(arg1);
+        },
+        __wbg_set_9cfc0f17d60ff0af: function(arg0, arg1, arg2) {
+            arg0.set(arg1, arg2 >>> 0);
+        },
+        __wbg_set_a377297433dfea63: function() { return handleError(function (arg0, arg1, arg2) {
+            const ret = Reflect.set(arg0, arg1, arg2);
+            return ret;
+        }, arguments); },
+        __wbg_set_access_a099cfbbeec9b96f: function(arg0, arg1) {
+            arg0.access = __wbindgen_enum_GpuStorageTextureAccess[arg1];
+        },
+        __wbg_set_array_layer_count_22afa0a979e4ad55: function(arg0, arg1) {
+            arg0.arrayLayerCount = arg1 >>> 0;
+        },
+        __wbg_set_aspect_a48d046965270281: function(arg0, arg1) {
+            arg0.aspect = __wbindgen_enum_GpuTextureAspect[arg1];
+        },
+        __wbg_set_aspect_b1a9909bf315433f: function(arg0, arg1) {
+            arg0.aspect = __wbindgen_enum_GpuTextureAspect[arg1];
+        },
+        __wbg_set_base_array_layer_2435ba92c80346ae: function(arg0, arg1) {
+            arg0.baseArrayLayer = arg1 >>> 0;
+        },
+        __wbg_set_base_mip_level_8b6093e875e7c65d: function(arg0, arg1) {
+            arg0.baseMipLevel = arg1 >>> 0;
+        },
+        __wbg_set_beginning_of_pass_write_index_fa9ae10d5d2804ce: function(arg0, arg1) {
+            arg0.beginningOfPassWriteIndex = arg1 >>> 0;
+        },
+        __wbg_set_bind_group_layouts_458c44ba55100b82: function(arg0, arg1, arg2) {
+            arg0.bindGroupLayouts = getArrayJsValueViewFromWasm0(arg1, arg2);
+        },
+        __wbg_set_binding_81b3fac7f7acaf8d: function(arg0, arg1) {
+            arg0.binding = arg1 >>> 0;
+        },
+        __wbg_set_binding_b6cee57f35ac5190: function(arg0, arg1) {
+            arg0.binding = arg1 >>> 0;
+        },
+        __wbg_set_buffer_1548ae88a9188037: function(arg0, arg1) {
+            arg0.buffer = arg1;
+        },
+        __wbg_set_buffer_8d0ac64ad20dfc84: function(arg0, arg1) {
+            arg0.buffer = arg1;
+        },
+        __wbg_set_bytes_per_row_c28583f0063160f1: function(arg0, arg1) {
+            arg0.bytesPerRow = arg1 >>> 0;
+        },
+        __wbg_set_code_5d5b0b9e2fd0dca7: function(arg0, arg1, arg2) {
+            arg0.code = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_compute_bc754d9e37f6e4c9: function(arg0, arg1) {
+            arg0.compute = arg1;
+        },
+        __wbg_set_depth_or_array_layers_e2f074a0284e4806: function(arg0, arg1) {
+            arg0.depthOrArrayLayers = arg1 >>> 0;
+        },
+        __wbg_set_device_210484a77b675c9c: function(arg0, arg1) {
+            arg0.device = arg1;
+        },
+        __wbg_set_dimension_3da9d03131a9f446: function(arg0, arg1) {
+            arg0.dimension = __wbindgen_enum_GpuTextureDimension[arg1];
+        },
+        __wbg_set_dimension_56332450afa3e0c0: function(arg0, arg1) {
+            arg0.dimension = __wbindgen_enum_GpuTextureViewDimension[arg1];
+        },
+        __wbg_set_end_of_pass_write_index_b54a8e3802b9ae0d: function(arg0, arg1) {
+            arg0.endOfPassWriteIndex = arg1 >>> 0;
+        },
+        __wbg_set_entries_6f866302103b81e9: function(arg0, arg1, arg2) {
+            arg0.entries = getArrayJsValueViewFromWasm0(arg1, arg2);
+        },
+        __wbg_set_entries_f26b77ab9548e906: function(arg0, arg1, arg2) {
+            arg0.entries = getArrayJsValueViewFromWasm0(arg1, arg2);
+        },
+        __wbg_set_entry_point_ac8db535971761fe: function(arg0, arg1, arg2) {
+            arg0.entryPoint = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_external_texture_7f966c604c4f8098: function(arg0, arg1) {
+            arg0.externalTexture = arg1;
+        },
+        __wbg_set_format_283dca56552f07a3: function(arg0, arg1) {
+            arg0.format = __wbindgen_enum_GpuTextureFormat[arg1];
+        },
+        __wbg_set_format_66735b94bd868ba2: function(arg0, arg1) {
+            arg0.format = __wbindgen_enum_GpuTextureFormat[arg1];
+        },
+        __wbg_set_format_92732ea75d3b79f5: function(arg0, arg1) {
+            arg0.format = __wbindgen_enum_GpuTextureFormat[arg1];
+        },
+        __wbg_set_format_f009e603f7d4c28e: function(arg0, arg1) {
+            arg0.format = __wbindgen_enum_GpuTextureFormat[arg1];
+        },
+        __wbg_set_has_dynamic_offset_0c72ffa900c5a269: function(arg0, arg1) {
+            arg0.hasDynamicOffset = arg1 !== 0;
+        },
+        __wbg_set_height_f6619158e5735877: function(arg0, arg1) {
+            arg0.height = arg1 >>> 0;
+        },
+        __wbg_set_label_09e2da5f8522dbe8: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_17202740051e9722: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_17b4858e1eef23dd: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_2fefb39c0e0dbbe8: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_3f2ccaafef5ff7c9: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_612add98a4398f92: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_70a09ee68d6b1b26: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_92cd3811e96b487c: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_c3eaf136aa464cba: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_c7987704d29f284b: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_cfe64bca8945ee30: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_label_ee172cd5f6a96961: function(arg0, arg1, arg2) {
+            arg0.label = getStringFromWasm0(arg1, arg2);
+        },
+        __wbg_set_layout_454e3a091b390cd4: function(arg0, arg1) {
+            arg0.layout = arg1;
+        },
+        __wbg_set_layout_4b5d5b12fbb72a76: function(arg0, arg1) {
+            arg0.layout = arg1;
+        },
+        __wbg_set_layout_gpu_auto_layout_mode_ee432e515c357fa8: function(arg0, arg1) {
+            arg0.layout = __wbindgen_enum_GpuAutoLayoutMode[arg1];
+        },
+        __wbg_set_mapped_at_creation_3f320fef6761b02c: function(arg0, arg1) {
+            arg0.mappedAtCreation = arg1 !== 0;
+        },
+        __wbg_set_min_binding_size_f64_897e3cd4496ddec9: function(arg0, arg1) {
+            arg0.minBindingSize = arg1;
+        },
+        __wbg_set_mip_level_count_047936c630acee7b: function(arg0, arg1) {
+            arg0.mipLevelCount = arg1 >>> 0;
+        },
+        __wbg_set_mip_level_count_44bc46a1ae6f6daa: function(arg0, arg1) {
+            arg0.mipLevelCount = arg1 >>> 0;
+        },
+        __wbg_set_mip_level_f3745730372683d5: function(arg0, arg1) {
+            arg0.mipLevel = arg1 >>> 0;
+        },
+        __wbg_set_module_c9946af218d23b53: function(arg0, arg1) {
+            arg0.module = arg1;
+        },
+        __wbg_set_multisampled_039f032dc4b67367: function(arg0, arg1) {
+            arg0.multisampled = arg1 !== 0;
+        },
+        __wbg_set_offset_f64_127e8a0aa5c5485a: function(arg0, arg1) {
+            arg0.offset = arg1;
+        },
+        __wbg_set_offset_f64_a903425d5a8e5815: function(arg0, arg1) {
+            arg0.offset = arg1;
+        },
+        __wbg_set_origin_gpu_origin_3d_dict_0619d4860adb4eb6: function(arg0, arg1) {
+            arg0.origin = arg1;
+        },
+        __wbg_set_power_preference_b42d00a8facfbade: function(arg0, arg1) {
+            arg0.powerPreference = __wbindgen_enum_GpuPowerPreference[arg1];
+        },
+        __wbg_set_query_set_f9a94586851fdba2: function(arg0, arg1) {
+            arg0.querySet = arg1;
+        },
+        __wbg_set_required_features_bbab71414c45e621: function(arg0, arg1, arg2) {
+            arg0.requiredFeatures = getArrayJsValueViewFromWasm0(arg1, arg2);
+        },
+        __wbg_set_required_limits_837f62d865e7cfac: function(arg0, arg1) {
+            arg0.requiredLimits = arg1;
+        },
+        __wbg_set_resource_8fd8658b30d86ecf: function(arg0, arg1) {
+            arg0.resource = arg1;
+        },
+        __wbg_set_resource_gpu_buffer_binding_33099b25da65b610: function(arg0, arg1) {
+            arg0.resource = arg1;
+        },
+        __wbg_set_resource_gpu_texture_view_4cffe7bc7c8e5cbe: function(arg0, arg1) {
+            arg0.resource = arg1;
+        },
+        __wbg_set_rows_per_image_c6d50d227e634379: function(arg0, arg1) {
+            arg0.rowsPerImage = arg1 >>> 0;
+        },
+        __wbg_set_sample_count_481c255a12054e1d: function(arg0, arg1) {
+            arg0.sampleCount = arg1 >>> 0;
+        },
+        __wbg_set_sample_type_ebc5fcd029513bda: function(arg0, arg1) {
+            arg0.sampleType = __wbindgen_enum_GpuTextureSampleType[arg1];
+        },
+        __wbg_set_sampler_89cb4a7efcfc6005: function(arg0, arg1) {
+            arg0.sampler = arg1;
+        },
+        __wbg_set_size_f64_2f591b0654540477: function(arg0, arg1) {
+            arg0.size = arg1;
+        },
+        __wbg_set_size_f64_e844c985b8f95261: function(arg0, arg1) {
+            arg0.size = arg1;
+        },
+        __wbg_set_size_gpu_extent_3d_dict_adf57388ab1d4f18: function(arg0, arg1) {
+            arg0.size = arg1;
+        },
+        __wbg_set_storage_texture_786aea7c5773b6c1: function(arg0, arg1) {
+            arg0.storageTexture = arg1;
+        },
+        __wbg_set_texture_95f2bfdf7767e76f: function(arg0, arg1) {
+            arg0.texture = arg1;
+        },
+        __wbg_set_texture_a33be3fe02ac6264: function(arg0, arg1) {
+            arg0.texture = arg1;
+        },
+        __wbg_set_timestamp_writes_5f240bbaad97fcaf: function(arg0, arg1) {
+            arg0.timestampWrites = arg1;
+        },
+        __wbg_set_type_43e0092f16775979: function(arg0, arg1) {
+            arg0.type = __wbindgen_enum_GpuSamplerBindingType[arg1];
+        },
+        __wbg_set_type_79cec55caf4cdb6d: function(arg0, arg1) {
+            arg0.type = __wbindgen_enum_GpuBufferBindingType[arg1];
+        },
+        __wbg_set_usage_1ee33d98267e787d: function(arg0, arg1) {
+            arg0.usage = arg1 >>> 0;
+        },
+        __wbg_set_usage_d53ee6f0c7aedbfa: function(arg0, arg1) {
+            arg0.usage = arg1 >>> 0;
+        },
+        __wbg_set_usage_f3e34822998d2147: function(arg0, arg1) {
+            arg0.usage = arg1 >>> 0;
+        },
+        __wbg_set_view_dimension_893e2d16561e56e8: function(arg0, arg1) {
+            arg0.viewDimension = __wbindgen_enum_GpuTextureViewDimension[arg1];
+        },
+        __wbg_set_view_dimension_f2c5fe4bf927c3fe: function(arg0, arg1) {
+            arg0.viewDimension = __wbindgen_enum_GpuTextureViewDimension[arg1];
+        },
+        __wbg_set_view_formats_427069064d8b7139: function(arg0, arg1, arg2) {
+            arg0.viewFormats = getArrayJsValueViewFromWasm0(arg1, arg2);
+        },
+        __wbg_set_visibility_d8a6821789538c25: function(arg0, arg1) {
+            arg0.visibility = arg1 >>> 0;
+        },
+        __wbg_set_width_b20525f5f4df4eb8: function(arg0, arg1) {
+            arg0.width = arg1 >>> 0;
+        },
+        __wbg_set_x_f470b03dd54724cd: function(arg0, arg1) {
+            arg0.x = arg1 >>> 0;
+        },
+        __wbg_set_y_4c44eb40ebca5bfc: function(arg0, arg1) {
+            arg0.y = arg1 >>> 0;
+        },
+        __wbg_set_z_2e6820ef0f5821ed: function(arg0, arg1) {
+            arg0.z = arg1 >>> 0;
+        },
+        __wbg_stack_3b0d974bbf31e44f: function(arg0, arg1) {
+            const ret = arg1.stack;
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc_command_export, wasm.__wbindgen_realloc_command_export);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg_static_accessor_GLOBAL_8eb4cd83130a11a0: function() {
+            const ret = typeof global === 'undefined' ? null : global;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_GLOBAL_THIS_1e7044f654e934db: function() {
+            const ret = typeof globalThis === 'undefined' ? null : globalThis;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_SELF_d8b50611246a6d92: function() {
+            const ret = typeof self === 'undefined' ? null : self;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_WINDOW_fd0bc376bf0f8b42: function() {
+            const ret = typeof window === 'undefined' ? null : window;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_subgroupMaxSize_b43be0aa16182403: function(arg0) {
+            const ret = arg0.subgroupMaxSize;
+            return ret;
+        },
+        __wbg_subgroupMinSize_03feb6ee0cda6775: function(arg0) {
+            const ret = arg0.subgroupMinSize;
+            return ret;
+        },
+        __wbg_submit_077c85cc28e36892: function(arg0, arg1, arg2) {
+            arg0.submit(getArrayJsValueViewFromWasm0(arg1, arg2));
+        },
+        __wbg_then_7a850dae4493f353: function(arg0, arg1, arg2) {
+            const ret = arg0.then(arg1, arg2);
+            return ret;
+        },
+        __wbg_then_b830475380919203: function(arg0, arg1) {
+            const ret = arg0.then(arg1);
+            return ret;
+        },
+        __wbg_unconfigure_835307f58dc68d80: function(arg0) {
+            arg0.unconfigure();
+        },
+        __wbg_unmap_6a96b14c9ef5f7f5: function(arg0) {
+            arg0.unmap();
+        },
+        __wbg_writeBuffer_f4bb3f54adfe1330: function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5, arg6) {
+            arg0.writeBuffer(arg1, arg2, getArrayU8FromWasm0(arg3, arg4), arg5, arg6);
+        }, arguments); },
+        __wbg_writeTexture_30e592e8c061c3d9: function() { return handleError(function (arg0, arg1, arg2, arg3, arg4, arg5) {
+            arg0.writeTexture(arg1, getArrayU8FromWasm0(arg2, arg3), arg4, arg5);
+        }, arguments); },
+        __wbindgen_generic_0000000000000001: function(arg0, arg1) {
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [Externref], shim_idx: 6972, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            const ret = makeMutClosure(arg0, arg1, wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___JsValue__core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_);
+            return ret;
+        },
+        __wbindgen_generic_0000000000000002: function(arg0, arg1) {
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("GPUDevice")], shim_idx: 6929, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            const ret = makeMutClosure(arg0, arg1, wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_);
+            return ret;
+        },
+        __wbindgen_generic_0000000000000003: function(arg0, arg1) {
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("any")], shim_idx: 6929, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            const ret = makeMutClosure(arg0, arg1, wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__13);
+            return ret;
+        },
+        __wbindgen_generic_0000000000000004: function(arg0, arg1) {
+            // Cast intrinsic for `Closure(Closure { owned: true, function: Function { arguments: [NamedExternref("undefined")], shim_idx: 6929, ret: Result(Unit), inner_ret: Some(Result(Unit)) }, mutable: true }) -> Externref`.
+            const ret = makeMutClosure(arg0, arg1, wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__14);
+            return ret;
+        },
+        __wbindgen_generic_0000000000000005: function(arg0) {
+            // Cast intrinsic for `F64 -> Externref`.
+            const ret = arg0;
+            return ret;
+        },
+        __wbindgen_generic_0000000000000006: function(arg0, arg1) {
+            // Cast intrinsic for `Ref(Slice(U8)) -> NamedExternref("Uint8Array")`.
+            const ret = getArrayU8FromWasm0(arg0, arg1);
+            return ret;
+        },
+        __wbindgen_generic_0000000000000007: function(arg0, arg1) {
+            // Cast intrinsic for `Ref(String) -> Externref`.
+            const ret = getStringFromWasm0(arg0, arg1);
+            return ret;
+        },
+        __wbindgen_generic_0000000000000008: function(arg0, arg1) {
+            var v0 = getArrayF32FromWasm0(arg0, arg1).slice();
+            wasm.__wbindgen_free_command_export(arg0, arg1 * 4, 4);
+            // Cast intrinsic for `Vector(F32) -> Externref`.
+            const ret = v0;
+            return ret;
+        },
+        __wbindgen_init_externref_table: function() {
+            const table = wasm.__wbindgen_externrefs;
+            const offset = table.grow(4);
+            table.set(0, undefined);
+            table.set(offset + 0, undefined);
+            table.set(offset + 1, null);
+            table.set(offset + 2, true);
+            table.set(offset + 3, false);
+        },
+    };
+    return {
+        __proto__: null,
+        "./tract_wgpu_web_bg.js": import0,
+    };
+}
+
+function wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___JsValue__core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_(arg0, arg1, arg2) {
+    const ret = wasm.wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___JsValue__core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_(arg0, arg1, arg2);
+    if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+    }
+}
+
+function wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_(arg0, arg1, arg2) {
+    const ret = wasm.wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_(arg0, arg1, arg2);
+    if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+    }
+}
+
+function wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__13(arg0, arg1, arg2) {
+    const ret = wasm.wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__13(arg0, arg1, arg2);
+    if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+    }
+}
+
+function wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__14(arg0, arg1, arg2) {
+    const ret = wasm.wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__14(arg0, arg1, arg2);
+    if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+    }
+}
+
+function wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined_______true_(arg0, arg1, arg2, arg3) {
+    wasm.wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined_______true_(arg0, arg1, arg2, arg3);
+}
+
+
+const __wbindgen_enum_GpuAutoLayoutMode = ["auto"];
+
+
+const __wbindgen_enum_GpuBufferBindingType = ["uniform", "storage", "read-only-storage"];
+
+
+const __wbindgen_enum_GpuPowerPreference = ["low-power", "high-performance"];
+
+
+const __wbindgen_enum_GpuSamplerBindingType = ["filtering", "non-filtering", "comparison"];
+
+
+const __wbindgen_enum_GpuStorageTextureAccess = ["write-only", "read-only", "read-write"];
+
+
+const __wbindgen_enum_GpuTextureAspect = ["all", "stencil-only", "depth-only"];
+
+
+const __wbindgen_enum_GpuTextureDimension = ["1d", "2d", "3d"];
+
+
+const __wbindgen_enum_GpuTextureFormat = ["r8unorm", "r8snorm", "r8uint", "r8sint", "r16unorm", "r16snorm", "r16uint", "r16sint", "r16float", "rg8unorm", "rg8snorm", "rg8uint", "rg8sint", "r32uint", "r32sint", "r32float", "rg16unorm", "rg16snorm", "rg16uint", "rg16sint", "rg16float", "rgba8unorm", "rgba8unorm-srgb", "rgba8snorm", "rgba8uint", "rgba8sint", "bgra8unorm", "bgra8unorm-srgb", "rgb9e5ufloat", "rgb10a2uint", "rgb10a2unorm", "rg11b10ufloat", "rg32uint", "rg32sint", "rg32float", "rgba16unorm", "rgba16snorm", "rgba16uint", "rgba16sint", "rgba16float", "rgba32uint", "rgba32sint", "rgba32float", "stencil8", "depth16unorm", "depth24plus", "depth24plus-stencil8", "depth32float", "depth32float-stencil8", "bc1-rgba-unorm", "bc1-rgba-unorm-srgb", "bc2-rgba-unorm", "bc2-rgba-unorm-srgb", "bc3-rgba-unorm", "bc3-rgba-unorm-srgb", "bc4-r-unorm", "bc4-r-snorm", "bc5-rg-unorm", "bc5-rg-snorm", "bc6h-rgb-ufloat", "bc6h-rgb-float", "bc7-rgba-unorm", "bc7-rgba-unorm-srgb", "etc2-rgb8unorm", "etc2-rgb8unorm-srgb", "etc2-rgb8a1unorm", "etc2-rgb8a1unorm-srgb", "etc2-rgba8unorm", "etc2-rgba8unorm-srgb", "eac-r11unorm", "eac-r11snorm", "eac-rg11unorm", "eac-rg11snorm", "astc-4x4-unorm", "astc-4x4-unorm-srgb", "astc-5x4-unorm", "astc-5x4-unorm-srgb", "astc-5x5-unorm", "astc-5x5-unorm-srgb", "astc-6x5-unorm", "astc-6x5-unorm-srgb", "astc-6x6-unorm", "astc-6x6-unorm-srgb", "astc-8x5-unorm", "astc-8x5-unorm-srgb", "astc-8x6-unorm", "astc-8x6-unorm-srgb", "astc-8x8-unorm", "astc-8x8-unorm-srgb", "astc-10x5-unorm", "astc-10x5-unorm-srgb", "astc-10x6-unorm", "astc-10x6-unorm-srgb", "astc-10x8-unorm", "astc-10x8-unorm-srgb", "astc-10x10-unorm", "astc-10x10-unorm-srgb", "astc-12x10-unorm", "astc-12x10-unorm-srgb", "astc-12x12-unorm", "astc-12x12-unorm-srgb"];
+
+
+const __wbindgen_enum_GpuTextureSampleType = ["float", "unfilterable-float", "depth", "sint", "uint"];
+
+
+const __wbindgen_enum_GpuTextureViewDimension = ["1d", "2d", "2d-array", "cube", "cube-array", "3d"];
+
+function addToExternrefTable0(obj) {
+    const idx = wasm.__externref_table_alloc_command_export();
+    wasm.__wbindgen_externrefs.set(idx, obj);
+    return idx;
+}
+
+const CLOSURE_DTORS = (typeof FinalizationRegistry === 'undefined')
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry(state => wasm.__wbindgen_destroy_closure_command_export(state.a, state.b));
+
+function debugString(val) {
+    // primitive types
+    const type = typeof val;
+    if (type == 'number' || type == 'boolean' || val == null) {
+        return  `${val}`;
+    }
+    if (type == 'string') {
+        return `"${val}"`;
+    }
+    if (type == 'symbol') {
+        const description = val.description;
+        if (description == null) {
+            return 'Symbol';
+        } else {
+            return `Symbol(${description})`;
+        }
+    }
+    if (type == 'function') {
+        const name = val.name;
+        if (typeof name == 'string' && name.length > 0) {
+            return `Function(${name})`;
+        } else {
+            return 'Function';
+        }
+    }
+    // objects
+    if (Array.isArray(val)) {
+        const length = val.length;
+        let debug = '[';
+        if (length > 0) {
+            debug += debugString(val[0]);
+        }
+        for(let i = 1; i < length; i++) {
+            debug += ', ' + debugString(val[i]);
+        }
+        debug += ']';
+        return debug;
+    }
+    // Test for built-in
+    const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+    let className;
+    if (builtInMatches && builtInMatches.length > 1) {
+        className = builtInMatches[1];
+    } else {
+        // Failed to match the standard '[object ClassName]'
+        return toString.call(val);
+    }
+    if (className == 'Object') {
+        // we're a user defined class or Object
+        // JSON.stringify avoids problems with cycles, and is generally much
+        // easier than looping through ownProperties of `val`.
+        try {
+            return 'Object(' + JSON.stringify(val) + ')';
+        } catch (_) {
+            return 'Object';
+        }
+    }
+    // errors
+    if (val instanceof Error) {
+        return `${val.name}: ${val.message}\n${val.stack}`;
+    }
+    // TODO we could test for more things here, like `Set`s and `Map`s.
+    return className;
+}
+
+function getArrayF32FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getFloat32ArrayMemory0().subarray(ptr / 4, ptr / 4 + len);
+}
+
+function getArrayJsValueViewFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    const mem = getDataViewMemory0();
+    const result = [];
+    for (let i = ptr; i < ptr + 4 * len; i += 4) {
+        result.push(wasm.__wbindgen_externrefs.get(mem.getUint32(i, true)));
+    }
+    return result;
+}
+
+function getArrayU32FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint32ArrayMemory0().subarray(ptr / 4, ptr / 4 + len);
+}
+
+function getArrayU8FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
+}
+
+let cachedDataViewMemory0 = null;
+function getDataViewMemory0() {
+    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+    }
+    return cachedDataViewMemory0;
+}
+
+let cachedFloat32ArrayMemory0 = null;
+function getFloat32ArrayMemory0() {
+    if (cachedFloat32ArrayMemory0 === null || cachedFloat32ArrayMemory0.byteLength === 0) {
+        cachedFloat32ArrayMemory0 = new Float32Array(wasm.memory.buffer);
+    }
+    return cachedFloat32ArrayMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    return decodeText(ptr >>> 0, len);
+}
+
+let cachedUint32ArrayMemory0 = null;
+function getUint32ArrayMemory0() {
+    if (cachedUint32ArrayMemory0 === null || cachedUint32ArrayMemory0.byteLength === 0) {
+        cachedUint32ArrayMemory0 = new Uint32Array(wasm.memory.buffer);
+    }
+    return cachedUint32ArrayMemory0;
+}
+
+let cachedUint8ArrayMemory0 = null;
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function handleError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        const idx = addToExternrefTable0(e);
+        wasm.__wbindgen_exn_store_command_export(idx);
+    }
+}
+
+function isLikeNone(x) {
+    return x === undefined || x === null;
+}
+
+function makeMutClosure(arg0, arg1, f) {
+    const state = { a: arg0, b: arg1, cnt: 1 };
+    const real = (...args) => {
+
+        // First up with a closure we increment the internal reference
+        // count. This ensures that the Rust closure environment won't
+        // be deallocated while we're invoking it.
+        state.cnt++;
+        const a = state.a;
+        state.a = 0;
+        try {
+            return f(a, state.b, ...args);
+        } finally {
+            state.a = a;
+            real._wbg_cb_unref();
+        }
+    };
+    real._wbg_cb_unref = () => {
+        if (--state.cnt === 0) {
+            wasm.__wbindgen_destroy_closure_command_export(state.a, state.b);
+            state.a = 0;
+            CLOSURE_DTORS.unregister(state);
+        }
+    };
+    CLOSURE_DTORS.register(real, state, state);
+    return real;
+}
+
+function passArray8ToWasm0(arg, malloc) {
+    const ptr = malloc(arg.length * 1, 1) >>> 0;
+    getUint8ArrayMemory0().set(arg, ptr / 1);
+    WASM_VECTOR_LEN = arg.length;
+    return ptr;
+}
+
+function passArrayF32ToWasm0(arg, malloc) {
+    const ptr = malloc(arg.length * 4, 4) >>> 0;
+    getFloat32ArrayMemory0().set(arg, ptr / 4);
+    WASM_VECTOR_LEN = arg.length;
+    return ptr;
+}
+
+function passStringToWasm0(arg, malloc, realloc) {
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
+
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
+
+    const mem = getUint8ArrayMemory0();
+
+    let offset = 0;
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = cachedTextEncoder.encodeInto(arg, view);
+
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
+
+    WASM_VECTOR_LEN = offset;
+    return ptr;
+}
+
+function takeFromExternrefTable0(idx) {
+    const value = wasm.__wbindgen_externrefs.get(idx);
+    wasm.__externref_table_dealloc_command_export(idx);
+    return value;
+}
+
+let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+cachedTextDecoder.decode();
+const MAX_SAFARI_DECODE_BYTES = 2146435072;
+let numBytesDecoded = 0;
+function decodeText(ptr, len) {
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+const cachedTextEncoder = new TextEncoder();
+
+if (!('encodeInto' in cachedTextEncoder)) {
+    cachedTextEncoder.encodeInto = function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+            read: arg.length,
+            written: buf.length
+        };
+    };
+}
+
+let WASM_VECTOR_LEN = 0;
+
+let wasmModule, wasmInstance, wasm;
+function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
+    wasm = instance.exports;
+    wasmModule = module;
+    cachedDataViewMemory0 = null;
+    cachedFloat32ArrayMemory0 = null;
+    cachedUint32ArrayMemory0 = null;
+    cachedUint8ArrayMemory0 = null;
+    wasm.__wbindgen_start();
+    return wasm;
+}
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (!module.ok) {
+            throw new Error(`failed to fetch Wasm: ${module.status} ${module.statusText} fetching '${module.url}'`);
+        }
+
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+            } catch (e) {
+                const validResponse = expectedResponseType(module.type);
+
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                } else { throw e; }
+            }
+        }
+
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
+        } else {
+            return instance;
+        }
+    }
+
+    function expectedResponseType(type) {
+        switch (type) {
+            case 'basic': case 'cors': case 'default': return true;
+        }
+        return false;
+    }
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module !== undefined) {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+    const instance = new WebAssembly.Instance(module, imports);
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module_or_path !== undefined) {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
+
+    if (module_or_path === undefined) {
+        module_or_path = new URL('tract_wgpu_web_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
+
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
+
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+export { initSync, __wbg_init as default };

--- a/examples/tract-wgpu-web/pkg/tract_wgpu_web_bg.wasm.d.ts
+++ b/examples/tract-wgpu-web/pkg/tract_wgpu_web_bg.wasm.d.ts
@@ -1,0 +1,27 @@
+/* tslint:disable */
+/* eslint-disable */
+export const memory: WebAssembly.Memory;
+export const ingest_rgba8: (a: number, b: number, c: number, d: number) => any;
+export const run_hybrid_logsoftmax: (a: number, b: number) => [number, number, number, number];
+export const run_two_op: (a: number, b: number) => any;
+export const segment_into_texture: (a: number, b: number, c: number, d: number) => [number, number, number];
+export const segmentation_device: () => [number, number, number];
+export const segmentation_mask_texture: () => [number, number, number];
+export const selfie_seg_bench: (a: number) => any;
+export const selfie_seg_bench_cpu: (a: number) => any;
+export const selfie_seg_phases: (a: number) => any;
+export const start: () => any;
+export const wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined___js_sys_6a2197ff0da30551___Function_fn_wasm_bindgen_c5cdf803200c69ee___JsValue_____wasm_bindgen_c5cdf803200c69ee___sys__Undefined_______true_: (a: number, b: number, c: any, d: any) => void;
+export const wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___JsValue__core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_: (a: number, b: number, c: any) => [number, number];
+export const wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true_: (a: number, b: number, c: any) => [number, number];
+export const wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__13: (a: number, b: number, c: any) => [number, number];
+export const wasm_bindgen_c5cdf803200c69ee___convert__closures_____invoke___wasm_bindgen_c5cdf803200c69ee___sys__JsNullable_wgpu_7873fc23d7c79807___backend__webgpu__webgpu_sys__gen_GpuError__GpuError___core_9b3796e30d99ddb7___result__Result_____wasm_bindgen_c5cdf803200c69ee___JsError___true__14: (a: number, b: number, c: any) => [number, number];
+export const __wbindgen_malloc_command_export: (a: number, b: number) => number;
+export const __wbindgen_realloc_command_export: (a: number, b: number, c: number, d: number) => number;
+export const __wbindgen_exn_store_command_export: (a: number) => void;
+export const __externref_table_alloc_command_export: () => number;
+export const __wbindgen_externrefs: WebAssembly.Table;
+export const __wbindgen_free_command_export: (a: number, b: number, c: number) => void;
+export const __wbindgen_destroy_closure_command_export: (a: number, b: number) => void;
+export const __externref_table_dealloc_command_export: (a: number) => void;
+export const __wbindgen_start: () => void;

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "tract-wgpu"
+version = "0.23.8-pre"
+license = "MIT OR Apache-2.0"
+authors = [
+	"Ckristian Zoli <czoli1976@users.noreply.github.com>",
+]
+description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
+repository = "https://github.com/snipsco/tract"
+keywords = [ "TensorFlow", "NeuralNetworks", "WebGPU", "wgpu" ]
+categories = [ "science" ]
+autobenches = false
+edition = "2024"
+rust-version.workspace = true
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[features]
+default = []
+# Browser WebGPU. Mutually exclusive with tract's wasm-bindgen-rayon
+# (+atomics,+bulk-memory) tier — see lib.rs.
+web = []
+# Wasm JSPI hybrid: uncovered ops fall back to tract CPU kernels via a
+# mid-graph mapAsync suspend. Not a default — Safari 26 has WebGPU but not
+# JSPI (Safari 27). Chrome 137+, Firefox 139+.
+jspi = []
+
+[dependencies]
+anyhow.workspace = true
+derive-new.workspace = true
+downcast-rs.workspace = true
+inventory.workspace = true
+log.workspace = true
+num-traits.workspace = true
+tract-core.workspace = true
+tract-pulse-opl.workspace = true
+tract-transformers.workspace = true
+tract-gpu.workspace = true
+wgpu.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pollster.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["VideoFrame"] }
+
+[dev-dependencies]
+proptest.workspace = true
+rand.workspace = true

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -1,0 +1,1278 @@
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::mem::ManuallyDrop;
+use std::num::NonZeroU64;
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+#[cfg(not(target_arch = "wasm32"))]
+use anyhow::Context;
+use anyhow::{anyhow, bail};
+use tract_core::internal::*;
+use tract_core::tract_linalg::block_quant::BlockQuantFact;
+use tract_gpu::device::{DeviceBuffer, DeviceContext};
+use tract_gpu::tensor::{DeviceTensor, OwnedDeviceTensor};
+use tract_gpu::utils::as_q40_tensor;
+use wgpu::util::DeviceExt;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
+compile_error!(
+    "tract-wgpu cannot be built with wasm atomics. It is mutually exclusive with the \
+     wasm-bindgen-rayon tier (+atomics,+bulk-memory,+mutable-globals,+simd128). \
+     Build wasm32-unknown-unknown without +atomics; see linalg/MULTITHREAD_BENCHMARKS.md."
+);
+
+use crate::kernels::shaders::{EntryPoint, LayoutKind, ModuleKey, PipelineKey, ShaderDtype};
+use crate::tensor::WgpuTensor;
+
+pub const UNIFORM_ALIGN: u64 = 256;
+/// Slots in the uniform ring. One dispatch takes one slot, and running out
+/// forces a submit-and-wait in the middle of a frame, so the ring holds more
+/// than a graph's worth of dispatches.
+const UNIFORM_SLOTS: u64 = 256;
+const UNIFORM_BYTES: u64 = UNIFORM_ALIGN * UNIFORM_SLOTS;
+const WORKGROUP: u32 = 64;
+
+/// Bind groups kept between frames before the cache is dropped wholesale.
+const BIND_GROUP_CACHE_CAP: usize = 8192;
+
+thread_local! {
+    static WGPU_QUEUE: RefCell<Option<WgpuQueue>> = const { RefCell::new(None) };
+}
+
+pub fn with_wgpu_queue<R>(f: impl FnOnce(&WgpuQueue) -> TractResult<R>) -> TractResult<R> {
+    wgpu_context();
+    WGPU_QUEUE.with(|cell| {
+        if cell.borrow().is_none() {
+            *cell.borrow_mut() = Some(WgpuQueue::new()?);
+        }
+        let borrow = cell.borrow();
+        f(borrow.as_ref().unwrap())
+    })
+}
+
+/// Cache behaviour, for the ignored probes: bind groups and pooled buffers
+/// found versus built.
+pub static CACHE_STATS: [std::sync::atomic::AtomicUsize; 5] = [
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+];
+
+fn bump(i: usize) {
+    CACHE_STATS[i].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn context_slot() -> &'static OnceLock<WgpuContext> {
+    static INSTANCE: OnceLock<WgpuContext> = OnceLock::new();
+    &INSTANCE
+}
+
+fn install_context(ctxt: WgpuContext) -> TractResult<WgpuContext> {
+    let _ = tract_gpu::device::set_context(Box::new(ctxt.clone()));
+    let _ = context_slot().set(ctxt.clone());
+    Ok(context_slot().get().cloned().unwrap_or(ctxt))
+}
+
+/// Native: creates the adapter synchronously. Wasm: panics unless
+/// [`wgpu_context_async`] has already completed — `pollster` cannot block
+/// the browser event loop.
+pub fn wgpu_context() -> WgpuContext {
+    #[cfg(target_arch = "wasm32")]
+    {
+        context_slot().get().cloned().expect(
+            "tract-wgpu on wasm32: await wgpu_context_async() once at startup \
+             (requestAdapter/requestDevice are async; PollType::Wait is a no-op on web)",
+        )
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        context_slot()
+            .get_or_init(|| {
+                let ctxt = WgpuContext::new().expect("Could not create wgpu context");
+                tract_gpu::device::set_context(Box::new(ctxt.clone()))
+                    .expect("Could not set wgpu context");
+                ctxt
+            })
+            .clone()
+    }
+}
+
+/// One-shot async device init. Safe to call from wasm `wasm_bindgen` async
+/// startup; subsequent [`wgpu_context`] calls are free.
+pub async fn wgpu_context_async() -> TractResult<WgpuContext> {
+    if let Some(ctxt) = context_slot().get() {
+        return Ok(ctxt.clone());
+    }
+    let ctxt = WgpuContext::new_async().await?;
+    install_context(ctxt)
+}
+
+#[derive(Clone)]
+pub struct WgpuContext {
+    inner: Arc<WgpuContextInner>,
+}
+
+struct WgpuContextInner {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    shader_f16: bool,
+    modules: RwLock<HashMap<ModuleKey, wgpu::ShaderModule>>,
+    pipelines: RwLock<HashMap<PipelineKey, wgpu::ComputePipeline>>,
+    chain_pipelines: RwLock<HashMap<String, wgpu::ComputePipeline>>,
+    layouts: RwLock<HashMap<LayoutKind, (wgpu::BindGroupLayout, wgpu::PipelineLayout)>>,
+    bind_groups: Mutex<HashMap<BindGroupKey, wgpu::BindGroup>>,
+    staging: Mutex<Option<wgpu::Buffer>>,
+    /// A graph allocates the same sizes in the same order every frame, so a
+    /// buffer is keyed by that position rather than by size alone: the Nth
+    /// allocation of a given size always gets the same buffer, and the bind
+    /// group built for it last frame still matches.
+    buffer_slots: Mutex<HashMap<(u64, u32), Arc<WgpuBuffer>>>,
+    slot_cursor: Mutex<HashMap<u64, u32>>,
+}
+
+/// `wgpu::Buffer` hashes by the resource it points at, so a cached entry stays
+/// valid for as long as that buffer lives — and holding the key's clones is
+/// what keeps it alive.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BindGroupKey {
+    layout: LayoutKind,
+    buffers: Vec<u64>,
+}
+
+impl std::fmt::Debug for WgpuContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgpuContext").field("shader_f16", &self.inner.shader_f16).finish()
+    }
+}
+
+impl WgpuContext {
+    async fn create_device() -> TractResult<(wgpu::Device, wgpu::Queue, bool)> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| anyhow!("No wgpu adapter: {e}"))?;
+
+        let info = adapter.get_info();
+        log::info!(
+            "tract-wgpu: adapter {:?} ({:?}) backend={:?}",
+            info.name,
+            info.device_type,
+            info.backend
+        );
+
+        let shader_f16 = adapter.features().contains(wgpu::Features::SHADER_F16);
+        let mut features = wgpu::Features::empty();
+        if shader_f16 {
+            features |= wgpu::Features::SHADER_F16;
+        }
+        if adapter.features().contains(wgpu::Features::TIMESTAMP_QUERY) {
+            features |= wgpu::Features::TIMESTAMP_QUERY;
+        }
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("tract-wgpu"),
+                required_features: features,
+                required_limits: adapter.limits(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            })
+            .await
+            .map_err(|e| anyhow!("request_device failed: {e}"))?;
+        Ok((device, queue, shader_f16))
+    }
+
+    fn from_device(
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        shader_f16: bool,
+    ) -> TractResult<Self> {
+        let ctxt = Self {
+            inner: Arc::new(WgpuContextInner {
+                device,
+                queue,
+                shader_f16,
+                modules: RwLock::new(HashMap::new()),
+                pipelines: RwLock::new(HashMap::new()),
+                chain_pipelines: RwLock::new(HashMap::new()),
+                layouts: RwLock::new(HashMap::new()),
+                bind_groups: Mutex::new(HashMap::new()),
+                staging: Mutex::new(None),
+                buffer_slots: Mutex::new(HashMap::new()),
+                slot_cursor: Mutex::new(HashMap::new()),
+            }),
+        };
+        ctxt.preload_pipelines()?;
+        Ok(ctxt)
+    }
+
+    pub fn new() -> TractResult<Self> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            bail!(
+                "WgpuContext::new() cannot block on wasm32. Await WgpuContext::new_async() \
+                 (or wgpu_context_async()) once at startup."
+            )
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let (device, queue, shader_f16) = pollster::block_on(Self::create_device())?;
+            Self::from_device(device, queue, shader_f16)
+        }
+    }
+
+    pub async fn new_async() -> TractResult<Self> {
+        let (device, queue, shader_f16) = Self::create_device().await?;
+        Self::from_device(device, queue, shader_f16)
+    }
+
+    pub fn device(&self) -> &wgpu::Device {
+        &self.inner.device
+    }
+
+    pub fn queue(&self) -> &wgpu::Queue {
+        &self.inner.queue
+    }
+
+    pub fn shader_f16(&self) -> bool {
+        self.inner.shader_f16
+    }
+
+    pub fn timestamps(&self) -> bool {
+        self.inner.device.features().contains(wgpu::Features::TIMESTAMP_QUERY)
+    }
+
+    fn preload_pipelines(&self) -> TractResult<()> {
+        for key in crate::kernels::element_wise::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::bin_ops::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::copy::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::reduce::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::pool::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::cast::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::conv::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::deconv::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::resize::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::softmax::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::ingest::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        for key in crate::kernels::matmul::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        Ok(())
+    }
+
+    pub fn layout(
+        &self,
+        kind: LayoutKind,
+    ) -> TractResult<(wgpu::BindGroupLayout, wgpu::PipelineLayout)> {
+        {
+            let cache = self.inner.layouts.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(v) = cache.get(&kind) {
+                return Ok(v.clone());
+            }
+        }
+        let mut cache = self.inner.layouts.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(v) = cache.get(&kind) {
+            return Ok(v.clone());
+        }
+        let entries = kind.bind_group_layout_entries();
+        let bgl = self.inner.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some(kind.label()),
+            entries: &entries,
+        });
+        let pl = self.inner.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some(kind.label()),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+        cache.insert(kind, (bgl.clone(), pl.clone()));
+        Ok((bgl, pl))
+    }
+
+    fn module(&self, key: ModuleKey) -> TractResult<wgpu::ShaderModule> {
+        {
+            let cache = self.inner.modules.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(m) = cache.get(&key) {
+                return Ok(m.clone());
+            }
+        }
+        let mut cache = self.inner.modules.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(m) = cache.get(&key) {
+            return Ok(m.clone());
+        }
+        if key.dtype == ShaderDtype::F16 && !self.shader_f16() {
+            bail!("f16 requested but adapter lacks shader-f16");
+        }
+        let src = key.wgsl();
+        let module = self.inner.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some(key.label()),
+            source: wgpu::ShaderSource::Wgsl(src.into()),
+        });
+        cache.insert(key, module.clone());
+        Ok(module)
+    }
+
+    pub fn pipeline(&self, key: PipelineKey) -> TractResult<wgpu::ComputePipeline> {
+        {
+            let cache = self.inner.pipelines.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(p) = cache.get(&key) {
+                return Ok(p.clone());
+            }
+        }
+        let mut cache = self.inner.pipelines.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(p) = cache.get(&key) {
+            return Ok(p.clone());
+        }
+        let module = self.module(key.module)?;
+        let (_bgl, pl) = self.layout(key.module.layout())?;
+        let entry = key.entry.name();
+        let pipeline =
+            self.inner.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(&entry),
+                layout: Some(&pl),
+                module: &module,
+                entry_point: Some(&entry),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                cache: None,
+            });
+        cache.insert(key, pipeline.clone());
+        Ok(pipeline)
+    }
+
+    /// Pipeline for a generated program, keyed by the program's own name;
+    /// `source` is only called on a miss.
+    pub fn chain_pipeline(
+        &self,
+        key: &str,
+        layout: LayoutKind,
+        entry: EntryPoint,
+        source: impl FnOnce() -> String,
+    ) -> TractResult<wgpu::ComputePipeline> {
+        {
+            let cache = self.inner.chain_pipelines.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(p) = cache.get(key) {
+                return Ok(p.clone());
+            }
+        }
+        let mut cache = self.inner.chain_pipelines.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(p) = cache.get(key) {
+            return Ok(p.clone());
+        }
+        let module = self.inner.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some(layout.label()),
+            source: wgpu::ShaderSource::Wgsl(source().into()),
+        });
+        let (_bgl, pl) = self.layout(layout)?;
+        let pipeline =
+            self.inner.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("tract-wgpu-generated"),
+                layout: Some(&pl),
+                module: &module,
+                entry_point: Some(&entry.name()),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                cache: None,
+            });
+        cache.insert(key.to_string(), pipeline.clone());
+        Ok(pipeline)
+    }
+
+    pub fn bind_group(
+        &self,
+        kind: LayoutKind,
+        buffers: &[&WgpuBuffer],
+        uniform: &wgpu::Buffer,
+    ) -> TractResult<wgpu::BindGroup> {
+        ensure!(kind != LayoutKind::Ingest, "Ingest layout binds a texture; use bind_group_ingest");
+        let key = BindGroupKey { layout: kind, buffers: buffers.iter().map(|b| b.id).collect() };
+        {
+            let cache = self.inner.bind_groups.lock().map_err(|e| anyhow!("{e}"))?;
+            if let Some(bg) = cache.get(&key) {
+                bump(0);
+                return Ok(bg.clone());
+            }
+        }
+        bump(1);
+        let (bgl, _) = self.layout(kind)?;
+        let mut entries: Vec<wgpu::BindGroupEntry<'_>> = Vec::with_capacity(buffers.len() + 1);
+        for (i, buf) in buffers.iter().enumerate() {
+            entries.push(wgpu::BindGroupEntry {
+                binding: i as u32,
+                resource: buf.inner.as_entire_binding(),
+            });
+        }
+        entries.push(uniform_entry(buffers.len() as u32, uniform));
+        let bg = self.inner.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(kind.label()),
+            layout: &bgl,
+            entries: &entries,
+        });
+        let mut cache = self.inner.bind_groups.lock().map_err(|e| anyhow!("{e}"))?;
+        cache.insert(key, bg.clone());
+        Ok(bg)
+    }
+
+    /// One storage buffer read, one storage texture written.
+    pub fn bind_group_export(
+        &self,
+        input: &wgpu::Buffer,
+        view: &wgpu::TextureView,
+        uniform: &wgpu::Buffer,
+    ) -> TractResult<wgpu::BindGroup> {
+        let (bgl, _) = self.layout(LayoutKind::Export)?;
+        let entries = [
+            wgpu::BindGroupEntry { binding: 0, resource: input.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: wgpu::BindingResource::TextureView(view) },
+            uniform_entry(2, uniform),
+        ];
+        Ok(self.inner.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(LayoutKind::Export.label()),
+            layout: &bgl,
+            entries: &entries,
+        }))
+    }
+
+    pub fn bind_group_ingest(
+        &self,
+        view: &wgpu::TextureView,
+        output: &wgpu::Buffer,
+        uniform: &wgpu::Buffer,
+    ) -> TractResult<wgpu::BindGroup> {
+        let (bgl, _) = self.layout(LayoutKind::Ingest)?;
+        let entries = [
+            wgpu::BindGroupEntry { binding: 0, resource: wgpu::BindingResource::TextureView(view) },
+            wgpu::BindGroupEntry { binding: 1, resource: output.as_entire_binding() },
+            uniform_entry(2, uniform),
+        ];
+        Ok(self.inner.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(LayoutKind::Ingest.label()),
+            layout: &bgl,
+            entries: &entries,
+        }))
+    }
+
+    pub fn create_storage_buffer(&self, bytes: &[u8]) -> wgpu::Buffer {
+        let padded = pad4(bytes);
+        self.inner.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("tract-wgpu-storage"),
+            contents: &padded,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+        })
+    }
+
+    /// Starts a new allocation sequence. Called when the queue flushes, which
+    /// is where a graph's intermediates are released.
+    /// Bind groups a frame no longer needs. The cache is only trimmed between
+    /// frames: sized to hold a graph's working set several times over, it
+    /// bounds a pathological model without ever evicting mid-frame what the
+    /// frame in flight is still binding.
+    pub(crate) fn trim_bind_groups(&self) {
+        if let Ok(mut cache) = self.inner.bind_groups.lock()
+            && cache.len() > BIND_GROUP_CACHE_CAP
+        {
+            cache.clear();
+        }
+    }
+
+    pub(crate) fn reset_buffer_slots(&self) {
+        if let Ok(mut cursor) = self.inner.slot_cursor.lock() {
+            cursor.clear();
+        }
+    }
+
+    fn next_buffer_id(&self) -> u64 {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// A storage buffer of `size` bytes for this position in the frame's
+    /// allocation sequence. Reuses the buffer that position held last frame,
+    /// unless it is still alive.
+    pub fn alloc_storage(&self, size: u64) -> Arc<WgpuBuffer> {
+        let size = size.max(4).next_multiple_of(4);
+        let seq = self
+            .inner
+            .slot_cursor
+            .lock()
+            .map(|mut c| {
+                let n = c.entry(size).or_insert(0);
+                let seq = *n;
+                *n += 1;
+                seq
+            })
+            .unwrap_or(u32::MAX);
+        if seq != u32::MAX
+            && let Ok(mut slots) = self.inner.buffer_slots.lock()
+        {
+            if let Some(held) = slots.get(&(size, seq))
+                && Arc::strong_count(held) == 1
+            {
+                bump(2);
+                return held.clone();
+            }
+            let fresh = Arc::new(WgpuBuffer {
+                inner: self.create_empty_storage(size),
+                id: self.next_buffer_id(),
+            });
+            bump(3);
+            slots.insert((size, seq), fresh.clone());
+            return fresh;
+        }
+        bump(3);
+        Arc::new(WgpuBuffer { inner: self.create_empty_storage(size), id: self.next_buffer_id() })
+    }
+
+    pub fn wrap_storage(&self, inner: wgpu::Buffer) -> WgpuBuffer {
+        WgpuBuffer { inner, id: self.next_buffer_id() }
+    }
+
+    pub fn create_empty_storage(&self, size: u64) -> wgpu::Buffer {
+        let size = size.max(4).next_multiple_of(4);
+        self.inner.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-storage"),
+            size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    /// A `MAP_READ` buffer of at least `size`, kept between calls: a fresh one
+    /// per frame costs an allocation and a device sync.
+    fn staging_at_least(&self, size: u64) -> wgpu::Buffer {
+        let mut slot = self.inner.staging.lock().unwrap();
+        if slot.as_ref().is_none_or(|b| b.size() < size) {
+            *slot = Some(self.inner.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tract-wgpu-staging"),
+                size: size.max(4),
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+        }
+        slot.as_ref().unwrap().clone()
+    }
+
+    /// Awaitable GPU→CPU copy. On web this is the single yield at the end of
+    /// `run()`; do not call it mid-graph. The copy rides the pending work's
+    /// own submission, so a frame costs one submit, not two.
+    pub async fn download_async(
+        &self,
+        buffer: &wgpu::Buffer,
+        offset: u64,
+        len: u64,
+    ) -> TractResult<Vec<u8>> {
+        if len == 0 {
+            with_wgpu_queue(|q| q.flush())?;
+            return Ok(vec![]);
+        }
+        let copy_len = len.next_multiple_of(4);
+        let staging = self.staging_at_least(copy_len);
+        with_wgpu_queue(|q| q.flush_after_copy(buffer, offset, &staging, copy_len))?;
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let slice = staging.slice(..copy_len);
+            let promise = js_sys::Promise::new(&mut |resolve, reject| {
+                slice.map_async(wgpu::MapMode::Read, move |r| match r {
+                    Ok(()) => {
+                        let _ = resolve.call0(&wasm_bindgen::JsValue::UNDEFINED);
+                    }
+                    Err(e) => {
+                        let _ = reject.call1(
+                            &wasm_bindgen::JsValue::UNDEFINED,
+                            &wasm_bindgen::JsValue::from_str(&format!("{e}")),
+                        );
+                    }
+                });
+            });
+            wasm_bindgen_futures::JsFuture::from(promise)
+                .await
+                .map_err(|e| anyhow!("mapAsync: {e:?}"))?;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let slice = staging.slice(..copy_len);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |r| {
+                let _ = tx.send(r);
+            });
+            self.poll_wait()?;
+            rx.recv().context("staging map channel")??;
+        }
+        let data = staging.slice(..copy_len).get_mapped_range()?;
+        let out = data[..len as usize].to_vec();
+        drop(data);
+        staging.unmap();
+        Ok(out)
+    }
+
+    fn poll_wait(&self) -> TractResult<()> {
+        // PollType::Wait is a no-op on web — the browser pumps GPU work.
+        // Never rely on it to complete mapAsync there.
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = self.inner.device.poll(wgpu::PollType::Poll);
+            Ok(())
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.inner
+                .device
+                .poll(wgpu::PollType::wait_indefinitely())
+                .map(|_| ())
+                .map_err(|e| anyhow!("wgpu poll: {e}"))
+        }
+    }
+}
+
+/// The uniform slot every layout ends with: one 256-byte window, addressed by
+/// the dynamic offset a dispatch passes.
+fn uniform_entry(binding: u32, uniform: &wgpu::Buffer) -> wgpu::BindGroupEntry<'_> {
+    wgpu::BindGroupEntry {
+        binding,
+        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+            buffer: uniform,
+            offset: 0,
+            size: Some(NonZeroU64::new(UNIFORM_ALIGN).unwrap()),
+        }),
+    }
+}
+
+fn pad4(bytes: &[u8]) -> Vec<u8> {
+    let mut v = bytes.to_vec();
+    while !v.len().is_multiple_of(4) {
+        v.push(0);
+    }
+    if v.is_empty() {
+        v.resize(4, 0);
+    }
+    v
+}
+
+impl DeviceContext for WgpuContext {
+    fn synchronize(&self) -> TractResult<()> {
+        with_wgpu_queue(|q| q.flush())
+    }
+
+    fn tensor_to_device(&self, tensor: TValue) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+        let view = tensor.view();
+        ensure!(
+            DeviceTensor::is_supported_dt(view.datum_type()),
+            "Tensor of {:?} is not copied. No device buffer can be allocated for it.",
+            view.datum_type(),
+        );
+        let bqs = as_q40_tensor(view.tensor);
+        let (data_bytes, bqf) = if let Some(bqs) = bqs {
+            (
+                bqs.value().as_bytes(),
+                Some(Box::new(BlockQuantFact::new(
+                    tract_core::dyn_clone::clone_box(bqs.format()),
+                    tensor.view().tensor.shape().into(),
+                )) as Box<dyn ExoticFact>),
+            )
+        } else {
+            (view.tensor.as_bytes(), None)
+        };
+        let buffer = Arc::new(self.wrap_storage(self.create_storage_buffer(data_bytes)));
+        Ok(Box::new(WgpuTensor {
+            buffer,
+            datum_type: view.datum_type(),
+            shape: view.shape().into(),
+            strides: view.strides().into(),
+            exotic_fact: bqf,
+        }))
+    }
+
+    fn uninitialized_device_tensor(
+        &self,
+        shape: &[usize],
+        dt: DatumType,
+    ) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+        let bytes = shape.iter().product::<usize>() * dt.size_of();
+        let buffer = self.alloc_storage(bytes as u64);
+        Ok(Box::new(WgpuTensor {
+            buffer,
+            datum_type: dt,
+            shape: shape.into(),
+            strides: Tensor::natural_strides(shape),
+            exotic_fact: None,
+        }))
+    }
+
+    fn uninitialized_device_exotic_tensor(
+        &self,
+        exotic_fact: Box<dyn ExoticFact>,
+    ) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+        if let Some(bqf) = exotic_fact.downcast_ref::<BlockQuantFact>() {
+            let blocks = bqf.shape().iter().product::<usize>() / bqf.format.block_len();
+            let bytes = blocks * bqf.format.block_bytes();
+            let buffer = self.alloc_storage(bytes as u64);
+            Ok(Box::new(WgpuTensor {
+                buffer,
+                datum_type: f32::datum_type(),
+                shape: tvec!(),
+                strides: tvec!(),
+                exotic_fact: Some(exotic_fact),
+            }))
+        } else {
+            bail!("Only BlockQuant tensor allocation supported for now")
+        }
+    }
+
+    fn copy_nd(
+        &self,
+        input: &DeviceTensor,
+        input_offset: usize,
+        input_strides: &[isize],
+        output: &DeviceTensor,
+        output_offset: usize,
+        output_shape: &[usize],
+        output_strides: &[isize],
+    ) -> TractResult<()> {
+        crate::kernels::copy::wgpu_copy_nd_dispatch(
+            input,
+            input_offset,
+            input_strides,
+            output,
+            output_offset,
+            output_shape,
+            output_strides,
+        )
+    }
+}
+
+struct Dispatch {
+    label: &'static str,
+    pipeline: wgpu::ComputePipeline,
+    bind_group: wgpu::BindGroup,
+    dynamic_offset: u32,
+    groups: [u32; 3],
+}
+
+/// GPU time attributed to one kernel family over a run.
+#[derive(Debug, Clone, Default)]
+pub struct KernelTime {
+    pub calls: usize,
+    pub nanos: f64,
+}
+
+pub struct WgpuQueue {
+    context: WgpuContext,
+    encoder: RefCell<Option<wgpu::CommandEncoder>>,
+    pending: RefCell<Vec<Dispatch>>,
+    uniform_staging: RefCell<Vec<u8>>,
+    profile: Cell<bool>,
+    profiled: RefCell<Vec<(&'static str, u32)>>,
+    queries: RefCell<Option<Queries>>,
+    uniform: ManuallyDrop<wgpu::Buffer>,
+    uniform_cursor: Cell<u64>,
+    retained: RefCell<Vec<DeviceTensor>>,
+    retained_textures: RefCell<Vec<wgpu::Texture>>,
+    staging: RefCell<Option<wgpu::Buffer>>,
+}
+
+/// One timestamp pair per dispatch, plus the buffers to read them back.
+struct Queries {
+    set: wgpu::QuerySet,
+    resolve: wgpu::Buffer,
+    read: wgpu::Buffer,
+    capacity: u32,
+}
+
+/// Timestamps are written per compute pass, so a profiled run puts every
+/// dispatch in a pass of its own: the attribution is real GPU time, but the
+/// total is not what an unprofiled run costs.
+const MAX_QUERIES: u32 = 4096;
+
+impl WgpuQueue {
+    /// GPU time per kernel family over `f`. Returns nothing when the adapter has
+    /// no timestamp queries.
+    pub fn profile<R>(
+        &self,
+        f: impl FnOnce() -> TractResult<R>,
+    ) -> TractResult<(R, Vec<(&'static str, KernelTime)>)> {
+        if !self.context.timestamps() {
+            return Ok((f()?, vec![]));
+        }
+        self.flush()?;
+        self.ensure_queries()?;
+        self.profiled.borrow_mut().clear();
+        self.profile.set(true);
+        let out = f();
+        let _ = self.flush();
+        self.profile.set(false);
+        Ok((out?, self.read_profile()?))
+    }
+
+    fn ensure_queries(&self) -> TractResult<()> {
+        let mut slot = self.queries.borrow_mut();
+        if slot.is_some() {
+            return Ok(());
+        }
+        let device = self.context.device();
+        let set = device.create_query_set(&wgpu::QuerySetDescriptor {
+            label: Some("tract-wgpu-timestamps"),
+            ty: wgpu::QueryType::Timestamp,
+            count: MAX_QUERIES,
+        });
+        let size = MAX_QUERIES as u64 * 8;
+        let resolve = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-timestamps-resolve"),
+            size,
+            usage: wgpu::BufferUsages::QUERY_RESOLVE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let read = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-timestamps-read"),
+            size,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        *slot = Some(Queries { set, resolve, read, capacity: MAX_QUERIES });
+        Ok(())
+    }
+
+    fn read_profile(&self) -> TractResult<Vec<(&'static str, KernelTime)>> {
+        let profiled = std::mem::take(&mut *self.profiled.borrow_mut());
+        if profiled.is_empty() {
+            return Ok(vec![]);
+        }
+        let slot = self.queries.borrow();
+        let queries = slot.as_ref().unwrap();
+        let used = profiled.len() as u32 * 2;
+        {
+            let mut encoder =
+                self.context.device().create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("tract-wgpu-resolve"),
+                });
+            encoder.resolve_query_set(&queries.set, 0..used, &queries.resolve, 0);
+            encoder.copy_buffer_to_buffer(&queries.resolve, 0, &queries.read, 0, used as u64 * 8);
+            self.context.queue().submit(Some(encoder.finish()));
+        }
+        let slice = queries.read.slice(..used as u64 * 8);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        self.context.poll_wait()?;
+        rx.recv().context("timestamp map channel")??;
+        let period = self.context.queue().get_timestamp_period() as f64;
+        let ticks: Vec<u64> = {
+            let data = slice.get_mapped_range()?;
+            data.chunks_exact(8).map(|c| u64::from_le_bytes(c.try_into().unwrap())).collect()
+        };
+        queries.read.unmap();
+
+        let mut by_label: HashMap<&'static str, KernelTime> = HashMap::new();
+        for (label, base) in profiled {
+            let (start, end) = (ticks[base as usize], ticks[base as usize + 1]);
+            let e = by_label.entry(label).or_default();
+            e.calls += 1;
+            e.nanos += end.saturating_sub(start) as f64 * period;
+        }
+        let mut out: Vec<_> = by_label.into_iter().collect();
+        out.sort_by(|a, b| b.1.nanos.total_cmp(&a.1.nanos));
+        Ok(out)
+    }
+}
+
+impl WgpuQueue {
+    fn new() -> TractResult<Self> {
+        let context = wgpu_context();
+        let uniform = context.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-uniform"),
+            size: UNIFORM_BYTES,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        Ok(Self {
+            context,
+            encoder: RefCell::new(None),
+            pending: RefCell::new(vec![]),
+            uniform_staging: RefCell::new(vec![]),
+            profile: Cell::new(false),
+            profiled: RefCell::new(vec![]),
+            queries: RefCell::new(None),
+            uniform: ManuallyDrop::new(uniform),
+            uniform_cursor: Cell::new(0),
+            retained: RefCell::new(vec![]),
+            retained_textures: RefCell::new(vec![]),
+            staging: RefCell::new(None),
+        })
+    }
+
+    pub fn context(&self) -> &WgpuContext {
+        &self.context
+    }
+
+    pub fn uniform(&self) -> &wgpu::Buffer {
+        &self.uniform
+    }
+
+    /// wgpu-core buffer drop takes a TLS snatch lock. Doing that from this
+    /// thread-local's destructor panics (`cannot access a Thread Local Storage
+    /// value during or after destruction`). Leak GPU objects; the device lives
+    /// in a process-level `OnceLock` for the rest of the run.
+    fn leak_gpu_objects(&mut self) {
+        std::mem::forget(self.encoder.replace(None));
+        std::mem::forget(self.staging.replace(None));
+        std::mem::forget(std::mem::take(&mut *self.retained.borrow_mut()));
+        std::mem::forget(std::mem::take(&mut *self.retained_textures.borrow_mut()));
+        unsafe {
+            std::mem::forget(ManuallyDrop::take(&mut self.uniform));
+        }
+    }
+
+    pub fn retain_tensor(&self, t: &DeviceTensor) {
+        self.retained.borrow_mut().push(t.clone());
+    }
+
+    pub fn retain_texture(&self, t: wgpu::Texture) {
+        self.retained_textures.borrow_mut().push(t);
+    }
+
+    fn encoder(&self) -> std::cell::RefMut<'_, wgpu::CommandEncoder> {
+        let mut slot = self.encoder.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(self.context.device().create_command_encoder(
+                &wgpu::CommandEncoderDescriptor { label: Some("tract-wgpu") },
+            ));
+        }
+        std::cell::RefMut::map(slot, |o| o.as_mut().unwrap())
+    }
+
+    /// Stages one dispatch's uniform block. The ring is uploaded once per
+    /// flush: a write per dispatch costs an allocation and a queue call each,
+    /// and a graph issues them by the hundred.
+    pub fn alloc_uniform(&self, bytes: &[u8]) -> TractResult<u32> {
+        ensure!(
+            bytes.len() as u64 <= UNIFORM_ALIGN,
+            "uniform payload {} > {UNIFORM_ALIGN}",
+            bytes.len()
+        );
+        let mut cursor = self.uniform_cursor.get();
+        if cursor + UNIFORM_ALIGN > UNIFORM_BYTES {
+            self.flush()?;
+            cursor = 0;
+        }
+        let mut staging = self.uniform_staging.borrow_mut();
+        let at = cursor as usize;
+        if staging.len() < at + UNIFORM_ALIGN as usize {
+            staging.resize(at + UNIFORM_ALIGN as usize, 0);
+        }
+        staging[at..at + bytes.len()].copy_from_slice(bytes);
+        staging[at + bytes.len()..at + UNIFORM_ALIGN as usize].fill(0);
+        self.uniform_cursor.set(cursor + UNIFORM_ALIGN);
+        Ok(cursor as u32)
+    }
+
+    /// Uploads the slots staged since the last flush, before anything reads
+    /// them.
+    fn upload_uniforms(&self) {
+        let used = self.uniform_cursor.get();
+        if used == 0 {
+            return;
+        }
+        let staging = self.uniform_staging.borrow();
+        self.context.queue().write_buffer(&self.uniform, 0, &staging[..used as usize]);
+    }
+
+    pub fn dispatch(
+        &self,
+        label: &'static str,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        dynamic_offset: u32,
+        n_elements: u64,
+    ) -> TractResult<()> {
+        if n_elements == 0 {
+            return Ok(());
+        }
+        let groups = n_elements.div_ceil(WORKGROUP as u64) as u32;
+        self.dispatch_grid(label, pipeline, bind_group, dynamic_offset, [groups, 1, 1])
+    }
+
+    /// A kernel whose workgroups tile a 2-D or 3-D iteration space itself.
+    pub fn dispatch_grid(
+        &self,
+        label: &'static str,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        dynamic_offset: u32,
+        groups: [u32; 3],
+    ) -> TractResult<()> {
+        if groups.contains(&0) {
+            return Ok(());
+        }
+        self.pending.borrow_mut().push(Dispatch {
+            label,
+            pipeline: pipeline.clone(),
+            bind_group: bind_group.clone(),
+            dynamic_offset,
+            groups,
+        });
+        Ok(())
+    }
+
+    /// Records everything queued since the last drain as a single compute pass.
+    /// WebGPU orders dispatches inside a pass and synchronizes their storage
+    /// accesses, so one pass per graph costs far less than one pass per kernel.
+    /// Anything that encodes a copy must drain first to keep its place in line.
+    fn drain_pending(&self) {
+        let pending = std::mem::take(&mut *self.pending.borrow_mut());
+        if pending.is_empty() {
+            return;
+        }
+        if self.profile.get() {
+            self.drain_profiled(&pending);
+            return;
+        }
+        let mut encoder = self.encoder();
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("tract-wgpu"),
+            timestamp_writes: None,
+        });
+        for d in &pending {
+            pass.set_pipeline(&d.pipeline);
+            pass.set_bind_group(0, &d.bind_group, &[d.dynamic_offset]);
+            pass.dispatch_workgroups(d.groups[0], d.groups[1], d.groups[2]);
+        }
+    }
+
+    /// Records `copy_buffer_to_buffer` behind the pending work and flushes the
+    /// lot in one submission.
+    pub fn flush_after_copy(
+        &self,
+        src: &wgpu::Buffer,
+        offset: u64,
+        dst: &wgpu::Buffer,
+        copy_len: u64,
+    ) -> TractResult<()> {
+        self.upload_uniforms();
+        self.drain_pending();
+        self.encoder().copy_buffer_to_buffer(src, offset, dst, 0, copy_len);
+        self.flush()
+    }
+
+    fn drain_profiled(&self, pending: &[Dispatch]) {
+        let slot = self.queries.borrow();
+        let Some(queries) = slot.as_ref() else { return };
+        let mut profiled = self.profiled.borrow_mut();
+        let mut encoder = self.encoder();
+        for d in pending {
+            let base = profiled.len() as u32 * 2;
+            if base + 2 > queries.capacity {
+                break;
+            }
+            profiled.push((d.label, base));
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some(d.label),
+                timestamp_writes: Some(wgpu::ComputePassTimestampWrites {
+                    query_set: &queries.set,
+                    beginning_of_pass_write_index: Some(base),
+                    end_of_pass_write_index: Some(base + 1),
+                }),
+            });
+            pass.set_pipeline(&d.pipeline);
+            pass.set_bind_group(0, &d.bind_group, &[d.dynamic_offset]);
+            pass.dispatch_workgroups(d.groups[0], d.groups[1], d.groups[2]);
+        }
+    }
+
+    pub fn flush(&self) -> TractResult<()> {
+        self.upload_uniforms();
+        self.drain_pending();
+        if let Some(encoder) = self.encoder.replace(None) {
+            self.context.queue().submit(Some(encoder.finish()));
+        }
+        self.context.poll_wait()?;
+        self.retained.borrow_mut().clear();
+        self.retained_textures.borrow_mut().clear();
+        self.uniform_cursor.set(0);
+        self.context.trim_bind_groups();
+        self.context.reset_buffer_slots();
+        Ok(())
+    }
+
+    fn copy_to_staging(
+        &self,
+        buffer: &wgpu::Buffer,
+        offset: u64,
+        copy_len: u64,
+    ) -> TractResult<()> {
+        {
+            let mut staging = self.staging.borrow_mut();
+            let need_new = staging.as_ref().map(|b| b.size() < copy_len).unwrap_or(true);
+            if need_new {
+                *staging = Some(self.context.device().create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("tract-wgpu-staging"),
+                    size: copy_len.max(4),
+                    usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                }));
+            }
+        }
+        let staging = self.staging.borrow();
+        let staging = staging.as_ref().unwrap();
+        let mut encoder =
+            self.context.device().create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("tract-wgpu-download"),
+            });
+        encoder.copy_buffer_to_buffer(buffer, offset, staging, 0, copy_len);
+        self.context.queue().submit(Some(encoder.finish()));
+        Ok(())
+    }
+
+    fn read_mapped_staging(&self, copy_len: u64, len: u64) -> TractResult<Vec<u8>> {
+        let staging = self.staging.borrow();
+        let staging = staging.as_ref().unwrap();
+        let slice = staging.slice(..copy_len);
+        let data = slice.get_mapped_range()?;
+        let out = data[..len as usize].to_vec();
+        drop(data);
+        staging.unmap();
+        Ok(out)
+    }
+
+    /// Blocking readback. On wasm without JSPI this errors: `PollType::Wait`
+    /// is a no-op. With `--features jspi`, [`crate::tensor::WgpuTensor::to_host`]
+    /// suspends via JSPI instead of calling this. Use [`Self::download_async`]
+    /// from an `async` entry.
+    pub fn download(&self, buffer: &wgpu::Buffer, offset: u64, len: u64) -> TractResult<Vec<u8>> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = (buffer, offset, len);
+            bail!(
+                "blocking GPU readback is not possible on web (PollType::Wait is a no-op). \
+                 After run(), await download_async / to_host_async once."
+            )
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.flush()?;
+            if len == 0 {
+                return Ok(vec![]);
+            }
+            let copy_len = len.next_multiple_of(4);
+            self.copy_to_staging(buffer, offset, copy_len)?;
+            let staging = self.staging.borrow();
+            let staging = staging.as_ref().unwrap();
+            let slice = staging.slice(..copy_len);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |r| {
+                let _ = tx.send(r);
+            });
+            let _ = staging;
+            self.context.poll_wait()?;
+            rx.recv().context("staging map channel")??;
+            self.read_mapped_staging(copy_len, len)
+        }
+    }
+
+    /// One await at the end of a run. Native path still blocks inside; web
+    /// yields to the browser so `mapAsync` can complete.
+    pub async fn download_async(
+        &self,
+        buffer: &wgpu::Buffer,
+        offset: u64,
+        len: u64,
+    ) -> TractResult<Vec<u8>> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.download(buffer, offset, len)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.flush()?;
+            if len == 0 {
+                return Ok(vec![]);
+            }
+            let copy_len = len.next_multiple_of(4);
+            self.copy_to_staging(buffer, offset, copy_len)?;
+            let staging = self.staging.borrow().as_ref().unwrap().clone();
+            let slice = staging.slice(..copy_len);
+            let promise = js_sys::Promise::new(&mut |resolve, reject| {
+                slice.map_async(wgpu::MapMode::Read, move |r| match r {
+                    Ok(()) => {
+                        let _ = resolve.call0(&wasm_bindgen::JsValue::UNDEFINED);
+                    }
+                    Err(e) => {
+                        let _ = reject.call1(
+                            &wasm_bindgen::JsValue::UNDEFINED,
+                            &wasm_bindgen::JsValue::from_str(&format!("{e}")),
+                        );
+                    }
+                });
+            });
+            wasm_bindgen_futures::JsFuture::from(promise)
+                .await
+                .map_err(|e| anyhow!("mapAsync: {e:?}"))?;
+            self.read_mapped_staging(copy_len, len)
+        }
+    }
+}
+
+impl Drop for WgpuQueue {
+    fn drop(&mut self) {
+        // Do not flush or drop wgpu buffers here: this type lives in TLS and
+        // wgpu-core buffer drop takes a TLS snatch lock.
+        self.leak_gpu_objects();
+    }
+}
+
+#[derive(Clone)]
+/// The identity a bind group is keyed on. It follows the buffer through the
+/// pool, so a graph that reuses its buffers reuses its bind groups; keying on
+/// the `wgpu::Buffer` itself would keep every buffer alive in the cache and
+/// leave the pool nothing to hand out.
+pub struct WgpuBuffer {
+    pub inner: wgpu::Buffer,
+    pub id: u64,
+}
+
+impl std::fmt::Debug for WgpuBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgpuBuffer").field("size", &self.inner.size()).finish()
+    }
+}
+
+impl DeviceBuffer for WgpuBuffer {
+    fn ptr(&self) -> *const c_void {
+        // Opaque identity of the wgpu buffer handle. WebGPU has no device
+        // address; launch functions downcast `WgpuBuffer` instead of using this.
+        std::ptr::from_ref(&self.inner) as *const c_void
+    }
+}

--- a/wgpu/src/coverage.rs
+++ b/wgpu/src/coverage.rs
@@ -1,0 +1,56 @@
+//! Load-time coverage check.
+//!
+//! Without JSPI a mid-graph GPU→CPU readback cannot complete in a browser.
+//! [`ensure_wgpu_coverage`] still fails with named ops for that case.
+//! The wgpu `Runtime::prepare` path skips it when
+//! [`crate::hybrid_fallback_available`] (native blocking poll, or wasm built
+//! with `--features jspi` on a JSPI browser): uncovered ops run on tract's
+//! CPU kernels instead.
+
+use tract_core::internal::*;
+use tract_core::ops::konst::Const;
+use tract_core::ops::source::TypedSource;
+use tract_gpu::fact::DeviceTypedFactExt;
+use tract_gpu::sync::DeviceSync;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UncoveredOp {
+    pub node: String,
+    pub op: String,
+}
+
+fn is_glue(node: &TypedNode) -> bool {
+    node.op_is::<TypedSource>() || node.op_is::<Const>() || node.op_is::<DeviceSync>()
+}
+
+/// Nodes the backend cannot run, in eval order. Glue (Source, Const, DeviceSync)
+/// is ignored; everything else must produce `DeviceFact` outputs.
+pub fn uncovered_ops(model: &TypedModel) -> TractResult<Vec<UncoveredOp>> {
+    let mut out = Vec::new();
+    for id in model.eval_order()? {
+        let node = &model.nodes()[id];
+        if is_glue(node) {
+            continue;
+        }
+        let facts = model.node_output_facts(id)?;
+        if facts.iter().all(|f| f.as_device_fact().is_some()) {
+            continue;
+        }
+        out.push(UncoveredOp { node: node.name.to_string(), op: node.op.name().to_string() });
+    }
+    Ok(out)
+}
+
+/// Reject a model that would need a mid-graph CPU fallback.
+pub fn ensure_wgpu_coverage(model: &TypedModel) -> TractResult<()> {
+    let bad = uncovered_ops(model)?;
+    if bad.is_empty() {
+        return Ok(());
+    }
+    let list =
+        bad.iter().map(|u| format!("{} (node {:?})", u.op, u.node)).collect::<Vec<_>>().join(", ");
+    bail!(
+        "tract-wgpu cannot run this model; no GPU kernel for: {list}. \
+         Mid-graph CPU fallback is not supported without JSPI."
+    )
+}

--- a/wgpu/src/jspi.rs
+++ b/wgpu/src/jspi.rs
@@ -1,0 +1,82 @@
+//! Optional JSPI hybrid fallback.
+//!
+//! Mid-graph GPU→CPU readback needs the wasm stack to suspend across
+//! `mapAsync`. JSPI does that; Asyncify is unavailable (`wasm32-unknown-emscripten`
+//! only) and must not become a load-time dependency:
+//!
+//! | Engine | WebGPU | JSPI |
+//! |---|---|---|
+//! | Chrome / Edge | 113+ | 137+ |
+//! | Firefox | Win 141+, macOS 147+ | 139+ |
+//! | Safari | 26.0 | 27 |
+//!
+//! Default wasm builds carry **no** `WebAssembly.Suspending` imports, so Safari
+//! 26 still loads a fully-covered model. Enable Cargo feature `jspi` for the
+//! hybrid binary (uncovered ops fall back to tract CPU kernels). Native always
+//! has blocking poll, so hybrid is on there with no feature flag.
+
+#[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+use tract_core::internal::*;
+
+/// True when a GPU→CPU sync can complete in the middle of `eval`.
+///
+/// Native: always (blocking `PollType::Wait`).
+/// Wasm: only if this crate was built with `--features jspi` **and** the
+/// browser exposes `WebAssembly.Suspending` / `WebAssembly.promising`.
+pub fn hybrid_fallback_available() -> bool {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        true
+    }
+    #[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+    {
+        jspi_in_browser()
+    }
+    #[cfg(all(target_arch = "wasm32", not(feature = "jspi")))]
+    {
+        false
+    }
+}
+
+/// `WebAssembly.Suspending` + `WebAssembly.promising` present on the global.
+#[cfg(target_arch = "wasm32")]
+pub fn jspi_in_browser() -> bool {
+    let Ok(wa) =
+        js_sys::Reflect::get(&js_sys::global(), &wasm_bindgen::JsValue::from_str("WebAssembly"))
+    else {
+        return false;
+    };
+    if wa.is_undefined() || wa.is_null() {
+        return false;
+    }
+    let sus = js_sys::Reflect::get(&wa, &wasm_bindgen::JsValue::from_str("Suspending")).ok();
+    let prom = js_sys::Reflect::get(&wa, &wasm_bindgen::JsValue::from_str("promising")).ok();
+    matches!(sus, Some(ref v) if v.is_function()) && matches!(prom, Some(ref v) if v.is_function())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn jspi_in_browser() -> bool {
+    false
+}
+
+/// Block on [`WgpuContext::download_async`] via JSPI. Must run inside a
+/// `#[wasm_bindgen(jspi)]` export (or a task spawned from one). Does not hold
+/// the `WGPU_QUEUE` TLS borrow across the suspend.
+#[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+pub fn download_jspi(buffer: &wgpu::Buffer, offset: u64, len: u64) -> TractResult<Vec<u8>> {
+    use wasm_bindgen::JsValue;
+
+    crate::with_wgpu_queue(|q| q.flush())?;
+    let ctx = crate::wgpu_context();
+    let buffer = buffer.clone();
+    let promise = wasm_bindgen_futures::future_to_promise(async move {
+        match ctx.download_async(&buffer, offset, len).await {
+            Ok(bytes) => Ok(js_sys::Uint8Array::from(bytes.as_slice()).into()),
+            Err(e) => Err(JsValue::from_str(&format!("{e:#}"))),
+        }
+    });
+    #[allow(deprecated)]
+    let val = js_sys::futures::jspi_block_on_promise(&promise)
+        .map_err(|e| anyhow::anyhow!("JSPI GPU readback failed: {e:?}"))?;
+    Ok(js_sys::Uint8Array::new(&val).to_vec())
+}

--- a/wgpu/src/kernels/bin_ops.rs
+++ b/wgpu/src/kernels/bin_ops.rs
@@ -1,0 +1,113 @@
+use tract_core::internal::*;
+use tract_core::ops::binary::BinMiniOp;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    BINARY_OPS, EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, Width,
+    broadcast_strides, dtypes, op_in_set, pack_u32s, pad8_u32,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{register_wgpu_op, with_wgpu_queue};
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    let mut keys = Vec::new();
+    for dt in dtypes(shader_f16) {
+        for name in BINARY_OPS {
+            for width in [Width::Scalar, Width::Vec4, Width::Vec4Splat] {
+                keys.push(PipelineKey {
+                    module: ModuleKey { kind: ModuleKind::Binary, dtype: *dt },
+                    entry: EntryPoint::wide(name, width, *dt),
+                });
+            }
+        }
+    }
+    keys
+}
+
+/// A wider thread only pays when the left operand runs with the output and the
+/// right one either does too or is constant across the four values.
+fn width_for(lhs: &DeviceTensor, rhs: &DeviceTensor, output: &DeviceTensor) -> Width {
+    let out_shape = output.shape();
+    let last = *out_shape.last().unwrap_or(&1);
+    if !output.len().is_multiple_of(4) || !last.is_multiple_of(4) {
+        return Width::Scalar;
+    }
+    let natural = Tensor::natural_strides(out_shape);
+    let runs_with_output = |t: &DeviceTensor| t.shape() == out_shape && t.strides() == &natural[..];
+    if !runs_with_output(lhs) {
+        return Width::Scalar;
+    }
+    if runs_with_output(rhs) {
+        Width::Vec4
+    } else if rhs.rank() == out_shape.len() && rhs.shape().last() == Some(&1) && last != 1 {
+        Width::Vec4Splat
+    } else {
+        Width::Scalar
+    }
+}
+
+pub fn is_supported(mini_op: &dyn BinMiniOp, dt: DatumType) -> bool {
+    let name = mini_op.name().to_lowercase();
+    BINARY_OPS.contains(&name.as_str()) && matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+pub fn wgpu_bin_op_dispatch(
+    mini_op: &dyn BinMiniOp,
+    lhs: &DeviceTensor,
+    rhs: &DeviceTensor,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(lhs);
+        q.retain_tensor(rhs);
+        q.retain_tensor(output);
+        ensure!(lhs.rank() == rhs.rank());
+        let dt = ShaderDtype::from_datum(lhs.datum_type())?;
+        let name = op_in_set(BINARY_OPS, mini_op.name())
+            .with_context(|| format!("tract-wgpu has no binary kernel for {}", mini_op.name()))?;
+        let width = width_for(lhs, rhs, output);
+        let key = PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Binary, dtype: dt },
+            entry: EntryPoint::wide(name, width, dt),
+        };
+        let pipeline = q.context().pipeline(key)?;
+        let lhs_buf = get_wgpu_buffer(lhs);
+        let rhs_buf = get_wgpu_buffer(rhs);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(
+            LayoutKind::Binary,
+            &[lhs_buf, rhs_buf, out_buf],
+            q.uniform(),
+        )?;
+
+        let out_shape = output.shape();
+        let lhs_s = broadcast_strides(lhs.shape(), lhs.strides(), out_shape);
+        let rhs_s = broadcast_strides(rhs.shape(), rhs.strides(), out_shape);
+        let shp = pad8_u32(out_shape);
+        let mut vals = vec![
+            element_offset(lhs, 0) as u32,
+            element_offset(rhs, 0) as u32,
+            element_offset(output, 0) as u32,
+            out_shape.len() as u32,
+            output.len() as u32,
+            0,
+            0,
+            0,
+        ];
+        vals.extend_from_slice(&lhs_s);
+        vals.extend_from_slice(&rhs_s);
+        vals.extend_from_slice(&shp);
+        let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+        let threads = if width == Width::Scalar { output.len() } else { output.len() / 4 };
+        q.dispatch("binary", &pipeline, &bg, dyn_off, threads as u64)
+    })
+}
+
+pub fn wgpu_bin_op(mini_op: Box<dyn BinMiniOp>) -> tract_gpu::ops::binary::GpuBinOp {
+    tract_gpu::ops::binary::GpuBinOp::new(mini_op, "Wgpu", wgpu_bin_op_dispatch)
+}
+
+register_wgpu_op!(tract_core::ops::binary::TypedBinOp, |source, node, op| {
+    rule_if!(is_supported(&*op.0, source.node_input_facts(node.id)?[0].datum_type));
+    Ok(Some(Box::new(wgpu_bin_op(op.0.clone()))))
+});

--- a/wgpu/src/kernels/cast.rs
+++ b/wgpu/src/kernels/cast.rs
@@ -1,0 +1,65 @@
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{register_wgpu_op, with_wgpu_queue};
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    if !shader_f16 {
+        return vec![];
+    }
+    vec![
+        PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Cast, dtype: ShaderDtype::F32 },
+            entry: EntryPoint::plain("cast_f32_f16"),
+        },
+        PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Cast, dtype: ShaderDtype::F16 },
+            entry: EntryPoint::plain("cast_f16_f32"),
+        },
+    ]
+}
+
+pub fn is_supported_dt(dt: DatumType) -> bool {
+    matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+pub fn wgpu_cast_dispatch(input: &DeviceTensor, output: &DeviceTensor) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        ensure!(input.shape() == output.shape());
+        let (dtype, entry) = match (input.datum_type(), output.datum_type()) {
+            (DatumType::F32, DatumType::F16) => {
+                (ShaderDtype::F32, EntryPoint::plain("cast_f32_f16"))
+            }
+            (DatumType::F16, DatumType::F32) => {
+                (ShaderDtype::F16, EntryPoint::plain("cast_f16_f32"))
+            }
+            (a, b) if a == b => return Ok(()),
+            (a, b) => bail!("tract-wgpu cast {a:?} -> {b:?} not implemented"),
+        };
+        let pipeline = q
+            .context()
+            .pipeline(PipelineKey { module: ModuleKey { kind: ModuleKind::Cast, dtype }, entry })?;
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(output, 0) as u32,
+            output.len() as u32,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("cast", &pipeline, &bg, dyn_off, output.len() as u64)
+    })
+}
+
+register_wgpu_op!(tract_core::ops::cast::Cast, |_source, _node, op| {
+    Ok(tract_gpu::ops::cast::GpuCast::new(op.to, "Wgpu", wgpu_cast_dispatch, is_supported_dt)
+        .map(|c| Box::new(c) as _))
+});

--- a/wgpu/src/kernels/chain.rs
+++ b/wgpu/src/kernels/chain.rs
@@ -1,0 +1,87 @@
+//! Dispatch for a fused elementwise chain.
+
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    ChainOperand, ChainStep, EntryPoint, LayoutKind, ShaderDtype, broadcast_strides, chain_key,
+    chain_wgsl, pack_u32s, pad8_u32,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+/// Extra operands a chain can read besides its head, bounded by what the
+/// 256-byte uniform slot holds.
+pub const MAX_EXTRA_INPUTS: usize = 3;
+
+pub fn wgpu_chain_dispatch(
+    steps: &[ChainStep],
+    inputs: &[&DeviceTensor],
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        ensure!(inputs.len() <= MAX_EXTRA_INPUTS + 1, "chain has too many inputs");
+        for t in inputs {
+            q.retain_tensor(t);
+        }
+        q.retain_tensor(output);
+        let dt = ShaderDtype::from_datum(output.datum_type())?;
+        let layout = LayoutKind::Chain(inputs.len() as u8 + 1);
+        let out_shape = output.shape();
+        let natural = Tensor::natural_strides(out_shape);
+        let contiguous: Vec<bool> =
+            inputs.iter().map(|t| t.shape() == out_shape && t.strides() == &natural[..]).collect();
+        // Four values a thread: the kernel is bandwidth-bound, so a wider load
+        // is the whole win. The four sit next to each other along the last
+        // axis, so an operand that broadcasts over that axis is one value for
+        // all of them and can be splatted; anything else still has to gather,
+        // and then a wider thread buys nothing.
+        let last = *out_shape.last().unwrap_or(&1);
+        let kinds: Option<Vec<ChainOperand>> = (output.len().is_multiple_of(4)
+            && last.is_multiple_of(4))
+        .then(|| {
+            inputs
+                .iter()
+                .zip(contiguous.iter())
+                .map(|(t, c)| {
+                    if *c {
+                        Some(ChainOperand::Contiguous)
+                    } else if t.rank() == out_shape.len()
+                        && t.shape().last() == Some(&1)
+                        && out_shape.last() != Some(&1)
+                    {
+                        Some(ChainOperand::Splat)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Option<Vec<_>>>()
+        })
+        .flatten();
+        let key = chain_key(dt, steps, &contiguous, kinds.as_deref());
+        let pipeline =
+            q.context().chain_pipeline(&key, layout, EntryPoint::plain("chain"), || {
+                chain_wgsl(dt, steps, &contiguous, kinds.as_deref())
+            })?;
+
+        let mut buffers: Vec<&crate::context::WgpuBuffer> =
+            inputs.iter().map(|t| get_wgpu_buffer(t)).collect();
+        buffers.push(get_wgpu_buffer(output));
+        let bg = q.context().bind_group(layout, &buffers, q.uniform())?;
+
+        let mut offsets = [0u32; 4];
+        for (i, t) in inputs.iter().enumerate() {
+            offsets[i] = element_offset(t, 0) as u32;
+        }
+        let mut vals =
+            vec![element_offset(output, 0) as u32, output.len() as u32, out_shape.len() as u32, 0];
+        vals.extend_from_slice(&offsets);
+        vals.extend_from_slice(&pad8_u32(out_shape));
+        for t in inputs {
+            vals.extend_from_slice(&broadcast_strides(t.shape(), t.strides(), out_shape));
+        }
+        let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+        let threads = if kinds.is_some() { output.len() / 4 } else { output.len() };
+        q.dispatch("chain", &pipeline, &bg, dyn_off, threads as u64)
+    })
+}

--- a/wgpu/src/kernels/conv.rs
+++ b/wgpu/src/kernels/conv.rs
@@ -1,0 +1,242 @@
+use tract_core::internal::*;
+use tract_core::ops::cnn::Conv;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    ChainStep, DW_WG, DepthwiseShape, EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey,
+    ShaderDtype, conv_depthwise_module, conv_module, keys_for, pack_u32s, program_key,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Conv, &["conv2d"], shader_f16)
+}
+
+fn as_u32_i32(v: i32) -> u32 {
+    v as u32
+}
+
+/// One filter per channel, no cross-channel sum: the tiled kernel applies.
+fn depthwise_shape(op: &Conv, channels_last: bool) -> Option<DepthwiseShape> {
+    let spec = &op.pool_spec;
+    if channels_last
+        || op.group == 1
+        || op.group != spec.input_channels
+        || spec.output_channels != spec.input_channels
+        || spec.kernel_shape.len() != 2
+    {
+        return None;
+    }
+    let strides = spec.strides();
+    let dilations = spec.dilations();
+    Some(DepthwiseShape {
+        kh: spec.kernel_shape[0] as u32,
+        kw: spec.kernel_shape[1] as u32,
+        stride_h: strides[0] as u32,
+        stride_w: strides[1] as u32,
+        dil_h: dilations[0] as u32,
+        dil_w: dilations[1] as u32,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dispatch_depthwise(
+    q: &crate::WgpuQueue,
+    op: &Conv,
+    shape: DepthwiseShape,
+    epilogue: &[ChainStep],
+    input: &DeviceTensor,
+    weights: &DeviceTensor,
+    extras: &[&DeviceTensor],
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    let dt = ShaderDtype::from_datum(input.datum_type())?;
+    let layout = LayoutKind::Chain(3 + extras.len() as u8);
+    let key = format!("convdw{}", shape.key());
+    let key = program_key(&key, dt, epilogue, extras.len());
+    let pipeline =
+        q.context().chain_pipeline(&key, layout, EntryPoint::typed("conv_dw", dt), || {
+            conv_depthwise_module(dt, shape, epilogue, extras.len())
+        })?;
+
+    let in_shape = op.pool_spec.data_format.shape(input.shape())?;
+    let out_shape = op.pool_spec.data_format.shape(output.shape())?;
+    let n = *in_shape.n().unwrap_or(&1);
+    let co = *out_shape.c();
+    let (oh, ow) = (out_shape.hw_dims()[0], out_shape.hw_dims()[1]);
+    let padding = op.pool_spec.computed_padding(in_shape.hw_dims());
+    let ws = weights.strides();
+
+    let mut buffers: Vec<&crate::context::WgpuBuffer> =
+        vec![get_wgpu_buffer(input), get_wgpu_buffer(weights)];
+    buffers.extend(extras.iter().map(|t| get_wgpu_buffer(t)));
+    buffers.push(get_wgpu_buffer(output));
+    let bg = q.context().bind_group(layout, &buffers, q.uniform())?;
+
+    let mut off_extra = [0u32; 4];
+    let mut mode_extra = [0u32; 4];
+    for (i, t) in extras.iter().enumerate() {
+        off_extra[i] = element_offset(t, 0) as u32;
+        mode_extra[i] = crate::kernels::matmul::epilogue_mode(t, co)?;
+    }
+    let mut vals = vec![
+        element_offset(input, 0) as u32,
+        element_offset(weights, 0) as u32,
+        element_offset(output, 0) as u32,
+        n as u32,
+        co as u32,
+        in_shape.hw_dims()[0] as u32,
+        in_shape.hw_dims()[1] as u32,
+        oh as u32,
+        ow as u32,
+        padding[0].pad_before as u32,
+        padding[1].pad_before as u32,
+        0,
+        as_u32_i32(*in_shape.n_stride().unwrap_or(&0) as i32),
+        as_u32_i32(*in_shape.c_stride() as i32),
+        as_u32_i32(in_shape.hw_strides()[0] as i32),
+        as_u32_i32(in_shape.hw_strides()[1] as i32),
+        as_u32_i32(ws[0] as i32),
+        as_u32_i32(ws[2] as i32),
+        as_u32_i32(ws[3] as i32),
+        0,
+        as_u32_i32(*out_shape.n_stride().unwrap_or(&0) as i32),
+        as_u32_i32(*out_shape.c_stride() as i32),
+        as_u32_i32(out_shape.hw_strides()[0] as i32),
+        as_u32_i32(out_shape.hw_strides()[1] as i32),
+    ];
+    vals.extend_from_slice(&off_extra);
+    vals.extend_from_slice(&mode_extra);
+    let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+    let groups = [(ow as u32).div_ceil(DW_WG), (oh as u32).div_ceil(DW_WG), (n * co) as u32];
+    q.dispatch_grid("conv_depthwise", &pipeline, &bg, dyn_off, groups)
+}
+
+pub fn wgpu_conv_dispatch(
+    op: &Conv,
+    epilogue: &[ChainStep],
+    input: &DeviceTensor,
+    weights: &DeviceTensor,
+    extras: &[&DeviceTensor],
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(weights);
+        for t in extras {
+            q.retain_tensor(t);
+        }
+        q.retain_tensor(output);
+        ensure!(matches!(input.datum_type(), DatumType::F32 | DatumType::F16));
+        let channels_last = op.pool_spec.data_format.c_is_last();
+        if let Some(shape) = depthwise_shape(op, channels_last) {
+            return dispatch_depthwise(q, op, shape, epilogue, input, weights, extras, output);
+        }
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let layout = LayoutKind::Chain(3 + extras.len() as u8);
+        let pipeline = if epilogue.is_empty() {
+            q.context().pipeline(PipelineKey {
+                module: ModuleKey { kind: ModuleKind::Conv, dtype: dt },
+                entry: EntryPoint::typed("conv2d", dt),
+            })?
+        } else {
+            let key = program_key("conv", dt, epilogue, extras.len());
+            q.context().chain_pipeline(&key, layout, EntryPoint::typed("conv2d", dt), || {
+                conv_module(dt, epilogue, extras.len())
+            })?
+        };
+
+        let in_shape = op.pool_spec.data_format.shape(input.shape())?;
+        let out_shape = op.pool_spec.data_format.shape(output.shape())?;
+        ensure!(in_shape.hw_rank() == 2, "tract-wgpu conv is 2D only");
+        let n = *in_shape.n().unwrap_or(&1);
+        let ci = *in_shape.c();
+        let co = *out_shape.c();
+        let ih = in_shape.hw_dims()[0];
+        let iw = in_shape.hw_dims()[1];
+        let oh = out_shape.hw_dims()[0];
+        let ow = out_shape.hw_dims()[1];
+        let kh = op.pool_spec.kernel_shape[0];
+        let kw = op.pool_spec.kernel_shape[1];
+        let groups = op.group;
+        let ci_pg = op.pool_spec.input_channels / groups;
+        let co_pg = op.pool_spec.output_channels / groups;
+        let padding = op.pool_spec.computed_padding(in_shape.hw_dims());
+        let strides = op.pool_spec.strides();
+        let dilations = op.pool_spec.dilations();
+        let channels_last = op.pool_spec.data_format.c_is_last() as u32;
+
+        let in_sn = *in_shape.n_stride().unwrap_or(&0);
+        let in_sc = *in_shape.c_stride();
+        let in_sh = in_shape.hw_strides()[0];
+        let in_sw = in_shape.hw_strides()[1];
+        let out_sn = *out_shape.n_stride().unwrap_or(&0);
+        let out_sc = *out_shape.c_stride();
+        let out_sh = out_shape.hw_strides()[0];
+        let out_sw = out_shape.hw_strides()[1];
+
+        // OIHW: [co, ci_pg, kh, kw]
+        let ws = weights.strides();
+        ensure!(ws.len() >= 4, "expected 4D OIHW kernel, got {:?}", weights.shape());
+        let w_so = ws[0];
+        let w_si = ws[1];
+        let w_sh = ws[2];
+        let w_sw = ws[3];
+
+        let mut buffers: Vec<&crate::context::WgpuBuffer> =
+            vec![get_wgpu_buffer(input), get_wgpu_buffer(weights)];
+        buffers.extend(extras.iter().map(|t| get_wgpu_buffer(t)));
+        buffers.push(get_wgpu_buffer(output));
+        let bg = q.context().bind_group(layout, &buffers, q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(weights, 0) as u32,
+            element_offset(output, 0) as u32,
+            n as u32,
+            ci as u32,
+            co as u32,
+            ih as u32,
+            iw as u32,
+            oh as u32,
+            ow as u32,
+            kh as u32,
+            kw as u32,
+            groups as u32,
+            ci_pg as u32,
+            co_pg as u32,
+            channels_last,
+            padding[0].pad_before as u32,
+            padding[1].pad_before as u32,
+            strides[0] as u32,
+            strides[1] as u32,
+            dilations[0] as u32,
+            dilations[1] as u32,
+            as_u32_i32(in_sn as i32),
+            as_u32_i32(in_sc as i32),
+            as_u32_i32(in_sh as i32),
+            as_u32_i32(in_sw as i32),
+            as_u32_i32(w_so as i32),
+            as_u32_i32(w_si as i32),
+            as_u32_i32(w_sh as i32),
+            as_u32_i32(w_sw as i32),
+            as_u32_i32(out_sn as i32),
+            as_u32_i32(out_sc as i32),
+            as_u32_i32(out_sh as i32),
+            as_u32_i32(out_sw as i32),
+        ]);
+        let mut tail = vec![0u32; 2];
+        let mut off_extra = [0u32; 4];
+        let mut mode_extra = [0u32; 4];
+        for (i, t) in extras.iter().enumerate() {
+            off_extra[i] = element_offset(t, 0) as u32;
+            mode_extra[i] = crate::kernels::matmul::epilogue_mode(t, co)?;
+        }
+        tail.extend_from_slice(&off_extra);
+        tail.extend_from_slice(&mode_extra);
+        let mut params = params;
+        params.extend_from_slice(&pack_u32s(&tail));
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("conv", &pipeline, &bg, dyn_off, (n * co * oh * ow) as u64)
+    })
+}

--- a/wgpu/src/kernels/copy.rs
+++ b/wgpu/src/kernels/copy.rs
@@ -1,0 +1,50 @@
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for, pack_u32s,
+    pad8_stride, pad8_u32,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Copy, &["copy"], shader_f16)
+}
+
+pub fn wgpu_copy_nd_dispatch(
+    input: &DeviceTensor,
+    input_offset: usize,
+    input_strides: &[isize],
+    output: &DeviceTensor,
+    output_offset: usize,
+    output_shape: &[usize],
+    output_strides: &[isize],
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let key = PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Copy, dtype: dt },
+            entry: EntryPoint::typed("copy", dt),
+        };
+        let pipeline = q.context().pipeline(key)?;
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let n: u64 = output_shape.iter().map(|d| *d as u64).product();
+        let rank = output_shape.len().max(1);
+        let mut vals = vec![
+            element_offset(input, input_offset) as u32,
+            element_offset(output, output_offset) as u32,
+            rank as u32,
+            n as u32,
+        ];
+        vals.extend_from_slice(&pad8_stride(input_strides));
+        vals.extend_from_slice(&pad8_stride(output_strides));
+        vals.extend_from_slice(&pad8_u32(output_shape));
+        let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+        q.dispatch("copy", &pipeline, &bg, dyn_off, n)
+    })
+}

--- a/wgpu/src/kernels/deconv.rs
+++ b/wgpu/src/kernels/deconv.rs
@@ -1,0 +1,119 @@
+use tract_core::internal::*;
+use tract_core::ops::cnn::Deconv;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Deconv, &["conv_transpose2d"], shader_f16)
+}
+
+fn as_u32_i32(v: i32) -> u32 {
+    v as u32
+}
+
+pub fn wgpu_deconv_dispatch(
+    op: &Deconv,
+    input: &DeviceTensor,
+    weights: &DeviceTensor,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(weights);
+        q.retain_tensor(output);
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let pipeline = q.context().pipeline(PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Deconv, dtype: dt },
+            entry: EntryPoint::typed("conv_transpose2d", dt),
+        })?;
+        let in_shape = op.pool_spec.data_format.shape(input.shape())?;
+        let out_shape = op.pool_spec.data_format.shape(output.shape())?;
+        ensure!(in_shape.hw_rank() == 2, "tract-wgpu conv_transpose is 2D only");
+        let n = *in_shape.n().unwrap_or(&1);
+        let ci = *in_shape.c();
+        let co = *out_shape.c();
+        let ih = in_shape.hw_dims()[0];
+        let iw = in_shape.hw_dims()[1];
+        let oh = out_shape.hw_dims()[0];
+        let ow = out_shape.hw_dims()[1];
+        let kh = op.pool_spec.kernel_shape[0];
+        let kw = op.pool_spec.kernel_shape[1];
+        let groups = op.group;
+        let ci_pg = op.pool_spec.input_channels / groups;
+        let co_pg = op.pool_spec.output_channels / groups;
+        let padding = op.pool_spec.padding.compute_for_deconv(
+            in_shape.hw_dims(),
+            &op.pool_spec.kernel_shape,
+            &op.pool_spec.dilations(),
+            &op.pool_spec.strides(),
+            &op.adjustments,
+        )?;
+        let strides = op.pool_spec.strides();
+        let dilations = op.pool_spec.dilations();
+
+        let in_sn = *in_shape.n_stride().unwrap_or(&0);
+        let in_sc = *in_shape.c_stride();
+        let in_sh = in_shape.hw_strides()[0];
+        let in_sw = in_shape.hw_strides()[1];
+        let out_sn = *out_shape.n_stride().unwrap_or(&0);
+        let out_sc = *out_shape.c_stride();
+        let out_sh = out_shape.hw_strides()[0];
+        let out_sw = out_shape.hw_strides()[1];
+        let ws = weights.strides();
+        ensure!(ws.len() >= 4);
+        // OIHW after tract's onnx converter: [co, ci_pg, kh, kw]
+        let w_so = ws[0];
+        let w_si = ws[1];
+        let w_sh = ws[2];
+        let w_sw = ws[3];
+
+        let in_buf = get_wgpu_buffer(input);
+        let w_buf = get_wgpu_buffer(weights);
+        let out_buf = get_wgpu_buffer(output);
+        let bg =
+            q.context().bind_group(LayoutKind::Binary, &[in_buf, w_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(weights, 0) as u32,
+            element_offset(output, 0) as u32,
+            n as u32,
+            ci as u32,
+            co as u32,
+            ih as u32,
+            iw as u32,
+            oh as u32,
+            ow as u32,
+            kh as u32,
+            kw as u32,
+            groups as u32,
+            ci_pg as u32,
+            co_pg as u32,
+            0,
+            padding[0].pad_before as u32,
+            padding[1].pad_before as u32,
+            strides[0] as u32,
+            strides[1] as u32,
+            dilations[0] as u32,
+            dilations[1] as u32,
+            as_u32_i32(in_sn as i32),
+            as_u32_i32(in_sc as i32),
+            as_u32_i32(in_sh as i32),
+            as_u32_i32(in_sw as i32),
+            as_u32_i32(w_so as i32),
+            as_u32_i32(w_si as i32),
+            as_u32_i32(w_sh as i32),
+            as_u32_i32(w_sw as i32),
+            as_u32_i32(out_sn as i32),
+            as_u32_i32(out_sc as i32),
+            as_u32_i32(out_sh as i32),
+            as_u32_i32(out_sw as i32),
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("deconv", &pipeline, &bg, dyn_off, (n * co * oh * ow) as u64)
+    })
+}

--- a/wgpu/src/kernels/element_wise.rs
+++ b/wgpu/src/kernels/element_wise.rs
@@ -1,0 +1,62 @@
+use tract_core::internal::*;
+use tract_core::ops::element_wise::ElementWiseMiniOp;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    ELEMENT_WISE_OPS, EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype,
+    keys_for, op_in_set, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{register_wgpu_op, with_wgpu_queue};
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::ElementWise, ELEMENT_WISE_OPS, shader_f16)
+}
+
+pub fn is_supported(mini_op: &dyn ElementWiseMiniOp, dt: DatumType) -> bool {
+    let name = mini_op.name().to_lowercase();
+    ELEMENT_WISE_OPS.contains(&name.as_str()) && matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+pub fn wgpu_element_wise_dispatch(
+    mini_op: &dyn ElementWiseMiniOp,
+    input: &DeviceTensor,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        ensure!(output.shape() == input.shape() && output.datum_type() == input.datum_type());
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let name = op_in_set(ELEMENT_WISE_OPS, &mini_op.name()).with_context(|| {
+            format!("tract-wgpu has no element-wise kernel for {}", mini_op.name())
+        })?;
+        let key = PipelineKey {
+            module: ModuleKey { kind: ModuleKind::ElementWise, dtype: dt },
+            entry: EntryPoint::typed(name, dt),
+        };
+        let pipeline = q.context().pipeline(key)?;
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(output, 0) as u32,
+            output.len() as u32,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("element_wise", &pipeline, &bg, dyn_off, output.len() as u64)
+    })
+}
+
+pub fn wgpu_element_wise_op(
+    mini_op: Box<dyn ElementWiseMiniOp>,
+) -> tract_gpu::ops::element_wise::GpuElementWise {
+    tract_gpu::ops::element_wise::GpuElementWise::new(mini_op, "Wgpu", wgpu_element_wise_dispatch)
+}
+
+register_wgpu_op!(tract_core::ops::element_wise::ElementWiseOp, |source, node, op| {
+    rule_if!(is_supported(&*op.0, source.node_input_facts(node.id)?[0].datum_type));
+    Ok(Some(Box::new(wgpu_element_wise_op(op.0.clone()))))
+});

--- a/wgpu/src/kernels/ingest.rs
+++ b/wgpu/src/kernels/ingest.rs
@@ -1,0 +1,186 @@
+//! RGBA8 texture → NCHW f32 ingest.
+//!
+//! Native: [`Queue::write_texture`] (bytes_per_row 256-aligned).
+//! Wasm: same CPU-bytes path, plus [`Queue::copy_external_image_to_texture`]
+//! for `VideoFrame` / `ImageBitmap` (wgpu 30 web `create_external_texture`
+//! is unimplemented). One GPU copy; the frame never lands as an f32 CPU tensor.
+
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{wgpu_context, with_wgpu_queue};
+
+pub fn all_pipeline_keys(_shader_f16: bool) -> Vec<PipelineKey> {
+    vec![PipelineKey {
+        module: ModuleKey { kind: ModuleKind::Ingest, dtype: ShaderDtype::F32 },
+        entry: EntryPoint::plain("rgba_to_nchw_f32"),
+    }]
+}
+
+fn ingest_usages() -> wgpu::TextureUsages {
+    wgpu::TextureUsages::TEXTURE_BINDING
+        | wgpu::TextureUsages::COPY_DST
+        | wgpu::TextureUsages::RENDER_ATTACHMENT
+}
+
+fn create_rgba8_texture(device: &wgpu::Device, width: u32, height: u32) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("tract-wgpu-ingest-rgba"),
+        size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: ingest_usages(),
+        view_formats: &[],
+    })
+}
+
+fn pad_rgba_rows(width: u32, height: u32, rgba: &[u8]) -> TractResult<(Vec<u8>, u32)> {
+    let row = width.checked_mul(4).context("width overflow")?;
+    ensure!(
+        rgba.len() == row as usize * height as usize,
+        "RGBA8 length {} != {width}x{height}x4",
+        rgba.len()
+    );
+    let padded_row = row.next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    if padded_row == row {
+        return Ok((rgba.to_vec(), row));
+    }
+    let mut out = vec![0u8; padded_row as usize * height as usize];
+    for y in 0..height as usize {
+        let src = y * row as usize;
+        let dst = y * padded_row as usize;
+        out[dst..dst + row as usize].copy_from_slice(&rgba[src..src + row as usize]);
+    }
+    Ok((out, padded_row))
+}
+
+fn dispatch_rgba_to_nchw(
+    q: &crate::WgpuQueue,
+    texture: wgpu::Texture,
+    width: u32,
+    height: u32,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    q.retain_tensor(output);
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let pipeline = q.context().pipeline(PipelineKey {
+        module: ModuleKey { kind: ModuleKind::Ingest, dtype: ShaderDtype::F32 },
+        entry: EntryPoint::plain("rgba_to_nchw_f32"),
+    })?;
+    let out_buf = get_wgpu_buffer(output);
+    let bg = q.context().bind_group_ingest(&view, &out_buf.inner, q.uniform())?;
+    let params = pack_u32s(&[element_offset(output, 0) as u32, width, height, 0]);
+    let dyn_off = q.alloc_uniform(&params)?;
+    q.dispatch("ingest", &pipeline, &bg, dyn_off, width as u64 * height as u64)?;
+    q.retain_texture(texture);
+    Ok(())
+}
+
+fn output_tensor(width: u32, height: u32) -> TractResult<DeviceTensor> {
+    DeviceTensor::uninitialized_dt(DatumType::F32, &[1, 3, height as usize, width as usize])
+}
+
+/// Upload tightly packed RGBA8 (`width * height * 4` bytes) and convert to
+/// NCHW f32 `[1, 3, H, W]` (alpha dropped). Works native and on wasm.
+pub fn tensor_from_rgba8(width: u32, height: u32, rgba: &[u8]) -> TractResult<DeviceTensor> {
+    ensure!(width > 0 && height > 0, "ingest size must be > 0");
+    wgpu_context();
+    with_wgpu_queue(|q| {
+        let (padded, bpr) = pad_rgba_rows(width, height, rgba)?;
+        let texture = create_rgba8_texture(q.context().device(), width, height);
+        q.context().queue().write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &padded,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bpr),
+                rows_per_image: Some(height),
+            },
+            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        );
+        let output = output_tensor(width, height)?;
+        dispatch_rgba_to_nchw(q, texture, width, height, &output)?;
+        Ok(output)
+    })
+}
+
+/// One-GPU-copy ingest from a WebCodecs `VideoFrame` / canvas / bitmap.
+/// Requires wgpu's web backend (`copy_external_image_to_texture`).
+#[cfg(target_arch = "wasm32")]
+pub fn tensor_from_external_image(
+    source: wgpu::ExternalImageSource,
+    width: u32,
+    height: u32,
+) -> TractResult<DeviceTensor> {
+    ensure!(width > 0 && height > 0, "ingest size must be > 0");
+    wgpu_context();
+    with_wgpu_queue(|q| {
+        let texture = create_rgba8_texture(q.context().device(), width, height);
+        q.context().queue().copy_external_image_to_texture(
+            &wgpu::CopyExternalImageSourceInfo {
+                source,
+                origin: wgpu::Origin2d::ZERO,
+                flip_y: false,
+            },
+            wgpu::CopyExternalImageDestInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+                color_space: wgpu::PredefinedColorSpace::Srgb,
+                premultiplied_alpha: false,
+            },
+            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        );
+        let output = output_tensor(width, height)?;
+        dispatch_rgba_to_nchw(q, texture, width, height, &output)?;
+        Ok(output)
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn tensor_from_video_frame(frame: web_sys::VideoFrame) -> TractResult<DeviceTensor> {
+    let width = frame.display_width();
+    let height = frame.display_height();
+    tensor_from_external_image(wgpu::ExternalImageSource::VideoFrame(frame), width, height)
+}
+
+/// Writes a single-channel tensor into a texture the caller owns, so a mask can
+/// be composited on the GPU instead of read back.
+pub fn tensor_to_texture(
+    mask: &DeviceTensor,
+    texture: &wgpu::Texture,
+    width: u32,
+    height: u32,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        ensure!(
+            mask.len() >= (width * height) as usize,
+            "mask of {} values is too small for {width}x{height}",
+            mask.len()
+        );
+        q.retain_tensor(mask);
+        let dt = ShaderDtype::from_datum(mask.datum_type())?;
+        let pipeline = q.context().pipeline(PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Export, dtype: dt },
+            entry: EntryPoint::typed("export", dt),
+        })?;
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let bg = q.context().bind_group_export(&get_wgpu_buffer(mask).inner, &view, q.uniform())?;
+        let params = pack_u32s(&[element_offset(mask, 0) as u32, width, height, 0]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.retain_texture(texture.clone());
+        q.dispatch("export", &pipeline, &bg, dyn_off, (width * height) as u64)
+    })
+}

--- a/wgpu/src/kernels/matmul.rs
+++ b/wgpu/src/kernels/matmul.rs
@@ -1,0 +1,167 @@
+//! Naive prefix-broadcasting GEMM: one thread per output element.
+//!
+//! `PrefixMatMul` is what tract lowers `EinSum` to, and a MobileNet-style
+//! segmenter reaches it through every pointwise convolution, so the backend
+//! needs it even though the tiled kernels (tfjs `matmul_packed`, ORT
+//! `subgroup_matrix_gemm`) are the ones worth having later.
+
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    ChainStep, EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for,
+    matmul_module, pack_u32s, program_key, rpad8_dims, rpad8_strides,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+/// Rank the 8 stride slots can address, two of them being the matmul axes.
+pub const MAX_RANK: usize = 8;
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::MatMul, &["matmul"], shader_f16)
+}
+
+/// `m`, `k`, `n` read off the trailing two axes of `a` and `b`.
+pub fn mkn(
+    a_shape: &[usize],
+    b_shape: &[usize],
+    transpose_a: bool,
+    transpose_b: bool,
+) -> TractResult<(usize, usize, usize)> {
+    let rank = a_shape.len();
+    ensure!(rank >= 2 && rank == b_shape.len(), "matmul wants two tensors of equal rank >= 2");
+    let (m, k) = if transpose_a {
+        (a_shape[rank - 1], a_shape[rank - 2])
+    } else {
+        (a_shape[rank - 2], a_shape[rank - 1])
+    };
+    let (kb, n) = if transpose_b {
+        (b_shape[rank - 1], b_shape[rank - 2])
+    } else {
+        (b_shape[rank - 2], b_shape[rank - 1])
+    };
+    ensure!(k == kb, "matmul k mismatch: a says {k}, b says {kb}");
+    Ok((m, k, n))
+}
+
+/// Output shape of `PrefixMatMul`: broadcast prefix, then `m`, `n` (swapped
+/// when `transpose_c`).
+pub fn output_shape(
+    a_shape: &[usize],
+    b_shape: &[usize],
+    transpose_a: bool,
+    transpose_b: bool,
+    transpose_c: bool,
+) -> TractResult<TVec<usize>> {
+    let rank = a_shape.len();
+    let (m, _, n) = mkn(a_shape, b_shape, transpose_a, transpose_b)?;
+    let mut shape: TVec<usize> =
+        (0..rank - 2).map(|ix| if a_shape[ix] == 1 { b_shape[ix] } else { a_shape[ix] }).collect();
+    if transpose_c {
+        shape.push(n);
+        shape.push(m);
+    } else {
+        shape.push(m);
+        shape.push(n);
+    }
+    Ok(shape)
+}
+
+pub fn is_supported_dt(dt: DatumType) -> bool {
+    matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+/// Epilogue operands are a scalar or one value per output column.
+pub fn epilogue_mode(extra: &DeviceTensor, n: usize) -> TractResult<u32> {
+    match extra.len() {
+        1 => Ok(0),
+        len if len == n => Ok(1),
+        len => bail!("epilogue operand of {len} values fits neither a scalar nor {n} columns"),
+    }
+}
+
+/// The transpose flags a `PrefixMatMul` carries, as the kernel reads them.
+#[derive(Debug, Clone, Copy)]
+pub struct Transposes {
+    pub a: bool,
+    pub b: bool,
+    pub c: bool,
+}
+
+pub fn wgpu_matmul_dispatch(
+    t: Transposes,
+    epilogue: &[ChainStep],
+    a: &DeviceTensor,
+    b: &DeviceTensor,
+    extras: &[&DeviceTensor],
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    let (transpose_a, transpose_b, transpose_c) = (t.a, t.b, t.c);
+    with_wgpu_queue(|q| {
+        q.retain_tensor(a);
+        q.retain_tensor(b);
+        q.retain_tensor(output);
+        ensure!(a.datum_type() == b.datum_type(), "matmul inputs must share a dtype");
+        ensure!(a.rank() <= MAX_RANK, "tract-wgpu matmul is limited to rank {MAX_RANK}");
+        for t in extras {
+            q.retain_tensor(t);
+        }
+        let dt = ShaderDtype::from_datum(a.datum_type())?;
+        let (m, k, n) = mkn(a.shape(), b.shape(), transpose_a, transpose_b)?;
+        let layout = LayoutKind::Chain(3 + extras.len() as u8);
+        let entry = EntryPoint::typed("matmul", dt);
+        let pipeline = if epilogue.is_empty() {
+            q.context().pipeline(PipelineKey {
+                module: ModuleKey { kind: ModuleKind::MatMul, dtype: dt },
+                entry,
+            })?
+        } else {
+            let key = program_key("matmul", dt, epilogue, extras.len());
+            q.context()
+                .chain_pipeline(&key, layout, entry, || matmul_module(dt, epilogue, extras.len()))?
+        };
+        let out_shape = output.shape();
+        ensure!(
+            out_shape
+                == &*output_shape(a.shape(), b.shape(), transpose_a, transpose_b, transpose_c)?,
+            "matmul output shape {out_shape:?} does not match its inputs"
+        );
+        let prefix: usize = out_shape[..out_shape.len() - 2].iter().product();
+
+        let mut buffers: Vec<&crate::context::WgpuBuffer> =
+            vec![get_wgpu_buffer(a), get_wgpu_buffer(b)];
+        buffers.extend(extras.iter().map(|t| get_wgpu_buffer(t)));
+        buffers.push(get_wgpu_buffer(output));
+        let bg = q.context().bind_group(layout, &buffers, q.uniform())?;
+
+        let mut vals = vec![
+            element_offset(a, 0) as u32,
+            element_offset(b, 0) as u32,
+            element_offset(output, 0) as u32,
+            prefix as u32,
+            m as u32,
+            k as u32,
+            n as u32,
+            transpose_a as u32,
+            transpose_b as u32,
+            transpose_c as u32,
+            0,
+            0,
+        ];
+        vals.extend_from_slice(&rpad8_strides(a.shape(), a.strides(), out_shape));
+        vals.extend_from_slice(&rpad8_strides(b.shape(), b.strides(), out_shape));
+        vals.extend_from_slice(&rpad8_strides(out_shape, output.strides(), out_shape));
+        vals.extend_from_slice(&rpad8_dims(out_shape));
+        let mut off_extra = [0u32; 4];
+        let mut mode_extra = [0u32; 4];
+        for (i, t) in extras.iter().enumerate() {
+            off_extra[i] = element_offset(t, 0) as u32;
+            mode_extra[i] = epilogue_mode(t, n)?;
+        }
+        vals.extend_from_slice(&off_extra);
+        vals.extend_from_slice(&mode_extra);
+        let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+        q.dispatch("matmul", &pipeline, &bg, dyn_off, (prefix * m * n) as u64)
+    })
+}

--- a/wgpu/src/kernels/mod.rs
+++ b/wgpu/src/kernels/mod.rs
@@ -1,0 +1,14 @@
+pub mod bin_ops;
+pub mod cast;
+pub mod chain;
+pub mod conv;
+pub mod copy;
+pub mod deconv;
+pub mod element_wise;
+pub mod ingest;
+pub mod matmul;
+pub mod pool;
+pub mod reduce;
+pub mod resize;
+pub mod shaders;
+pub mod softmax;

--- a/wgpu/src/kernels/pool.rs
+++ b/wgpu/src/kernels/pool.rs
@@ -1,0 +1,92 @@
+use tract_core::internal::*;
+use tract_core::ops::cnn::PoolSpec;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolKind {
+    Max,
+    Sum { count_include_pad: bool, normalize: bool },
+}
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Pool, &["max_pool_2d", "sum_pool_2d"], shader_f16)
+}
+
+pub fn wgpu_pool_supported(pool_spec: &PoolSpec, fact: &TypedFact) -> bool {
+    matches!(fact.datum_type, DatumType::F16 | DatumType::F32)
+        && fact.rank() == 4
+        && pool_spec.kernel_shape.len() == 2
+        && fact.shape.as_concrete().is_some()
+}
+
+pub fn wgpu_pool_dispatch(
+    pool_spec: &PoolSpec,
+    kind: PoolKind,
+    input: &DeviceTensor,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let stem = match kind {
+            PoolKind::Max => "max_pool_2d",
+            PoolKind::Sum { .. } => "sum_pool_2d",
+        };
+        let pipeline = q.context().pipeline(PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Pool, dtype: dt },
+            entry: EntryPoint::typed(stem, dt),
+        })?;
+        let in_shape = pool_spec.data_format.shape(input.shape())?;
+        let out_shape = pool_spec.data_format.shape(output.shape())?;
+        ensure!(in_shape.hw_rank() == 2);
+        let strides = pool_spec.strides();
+        let dilations = pool_spec.dilations();
+        let padding = pool_spec.computed_padding(in_shape.hw_dims());
+        let (count_include_pad, normalize) = match kind {
+            PoolKind::Max => (0u32, 0u32),
+            PoolKind::Sum { count_include_pad, normalize } => {
+                (count_include_pad as u32, normalize as u32)
+            }
+        };
+        let channels_last = pool_spec.data_format.c_is_last() as u32;
+        let n = *in_shape.n().unwrap_or(&1);
+        let c = *in_shape.c();
+        let oh = out_shape.hw_dims()[0];
+        let ow = out_shape.hw_dims()[1];
+        let nelem = (n * oh * ow * c) as u64;
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(output, 0) as u32,
+            n as u32,
+            in_shape.hw_dims()[0] as u32,
+            in_shape.hw_dims()[1] as u32,
+            c as u32,
+            oh as u32,
+            ow as u32,
+            pool_spec.kernel_shape[0] as u32,
+            pool_spec.kernel_shape[1] as u32,
+            strides[0] as u32,
+            strides[1] as u32,
+            padding[0].pad_before as u32,
+            padding[1].pad_before as u32,
+            dilations[0] as u32,
+            dilations[1] as u32,
+            count_include_pad,
+            normalize,
+            channels_last,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("pool", &pipeline, &bg, dyn_off, nelem)
+    })
+}

--- a/wgpu/src/kernels/reduce.rs
+++ b/wgpu/src/kernels/reduce.rs
@@ -1,0 +1,82 @@
+use tract_core::internal::*;
+use tract_gpu::ops::reduce::Reducer;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for, op_in_set,
+    pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{register_wgpu_op, with_wgpu_queue};
+
+/// The reducers the module has an entry point for, spelled as the WGSL names
+/// them.
+const REDUCE_OPS: &[&str] =
+    &["reduce_sum", "reduce_prod", "reduce_max", "reduce_min", "reduce_mean_of_squares"];
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Reduce, REDUCE_OPS, shader_f16)
+}
+
+fn reshape_to_rank_3(shape: &[usize], axis: usize) -> [usize; 3] {
+    let outer: usize = shape[..axis].iter().product();
+    let k = shape[axis];
+    let inner: usize = shape[axis + 1..].iter().product();
+    [outer.max(1), k, inner.max(1)]
+}
+
+pub fn wgpu_reduce_launch(
+    reducer: &Reducer,
+    input: &DeviceTensor,
+    axis: usize,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        ensure!(output.datum_type() == input.datum_type());
+        ensure!(output.shape()[axis] == 1);
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        if reducer.is_logic() {
+            bail!("tract-wgpu reduce has no bool path yet");
+        }
+        let name = op_in_set(REDUCE_OPS, &format!("reduce_{reducer}"))
+            .with_context(|| format!("tract-wgpu has no reduce kernel for {reducer}"))?;
+        let key = PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Reduce, dtype: dt },
+            entry: EntryPoint::typed(name, dt),
+        };
+        let pipeline = q.context().pipeline(key)?;
+        let nd3 = reshape_to_rank_3(input.shape(), axis);
+        let n = (nd3[0] * nd3[2]) as u64;
+        if n == 0 || nd3[1] == 0 {
+            return Ok(());
+        }
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(output, 0) as u32,
+            nd3[0] as u32,
+            nd3[1] as u32,
+            nd3[2] as u32,
+            0,
+            0,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("reduce", &pipeline, &bg, dyn_off, n)
+    })
+}
+
+register_wgpu_op!(tract_core::ops::nn::Reduce, |source, node, op| {
+    let dt = source.node_input_facts(node.id)?[0].datum_type;
+    if let Ok(gpu_op) =
+        tract_gpu::ops::reduce::GpuReduce::from_tract_core(op, "Wgpu", wgpu_reduce_launch)
+    {
+        rule_if!(gpu_op.reducer.is_supported_dt(dt));
+        return Ok(Some(Box::new(gpu_op)));
+    }
+    Ok(None)
+});

--- a/wgpu/src/kernels/resize.rs
+++ b/wgpu/src/kernels/resize.rs
@@ -1,0 +1,117 @@
+use anyhow::ensure;
+use tract_core::internal::*;
+use tract_core::ops::nn::resize::Resize as CoreResize;
+use tract_gpu::ops::resize::GpuResize;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Resize, &["resize_axis"], shader_f16)
+}
+
+pub fn wgpu_resize_axis_dispatch(
+    input: &DeviceTensor,
+    axis: usize,
+    indices: &DeviceTensor,
+    weights: &DeviceTensor,
+    window: usize,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(indices);
+        q.retain_tensor(weights);
+        q.retain_tensor(output);
+        ensure!(input.rank() > axis);
+        ensure!(indices.datum_type() == i32::datum_type());
+        ensure!(weights.datum_type() == f32::datum_type());
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let pipeline = q.context().pipeline(PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Resize, dtype: dt },
+            entry: EntryPoint::typed("resize_axis", dt),
+        })?;
+        let len_in = input.shape()[axis];
+        let len_out = output.shape()[axis];
+        let inner: usize = input.shape()[axis + 1..].iter().product();
+        let outer: usize = input.shape()[..axis].iter().product();
+        let n = (outer.max(1) * len_out * inner.max(1)) as u64;
+        let in_buf = get_wgpu_buffer(input);
+        let idx_buf = get_wgpu_buffer(indices);
+        let w_buf = get_wgpu_buffer(weights);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(
+            LayoutKind::Resize,
+            &[in_buf, idx_buf, w_buf, out_buf],
+            q.uniform(),
+        )?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(indices, 0) as u32,
+            element_offset(weights, 0) as u32,
+            element_offset(output, 0) as u32,
+            outer.max(1) as u32,
+            len_in as u32,
+            len_out as u32,
+            inner.max(1) as u32,
+            window as u32,
+            0,
+            0,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("resize", &pipeline, &bg, dyn_off, n)
+    })
+}
+
+fn baked_plans(
+    source: &TypedModel,
+    node: &TypedNode,
+    op: &CoreResize,
+) -> TractResult<Option<GpuResize>> {
+    let facts = source.node_input_facts(node.id)?;
+    let Some(input_shape) = facts[0].shape.as_concrete() else { return Ok(None) };
+    let aux = |ix: Option<usize>| ix.and_then(|ix| facts.get(ix)?.konst.as_deref());
+    let scales_konst = aux(op.optional_scales_input);
+    let sizes_konst = aux(op.optional_sizes_input);
+    if scales_konst.is_none() && sizes_konst.is_none() {
+        return Ok(None);
+    }
+    let output_shape: TVec<usize> =
+        op.compute_output_shape(input_shape, scales_konst, sizes_konst)?;
+    let scales: TVec<f32> = match scales_konst.filter(|s| s.len() == input_shape.len()) {
+        Some(scales) => scales.cast_to::<f32>()?.try_as_plain()?.as_slice::<f32>()?.into(),
+        None => output_shape.iter().zip(input_shape).map(|(o, i)| *o as f32 / *i as f32).collect(),
+    };
+    let (mut axes, mut windows, mut plans) = (tvec!(), tvec!(), tvec!());
+    for (axis, &scale) in scales.iter().enumerate() {
+        let (len_in, len_out) = (input_shape[axis], output_shape[axis]);
+        if len_in == len_out && scale == 1.0 {
+            continue;
+        }
+        let plan = op.plan_axis(scale, len_in, len_out);
+        let indices: Vec<i32> = plan.indices.iter().map(|&i| i as i32).collect();
+        plans.push((
+            tract_ndarray::arr1(&indices).into_arc_tensor(),
+            tract_ndarray::arr1(&plan.weights).into_arc_tensor(),
+        ));
+        axes.push(axis);
+        windows.push(plan.window);
+    }
+    if axes.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(GpuResize::new(axes, windows, plans, output_shape, "Wgpu", wgpu_resize_axis_dispatch)))
+}
+
+pub fn wgpu_resize(source: &TypedModel, node: &TypedNode) -> TractResult<Option<Box<dyn TypedOp>>> {
+    let Some(op) = node.op_as::<CoreResize>() else { return Ok(None) };
+    let facts = source.node_input_facts(node.id)?;
+    rule_if!(facts[0].is_plain());
+    rule_if!(matches!(facts[0].datum_type, DatumType::F32 | DatumType::F16));
+    Ok(baked_plans(source, node, op)?.map(|op| Box::new(op) as Box<dyn TypedOp>))
+}

--- a/wgpu/src/kernels/shaders.rs
+++ b/wgpu/src/kernels/shaders.rs
@@ -1,0 +1,1963 @@
+//! WGSL sources for Phase 1 kernels.
+//!
+//! Flattened 1-D indexing: `dispatch_workgroups` is 3-D, tract tensors are
+//! routinely 4-D+, so shaders take a linear id and apply strides from uniforms.
+//! Byte offsets live in uniforms so arena views work without 256-byte-aligned
+//! `GPUBufferBinding.offset` (the whole storage buffer is bound at 0).
+//!
+//! Structure follows tfjs-backend-webgpu unary/binary (Apache-2.0): one entry
+//! point per op, tightly packed storage arrays. Not a transcription of their
+//! TypeScript generators.
+
+use tract_core::internal::*;
+
+pub const WORKGROUP: u32 = 64;
+
+/// Reads one of the eight values a uniform packs as two `vec4<u32>`.
+const AT8: &str = "fn at8(a: vec4<u32>, b: vec4<u32>, i: u32) -> u32 {
+    if (i < 4u) { return a[i]; }
+    return b[i - 4u];
+}";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LayoutKind {
+    Unary,
+    Binary,
+    Resize,
+    Ingest,
+    /// Writes a tensor into a storage texture the caller owns.
+    Export,
+    /// A fused elementwise chain: `n` storage buffers, the last one the output.
+    Chain(u8),
+}
+
+impl LayoutKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Unary => "tract-wgpu-unary-layout",
+            Self::Binary => "tract-wgpu-binary-layout",
+            Self::Resize => "tract-wgpu-resize-layout",
+            Self::Ingest => "tract-wgpu-ingest-layout",
+            Self::Export => "tract-wgpu-export-layout",
+            Self::Chain(_) => "tract-wgpu-chain-layout",
+        }
+    }
+
+    pub fn storage_count(self) -> u32 {
+        match self {
+            Self::Unary => 2,
+            Self::Binary => 3,
+            Self::Resize => 4,
+            Self::Ingest => 1,
+            Self::Export => 1,
+            Self::Chain(n) => n as u32,
+        }
+    }
+
+    pub fn bind_group_layout_entries(self) -> Vec<wgpu::BindGroupLayoutEntry> {
+        if self == Self::Export {
+            return vec![
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::StorageTexture {
+                        access: wgpu::StorageTextureAccess::WriteOnly,
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: std::num::NonZeroU64::new(256),
+                    },
+                    count: None,
+                },
+            ];
+        }
+        if self == Self::Ingest {
+            return vec![
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: std::num::NonZeroU64::new(256),
+                    },
+                    count: None,
+                },
+            ];
+        }
+        let mut entries = Vec::new();
+        let n = self.storage_count();
+        for i in 0..n {
+            let read_only = i + 1 < n;
+            entries.push(wgpu::BindGroupLayoutEntry {
+                binding: i,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            });
+        }
+        entries.push(wgpu::BindGroupLayoutEntry {
+            binding: n,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: true,
+                min_binding_size: std::num::NonZeroU64::new(256),
+            },
+            count: None,
+        });
+        entries
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShaderDtype {
+    F32,
+    F16,
+}
+
+impl ShaderDtype {
+    pub fn from_datum(dt: DatumType) -> TractResult<Self> {
+        match dt {
+            DatumType::F32 => Ok(Self::F32),
+            DatumType::F16 => Ok(Self::F16),
+            _ => bail!("tract-wgpu Phase 1 kernel has no WGSL path for {dt:?}"),
+        }
+    }
+
+    pub fn wgsl(self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::F16 => "f16",
+        }
+    }
+
+    /// Entry points are suffixed with the WGSL type they were generated for.
+    pub fn suffix(self) -> &'static str {
+        self.wgsl()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ModuleKind {
+    ElementWise,
+    Binary,
+    Copy,
+    Reduce,
+    Pool,
+    Cast,
+    Conv,
+    Deconv,
+    Resize,
+    Softmax,
+    Ingest,
+    Export,
+    MatMul,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ModuleKey {
+    pub kind: ModuleKind,
+    pub dtype: ShaderDtype,
+}
+
+impl ModuleKey {
+    pub fn label(self) -> &'static str {
+        match (self.kind, self.dtype) {
+            (ModuleKind::ElementWise, ShaderDtype::F32) => "element_wise_f32",
+            (ModuleKind::ElementWise, ShaderDtype::F16) => "element_wise_f16",
+            (ModuleKind::Binary, ShaderDtype::F32) => "binary_f32",
+            (ModuleKind::Binary, ShaderDtype::F16) => "binary_f16",
+            (ModuleKind::Copy, ShaderDtype::F32) => "copy_f32",
+            (ModuleKind::Copy, ShaderDtype::F16) => "copy_f16",
+            (ModuleKind::Reduce, ShaderDtype::F32) => "reduce_f32",
+            (ModuleKind::Reduce, ShaderDtype::F16) => "reduce_f16",
+            (ModuleKind::Pool, ShaderDtype::F32) => "pool_f32",
+            (ModuleKind::Pool, ShaderDtype::F16) => "pool_f16",
+            (ModuleKind::Cast, ShaderDtype::F32) => "cast_f32",
+            (ModuleKind::Cast, ShaderDtype::F16) => "cast_f16",
+            (ModuleKind::Conv, ShaderDtype::F32) => "conv_f32",
+            (ModuleKind::Conv, ShaderDtype::F16) => "conv_f16",
+            (ModuleKind::Deconv, ShaderDtype::F32) => "deconv_f32",
+            (ModuleKind::Deconv, ShaderDtype::F16) => "deconv_f16",
+            (ModuleKind::Resize, ShaderDtype::F32) => "resize_f32",
+            (ModuleKind::Resize, ShaderDtype::F16) => "resize_f16",
+            (ModuleKind::Softmax, ShaderDtype::F32) => "softmax_f32",
+            (ModuleKind::Softmax, ShaderDtype::F16) => "softmax_f16",
+            (ModuleKind::Export, ShaderDtype::F32) => "export_f32",
+            (ModuleKind::Export, ShaderDtype::F16) => "export_f16",
+            (ModuleKind::Ingest, ShaderDtype::F32) => "ingest_f32",
+            (ModuleKind::Ingest, ShaderDtype::F16) => "ingest_f16",
+            (ModuleKind::MatMul, ShaderDtype::F32) => "matmul_f32",
+            (ModuleKind::MatMul, ShaderDtype::F16) => "matmul_f16",
+        }
+    }
+
+    pub fn layout(self) -> LayoutKind {
+        match self.kind {
+            ModuleKind::ElementWise
+            | ModuleKind::Copy
+            | ModuleKind::Reduce
+            | ModuleKind::Pool
+            | ModuleKind::Cast
+            | ModuleKind::Softmax => LayoutKind::Unary,
+            ModuleKind::Binary | ModuleKind::Conv | ModuleKind::Deconv | ModuleKind::MatMul => {
+                LayoutKind::Binary
+            }
+            ModuleKind::Resize => LayoutKind::Resize,
+            ModuleKind::Ingest => LayoutKind::Ingest,
+            ModuleKind::Export => LayoutKind::Export,
+        }
+    }
+
+    pub fn wgsl(self) -> String {
+        match self.kind {
+            ModuleKind::ElementWise => element_wise_wgsl(self.dtype),
+            ModuleKind::Binary => binary_wgsl(self.dtype),
+            ModuleKind::Copy => copy_wgsl(self.dtype),
+            ModuleKind::Reduce => reduce_wgsl(self.dtype),
+            ModuleKind::Pool => pool_wgsl(self.dtype),
+            ModuleKind::Cast => cast_wgsl(self.dtype),
+            ModuleKind::Conv => conv_wgsl(self.dtype),
+            ModuleKind::Deconv => deconv_wgsl(self.dtype),
+            ModuleKind::Resize => resize_wgsl(self.dtype),
+            ModuleKind::Softmax => softmax_wgsl(self.dtype),
+            ModuleKind::Ingest => ingest_wgsl(self.dtype),
+            ModuleKind::Export => export_wgsl(self.dtype),
+            ModuleKind::MatMul => matmul_wgsl(self.dtype),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PipelineKey {
+    pub module: ModuleKey,
+    pub entry: EntryPoint,
+}
+
+/// How many values of the last axis one thread of a kernel handles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Width {
+    Scalar,
+    Vec4,
+    Vec4Splat,
+}
+
+impl Width {
+    fn infix(self) -> &'static str {
+        match self {
+            Self::Scalar => "",
+            Self::Vec4 => "_v4",
+            Self::Vec4Splat => "_v4s",
+        }
+    }
+}
+
+/// A kernel's WGSL entry point, held in the pieces the generator spells it
+/// from so that naming one costs no allocation on the dispatch path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntryPoint {
+    stem: &'static str,
+    infix: &'static str,
+    suffix: &'static str,
+}
+
+impl EntryPoint {
+    /// One of a module's per-dtype entry points, `<stem>_<dtype>`.
+    pub fn typed(stem: &'static str, dtype: ShaderDtype) -> Self {
+        Self { stem, infix: "", suffix: dtype.suffix() }
+    }
+
+    /// A per-dtype entry point in its `width`-value-per-thread form.
+    pub fn wide(stem: &'static str, width: Width, dtype: ShaderDtype) -> Self {
+        Self { stem, infix: width.infix(), suffix: dtype.suffix() }
+    }
+
+    /// An entry point that names the dtypes it works on itself.
+    pub fn plain(name: &'static str) -> Self {
+        Self { stem: name, infix: "", suffix: "" }
+    }
+
+    /// Spelled out, as the generated WGSL declares it. Only a pipeline cache
+    /// miss needs this.
+    pub fn name(&self) -> String {
+        let sep = if self.suffix.is_empty() { "" } else { "_" };
+        format!("{}{}{sep}{}", self.stem, self.infix, self.suffix)
+    }
+}
+
+/// The dtypes this device can run a kernel for.
+pub fn dtypes(shader_f16: bool) -> &'static [ShaderDtype] {
+    if shader_f16 { &[ShaderDtype::F32, ShaderDtype::F16] } else { &[ShaderDtype::F32] }
+}
+
+/// Every pipeline a module serves: each of `stems` at each dtype the device
+/// can run.
+pub fn keys_for(kind: ModuleKind, stems: &[&'static str], shader_f16: bool) -> Vec<PipelineKey> {
+    dtypes(shader_f16)
+        .iter()
+        .flat_map(|dt| {
+            stems.iter().map(|stem| PipelineKey {
+                module: ModuleKey { kind, dtype: *dt },
+                entry: EntryPoint::typed(stem, *dt),
+            })
+        })
+        .collect()
+}
+
+/// The set's own `&'static str` for `name`, matched the way an op reaches us
+/// from tract: case-insensitively, and without allocating to lowercase it.
+pub fn op_in_set(set: &'static [&'static str], name: &str) -> Option<&'static str> {
+    set.iter().copied().find(|op| op.eq_ignore_ascii_case(name))
+}
+
+fn preamble(dt: ShaderDtype) -> String {
+    let enable = match dt {
+        ShaderDtype::F16 => "enable f16;\n",
+        ShaderDtype::F32 => "",
+    };
+    enable.to_string()
+}
+
+/// One link of a fused elementwise chain. `Binary` reads its second operand
+/// from an extra input; `swapped` puts the running value on the right.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ChainStep {
+    Unary(String),
+    Binary { op: String, rhs: usize, swapped: bool },
+}
+
+/// Names the generated program, and so keys its pipeline. `contiguous` says
+/// which inputs share the output's layout and can skip index arithmetic.
+/// How a chain operand is read: element for element with the output, one value
+/// splatted across the four a thread handles, or gathered through its strides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainOperand {
+    Contiguous,
+    Splat,
+    Gather,
+}
+
+pub fn chain_key(
+    dt: ShaderDtype,
+    steps: &[ChainStep],
+    contiguous: &[bool],
+    kinds: Option<&[ChainOperand]>,
+) -> String {
+    let mut key = format!("chain_{}", dt.suffix());
+    match kinds {
+        Some(kinds) => {
+            key.push_str("_v4");
+            for k in kinds {
+                key.push(match k {
+                    ChainOperand::Contiguous => 'c',
+                    ChainOperand::Splat => 's',
+                    ChainOperand::Gather => 'g',
+                });
+            }
+        }
+        None => {
+            for c in contiguous {
+                key.push(if *c { 'c' } else { 'b' });
+            }
+        }
+    }
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => key.push_str(&format!("_{op}")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                key.push_str(&format!("_{op}{rhs}{}", if *swapped { "r" } else { "" }))
+            }
+        }
+    }
+    key
+}
+
+/// The chain over `vec4`s: a thread takes four values at a time, which is
+/// where the win is on a bandwidth-bound kernel. The four are adjacent along
+/// the last axis, so an operand broadcasting over that axis is read once and
+/// splatted.
+fn chain_vec4_wgsl(dt: ShaderDtype, steps: &[ChainStep], kinds: &[ChainOperand]) -> String {
+    let t = dt.wgsl();
+    let inputs = kinds.len();
+    let mut s = preamble(dt);
+    s.push_str("struct Params {\n    off_out: u32,\n    len: u32,\n    rank: u32,\n    _p: u32,\n    off_in: vec4<u32>,\n    out_sh0: vec4<u32>,\n    out_sh1: vec4<u32>,\n");
+    for i in 0..inputs {
+        s.push_str(&format!("    s{i}_0: vec4<u32>,\n    s{i}_1: vec4<u32>,\n"));
+    }
+    s.push_str("}\n\n");
+    for (i, kind) in kinds.iter().enumerate() {
+        let ty = match kind {
+            ChainOperand::Contiguous => format!("array<vec4<{t}>>"),
+            _ => format!("array<{t}>"),
+        };
+        s.push_str(&format!("@group(0) @binding({i}) var<storage, read> in{i}: {ty};\n"));
+    }
+    s.push_str(&format!(
+        "@group(0) @binding({inputs}) var<storage, read_write> outp: array<vec4<{t}>>;\n"
+    ));
+    s.push_str(&format!("@group(0) @binding({}) var<uniform> params: Params;\n\n", inputs + 1));
+    s.push_str(AT8);
+    s.push_str("\n\n");
+    s.push_str(&unary_ops_wgsl(t));
+    s.push_str(&binary_ops_wgsl(t));
+    s.push_str(&unary_ops_vec4_wgsl(t));
+    s.push_str(&binary_ops_vec4_wgsl(t));
+    for (i, kind) in kinds.iter().enumerate() {
+        if *kind == ChainOperand::Contiguous {
+            continue;
+        }
+        s.push_str(&format!(
+            r#"
+fn gather{i}(linear: u32) -> u32 {{
+    var rest = linear;
+    var idx = 0u;
+    for (var k = 0u; k < params.rank; k++) {{
+        let axis = params.rank - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        idx += c * at8(params.s{i}_0, params.s{i}_1, axis);
+    }}
+    return idx;
+}}
+"#
+        ));
+    }
+    s.push_str(&format!(
+        r#"
+@compute @workgroup_size({WORKGROUP})
+fn chain(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let base = i * 4u;
+    if (base >= params.len) {{ return; }}
+    var v = in0[params.off_in[0u] / 4u + i];
+"#
+    ));
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => s.push_str(&format!("    v = op_{op}_v(v);\n")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                match kinds[*rhs] {
+                    ChainOperand::Contiguous => s.push_str(&format!(
+                        "    let b{rhs} = in{rhs}[params.off_in[{rhs}u] / 4u + i];\n"
+                    )),
+                    _ => s.push_str(&format!(
+                        "    let b{rhs} = vec4<{t}>(in{rhs}[params.off_in[{rhs}u] + gather{rhs}(base)]);\n"
+                    )),
+                }
+                if *swapped {
+                    s.push_str(&format!("    v = op_{op}_v(b{rhs}, v);\n"));
+                } else {
+                    s.push_str(&format!("    v = op_{op}_v(v, b{rhs});\n"));
+                }
+            }
+        }
+    }
+    s.push_str("    outp[params.off_out / 4u + i] = v;\n}\n");
+    s
+}
+
+/// A whole elementwise chain as one kernel: the running value stays in
+/// registers, so only the chain's own inputs and its final output touch memory.
+/// Extra operands broadcast against the output shape; the head and the output
+/// share it.
+pub fn chain_wgsl(
+    dt: ShaderDtype,
+    steps: &[ChainStep],
+    contiguous: &[bool],
+    kinds: Option<&[ChainOperand]>,
+) -> String {
+    if let Some(kinds) = kinds {
+        return chain_vec4_wgsl(dt, steps, kinds);
+    }
+    let t = dt.wgsl();
+    let inputs = contiguous.len();
+    let mut s = preamble(dt);
+    s.push_str("struct Params {\n    off_out: u32,\n    len: u32,\n    rank: u32,\n    _p: u32,\n    off_in: vec4<u32>,\n    out_sh0: vec4<u32>,\n    out_sh1: vec4<u32>,\n");
+    for i in 0..inputs {
+        s.push_str(&format!("    s{i}_0: vec4<u32>,\n    s{i}_1: vec4<u32>,\n"));
+    }
+    s.push_str("}\n\n");
+    for i in 0..inputs {
+        s.push_str(&format!("@group(0) @binding({i}) var<storage, read> in{i}: array<{t}>;\n"));
+    }
+    s.push_str(&format!(
+        "@group(0) @binding({inputs}) var<storage, read_write> outp: array<{t}>;\n"
+    ));
+    s.push_str(&format!("@group(0) @binding({}) var<uniform> params: Params;\n\n", inputs + 1));
+    s.push_str(AT8);
+    s.push_str("\n\n");
+    s.push_str(&unary_ops_wgsl(t));
+    s.push_str(&binary_ops_wgsl(t));
+    for (i, contig) in contiguous.iter().enumerate() {
+        if *contig {
+            s.push_str(&format!("\nfn gather{i}(linear: u32) -> u32 {{ return linear; }}\n"));
+            continue;
+        }
+        s.push_str(&format!(
+            r#"
+fn gather{i}(linear: u32) -> u32 {{
+    var rest = linear;
+    var idx = 0u;
+    for (var k = 0u; k < params.rank; k++) {{
+        let axis = params.rank - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        idx += c * at8(params.s{i}_0, params.s{i}_1, axis);
+    }}
+    return idx;
+}}
+"#
+        ));
+    }
+    s.push_str(&format!(
+        r#"
+@compute @workgroup_size({WORKGROUP})
+fn chain(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    var v = in0[params.off_in[0] + gather0(i)];
+"#
+    ));
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => s.push_str(&format!("    v = op_{op}(v);\n")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                s.push_str(&format!(
+                    "    let b{rhs} = in{rhs}[params.off_in[{rhs}] + gather{rhs}(i)];\n"
+                ));
+                if *swapped {
+                    s.push_str(&format!("    v = op_{op}(b{rhs}, v);\n"));
+                } else {
+                    s.push_str(&format!("    v = op_{op}(v, b{rhs});\n"));
+                }
+            }
+        }
+    }
+    s.push_str("    outp[params.off_out + i] = v;\n}\n");
+    s
+}
+
+/// A four-wide wrapper for each op, so a kernel that moves whole `vec4`s can
+/// still call them. The bodies stay scalar: the win here is the wider load and
+/// store, not the arithmetic.
+fn unary_ops_vec4_wgsl(t: &str) -> String {
+    let mut s = String::new();
+    for name in ELEMENT_WISE_OPS {
+        s.push_str(&format!(
+            "fn op_{name}_v(x: vec4<{t}>) -> vec4<{t}> {{ return vec4<{t}>(op_{name}(x.x), op_{name}(x.y), op_{name}(x.z), op_{name}(x.w)); }}\n"
+        ));
+    }
+    s
+}
+
+fn binary_ops_vec4_wgsl(t: &str) -> String {
+    let mut s = String::new();
+    for name in BINARY_OPS {
+        s.push_str(&format!(
+            "fn op_{name}_v(a: vec4<{t}>, b: vec4<{t}>) -> vec4<{t}> {{ return vec4<{t}>(op_{name}(a.x, b.x), op_{name}(a.y, b.y), op_{name}(a.z, b.z), op_{name}(a.w, b.w)); }}\n"
+        ));
+    }
+    s
+}
+
+/// Every unary `op_*` a kernel may call, plus the erf polynomial they share.
+fn unary_ops_wgsl(t: &str) -> String {
+    format!(
+        r#"fn approx_erf(x: f32) -> f32 {{
+    let a1 = 0.0705230784;
+    let a2 = 0.0422820123;
+    let a3 = 0.0092705272;
+    let a4 = 0.0001520143;
+    let a5 = 0.0002765672;
+    let a6 = 0.0000430638;
+    let ax = abs(x);
+    var y = a6 * ax;
+    y = (a5 + y) * ax;
+    y = (a4 + y) * ax;
+    y = (a3 + y) * ax;
+    y = (a2 + y) * ax;
+    y = (a1 + y) * ax;
+    y = 1.0 - (1.0 / pow(y + 1.0, 16.0));
+    return sign(x) * y;
+}}
+
+fn op_abs(x: {t}) -> {t} {{ return abs(x); }}
+fn op_exp(x: {t}) -> {t} {{ return exp(x); }}
+fn op_ln(x: {t}) -> {t} {{ return log(x); }}
+fn op_sqrt(x: {t}) -> {t} {{ return sqrt(x); }}
+fn op_rsqrt(x: {t}) -> {t} {{ return inverseSqrt(x); }}
+fn op_sigmoid(x: {t}) -> {t} {{
+    let y = {t}(1.0) / ({t}(1.0) + exp(-abs(x)));
+    if (x < {t}(0.0)) {{ return {t}(1.0) - y; }}
+    return y;
+}}
+fn op_square(x: {t}) -> {t} {{ return x * x; }}
+fn op_recip(x: {t}) -> {t} {{ return {t}(1.0) / x; }}
+fn op_ceil(x: {t}) -> {t} {{ return ceil(x); }}
+fn op_floor(x: {t}) -> {t} {{ return floor(x); }}
+fn op_round(x: {t}) -> {t} {{ return round(x); }}
+fn op_roundhalftoeven(x: {t}) -> {t} {{ return round(x); }}
+fn op_cos(x: {t}) -> {t} {{ return cos(x); }}
+fn op_sin(x: {t}) -> {t} {{ return sin(x); }}
+fn op_tan(x: {t}) -> {t} {{ return tan(x); }}
+fn op_acos(x: {t}) -> {t} {{ return acos(x); }}
+fn op_asin(x: {t}) -> {t} {{ return asin(x); }}
+fn op_atan(x: {t}) -> {t} {{ return atan(x); }}
+fn op_cosh(x: {t}) -> {t} {{ return cosh(x); }}
+fn op_sinh(x: {t}) -> {t} {{ return sinh(x); }}
+fn op_tanh(x: {t}) -> {t} {{ return tanh(x); }}
+fn op_acosh(x: {t}) -> {t} {{ return acosh(x); }}
+fn op_asinh(x: {t}) -> {t} {{ return asinh(x); }}
+fn op_atanh(x: {t}) -> {t} {{ return atanh(x); }}
+fn op_erf(x: {t}) -> {t} {{ return {t}(approx_erf(f32(x))); }}
+fn op_neg(x: {t}) -> {t} {{ return -x; }}
+fn op_sign(x: {t}) -> {t} {{ return sign(x); }}
+fn op_hardswish(x: {t}) -> {t} {{
+    let h = max({t}(0.0), min({t}(1.0), x / {t}(6.0) + {t}(0.5)));
+    return x * h;
+}}
+fn op_silu(x: {t}) -> {t} {{ return x / ({t}(1.0) + exp(-x)); }}
+"#
+    )
+}
+
+/// Every binary `op_*` a kernel may call.
+fn binary_ops_wgsl(t: &str) -> String {
+    format!(
+        r#"fn op_add(a: {t}, b: {t}) -> {t} {{ return a + b; }}
+fn op_sub(a: {t}, b: {t}) -> {t} {{ return a - b; }}
+fn op_mul(a: {t}, b: {t}) -> {t} {{ return a * b; }}
+fn op_div(a: {t}, b: {t}) -> {t} {{ return a / b; }}
+fn op_min(a: {t}, b: {t}) -> {t} {{ return min(a, b); }}
+fn op_max(a: {t}, b: {t}) -> {t} {{ return max(a, b); }}
+fn op_pow(a: {t}, b: {t}) -> {t} {{ return pow(a, b); }}
+"#
+    )
+}
+
+fn element_wise_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let lib = unary_ops_wgsl(t);
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_out: u32,
+    len: u32,
+    _pad: u32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+{lib}
+"#
+    ));
+    for name in ELEMENT_WISE_OPS {
+        s.push_str(&format!(
+            r#"
+@compute @workgroup_size({WORKGROUP})
+fn {name}_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    outp[params.off_out + i] = op_{name}(inp[params.off_in + i]);
+}}
+"#
+        ));
+    }
+    s
+}
+
+pub const ELEMENT_WISE_OPS: &[&str] = &[
+    "abs",
+    "exp",
+    "ln",
+    "sigmoid",
+    "square",
+    "sqrt",
+    "rsqrt",
+    "recip",
+    "ceil",
+    "floor",
+    "round",
+    "roundhalftoeven",
+    "cos",
+    "acos",
+    "acosh",
+    "cosh",
+    "sin",
+    "asin",
+    "asinh",
+    "sinh",
+    "tan",
+    "atan",
+    "atanh",
+    "tanh",
+    "erf",
+    "neg",
+    "sign",
+    "hardswish",
+    "silu",
+];
+
+fn binary_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let lib = binary_ops_wgsl(t);
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_lhs: u32,
+    off_rhs: u32,
+    off_out: u32,
+    rank: u32,
+    len: u32,
+    _p0: u32,
+    _p1: u32,
+    _p2: u32,
+    lhs_s0: vec4<u32>,
+    lhs_s1: vec4<u32>,
+    rhs_s0: vec4<u32>,
+    rhs_s1: vec4<u32>,
+    out_sh0: vec4<u32>,
+    out_sh1: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> lhs: array<{t}>;
+@group(0) @binding(1) var<storage, read> rhs: array<{t}>;
+@group(0) @binding(2) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+{AT8}
+
+fn gather_idx(linear: u32, is_lhs: bool) -> u32 {{
+    var rest = linear;
+    var idx = 0u;
+    let r = params.rank;
+    for (var k = 0u; k < r; k++) {{
+        let axis = r - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        let stride = select(
+            at8(params.rhs_s0, params.rhs_s1, axis),
+            at8(params.lhs_s0, params.lhs_s1, axis),
+            is_lhs,
+        );
+        idx += c * stride;
+    }}
+    return idx;
+}}
+
+{lib}"#
+    ));
+    for name in BINARY_OPS {
+        s.push_str(&format!(
+            r#"
+@compute @workgroup_size({WORKGROUP})
+fn {name}_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    let li = params.off_lhs + gather_idx(i, true);
+    let ri = params.off_rhs + gather_idx(i, false);
+    outp[params.off_out + i] = op_{name}(lhs[li], rhs[ri]);
+}}
+"#
+        ));
+    }
+    s.push_str(&binary_vec4_entries(t, suf));
+    s
+}
+
+/// The four-wide binary entries. `_v4` is both operands element for element
+/// with the output; `_v4s` is a right operand that broadcasts over the last
+/// axis, so one value covers the four a thread handles. Anything else gathers
+/// per element and gains nothing from a wider thread.
+fn binary_vec4_entries(t: &str, suf: &str) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        r#"
+fn lhs4(i: u32) -> vec4<{t}> {{
+    let b = params.off_lhs + i * 4u;
+    return vec4<{t}>(lhs[b], lhs[b + 1u], lhs[b + 2u], lhs[b + 3u]);
+}}
+
+fn rhs4(i: u32) -> vec4<{t}> {{
+    let b = params.off_rhs + i * 4u;
+    return vec4<{t}>(rhs[b], rhs[b + 1u], rhs[b + 2u], rhs[b + 3u]);
+}}
+
+fn store4(i: u32, v: vec4<{t}>) {{
+    let b = params.off_out + i * 4u;
+    outp[b] = v.x;
+    outp[b + 1u] = v.y;
+    outp[b + 2u] = v.z;
+    outp[b + 3u] = v.w;
+}}
+"#
+    ));
+    s.push_str(&binary_ops_vec4_wgsl(t));
+    for name in BINARY_OPS {
+        s.push_str(&format!(
+            r#"
+@compute @workgroup_size({WORKGROUP})
+fn {name}_v4_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i * 4u >= params.len) {{ return; }}
+    store4(i, op_{name}_v(lhs4(i), rhs4(i)));
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn {name}_v4s_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i * 4u >= params.len) {{ return; }}
+    let r = vec4<{t}>(rhs[params.off_rhs + gather_idx(i * 4u, false)]);
+    store4(i, op_{name}_v(lhs4(i), r));
+}}
+"#
+        ));
+    }
+    s
+}
+
+pub const BINARY_OPS: &[&str] = &["mul", "add", "div", "sub", "pow", "min", "max"];
+
+fn copy_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_out: u32,
+    rank: u32,
+    len: u32,
+    in_s0: vec4<u32>,
+    in_s1: vec4<u32>,
+    out_s0: vec4<u32>,
+    out_s1: vec4<u32>,
+    out_sh0: vec4<u32>,
+    out_sh1: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+{AT8}
+
+@compute @workgroup_size({WORKGROUP})
+fn copy_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    var rest = i;
+    var in_i = params.off_in;
+    var out_i = params.off_out;
+    let r = params.rank;
+    for (var k = 0u; k < r; k++) {{
+        let axis = r - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        in_i += c * at8(params.in_s0, params.in_s1, axis);
+        out_i += c * at8(params.out_s0, params.out_s1, axis);
+    }}
+    outp[out_i] = inp[in_i];
+}}
+"#
+    ));
+    s
+}
+
+fn reduce_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_out: u32,
+    outer: u32,
+    k: u32,
+    inner: u32,
+    _p0: u32,
+    _p1: u32,
+    _p2: u32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn reduce_sum_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.outer * params.inner;
+    if (i >= n) {{ return; }}
+    let o = i / params.inner;
+    let r = i % params.inner;
+    var acc = {t}(0.0);
+    for (var k = 0u; k < params.k; k++) {{
+        acc += inp[params.off_in + (o * params.k + k) * params.inner + r];
+    }}
+    outp[params.off_out + i] = acc;
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn reduce_prod_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.outer * params.inner;
+    if (i >= n) {{ return; }}
+    let o = i / params.inner;
+    let r = i % params.inner;
+    var acc = {t}(1.0);
+    for (var k = 0u; k < params.k; k++) {{
+        acc *= inp[params.off_in + (o * params.k + k) * params.inner + r];
+    }}
+    outp[params.off_out + i] = acc;
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn reduce_max_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.outer * params.inner;
+    if (i >= n) {{ return; }}
+    let o = i / params.inner;
+    let r = i % params.inner;
+    var acc = inp[params.off_in + (o * params.k) * params.inner + r];
+    for (var k = 1u; k < params.k; k++) {{
+        acc = max(acc, inp[params.off_in + (o * params.k + k) * params.inner + r]);
+    }}
+    outp[params.off_out + i] = acc;
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn reduce_min_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.outer * params.inner;
+    if (i >= n) {{ return; }}
+    let o = i / params.inner;
+    let r = i % params.inner;
+    var acc = inp[params.off_in + (o * params.k) * params.inner + r];
+    for (var k = 1u; k < params.k; k++) {{
+        acc = min(acc, inp[params.off_in + (o * params.k + k) * params.inner + r]);
+    }}
+    outp[params.off_out + i] = acc;
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn reduce_mean_of_squares_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.outer * params.inner;
+    if (i >= n) {{ return; }}
+    let o = i / params.inner;
+    let r = i % params.inner;
+    var acc = {t}(0.0);
+    for (var k = 0u; k < params.k; k++) {{
+        let v = inp[params.off_in + (o * params.k + k) * params.inner + r];
+        acc += v * v;
+    }}
+    outp[params.off_out + i] = acc / {t}(f32(params.k));
+}}
+"#
+    ));
+    s
+}
+
+fn pool_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let neg_inf = match dt {
+        ShaderDtype::F32 => "f32(-3.402823e+38)",
+        ShaderDtype::F16 => "f16(-65504.0)",
+    };
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_out: u32,
+    n: i32,
+    ih: i32,
+    iw: i32,
+    c: i32,
+    oh: i32,
+    ow: i32,
+    kh: i32,
+    kw: i32,
+    stride_h: i32,
+    stride_w: i32,
+    pad_h: i32,
+    pad_w: i32,
+    dil_h: i32,
+    dil_w: i32,
+    count_include_pad: i32,
+    normalize: i32,
+    channels_last: i32,
+    _p0: i32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+fn in_idx_nhwc(n: i32, h: i32, w: i32, c: i32) -> u32 {{
+    return u32(((n * params.ih + h) * params.iw + w) * params.c + c);
+}}
+fn in_idx_nchw(n: i32, c: i32, h: i32, w: i32) -> u32 {{
+    return u32(((n * params.c + c) * params.ih + h) * params.iw + w);
+}}
+fn out_idx_nhwc(n: i32, h: i32, w: i32, c: i32) -> u32 {{
+    return u32(((n * params.oh + h) * params.ow + w) * params.c + c);
+}}
+fn out_idx_nchw(n: i32, c: i32, h: i32, w: i32) -> u32 {{
+    return u32(((n * params.c + c) * params.oh + h) * params.ow + w);
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn max_pool_2d_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = i32(gid.x);
+    let nout = params.n * params.oh * params.ow * params.c;
+    if (i >= nout) {{ return; }}
+    var rest = i;
+    let c = rest % params.c; rest = rest / params.c;
+    let ow = rest % params.ow; rest = rest / params.ow;
+    let oh = rest % params.oh;
+    let n = rest / params.oh;
+    let h0 = oh * params.stride_h - params.pad_h;
+    let w0 = ow * params.stride_w - params.pad_w;
+    var best = {neg_inf};
+    for (var kh = 0; kh < params.kh; kh++) {{
+        let ih = h0 + kh * params.dil_h;
+        if (ih < 0 || ih >= params.ih) {{ continue; }}
+        for (var kw = 0; kw < params.kw; kw++) {{
+            let iw = w0 + kw * params.dil_w;
+            if (iw < 0 || iw >= params.iw) {{ continue; }}
+            var idx: u32;
+            if (params.channels_last != 0) {{
+                idx = in_idx_nhwc(n, ih, iw, c);
+            }} else {{
+                idx = in_idx_nchw(n, c, ih, iw);
+            }}
+            best = max(best, inp[params.off_in + idx]);
+        }}
+    }}
+    var oidx: u32;
+    if (params.channels_last != 0) {{
+        oidx = out_idx_nhwc(n, oh, ow, c);
+    }} else {{
+        oidx = out_idx_nchw(n, c, oh, ow);
+    }}
+    outp[params.off_out + oidx] = best;
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn sum_pool_2d_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = i32(gid.x);
+    let nout = params.n * params.oh * params.ow * params.c;
+    if (i >= nout) {{ return; }}
+    var rest = i;
+    let c = rest % params.c; rest = rest / params.c;
+    let ow = rest % params.ow; rest = rest / params.ow;
+    let oh = rest % params.oh;
+    let n = rest / params.oh;
+    let h0 = oh * params.stride_h - params.pad_h;
+    let w0 = ow * params.stride_w - params.pad_w;
+    var acc = {t}(0.0);
+    var count = 0;
+    for (var kh = 0; kh < params.kh; kh++) {{
+        let ih = h0 + kh * params.dil_h;
+        if (ih < 0 || ih >= params.ih) {{ continue; }}
+        for (var kw = 0; kw < params.kw; kw++) {{
+            let iw = w0 + kw * params.dil_w;
+            if (iw < 0 || iw >= params.iw) {{ continue; }}
+            var idx: u32;
+            if (params.channels_last != 0) {{
+                idx = in_idx_nhwc(n, ih, iw, c);
+            }} else {{
+                idx = in_idx_nchw(n, c, ih, iw);
+            }}
+            acc += inp[params.off_in + idx];
+            count += 1;
+        }}
+    }}
+    if (params.normalize != 0) {{
+        var denom = count;
+        if (params.count_include_pad != 0) {{
+            denom = params.kh * params.kw;
+        }}
+        if (denom > 0) {{
+            acc = acc / {t}(f32(denom));
+        }}
+    }}
+    var oidx: u32;
+    if (params.channels_last != 0) {{
+        oidx = out_idx_nhwc(n, oh, ow, c);
+    }} else {{
+        oidx = out_idx_nchw(n, c, oh, ow);
+    }}
+    outp[params.off_out + oidx] = acc;
+}}
+"#
+    ));
+    s
+}
+
+fn cast_wgsl(dt: ShaderDtype) -> String {
+    match dt {
+        ShaderDtype::F32 => {
+            // f32 -> f16
+            format!(
+                r#"
+enable f16;
+struct Params {{ off_in: u32, off_out: u32, len: u32, _p: u32 }}
+@group(0) @binding(0) var<storage, read> inp: array<f32>;
+@group(0) @binding(1) var<storage, read_write> outp: array<f16>;
+@group(0) @binding(2) var<uniform> params: Params;
+@compute @workgroup_size({WORKGROUP})
+fn cast_f32_f16(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    outp[params.off_out + i] = f16(inp[params.off_in + i]);
+}}
+"#
+            )
+        }
+        ShaderDtype::F16 => {
+            format!(
+                r#"
+enable f16;
+struct Params {{ off_in: u32, off_out: u32, len: u32, _p: u32 }}
+@group(0) @binding(0) var<storage, read> inp: array<f16>;
+@group(0) @binding(1) var<storage, read_write> outp: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+@compute @workgroup_size({WORKGROUP})
+fn cast_f16_f32(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    outp[params.off_out + i] = f32(inp[params.off_in + i]);
+}}
+"#
+            )
+        }
+    }
+}
+
+/// Workgroup edge of the depthwise tile: 16x16 output values per workgroup.
+pub const DW_WG: u32 = 16;
+
+/// Shape of one depthwise convolution, baked into its program so the filter
+/// loops unroll and the halo tile is sized exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DepthwiseShape {
+    pub kh: u32,
+    pub kw: u32,
+    pub stride_h: u32,
+    pub stride_w: u32,
+    pub dil_h: u32,
+    pub dil_w: u32,
+}
+
+impl DepthwiseShape {
+    fn tile_h(&self) -> u32 {
+        (DW_WG - 1) * self.stride_h + (self.kh - 1) * self.dil_h + 1
+    }
+
+    fn tile_w(&self) -> u32 {
+        (DW_WG - 1) * self.stride_w + (self.kw - 1) * self.dil_w + 1
+    }
+
+    pub fn key(&self) -> String {
+        format!(
+            "{}x{}s{}x{}d{}x{}",
+            self.kh, self.kw, self.stride_h, self.stride_w, self.dil_h, self.dil_w
+        )
+    }
+}
+
+/// Depthwise convolution, ported from tfjs-backend-webgpu
+/// `DepthwiseConv2DNCHWSharedProgram`
+/// (tfjs-backend-webgpu/src/depthwise_conv2d_nchw_shared_webgpu.ts, Apache-2.0,
+/// Copyright 2021 Google LLC): a workgroup owns one 16x16 output tile of one
+/// channel, staging that tile's input halo and the filter in workgroup memory,
+/// so each input value is read once instead of once per filter tap. Strides and
+/// dilations size the halo here, where tfjs assumed one; indices come from
+/// tract's strides, and the epilogue replaces their bias/activation snippet.
+pub fn conv_depthwise_module(
+    dt: ShaderDtype,
+    shape: DepthwiseShape,
+    epilogue: &[ChainStep],
+    extras: usize,
+) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let DepthwiseShape { kh, kw, stride_h, stride_w, dil_h, dil_w } = shape;
+    let (tile_h, tile_w) = (shape.tile_h(), shape.tile_w());
+    let wg = DW_WG;
+    let out_binding = 2 + extras;
+    let uniform_binding = 3 + extras;
+    let extra_bindings = (0..extras)
+        .map(|i| {
+            format!("@group(0) @binding({}) var<storage, read> extra{i}: array<{t}>;\n", 2 + i)
+        })
+        .collect::<String>();
+    let lib = if epilogue.is_empty() {
+        String::new()
+    } else {
+        format!("{}{}", unary_ops_wgsl(t), binary_ops_wgsl(t))
+    };
+    let epilogue = epilogue_body(epilogue, "co");
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_w: u32,
+    off_out: u32,
+    n: u32,
+    co: u32,
+    ih: u32,
+    iw: u32,
+    oh: u32,
+    ow: u32,
+    pad_h: i32,
+    pad_w: i32,
+    _p0: u32,
+    in_sn: i32,
+    in_sc: i32,
+    in_sh: i32,
+    in_sw: i32,
+    w_so: i32,
+    w_sh: i32,
+    w_sw: i32,
+    _p1: u32,
+    out_sn: i32,
+    out_sc: i32,
+    out_sh: i32,
+    out_sw: i32,
+    off_extra: vec4<u32>,
+    mode_extra: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read> wgt: array<{t}>;
+{extra_bindings}@group(0) @binding({out_binding}) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding({uniform_binding}) var<uniform> params: Params;
+{lib}
+var<workgroup> x_tile: array<array<f32, {tile_w}>, {tile_h}>;
+var<workgroup> w_tile: array<array<f32, {kw}>, {kh}>;
+
+@compute @workgroup_size({wg}, {wg}, 1)
+fn conv_dw_{suf}(
+    @builtin(workgroup_id) wid: vec3<u32>,
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(local_invocation_index) lidx: u32,
+) {{
+    let co = wid.z % params.co;
+    let n = wid.z / params.co;
+    let oh0 = wid.y * {wg}u;
+    let ow0 = wid.x * {wg}u;
+    let ih0 = i32(oh0) * {stride_h} - params.pad_h;
+    let iw0 = i32(ow0) * {stride_w} - params.pad_w;
+
+    for (var r = lid.y; r < {tile_h}u; r = r + {wg}u) {{
+        for (var c = lid.x; c < {tile_w}u; c = c + {wg}u) {{
+            let ih = ih0 + i32(r);
+            let iw = iw0 + i32(c);
+            var v = 0.0;
+            if (ih >= 0 && ih < i32(params.ih) && iw >= 0 && iw < i32(params.iw)) {{
+                let idx = params.off_in + u32(
+                    i32(n) * params.in_sn
+                    + i32(co) * params.in_sc
+                    + ih * params.in_sh
+                    + iw * params.in_sw
+                );
+                v = f32(inp[idx]);
+            }}
+            x_tile[r][c] = v;
+        }}
+    }}
+    if (lidx < {kh}u * {kw}u) {{
+        let wr = lidx / {kw}u;
+        let wc = lidx % {kw}u;
+        let idx = params.off_w + u32(
+            i32(co) * params.w_so + i32(wr) * params.w_sh + i32(wc) * params.w_sw
+        );
+        w_tile[wr][wc] = f32(wgt[idx]);
+    }}
+    workgroupBarrier();
+
+    let oh = oh0 + lid.y;
+    let ow = ow0 + lid.x;
+    if (oh >= params.oh || ow >= params.ow) {{ return; }}
+    var acc = 0.0;
+    for (var wr = 0u; wr < {kh}u; wr++) {{
+        for (var wc = 0u; wc < {kw}u; wc++) {{
+            acc = fma(
+                x_tile[lid.y * {stride_h}u + wr * {dil_h}u][lid.x * {stride_w}u + wc * {dil_w}u],
+                w_tile[wr][wc],
+                acc
+            );
+        }}
+    }}
+    var v = {t}(acc);
+{epilogue}
+    let out_i = params.off_out + u32(
+        i32(n) * params.out_sn
+        + i32(co) * params.out_sc
+        + i32(oh) * params.out_sh
+        + i32(ow) * params.out_sw
+    );
+    outp[out_i] = v;
+}}
+"#
+    ));
+    s
+}
+
+fn conv_wgsl(dt: ShaderDtype) -> String {
+    conv_module(dt, &[], 0)
+}
+
+/// `extras` epilogue operands bind between the weights and the output.
+pub fn conv_module(dt: ShaderDtype, epilogue: &[ChainStep], extras: usize) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let out_binding = 2 + extras;
+    let uniform_binding = 3 + extras;
+    let extra_bindings = (0..extras)
+        .map(|i| {
+            format!("@group(0) @binding({}) var<storage, read> extra{i}: array<{t}>;\n", 2 + i)
+        })
+        .collect::<String>();
+    let lib = if epilogue.is_empty() {
+        String::new()
+    } else {
+        format!("{}{}", unary_ops_wgsl(t), binary_ops_wgsl(t))
+    };
+    let epilogue = epilogue_body(epilogue, "co");
+    let mut s = preamble(dt);
+    // Packed params: see kernels/conv.rs. 2D NCHW/NHWC, OIHW weights.
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_w: u32,
+    off_out: u32,
+    n: u32,
+    ci: u32,
+    co: u32,
+    ih: u32,
+    iw: u32,
+    oh: u32,
+    ow: u32,
+    kh: u32,
+    kw: u32,
+    groups: u32,
+    ci_pg: u32,
+    co_pg: u32,
+    channels_last: u32,
+    pad_h: i32,
+    pad_w: i32,
+    stride_h: i32,
+    stride_w: i32,
+    dil_h: i32,
+    dil_w: i32,
+    in_sn: i32,
+    in_sc: i32,
+    in_sh: i32,
+    in_sw: i32,
+    w_so: i32,
+    w_si: i32,
+    w_sh: i32,
+    w_sw: i32,
+    out_sn: i32,
+    out_sc: i32,
+    out_sh: i32,
+    out_sw: i32,
+    _pad: vec2<u32>,
+    off_extra: vec4<u32>,
+    mode_extra: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read> wgt: array<{t}>;
+{extra_bindings}@group(0) @binding({out_binding}) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding({uniform_binding}) var<uniform> params: Params;
+{lib}
+@compute @workgroup_size({WORKGROUP})
+fn conv2d_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let nout = params.n * params.co * params.oh * params.ow;
+    if (i >= nout) {{ return; }}
+    var rest = i;
+    let ow = rest % params.ow; rest = rest / params.ow;
+    let oh = rest % params.oh; rest = rest / params.oh;
+    let co = rest % params.co;
+    let n = rest / params.co;
+    let g = co / params.co_pg;
+    let ci0 = g * params.ci_pg;
+    var acc = 0.0;
+    // Where a tap reads does not depend on the channel, so the channels run
+    // innermost and the window is walked once rather than once per channel.
+    for (var kh = 0u; kh < params.kh; kh++) {{
+        let ih = i32(oh) * params.stride_h + i32(kh) * params.dil_h - params.pad_h;
+        if (ih < 0 || ih >= i32(params.ih)) {{ continue; }}
+        for (var kw = 0u; kw < params.kw; kw++) {{
+            let iw = i32(ow) * params.stride_w + i32(kw) * params.dil_w - params.pad_w;
+            if (iw < 0 || iw >= i32(params.iw)) {{ continue; }}
+            let in_base = i32(n) * params.in_sn
+                + i32(ci0) * params.in_sc
+                + ih * params.in_sh
+                + iw * params.in_sw;
+            let w_base = i32(co) * params.w_so
+                + i32(kh) * params.w_sh
+                + i32(kw) * params.w_sw;
+            for (var ci = 0u; ci < params.ci_pg; ci++) {{
+                let in_i = params.off_in + u32(in_base + i32(ci) * params.in_sc);
+                let w_i = params.off_w + u32(w_base + i32(ci) * params.w_si);
+                acc += f32(inp[in_i]) * f32(wgt[w_i]);
+            }}
+        }}
+    }}
+    let out_i = params.off_out + u32(
+        i32(n) * params.out_sn
+        + i32(co) * params.out_sc
+        + i32(oh) * params.out_sh
+        + i32(ow) * params.out_sw
+    );
+    var v = {t}(acc);
+{epilogue}
+    outp[out_i] = v;
+}}
+"#
+    ));
+    s
+}
+
+fn deconv_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    // Gather-based conv_transpose (ORT style). WGSL has no float atomics.
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_w: u32,
+    off_out: u32,
+    n: u32,
+    ci: u32,
+    co: u32,
+    ih: u32,
+    iw: u32,
+    oh: u32,
+    ow: u32,
+    kh: u32,
+    kw: u32,
+    groups: u32,
+    ci_pg: u32,
+    co_pg: u32,
+    _p0: u32,
+    pad_h: i32,
+    pad_w: i32,
+    stride_h: i32,
+    stride_w: i32,
+    dil_h: i32,
+    dil_w: i32,
+    in_sn: i32,
+    in_sc: i32,
+    in_sh: i32,
+    in_sw: i32,
+    w_so: i32,
+    w_si: i32,
+    w_sh: i32,
+    w_sw: i32,
+    out_sn: i32,
+    out_sc: i32,
+    out_sh: i32,
+    out_sw: i32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read> wgt: array<{t}>;
+@group(0) @binding(2) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn conv_transpose2d_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let nout = params.n * params.co * params.oh * params.ow;
+    if (i >= nout) {{ return; }}
+    var rest = i;
+    let ow = rest % params.ow; rest = rest / params.ow;
+    let oh = rest % params.oh; rest = rest / params.oh;
+    let co = rest % params.co;
+    let n = rest / params.co;
+    let g = co / params.co_pg;
+    let ci0 = g * params.ci_pg;
+    var acc = 0.0;
+    // Which taps land on an input pixel does not depend on the channel, and
+    // finding out costs two integer divisions, so the channels run innermost.
+    for (var kh = 0u; kh < params.kh; kh++) {{
+        let ih_num = i32(oh) + params.pad_h - i32(kh) * params.dil_h;
+        if (params.stride_h == 0 || ih_num % params.stride_h != 0) {{ continue; }}
+        let ih = ih_num / params.stride_h;
+        if (ih < 0 || ih >= i32(params.ih)) {{ continue; }}
+        for (var kw = 0u; kw < params.kw; kw++) {{
+            let iw_num = i32(ow) + params.pad_w - i32(kw) * params.dil_w;
+            if (params.stride_w == 0 || iw_num % params.stride_w != 0) {{ continue; }}
+            let iw = iw_num / params.stride_w;
+            if (iw < 0 || iw >= i32(params.iw)) {{ continue; }}
+            let in_base = i32(n) * params.in_sn
+                + i32(ci0) * params.in_sc
+                + ih * params.in_sh
+                + iw * params.in_sw;
+            let w_base = i32(co) * params.w_so
+                + i32(kh) * params.w_sh
+                + i32(kw) * params.w_sw;
+            for (var ci = 0u; ci < params.ci_pg; ci++) {{
+                let in_i = params.off_in + u32(in_base + i32(ci) * params.in_sc);
+                let w_i = params.off_w + u32(w_base + i32(ci) * params.w_si);
+                acc += f32(inp[in_i]) * f32(wgt[w_i]);
+            }}
+        }}
+    }}
+    let out_i = params.off_out + u32(
+        i32(n) * params.out_sn
+        + i32(co) * params.out_sc
+        + i32(oh) * params.out_sh
+        + i32(ow) * params.out_sw
+    );
+    outp[out_i] = {t}(acc);
+}}
+"#
+    ));
+    s
+}
+
+fn resize_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_idx: u32,
+    off_w: u32,
+    off_out: u32,
+    outer: u32,
+    len_in: u32,
+    len_out: u32,
+    inner: u32,
+    window: u32,
+    _p0: u32,
+    _p1: u32,
+    _p2: u32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read> indices: array<i32>;
+@group(0) @binding(2) var<storage, read> weights: array<f32>;
+@group(0) @binding(3) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(4) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn resize_axis_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.outer * params.len_out * params.inner;
+    if (i >= n) {{ return; }}
+    let inner_i = i % params.inner;
+    let t = i / params.inner;
+    let xo = t % params.len_out;
+    let outer_i = t / params.len_out;
+    var acc = 0.0;
+    for (var w = 0u; w < params.window; w++) {{
+        let ix = indices[params.off_idx + xo * params.window + w];
+        let wt = weights[params.off_w + xo * params.window + w];
+        let in_i = params.off_in + (outer_i * params.len_in + u32(ix)) * params.inner + inner_i;
+        acc += f32(inp[in_i]) * wt;
+    }}
+    outp[params.off_out + (outer_i * params.len_out) * params.inner + xo * params.inner + inner_i] = {t}(acc);
+}}
+"#
+    ));
+    s
+}
+
+fn softmax_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_out: u32,
+    outer: u32,
+    k: u32,
+    inner: u32,
+    _p0: u32,
+    _p1: u32,
+    _p2: u32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn softmax_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.outer * params.inner;
+    if (i >= n) {{ return; }}
+    let o = i / params.inner;
+    let r = i % params.inner;
+    var m = inp[params.off_in + (o * params.k) * params.inner + r];
+    for (var k = 1u; k < params.k; k++) {{
+        m = max(m, inp[params.off_in + (o * params.k + k) * params.inner + r]);
+    }}
+    var sum = {t}(0.0);
+    for (var k = 0u; k < params.k; k++) {{
+        let e = exp(inp[params.off_in + (o * params.k + k) * params.inner + r] - m);
+        outp[params.off_out + (o * params.k + k) * params.inner + r] = e;
+        sum += e;
+    }}
+    let inv = {t}(1.0) / sum;
+    for (var k = 0u; k < params.k; k++) {{
+        let idx = params.off_out + (o * params.k + k) * params.inner + r;
+        outp[idx] = outp[idx] * inv;
+    }}
+}}
+"#
+    ));
+    s
+}
+
+/// Applies the fused steps to `v`, reading each extra operand at `index`.
+fn epilogue_body(steps: &[ChainStep], index: &str) -> String {
+    let mut s = String::new();
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => s.push_str(&format!("    v = op_{op}(v);\n")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                let i = rhs - 1;
+                s.push_str(&format!(
+                    "    let e{i} = extra{i}[params.off_extra[{i}u] + select(0u, {index}, params.mode_extra[{i}u] != 0u)];\n"
+                ));
+                if *swapped {
+                    s.push_str(&format!("    v = op_{op}(e{i}, v);\n"));
+                } else {
+                    s.push_str(&format!("    v = op_{op}(v, e{i});\n"));
+                }
+            }
+        }
+    }
+    s
+}
+
+/// Names a generated program by its kernel and fused epilogue.
+pub fn program_key(kind: &str, dt: ShaderDtype, steps: &[ChainStep], extras: usize) -> String {
+    let mut key = format!("{kind}_{}_{extras}", dt.suffix());
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => key.push_str(&format!("_{op}")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                key.push_str(&format!("_{op}{rhs}{}", if *swapped { "r" } else { "" }))
+            }
+        }
+    }
+    key
+}
+
+fn matmul_wgsl(dt: ShaderDtype) -> String {
+    matmul_module(dt, &[], 0)
+}
+
+/// `extras` epilogue operands bind between B and the output.
+pub fn matmul_module(dt: ShaderDtype, epilogue: &[ChainStep], extras: usize) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let out_binding = 2 + extras;
+    let uniform_binding = 3 + extras;
+    let extra_bindings = (0..extras)
+        .map(|i| {
+            format!("@group(0) @binding({}) var<storage, read> extra{i}: array<{t}>;\n", 2 + i)
+        })
+        .collect::<String>();
+    let lib = if epilogue.is_empty() {
+        String::new()
+    } else {
+        format!("{}{}", unary_ops_wgsl(t), binary_ops_wgsl(t))
+    };
+    let epilogue = epilogue_body(epilogue, "col");
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_a: u32,
+    off_b: u32,
+    off_out: u32,
+    prefix: u32,
+    m: u32,
+    k: u32,
+    n: u32,
+    ta: u32,
+    tb: u32,
+    tc: u32,
+    _p0: u32,
+    _p1: u32,
+    a_s0: vec4<u32>,
+    a_s1: vec4<u32>,
+    b_s0: vec4<u32>,
+    b_s1: vec4<u32>,
+    out_s0: vec4<u32>,
+    out_s1: vec4<u32>,
+    out_sh0: vec4<u32>,
+    out_sh1: vec4<u32>,
+    off_extra: vec4<u32>,
+    mode_extra: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> a: array<{t}>;
+@group(0) @binding(1) var<storage, read> b: array<{t}>;
+{extra_bindings}@group(0) @binding({out_binding}) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding({uniform_binding}) var<uniform> params: Params;
+{lib}
+{AT8}
+
+@compute @workgroup_size({WORKGROUP})
+fn matmul_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let mn = params.m * params.n;
+    let nout = params.prefix * mn;
+    if (i >= nout) {{ return; }}
+    let pref = i / mn;
+    let rest = i % mn;
+    var row: u32;
+    var col: u32;
+    if (params.tc != 0u) {{
+        row = rest % params.m;
+        col = rest / params.m;
+    }} else {{
+        col = rest % params.n;
+        row = rest / params.n;
+    }}
+    // Shapes and strides are right-aligned in the 8 slots: the two matmul axes
+    // land in slots 6 and 7, prefix axes in 0..5, padded with dim 1 stride 0.
+    // `pref` is row-major over the prefix, so decode from the fastest axis up.
+    var a_i = params.off_a;
+    var b_i = params.off_b;
+    var o_i = params.off_out;
+    var restp = pref;
+    for (var j = 0u; j < 6u; j++) {{
+        let ax = 5u - j;
+        let dim = max(at8(params.out_sh0, params.out_sh1, ax), 1u);
+        let c = restp % dim;
+        restp = restp / dim;
+        a_i += c * at8(params.a_s0, params.a_s1, ax);
+        b_i += c * at8(params.b_s0, params.b_s1, ax);
+        o_i += c * at8(params.out_s0, params.out_s1, ax);
+    }}
+    let a_row_s = select(at8(params.a_s0, params.a_s1, 6u), at8(params.a_s0, params.a_s1, 7u), params.ta != 0u);
+    let a_col_s = select(at8(params.a_s0, params.a_s1, 7u), at8(params.a_s0, params.a_s1, 6u), params.ta != 0u);
+    let b_row_s = select(at8(params.b_s0, params.b_s1, 6u), at8(params.b_s0, params.b_s1, 7u), params.tb != 0u);
+    let b_col_s = select(at8(params.b_s0, params.b_s1, 7u), at8(params.b_s0, params.b_s1, 6u), params.tb != 0u);
+    var acc = 0.0;
+    for (var kk = 0u; kk < params.k; kk++) {{
+        let av = f32(a[a_i + row * a_row_s + kk * a_col_s]);
+        let bv = f32(b[b_i + kk * b_row_s + col * b_col_s]);
+        acc += av * bv;
+    }}
+    let o_row_s = select(at8(params.out_s0, params.out_s1, 6u), at8(params.out_s0, params.out_s1, 7u), params.tc != 0u);
+    let o_col_s = select(at8(params.out_s0, params.out_s1, 7u), at8(params.out_s0, params.out_s1, 6u), params.tc != 0u);
+    var v = {t}(acc);
+{epilogue}
+    outp[o_i + row * o_row_s + col * o_col_s] = v;
+}}
+"#
+    ));
+    s
+}
+
+/// A single-channel tensor into a texture the caller can sample: the mask
+/// leaves the graph as a GPU resource rather than as bytes on the host.
+fn export_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    width: u32,
+    height: u32,
+    _p: u32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var dst: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn export_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.width * params.height;
+    if (i >= n) {{ return; }}
+    let x = i % params.width;
+    let y = i / params.width;
+    let v = clamp(f32(inp[params.off_in + i]), 0.0, 1.0);
+    textureStore(dst, vec2<i32>(i32(x), i32(y)), vec4<f32>(v, v, v, 1.0));
+}}
+"#
+    ));
+    s
+}
+
+fn ingest_wgsl(dt: ShaderDtype) -> String {
+    let _ = dt;
+    format!(
+        r#"
+struct Params {{
+    off_out: u32,
+    width: u32,
+    height: u32,
+    _p: u32,
+}}
+
+@group(0) @binding(0) var src: texture_2d<f32>;
+@group(0) @binding(1) var<storage, read_write> outp: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn rgba_to_nchw_f32(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.width * params.height;
+    if (i >= n) {{ return; }}
+    let x = i % params.width;
+    let y = i / params.width;
+    let px = textureLoad(src, vec2<i32>(i32(x), i32(y)), 0);
+    let hw = params.width * params.height;
+    let o = params.off_out + i;
+    outp[o] = px.r;
+    outp[o + hw] = px.g;
+    outp[o + 2u * hw] = px.b;
+}}
+"#
+    )
+}
+
+pub fn pack_u32s(vals: &[u32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vals.len() * 4);
+    for v in vals {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+pub fn pad8_u32(xs: &[usize]) -> [u32; 8] {
+    let mut out = [1u32; 8];
+    for (i, v) in xs.iter().take(8).enumerate() {
+        out[i] = *v as u32;
+    }
+    out
+}
+
+pub fn pad8_stride(xs: &[isize]) -> [u32; 8] {
+    let mut out = [0u32; 8];
+    for (i, s) in xs.iter().take(8).enumerate() {
+        out[i] = (*s).max(0) as u32;
+    }
+    out
+}
+
+/// Right-aligned into the 8 slots: axis `i` of a rank-`r` tensor lands in slot
+/// `8 - r + i`, so a matmul's two trailing axes always sit in slots 6 and 7 and
+/// the prefix in 0..6. Absent axes read as dim 1.
+pub fn rpad8_dims(shape: &[usize]) -> [u32; 8] {
+    let mut out = [1u32; 8];
+    let base = 8 - shape.len().min(8);
+    for (i, d) in shape.iter().take(8).enumerate() {
+        out[base + i] = *d as u32;
+    }
+    out
+}
+
+/// [`rpad8_dims`] for strides: absent axes read as stride 0, and so do axes this
+/// tensor broadcasts over (`shape[i] == 1 && out_shape[i] != 1`).
+pub fn rpad8_strides(shape: &[usize], strides: &[isize], out_shape: &[usize]) -> [u32; 8] {
+    let mut out = [0u32; 8];
+    let base = 8 - shape.len().min(8);
+    for i in 0..shape.len().min(8) {
+        if shape[i] == 1 && out_shape.get(i).is_some_and(|d| *d != 1) {
+            continue;
+        }
+        out[base + i] = strides[i].max(0) as u32;
+    }
+    out
+}
+
+/// Strides in elements, zeroed on broadcast axes (`shape[i] == 1 && out[i] != 1`).
+pub fn broadcast_strides(shape: &[usize], strides: &[isize], out_shape: &[usize]) -> [u32; 8] {
+    let mut out = [0u32; 8];
+    for i in 0..out_shape.len().min(8) {
+        if i < shape.len() && shape[i] == 1 && out_shape[i] != 1 {
+            out[i] = 0;
+        } else if i < strides.len() {
+            out[i] = strides[i].max(0) as u32;
+        }
+    }
+    out
+}

--- a/wgpu/src/kernels/softmax.rs
+++ b/wgpu/src/kernels/softmax.rs
@@ -1,0 +1,70 @@
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{register_wgpu_op, with_wgpu_queue};
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Softmax, &["softmax"], shader_f16)
+}
+
+fn reshape_to_rank_3(shape: &[usize], axis: usize) -> [usize; 3] {
+    let outer: usize = shape[..axis].iter().product();
+    let k = shape[axis];
+    let inner: usize = shape[axis + 1..].iter().product();
+    [outer.max(1), k, inner.max(1)]
+}
+
+pub fn wgpu_softmax_dispatch(
+    input: &DeviceTensor,
+    axis: usize,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        ensure!(output.shape() == input.shape());
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let pipeline = q.context().pipeline(PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Softmax, dtype: dt },
+            entry: EntryPoint::typed("softmax", dt),
+        })?;
+        let nd3 = reshape_to_rank_3(input.shape(), axis);
+        let n = (nd3[0] * nd3[2]) as u64;
+        if n == 0 || nd3[1] == 0 {
+            return Ok(());
+        }
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(output, 0) as u32,
+            nd3[0] as u32,
+            nd3[1] as u32,
+            nd3[2] as u32,
+            0,
+            0,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("softmax", &pipeline, &bg, dyn_off, n)
+    })
+}
+
+register_wgpu_op!(tract_core::ops::nn::Softmax, |source, node, op| {
+    rule_if!(matches!(
+        source.node_input_facts(node.id)?[0].datum_type,
+        DatumType::F32 | DatumType::F16
+    ));
+    rule_if!(op.quant_output_dt.is_none());
+    rule_if!(op.kind == tract_core::ops::nn::SoftmaxKind::Softmax);
+    Ok(Some(Box::new(tract_gpu::ops::softmax::GpuSoftmax::from_tract_core(
+        op,
+        "Wgpu",
+        wgpu_softmax_dispatch,
+    )?)))
+});

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1,0 +1,148 @@
+//! WebGPU backend for tract, built on the `wgpu` crate.
+//!
+//! Native (Vulkan/Metal/DX12): blocking `request_adapter` / `PollType::Wait`.
+//! Wasm (`wasm32-unknown-unknown`): enable wgpu's
+//! `fragile-send-sync-non-atomic-wasm` feature (on by default here). That is
+//! sound **only** because tract's browser CPU tiers compile **without**
+//! atomics — `DeviceContext` / `OwnedDeviceTensor` require `Send + Sync`, and
+//! wgpu's web types are `!Send`/`!Sync` otherwise.
+//!
+//! **Mutually exclusive** with the
+//! `+atomics,+bulk-memory,+mutable-globals,+simd128` wasm-bindgen-rayon tier
+//! (`linalg/MULTITHREAD_BENCHMARKS.md`). In a video call that is the correct
+//! trade: inference must not take four CPU cores.
+//!
+//! Startup is one async (`wgpu_context_async`). Fully-covered models stay
+//! synchronous: **one await at the end of `run()`**. On web, `PollType::Wait`
+//! is a no-op — do not use blocking `to_host` unless Cargo feature `jspi` is
+//! on (JSPI suspends across `mapAsync`; Safari 26 lacks it, Safari 27 has it).
+//! Await [`to_host_async`] **once** after `run()` on the default wasm path.
+//!
+//! `DeviceBuffer::ptr()` is an identity of the `wgpu::Buffer` handle, not a
+//! GPU address. Kernels downcast `WgpuBuffer` and bind
+//! `(buffer, byte_offset as uniform)`.
+
+mod context;
+pub mod coverage;
+pub mod jspi;
+pub mod kernels;
+pub mod ops;
+mod rewrite_rules;
+mod tensor;
+mod tests;
+mod transform;
+mod utils;
+
+use tract_core::internal::*;
+use tract_core::transform::ModelTransform;
+
+pub use crate::context::{
+    CACHE_STATS, KernelTime, WgpuContext, WgpuQueue, wgpu_context, wgpu_context_async,
+    with_wgpu_queue,
+};
+pub use crate::coverage::{UncoveredOp, ensure_wgpu_coverage, uncovered_ops};
+pub use crate::jspi::{hybrid_fallback_available, jspi_in_browser};
+#[cfg(target_arch = "wasm32")]
+pub use crate::kernels::ingest::{tensor_from_external_image, tensor_from_video_frame};
+pub use crate::kernels::ingest::{tensor_from_rgba8, tensor_to_texture};
+
+/// The `GPUDevice` this backend runs on, so a compositor in the page can be
+/// built against the same device and read the mask where it already is.
+#[cfg(target_arch = "wasm32")]
+pub fn webgpu_device() -> Option<wasm_bindgen::JsValue> {
+    use wasm_bindgen::JsCast;
+    wgpu_context().device().as_webgpu().map(|d| d.clone().unchecked_into())
+}
+
+/// A texture this backend can write a mask into, handed to the page as a
+/// `GPUTexture`.
+#[cfg(target_arch = "wasm32")]
+pub fn mask_texture(
+    width: u32,
+    height: u32,
+) -> TractResult<(wgpu::Texture, wasm_bindgen::JsValue)> {
+    use wasm_bindgen::JsCast;
+    let texture = wgpu_context().device().create_texture(&wgpu::TextureDescriptor {
+        label: Some("tract-wgpu-mask"),
+        size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::STORAGE_BINDING
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let handle = texture
+        .as_webgpu()
+        .context("mask texture is not a WebGPU texture")?
+        .clone()
+        .unchecked_into();
+    Ok((texture, handle))
+}
+pub use crate::transform::WgpuTransform;
+
+use crate::utils::get_wgpu_buffer;
+use tract_gpu::tensor::DeviceTensor;
+
+/// Single await after `run()` on web (and a blocking poll on native).
+pub async fn to_host_async(tensor: &DeviceTensor) -> TractResult<Tensor> {
+    let ctx = wgpu_context();
+    let buffer = get_wgpu_buffer(tensor).inner.clone();
+    let offset = tensor.buffer_offset::<usize>() as u64;
+    let len = (tensor.len() * tensor.datum_type().size_of()) as u64;
+    let bytes = ctx.download_async(&buffer, offset, len).await?;
+    unsafe { Tensor::from_raw_dt(tensor.datum_type(), tensor.shape(), &bytes) }
+}
+
+#[derive(Debug)]
+struct WgpuRuntime;
+
+impl Runtime for WgpuRuntime {
+    fn name(&self) -> StaticName {
+        "wgpu".into()
+    }
+
+    fn prepare_with_options(
+        &self,
+        mut model: TypedModel,
+        options: &RunOptions,
+    ) -> TractResult<Box<dyn Runnable>> {
+        WgpuTransform.transform(&mut model)?;
+        model = model.into_optimized()?;
+        if hybrid_fallback_available() {
+            let bad = uncovered_ops(&model)?;
+            if !bad.is_empty() {
+                let list = bad
+                    .iter()
+                    .map(|u| format!("{} (node {:?})", u.op, u.node))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                log::warn!(
+                    "tract-wgpu hybrid fallback: running on CPU for {list}. \
+                     Covered ops stay on GPU."
+                );
+            }
+        } else {
+            ensure_wgpu_coverage(&model)?;
+        }
+
+        let options = RunOptions { skip_order_opt_ram: true, ..options.clone() };
+        let mut runnable = TypedSimplePlan::build(model, &options)?;
+        if let Some(hints) = options.memory_sizing_hints {
+            let turn_handler =
+                tract_gpu::turn_handler::DeviceTurnHandler::from_plan(&runnable, &hints)
+                    .context("While sizing memory arena. Missing hint ?")?;
+            runnable = runnable.with_turn_handler(turn_handler);
+        }
+
+        Ok(Box::new(Arc::new(runnable)))
+    }
+
+    fn check(&self) -> TractResult<()> {
+        Ok(())
+    }
+}
+
+register_runtime!(WgpuRuntime = WgpuRuntime);

--- a/wgpu/src/ops/chain.rs
+++ b/wgpu/src/ops/chain.rs
@@ -1,0 +1,61 @@
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensorExt;
+
+use crate::kernels::chain::wgpu_chain_dispatch;
+use crate::kernels::shaders::ChainStep;
+
+/// A run of elementwise ops evaluated as one kernel. Input 0 is the head of the
+/// chain and carries the output shape; the rest are the second operands of the
+/// binary links, and broadcast against it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WgpuElementWiseChain {
+    pub steps: Vec<ChainStep>,
+}
+
+impl Op for WgpuElementWiseChain {
+    fn name(&self) -> StaticName {
+        "WgpuElementWiseChain".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(self
+            .steps
+            .iter()
+            .map(|s| match s {
+                ChainStep::Unary(op) => op.clone(),
+                ChainStep::Binary { op, rhs, swapped } => {
+                    format!("{op}(#{rhs}){}", if *swapped { " swapped" } else { "" })
+                }
+            })
+            .collect())
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuElementWiseChain {
+    op_out_of_plan!();
+
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let inputs =
+            inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
+        let head = inputs[0];
+        let output =
+            tract_gpu::turn_handler::make_tensor_for_node(ctx, head.datum_type(), head.shape())?;
+        if output.len() > 0 {
+            wgpu_chain_dispatch(&self.steps, &inputs, &output)?;
+        }
+        Ok(tvec!(output.into_tensor().into_tvalue()))
+    }
+}
+
+impl TypedOp for WgpuElementWiseChain {
+    as_op!();
+
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        tract_gpu::utils::facts_to_device_facts(inputs, |facts| {
+            Ok(tvec!(facts[0].datum_type.fact(facts[0].shape.clone())))
+        })
+        .with_context(|| "Error while computing facts for WgpuElementWiseChain")
+    }
+}

--- a/wgpu/src/ops/conv.rs
+++ b/wgpu/src/ops/conv.rs
@@ -1,0 +1,101 @@
+use crate::kernels::bin_ops::wgpu_bin_op;
+use crate::kernels::conv::wgpu_conv_dispatch;
+use tract_core::internal::*;
+use tract_core::ops::cnn::Conv;
+use tract_gpu::ops::change_axes::GpuAxisOp;
+use tract_gpu::tensor::DeviceTensorExt;
+
+pub fn wire_wgpu_conv(
+    source: &TypedModel,
+    node: &TypedNode,
+    target: &mut TypedModel,
+    inputs: &[OutletId],
+    op: &Conv,
+) -> TractResult<TVec<OutletId>> {
+    let facts = source.node_input_facts(node.id)?;
+    let data_shape = op.pool_spec.data_format.shape(&facts[0].shape)?;
+    let prefix = &node.name;
+    let bias = &facts[2];
+    let need_bias = !(bias.konst.is_some() && bias.konst.as_ref().unwrap().is_all_zero()?);
+    let conv_name = format!("{prefix}.conv");
+    let mut conv_wire = target.wire_node(
+        if need_bias { &conv_name } else { &node.name },
+        WgpuConv { op: op.clone(), epilogue: vec![] },
+        &inputs[0..2],
+    )?[0];
+    if need_bias {
+        let mut needed_shape = tvec![1.to_dim(); node.outputs[0].fact.rank()];
+        needed_shape[data_shape.c_axis()] = op.pool_spec.output_channels.to_dim();
+        let reshaped = target.wire_node(
+            format!("{prefix}.bias_reshaped"),
+            GpuAxisOp::new(AxisOp::Reshape(0, bias.shape.to_tvec(), needed_shape)),
+            &[inputs[2]],
+        )?[0];
+        conv_wire = target.wire_node(
+            prefix,
+            wgpu_bin_op(Box::new(tract_core::ops::math::Add)),
+            &[conv_wire, reshaped],
+        )?[0];
+    }
+    Ok(tvec!(conv_wire))
+}
+
+/// A convolution with any elementwise ops that followed it applied to each
+/// result before it is stored. Inputs past the data and the weights belong to
+/// the epilogue, one per binary step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgpuConv {
+    pub op: Conv,
+    pub epilogue: Vec<crate::kernels::shaders::ChainStep>,
+}
+
+impl Op for WgpuConv {
+    fn name(&self) -> StaticName {
+        "WgpuConv".into()
+    }
+    fn info(&self) -> TractResult<Vec<String>> {
+        self.op.info()
+    }
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuConv {
+    op_out_of_plan!();
+
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let inputs =
+            inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
+        let output_shape = self.op.pool_spec.output_shape(inputs[0].shape())?;
+        let output = tract_gpu::turn_handler::make_tensor_for_node(
+            ctx,
+            inputs[0].datum_type(),
+            &output_shape.shape,
+        )?;
+        if output.len() > 0 {
+            wgpu_conv_dispatch(
+                &self.op,
+                &self.epilogue,
+                inputs[0],
+                inputs[1],
+                &inputs[2..],
+                &output,
+            )?;
+        }
+        Ok(tvec!(output.into_tensor().into_tvalue()))
+    }
+}
+
+impl TypedOp for WgpuConv {
+    as_op!();
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        tract_gpu::utils::facts_to_device_facts(inputs, |facts| {
+            let zero = facts[0].datum_type.scalar_fact();
+            let mut facts: TVec<&TypedFact> = facts[0..2.min(facts.len())].into();
+            if facts.len() == 2 {
+                facts.push(&zero);
+            }
+            self.op.output_facts(&facts)
+        })
+        .with_context(|| "Error while computing facts for WgpuConv")
+    }
+}

--- a/wgpu/src/ops/deconv.rs
+++ b/wgpu/src/ops/deconv.rs
@@ -1,0 +1,95 @@
+use crate::kernels::bin_ops::wgpu_bin_op;
+use crate::kernels::deconv::wgpu_deconv_dispatch;
+use tract_core::internal::*;
+use tract_core::ops::cnn::Deconv;
+use tract_gpu::ops::change_axes::GpuAxisOp;
+use tract_gpu::tensor::DeviceTensorExt;
+
+pub fn wire_wgpu_deconv(
+    source: &TypedModel,
+    node: &TypedNode,
+    target: &mut TypedModel,
+    inputs: &[OutletId],
+    op: &Deconv,
+) -> TractResult<TVec<OutletId>> {
+    let facts = source.node_input_facts(node.id)?;
+    let prefix = &node.name;
+    let has_bias = facts.len() > 2;
+    let need_bias = has_bias
+        && !(facts[2].konst.is_some() && facts[2].konst.as_ref().unwrap().is_all_zero()?);
+    let name = format!("{prefix}.deconv");
+    let mut wire = target.wire_node(
+        if need_bias { &name } else { &node.name },
+        WgpuDeconv { op: op.clone() },
+        &inputs[0..2],
+    )?[0];
+    if need_bias {
+        let data_shape = op.pool_spec.data_format.shape(&facts[0].shape)?;
+        let mut needed_shape = tvec![1.to_dim(); node.outputs[0].fact.rank()];
+        needed_shape[data_shape.c_axis()] = op.pool_spec.output_channels.to_dim();
+        let reshaped = target.wire_node(
+            format!("{prefix}.bias_reshaped"),
+            GpuAxisOp::new(AxisOp::Reshape(0, facts[2].shape.to_tvec(), needed_shape)),
+            &[inputs[2]],
+        )?[0];
+        wire = target.wire_node(
+            prefix,
+            wgpu_bin_op(Box::new(tract_core::ops::math::Add)),
+            &[wire, reshaped],
+        )?[0];
+    }
+    Ok(tvec!(wire))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgpuDeconv {
+    pub op: Deconv,
+}
+
+impl Op for WgpuDeconv {
+    fn name(&self) -> StaticName {
+        "WgpuConvTranspose".into()
+    }
+    fn info(&self) -> TractResult<Vec<String>> {
+        self.op.info()
+    }
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuDeconv {
+    op_out_of_plan!();
+
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let inputs =
+            inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
+        let output_shape = tract_core::ops::cnn::deconv::output_shape(
+            &self.op.pool_spec,
+            inputs[0].shape(),
+            &self.op.adjustments,
+        )?;
+        let output = tract_gpu::turn_handler::make_tensor_for_node(
+            ctx,
+            inputs[0].datum_type(),
+            &output_shape,
+        )?;
+        if output.len() > 0 {
+            wgpu_deconv_dispatch(&self.op, inputs[0], inputs[1], &output)?;
+        }
+        Ok(tvec!(output.into_tensor().into_tvalue()))
+    }
+}
+
+impl TypedOp for WgpuDeconv {
+    as_op!();
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        tract_gpu::utils::facts_to_device_facts(inputs, |facts| {
+            let zero = facts[0].datum_type.scalar_fact();
+            let mut facts: TVec<&TypedFact> = facts.into();
+            if facts.len() == 2 {
+                facts.push(&zero);
+            }
+            self.op.output_facts(&facts)
+        })
+        .with_context(|| "Error while computing facts for WgpuDeconv")
+    }
+}

--- a/wgpu/src/ops/fused_axis_op.rs
+++ b/wgpu/src/ops/fused_axis_op.rs
@@ -1,0 +1,189 @@
+//! Applies a chain of shape-only axis ops to an op's inputs as views, so a
+//! `Reshape` / `Add` / `Rm` (and a `Move` its consumer can restride) costs no
+//! kernel and no copy. Mirrors `MetalFusedAxisOp`.
+
+use derive_new::new;
+use tract_core::internal::tract_smallvec::ToSmallVec;
+use tract_core::internal::*;
+use tract_gpu::ops::change_axes::GpuAxisOp;
+use tract_gpu::tensor::{DeviceTensor, DeviceTensorExt};
+
+#[derive(Clone, Debug, new, PartialEq, Eq)]
+pub struct WgpuFusedAxisOp {
+    /// List of axis ops to apply for each op inputs
+    /// Length of the list is equal to number of inputs
+    pub grouped_axis_ops: TVec<TVec<GpuAxisOp>>,
+    pub op: Box<dyn TypedOp>,
+}
+
+#[derive(Debug, Clone, new)]
+pub struct WgpuFusedAxisOpState {
+    pub op_state: Box<dyn OpState>,
+}
+
+fn compute_reshaped_inputs(
+    inputs: TVec<TValue>,
+    grouped_axis_ops: &TVec<TVec<GpuAxisOp>>,
+    ctx: &EvalContext,
+) -> TractResult<TVec<TValue>> {
+    // Apply Axis Ops per input
+
+    inputs
+        .into_iter()
+        .zip(grouped_axis_ops.iter())
+        .map(|(input, axis_ops)| {
+            if axis_ops.is_empty() {
+                return Ok(input);
+            };
+            let m_input = input.to_device_tensor()?;
+            let reshaped_input = axis_ops.iter().try_fold(
+                m_input.clone(),
+                |t, axis_op| -> TractResult<DeviceTensor> {
+                    let new_shape = match &axis_op.inner {
+                        AxisOp::Reshape(skip, from, to) => {
+                            let from = from.iter().map(|d| d.eval(ctx.symbols)).collect();
+                            let to = to.iter().map(|d| d.eval(ctx.symbols)).collect();
+                            let mut shape: TVec<usize> = t.shape().into();
+                            AxisOp::Reshape(*skip, from, to)
+                                .change_shape_array(&mut shape, false)?;
+                            shape
+                        }
+                        AxisOp::Add(_) | AxisOp::Rm(_) | AxisOp::Move(..) => {
+                            let mut shape: TVec<usize> = t.shape().into();
+                            axis_op.inner.change_shape_array(&mut shape, false)?;
+                            shape
+                        }
+                    };
+                    if let AxisOp::Move(from, to) = axis_op.inner {
+                        let mut out_strides: TVec<isize> = t.strides().to_smallvec();
+                        let removed_stride = out_strides.remove(from);
+                        out_strides.insert(to, removed_stride);
+                        let tmp_t = t.reshaped(new_shape)?;
+                        tmp_t.restrided(out_strides)
+                    } else {
+                        t.reshaped(new_shape)
+                    }
+                },
+            )?;
+
+            Ok(reshaped_input.into_tensor().into())
+        })
+        .collect::<TractResult<TVec<_>>>()
+}
+
+impl OpState for WgpuFusedAxisOpState {
+    fn init_tensor_fact(&self) -> Option<(String, TypedFact)> {
+        self.op_state.init_tensor_fact()
+    }
+
+    fn has_init_tensor_fact(&self) -> bool {
+        self.op_state.has_init_tensor_fact()
+    }
+
+    fn load_from(
+        &mut self,
+        turn: &mut TurnState,
+        states: &mut dyn Iterator<Item = tract_core::value::TValue>,
+    ) -> TractResult<()> {
+        self.op_state.load_from(turn, states)
+    }
+
+    fn save_to(&self, states: &mut Vec<TValue>) -> TractResult<()> {
+        self.op_state.save_to(states)
+    }
+
+    fn resolve_symbols(&mut self, turn: &mut TurnState) -> TractResult<()> {
+        self.op_state.resolve_symbols(turn)
+    }
+
+    fn eval(
+        &mut self,
+        ctx: &EvalContext,
+        op: &dyn Op,
+        inputs: TVec<TValue>,
+    ) -> TractResult<TVec<TValue>> {
+        let fused_axis_op = op.downcast_ref::<WgpuFusedAxisOp>().unwrap();
+        let inputs = compute_reshaped_inputs(inputs, &fused_axis_op.grouped_axis_ops, ctx)?;
+        // Runner inner op
+        self.op_state.eval(ctx, fused_axis_op.op.as_op(), inputs)
+    }
+
+    fn reset_lanes(&mut self, lanes: &[LaneId]) -> TractResult<()> {
+        self.op_state.reset_lanes(lanes)
+    }
+}
+
+impl Op for WgpuFusedAxisOp {
+    fn name(&self) -> StaticName {
+        self.op.name()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        let mut info = self.op.info()?;
+        for (idx, axis_ops) in self.grouped_axis_ops.iter().enumerate() {
+            if !axis_ops.is_empty() {
+                info.push(format!(
+                    "Fused axis Op on Input #{idx}: {}",
+                    axis_ops
+                        .iter()
+                        .map(|axis_op| Ok(format!(
+                            "{} - {}",
+                            axis_op.name(),
+                            axis_op.info()?.join(" | ")
+                        )))
+                        .collect::<TractResult<TVec<_>>>()?
+                        .join(" | ")
+                ));
+            }
+        }
+        Ok(info)
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuFusedAxisOp {
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        let ctx = EvalContext::out_of_plan();
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, &ctx)?;
+        self.op.eval_out_of_plan(inputs)
+    }
+
+    fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
+        if let Some(state) = self.op.state(ctx)? {
+            Ok(Some(Box::new(WgpuFusedAxisOpState { op_state: state })))
+        } else {
+            Ok(None)
+        }
+    }
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, ctx)?;
+        // Runner inner op
+        self.op.eval(ctx, inputs)
+    }
+}
+
+impl TypedOp for WgpuFusedAxisOp {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        ensure!(
+            inputs.len() == self.grouped_axis_ops.len(),
+            "Number of inputs and fused axis ops are not aligned"
+        );
+        // Apply AxisOp
+        let inputs = inputs
+            .iter()
+            .zip(self.grouped_axis_ops.iter())
+            .map(|(i, axis_ops)| {
+                axis_ops.iter().try_fold((*i).clone(), |reshaped_i, axis_op| {
+                    Ok(axis_op.output_facts(&[&reshaped_i])?[0].clone())
+                })
+            })
+            .collect::<TractResult<TVec<_>>>()?;
+
+        let inputs_ref = inputs.iter().collect::<TVec<_>>();
+        // Apply Op
+        self.op.output_facts(&inputs_ref)
+    }
+
+    as_op!();
+}

--- a/wgpu/src/ops/matmul.rs
+++ b/wgpu/src/ops/matmul.rs
@@ -1,0 +1,76 @@
+use tract_core::internal::*;
+use tract_core::ops::einsum::prefix_matmul::PrefixMatMul;
+use tract_gpu::tensor::DeviceTensorExt;
+
+use crate::kernels::matmul::{Transposes, output_shape, wgpu_matmul_dispatch};
+use crate::kernels::shaders::ChainStep;
+
+/// `PrefixMatMul` on the GPU, with any elementwise ops that followed it applied
+/// to each result before it is stored. Inputs past the two operands belong to
+/// the epilogue, one per binary step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgpuGemm {
+    pub op: PrefixMatMul,
+    pub epilogue: Vec<ChainStep>,
+}
+
+impl Op for WgpuGemm {
+    fn name(&self) -> StaticName {
+        "WgpuGemm".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        let mut info = vec![format!(
+            "transpose_a: {} transpose_b: {} transpose_c: {}",
+            self.op.transpose_a, self.op.transpose_b, self.op.transpose_c
+        )];
+        if !self.epilogue.is_empty() {
+            info.push(format!("epilogue: {:?}", self.epilogue));
+        }
+        Ok(info)
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuGemm {
+    op_out_of_plan!();
+
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let inputs =
+            inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
+        let (a, b) = (inputs[0], inputs[1]);
+        let shape = output_shape(
+            a.shape(),
+            b.shape(),
+            self.op.transpose_a,
+            self.op.transpose_b,
+            self.op.transpose_c,
+        )?;
+        let output = tract_gpu::turn_handler::make_tensor_for_node(ctx, a.datum_type(), &shape)?;
+        if output.len() > 0 {
+            wgpu_matmul_dispatch(
+                Transposes {
+                    a: self.op.transpose_a,
+                    b: self.op.transpose_b,
+                    c: self.op.transpose_c,
+                },
+                &self.epilogue,
+                a,
+                b,
+                &inputs[2..],
+                &output,
+            )?;
+        }
+        Ok(tvec!(output.into_tensor().into_tvalue()))
+    }
+}
+
+impl TypedOp for WgpuGemm {
+    as_op!();
+
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        tract_gpu::utils::facts_to_device_facts(inputs, |facts| self.op.output_facts(&facts[0..2]))
+            .with_context(|| "Error while computing facts for WgpuGemm")
+    }
+}

--- a/wgpu/src/ops/mod.rs
+++ b/wgpu/src/ops/mod.rs
@@ -1,0 +1,6 @@
+pub mod chain;
+pub mod conv;
+pub mod deconv;
+pub mod fused_axis_op;
+pub mod matmul;
+pub mod pool;

--- a/wgpu/src/ops/pool.rs
+++ b/wgpu/src/ops/pool.rs
@@ -1,0 +1,111 @@
+use crate::kernels::pool::{PoolKind, wgpu_pool_dispatch, wgpu_pool_supported};
+use tract_core::internal::*;
+use tract_core::ops::cnn::{MaxPool, OptMaxPool, OptSumPool, PoolSpec, SumPool};
+use tract_gpu::tensor::DeviceTensorExt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WgpuPool {
+    pub pool_spec: PoolSpec,
+    pub kind: PoolKindOp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PoolKindOp {
+    Max,
+    Sum { count_include_pad: bool, normalize: bool },
+}
+
+impl From<PoolKindOp> for PoolKind {
+    fn from(k: PoolKindOp) -> Self {
+        match k {
+            PoolKindOp::Max => PoolKind::Max,
+            PoolKindOp::Sum { count_include_pad, normalize } => {
+                PoolKind::Sum { count_include_pad, normalize }
+            }
+        }
+    }
+}
+
+impl Op for WgpuPool {
+    fn name(&self) -> StaticName {
+        match self.kind {
+            PoolKindOp::Max => "WgpuMaxPool".into(),
+            PoolKindOp::Sum { .. } => "WgpuSumPool".into(),
+        }
+    }
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(self.pool_spec.info())
+    }
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuPool {
+    op_out_of_plan!();
+
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let input = inputs[0].to_device_tensor()?;
+        let output_shape = self.pool_spec.output_shape(input.shape())?;
+        let output = tract_gpu::turn_handler::make_tensor_for_node(
+            ctx,
+            input.datum_type(),
+            &output_shape.shape,
+        )?;
+        if output.len() > 0 {
+            wgpu_pool_dispatch(&self.pool_spec, self.kind.into(), input, &output)?;
+        }
+        Ok(tvec!(output.into_tensor().into_tvalue()))
+    }
+}
+
+impl TypedOp for WgpuPool {
+    as_op!();
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        tract_gpu::utils::facts_to_device_facts(inputs, |facts| {
+            let shape = self.pool_spec.output_shape(&facts[0].shape)?;
+            Ok(tvec!(facts[0].datum_type.fact(shape.shape)))
+        })
+        .with_context(|| "Error while computing facts for WgpuPool")
+    }
+}
+
+crate::register_wgpu_op!(OptMaxPool, |source, node, op| {
+    let facts = source.node_input_facts(node.id)?;
+    if op.with_index_outputs.is_some() || !wgpu_pool_supported(&op.pool_spec, facts[0]) {
+        return Ok(None);
+    }
+    Ok(Some(Box::new(WgpuPool { pool_spec: op.pool_spec.clone(), kind: PoolKindOp::Max })
+        as Box<dyn TypedOp>))
+});
+
+crate::register_wgpu_op!(MaxPool, |source, node, op| {
+    let facts = source.node_input_facts(node.id)?;
+    if op.with_index_outputs.is_some() || !wgpu_pool_supported(&op.pool_spec, facts[0]) {
+        return Ok(None);
+    }
+    Ok(Some(Box::new(WgpuPool { pool_spec: op.pool_spec.clone(), kind: PoolKindOp::Max })
+        as Box<dyn TypedOp>))
+});
+
+crate::register_wgpu_op!(OptSumPool, |source, node, op| {
+    let facts = source.node_input_facts(node.id)?;
+    if !wgpu_pool_supported(&op.pool_spec, facts[0]) {
+        return Ok(None);
+    }
+    Ok(Some(Box::new(WgpuPool {
+        pool_spec: op.pool_spec.clone(),
+        kind: PoolKindOp::Sum { count_include_pad: op.count_include_pad, normalize: op.normalize },
+    }) as Box<dyn TypedOp>))
+});
+
+crate::register_wgpu_op!(SumPool, |source, node, op| {
+    let facts = source.node_input_facts(node.id)?;
+    if !wgpu_pool_supported(&op.pool_spec, facts[0]) {
+        return Ok(None);
+    }
+    Ok(Some(Box::new(WgpuPool {
+        pool_spec: op.pool_spec.clone(),
+        kind: PoolKindOp::Sum { count_include_pad: op.count_include_pad, normalize: op.normalize },
+    }) as Box<dyn TypedOp>))
+});
+
+pub fn link_translators() {}

--- a/wgpu/src/rewrite_rules/fuse_axis_op.rs
+++ b/wgpu/src/rewrite_rules/fuse_axis_op.rs
@@ -1,0 +1,248 @@
+use crate::ops::fused_axis_op::WgpuFusedAxisOp;
+use tract_core::internal::*;
+use tract_core::tract_data::itertools::Itertools;
+use tract_gpu::fact::DeviceTypedFactExt;
+use tract_gpu::ops::change_axes::GpuAxisOp;
+use tract_gpu::rule_ensure;
+use tract_gpu::sync::DeviceSync;
+
+fn is_supported_axis_op(op: &GpuAxisOp) -> bool {
+    matches!(op.inner, AxisOp::Add(_) | AxisOp::Rm(_) | AxisOp::Reshape(..))
+}
+
+/// Ops that read every input through explicit strides, so a `Move` in front of
+/// one is a permutation of those strides rather than a copy.
+fn can_fuse_move(model: &TypedModel, axis_node: &TypedNode) -> bool {
+    model.single_succ(axis_node.id).unwrap().is_some_and(|node| {
+        node.op_is::<crate::ops::matmul::WgpuGemm>()
+            || node.op_is::<crate::ops::chain::WgpuElementWiseChain>()
+            || node.op_is::<tract_gpu::ops::concat::GpuConcat>()
+            || node.op_is::<tract_gpu::ops::apply_rope::GpuApplyRope>()
+            || node.op_is::<tract_gpu::ops::scaled_masked_softmax::GpuScaledMaskedSoftmax>()
+            || node.op_is::<tract_gpu::ops::slice::GpuSlice>()
+            || node.op_is::<tract_gpu::ops::broadcast::GpuMultiBroadcastTo>()
+            || node.op_is::<tract_gpu::ops::dyn_kv_cache::GpuDynKVCache>()
+    })
+}
+
+pub fn collect_chain_of_axis_ops<'a>(
+    model: &'a TypedModel,
+    mut cursor: &'a TypedNode,
+) -> TractResult<Option<(TVec<GpuAxisOp>, &'a TypedNode)>> {
+    let mut acc_axis_ops = tvec![];
+    let mut head_of_chain = cursor;
+
+    while let Some(axis_op) = cursor.op_as::<GpuAxisOp>().filter(|o| {
+        is_supported_axis_op(o)
+            || (matches!(o.inner, AxisOp::Move(..)) && can_fuse_move(model, cursor))
+    }) {
+        acc_axis_ops.push(axis_op.clone());
+        head_of_chain = cursor;
+
+        if let Some(prev) = model.single_prec(cursor.id)? {
+            cursor = prev;
+        } else {
+            break;
+        }
+    }
+
+    Ok(if acc_axis_ops.is_empty() {
+        None
+    } else {
+        Some((acc_axis_ops.into_iter().rev().collect(), head_of_chain))
+    })
+}
+
+fn split_succs(
+    model: &TypedModel,
+    axis_node: &TypedNode,
+    axis_node_name: &str,
+    axis_op: &GpuAxisOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    let succs = model.all_succ(axis_node.id)?.context("Expected node with successors")?;
+
+    let mut patch = TypedModelPatch::default();
+    let input = patch.tap_model(model, axis_node.inputs[0])?;
+
+    for (i, succ) in succs.iter().enumerate() {
+        let axis_out =
+            patch.wire_node(format!("{axis_node_name}.{i}"), axis_op.clone(), &[input])?[0];
+
+        let mut op_ins = patch.taps(model, &succ.inputs)?;
+
+        let (idx, _) = succ
+            .inputs
+            .iter()
+            .enumerate()
+            .find(|(_, inlet)| inlet.node == axis_node.id)
+            .context("Axis node not found in its successor inputs")?;
+
+        op_ins[idx] = axis_out;
+
+        let op_outs = patch.wire_node(succ.name.clone(), succ.op.clone(), &op_ins)?;
+        for out in op_outs {
+            patch.shunt_outside(model, succ.id.into(), out)?;
+        }
+    }
+
+    Ok(Some(patch))
+}
+
+pub fn fuse_axis_op(
+    _ctx: &(),
+    model: &TypedModel,
+    axis_node: &TypedNode,
+    axis_node_name: &str,
+    axis_op: &GpuAxisOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    // Only support certain axis ops (or a Move, which is handled specially below)
+    rule_ensure!(is_supported_axis_op(axis_op) || matches!(axis_op.inner, AxisOp::Move(..)));
+
+    let Some(node) = model.single_succ(axis_node.id)? else {
+        return split_succs(model, axis_node, axis_node_name, axis_op);
+    };
+
+    // A sync must stay a node of its own: `rewire_syncs` looks for it by type,
+    // and the load-time coverage check reads it as glue.
+    rule_ensure!(!node.op_is::<DeviceSync>());
+
+    // Disallow fusing when the successor is already an axis/fused op or a sync,
+    // *unless* it's a Move AxisOp (we allow that via the early-quit branch).
+    let is_axis_like = node.op_is::<GpuAxisOp>() || node.op_is::<WgpuFusedAxisOp>();
+    let is_allowed_move =
+        node.op_as::<GpuAxisOp>().is_some_and(|op| matches!(op.inner, AxisOp::Move(..)));
+
+    rule_ensure!(!is_axis_like || is_allowed_move);
+
+    let node_name = &node.name;
+
+    rule_if_some!(in_nodes = model.all_prec(node.id)?);
+
+    let mut grouped_axis_ops: TVec<TVec<GpuAxisOp>> = tvec![];
+    let mut tap_inputs = tvec![];
+    let mut patch = TypedModelPatch::default();
+
+    for (in_idx, in_node) in in_nodes.into_iter().enumerate() {
+        match collect_chain_of_axis_ops(model, in_node)? {
+            Some((acc_axis_ops, head_of_chain)) => {
+                grouped_axis_ops.push(acc_axis_ops);
+                tap_inputs.push(patch.tap_model(model, head_of_chain.inputs[0])?);
+            }
+            None => {
+                grouped_axis_ops.push(tvec![]);
+                tap_inputs.push(patch.tap_model(model, node.inputs[in_idx])?);
+            }
+        }
+    }
+
+    // If the successor is a Move, we may fuse it now or defer.
+    if let Some(op) = node.op_as::<GpuAxisOp>()
+        && matches!(op.inner, AxisOp::Move(..))
+    {
+        let should_defer_move = !grouped_axis_ops[0].is_empty() && !can_fuse_move(model, node);
+        if should_defer_move {
+            let out = patch.wire_node(
+                format!("{node_name}.fused_axis_op"),
+                WgpuFusedAxisOp { grouped_axis_ops, op: Box::new(op.clone()) },
+                &tap_inputs,
+            )?;
+            patch.shunt_outside(model, node.id.into(), out[0])?;
+            return Ok(Some(patch));
+        } else {
+            // Nothing to do right now; we’ll fuse on a later pass.
+            return Ok(None);
+        }
+    }
+
+    // General case: fuse using the successor's op.
+    let out = patch.wire_node(
+        format!("{node_name}.fused_axis_op"),
+        WgpuFusedAxisOp { grouped_axis_ops, op: node.op.clone() },
+        &tap_inputs,
+    )?;
+    patch.shunt_outside(model, node.id.into(), out[0])?;
+    Ok(Some(patch))
+}
+
+pub fn fuse_move_axis(
+    _ctx: &(),
+    model: &TypedModel,
+    axis_node: &TypedNode,
+    axis_node_name: &str,
+    axis_op: &GpuAxisOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_ensure!(matches!(axis_op.inner, AxisOp::Move(..)));
+
+    let in_fact = model.node_input_facts(axis_node.id)?[0];
+    let in_shape =
+        in_fact.as_device_fact().map(|mf| mf.shape.clone()).unwrap_or(in_fact.shape.clone());
+
+    let out_fact = model.node_output_facts(axis_node.id)?[0];
+    let out_shape =
+        out_fact.as_device_fact().map(|mf| mf.shape.clone()).unwrap_or(out_fact.shape.clone());
+
+    // Checks if MoveAxis has no impact on shape + layout
+    if in_shape == out_shape
+        && let (Some(in_strides), AxisOp::Move(from, to)) =
+            (in_shape.as_concrete().map(Tensor::natural_strides), axis_op.inner.clone())
+    {
+        let mut out_strides = in_strides.clone();
+        let remove_stride = out_strides.remove(from);
+        out_strides.insert(to, remove_stride);
+        if in_strides == out_strides {
+            return TypedModelPatch::shunt_one_op(model, axis_node);
+        }
+    }
+
+    // Reshape are always fusable. Change Move by Reshape if possible
+    let simpl_op = GpuAxisOp::simplify_axis_op(axis_op.inner.clone(), in_shape.dims());
+    if simpl_op != *axis_op {
+        return Ok(Some(TypedModelPatch::replace_single_op(
+            model,
+            axis_node,
+            &[axis_node.inputs[0]],
+            simpl_op,
+        )?));
+    }
+
+    // Fuse consecutive MoveAxis if possible
+    rule_if_some!(cursor = model.single_succ(axis_node.id)?);
+    if let (AxisOp::Move(from_1, to_1), AxisOp::Move(from_2, to_2)) = (
+        axis_op.inner.clone(),
+        cursor.op_as::<GpuAxisOp>().map(|ax_op| ax_op.inner.clone()).unwrap_or(AxisOp::Add(0)),
+    ) {
+        let max_rank = [from_1, from_2, to_1, to_2].iter().max().unwrap() + 1;
+        let mut perm: TVec<usize> = (0..max_rank).collect_vec().into();
+
+        AxisOp::Move(from_1, to_1).change_shape_array(&mut perm, false)?;
+        AxisOp::Move(from_2, to_2).change_shape_array(&mut perm, false)?;
+        let new_axis_ops = perm_to_ops(&perm);
+        if new_axis_ops.len() == 1 {
+            let mut patch = TypedModelPatch::default();
+            let inputs = patch.taps(model, &axis_node.inputs)?;
+            let out = patch.wire_node(
+                format!("{axis_node_name}.fused_move_axis"),
+                GpuAxisOp::new(new_axis_ops[0].clone()),
+                &inputs,
+            )?;
+            patch.shunt_outside(model, cursor.id.into(), out[0])?;
+            return Ok(Some(patch));
+        }
+    }
+
+    // Add(x) -> Move(x, y)
+    rule_if_some!(cursor = model.single_prec(axis_node.id)?);
+    if let (AxisOp::Move(from_1, to_1), AxisOp::Add(ax)) = (
+        axis_op.inner.clone(),
+        cursor.op_as::<GpuAxisOp>().map(|ax_op| ax_op.inner.clone()).unwrap_or(AxisOp::Rm(0)),
+    ) && ax == from_1
+    {
+        let mut patch = TypedModelPatch::default();
+        let inputs = patch.taps(model, &cursor.inputs)?;
+        let out =
+            patch.wire_node(cursor.name.clone(), GpuAxisOp::new(AxisOp::Add(to_1)), &inputs)?;
+        patch.shunt_outside(model, axis_node.id.into(), out[0])?;
+        return Ok(Some(patch));
+    }
+    Ok(None)
+}

--- a/wgpu/src/rewrite_rules/fuse_elementwise.rs
+++ b/wgpu/src/rewrite_rules/fuse_elementwise.rs
@@ -1,0 +1,112 @@
+use tract_core::internal::*;
+use tract_gpu::ops::binary::GpuBinOp;
+use tract_gpu::ops::element_wise::GpuElementWise;
+use tract_gpu::rule_ensure;
+
+use crate::kernels::chain::MAX_EXTRA_INPUTS;
+use crate::kernels::shaders::{BINARY_OPS, ChainStep, ELEMENT_WISE_OPS};
+use crate::ops::chain::WgpuElementWiseChain;
+
+/// The op's name as the generated WGSL spells it, if there is one.
+fn unary_name(node: &TypedNode) -> Option<String> {
+    let op = node.op_as::<GpuElementWise>()?;
+    let name = op.mini_op.name().to_lowercase();
+    ELEMENT_WISE_OPS.contains(&name.as_str()).then_some(name)
+}
+
+fn binary_name(node: &TypedNode) -> Option<String> {
+    let op = node.op_as::<GpuBinOp>()?;
+    let name = op.mini_op.name().to_lowercase();
+    BINARY_OPS.contains(&name.as_str()).then_some(name)
+}
+
+/// A single elementwise op, as the one step it becomes. `slot` is the input the
+/// running value arrives on, so the other one is the step's extra operand.
+fn one_step(node: &TypedNode, slot: usize, rhs: usize) -> Option<(ChainStep, Option<OutletId>)> {
+    if let Some(op) = unary_name(node) {
+        return Some((ChainStep::Unary(op), None));
+    }
+    let op = binary_name(node)?;
+    let other = node.inputs[1 - slot];
+    Some((ChainStep::Binary { op, rhs, swapped: slot == 1 }, Some(other)))
+}
+
+pub fn grow_elementwise_chain(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &WgpuElementWiseChain,
+) -> TractResult<Option<TypedModelPatch>> {
+    fuse_into_successor(model, node, node_name, op.steps.clone(), node.inputs.len() - 1)
+}
+
+pub fn start_elementwise_chain(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    _op: &GpuElementWise,
+) -> TractResult<Option<TypedModelPatch>> {
+    let Some(name) = unary_name(node) else { return Ok(None) };
+    fuse_into_successor(model, node, node_name, vec![ChainStep::Unary(name)], 0)
+}
+
+pub fn start_binary_chain(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    _op: &GpuBinOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    // The head of a chain carries its shape, so it has to be the operand that
+    // is not broadcast.
+    let facts = model.node_input_facts(node.id)?;
+    let out_shape = model.node_output_facts(node.id)?[0].shape.clone();
+    rule_ensure!(facts[0].shape == out_shape);
+    let Some(name) = binary_name(node) else { return Ok(None) };
+    fuse_into_successor(
+        model,
+        node,
+        node_name,
+        vec![ChainStep::Binary { op: name, rhs: 1, swapped: false }],
+        1,
+    )
+}
+
+/// Merges `node` and its single consumer into one chain kernel. Growth stops at
+/// a value anyone else reads, at a step that would change the running shape,
+/// and at the uniform slot's operand budget.
+fn fuse_into_successor(
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    mut steps: Vec<ChainStep>,
+    extras: usize,
+) -> TractResult<Option<TypedModelPatch>> {
+    let Some(succ) = model.single_succ(node.id)? else { return Ok(None) };
+    rule_ensure!(!succ.op_is::<WgpuElementWiseChain>());
+    rule_ensure!(unary_name(succ).is_some() || binary_name(succ).is_some());
+    rule_ensure!(succ.inputs.iter().filter(|i| i.node == node.id).count() == 1);
+    rule_ensure!(
+        model.node_output_facts(succ.id)?[0].shape == model.node_output_facts(node.id)?[0].shape
+    );
+    rule_ensure!(extras < MAX_EXTRA_INPUTS);
+
+    let slot = succ.inputs.iter().position(|i| i.node == node.id).unwrap();
+    let Some((step, extra)) = one_step(succ, slot, extras + 1) else { return Ok(None) };
+    steps.push(step);
+
+    let mut patch = TypedModelPatch::default();
+    let mut inputs = vec![];
+    for inlet in node.inputs.iter() {
+        inputs.push(patch.tap_model(model, *inlet)?);
+    }
+    if let Some(extra) = extra {
+        inputs.push(patch.tap_model(model, extra)?);
+    }
+    let out =
+        patch.wire_node(format!("{node_name}.chain"), WgpuElementWiseChain { steps }, &inputs)?;
+    patch.shunt_outside(model, succ.id.into(), out[0])?;
+    Ok(Some(patch))
+}

--- a/wgpu/src/rewrite_rules/fuse_epilogue.rs
+++ b/wgpu/src/rewrite_rules/fuse_epilogue.rs
@@ -1,0 +1,122 @@
+use tract_core::internal::*;
+use tract_gpu::fact::DeviceTypedFactExt;
+use tract_gpu::ops::binary::GpuBinOp;
+use tract_gpu::ops::element_wise::GpuElementWise;
+use tract_gpu::rule_ensure;
+
+use crate::kernels::shaders::{BINARY_OPS, ChainStep, ELEMENT_WISE_OPS};
+use crate::ops::chain::WgpuElementWiseChain;
+use crate::ops::conv::WgpuConv;
+use crate::ops::matmul::WgpuGemm;
+
+/// Epilogue operands ride in one `vec4` of offsets.
+const MAX_EPILOGUE_OPERANDS: usize = 3;
+
+fn shape_of(model: &TypedModel, outlet: OutletId) -> TractResult<TVec<TDim>> {
+    let fact = model.outlet_fact(outlet)?;
+    Ok(fact
+        .as_device_fact()
+        .map(|f| f.shape.dims().into())
+        .unwrap_or_else(|| fact.shape.dims().into()))
+}
+
+/// A GEMM's epilogue can only read an operand that is one value, or one per
+/// output column — that is what a convolution bias becomes here.
+fn addressable(model: &TypedModel, outlet: OutletId, columns: &TDim) -> TractResult<bool> {
+    let shape = shape_of(model, outlet)?;
+    let len = shape.iter().product::<TDim>();
+    Ok(len == 1.to_dim() || len == *columns)
+}
+
+fn steps_of(node: &TypedNode, slot: usize, rhs: usize) -> Option<(Vec<ChainStep>, usize)> {
+    if let Some(chain) = node.op_as::<WgpuElementWiseChain>() {
+        return Some((chain.steps.clone(), node.inputs.len() - 1));
+    }
+    if let Some(op) = node.op_as::<GpuElementWise>() {
+        let name = op.mini_op.name().to_lowercase();
+        return ELEMENT_WISE_OPS
+            .contains(&name.as_str())
+            .then(|| (vec![ChainStep::Unary(name)], 0));
+    }
+    let op = node.op_as::<GpuBinOp>()?;
+    let name = op.mini_op.name().to_lowercase();
+    BINARY_OPS
+        .contains(&name.as_str())
+        .then(|| (vec![ChainStep::Binary { op: name, rhs, swapped: slot == 1 }], 1))
+}
+
+/// Folds the elementwise ops that follow a convolution into it, the same way.
+pub fn fuse_conv_epilogue(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &WgpuConv,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_ensure!(op.epilogue.is_empty());
+    let channels = op.op.pool_spec.output_channels.to_dim();
+    absorb(model, node, node_name, channels, |steps| WgpuConv {
+        op: op.op.clone(),
+        epilogue: steps,
+    })
+}
+
+/// Folds the elementwise ops that follow a GEMM into the GEMM itself, so a
+/// bias and its activation cost no extra pass over the result.
+pub fn fuse_gemm_epilogue(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &WgpuGemm,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_ensure!(op.epilogue.is_empty());
+    let out_shape = shape_of(model, node.id.into())?;
+    rule_ensure!(out_shape.len() >= 2);
+    let columns = if op.op.transpose_c {
+        out_shape[out_shape.len() - 2].clone()
+    } else {
+        out_shape[out_shape.len() - 1].clone()
+    };
+    absorb(model, node, node_name, columns, |steps| WgpuGemm { op: op.op, epilogue: steps })
+}
+
+fn absorb<O: TypedOp>(
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    columns: TDim,
+    build: impl FnOnce(Vec<ChainStep>) -> O,
+) -> TractResult<Option<TypedModelPatch>> {
+    let Some(succ) = model.single_succ(node.id)? else { return Ok(None) };
+    rule_ensure!(succ.inputs.iter().filter(|i| i.node == node.id).count() == 1);
+    rule_ensure!(shape_of(model, succ.id.into())? == shape_of(model, node.id.into())?);
+
+    let slot = succ.inputs.iter().position(|i| i.node == node.id).unwrap();
+    let Some((steps, operands)) = steps_of(succ, slot, 1) else { return Ok(None) };
+    rule_ensure!(operands <= MAX_EPILOGUE_OPERANDS);
+
+    let extras: TVec<OutletId> = succ
+        .inputs
+        .iter()
+        .enumerate()
+        .filter(|(i, inlet)| {
+            !(succ.op_is::<WgpuElementWiseChain>() && *i == 0) && inlet.node != node.id
+        })
+        .map(|(_, inlet)| *inlet)
+        .collect();
+    rule_ensure!(extras.len() == operands);
+    for extra in &extras {
+        rule_ensure!(addressable(model, *extra, &columns)?);
+    }
+
+    let mut patch = TypedModelPatch::default();
+    let mut inputs = vec![patch.tap_model(model, node.inputs[0])?];
+    inputs.push(patch.tap_model(model, node.inputs[1])?);
+    for extra in extras {
+        inputs.push(patch.tap_model(model, extra)?);
+    }
+    let out = patch.wire_node(format!("{node_name}.epilogue"), build(steps), &inputs)?;
+    patch.shunt_outside(model, succ.id.into(), out[0])?;
+    Ok(Some(patch))
+}

--- a/wgpu/src/rewrite_rules/mod.rs
+++ b/wgpu/src/rewrite_rules/mod.rs
@@ -1,0 +1,7 @@
+mod fuse_axis_op;
+mod fuse_elementwise;
+mod fuse_epilogue;
+
+pub use fuse_axis_op::{fuse_axis_op, fuse_move_axis};
+pub use fuse_elementwise::{grow_elementwise_chain, start_binary_chain, start_elementwise_chain};
+pub use fuse_epilogue::{fuse_conv_epilogue, fuse_gemm_epilogue};

--- a/wgpu/src/tensor.rs
+++ b/wgpu/src/tensor.rs
@@ -1,0 +1,143 @@
+use std::fmt::Display;
+use std::sync::Arc;
+
+use tract_core::internal::*;
+use tract_gpu::device::DeviceBuffer;
+use tract_gpu::tensor::{DeviceTensor, OwnedDeviceTensor};
+use tract_gpu::utils::check_strides_validity;
+
+use crate::context::WgpuBuffer;
+#[cfg(not(all(target_arch = "wasm32", feature = "jspi")))]
+use crate::context::with_wgpu_queue;
+
+#[derive(Clone)]
+pub struct WgpuTensor {
+    pub buffer: Arc<WgpuBuffer>,
+    pub datum_type: DatumType,
+    pub shape: TVec<usize>,
+    pub strides: TVec<isize>,
+    pub exotic_fact: Option<Box<dyn ExoticFact>>,
+}
+
+impl std::fmt::Debug for WgpuTensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgpuTensor")
+            .field("datum_type", &self.datum_type)
+            .field("shape", &self.shape)
+            .finish()
+    }
+}
+
+impl PartialEq for WgpuTensor {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.buffer.as_ref(), other.buffer.as_ref())
+            && self.datum_type == other.datum_type
+            && self.shape == other.shape
+            && self.strides == other.strides
+    }
+}
+impl Eq for WgpuTensor {}
+
+impl OwnedDeviceTensor for WgpuTensor {
+    fn datum_type(&self) -> DatumType {
+        self.datum_type
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    fn reshaped(&self, shape: TVec<usize>) -> TractResult<DeviceTensor> {
+        if self.len() != shape.iter().product::<usize>() {
+            bail!("Invalid reshape {:?} to {:?}", self.shape(), shape);
+        }
+        if shape.as_slice() != self.shape() {
+            Ok(DeviceTensor::Owned(Box::new(WgpuTensor {
+                strides: Tensor::natural_strides(&shape),
+                shape,
+                buffer: Arc::clone(&self.buffer),
+                datum_type: self.datum_type,
+                exotic_fact: self.exotic_fact.clone(),
+            })))
+        } else {
+            Ok(DeviceTensor::Owned(Box::new(self.clone())))
+        }
+    }
+
+    fn restrided(&self, strides: TVec<isize>) -> TractResult<DeviceTensor> {
+        check_strides_validity(self.shape().into(), strides.clone())?;
+        if strides.as_slice() != self.strides() {
+            Ok(DeviceTensor::Owned(Box::new(WgpuTensor {
+                strides,
+                buffer: Arc::clone(&self.buffer),
+                datum_type: self.datum_type,
+                shape: self.shape.clone(),
+                exotic_fact: self.exotic_fact.clone(),
+            })))
+        } else {
+            Ok(DeviceTensor::Owned(Box::new(self.clone())))
+        }
+    }
+
+    fn device_buffer(&self) -> &dyn DeviceBuffer {
+        self.buffer.as_ref()
+    }
+
+    fn to_host(&self) -> TractResult<Arc<Tensor>> {
+        let (offset, len) = if let Some(of) = &self.exotic_fact {
+            (0u64, of.mem_size().as_i64().context("Symbolic exotic tensor size")? as u64)
+        } else {
+            (0u64, (self.len() * self.datum_type.size_of()) as u64)
+        };
+        let bytes = download_owned_bytes(&self.buffer.inner, offset, len)?;
+        let t = if let Some(of) = &self.exotic_fact {
+            let bqf = of
+                .downcast_ref::<tract_core::tract_linalg::block_quant::BlockQuantFact>()
+                .context("Unknown exotic fact")?;
+            let blob = tract_data::internal::Blob::from_bytes(&bytes)?;
+            tract_core::tract_linalg::block_quant::BlockQuantStorage::new(
+                bqf.format.clone(),
+                bqf.m(),
+                bqf.k(),
+                Arc::new(blob),
+            )?
+            .into_tensor_with_shape(self.datum_type, &self.shape)
+        } else {
+            unsafe { Tensor::from_raw_dt(self.datum_type, &self.shape, &bytes)? }
+        };
+        Ok(Arc::new(t))
+    }
+
+    fn exotic_fact(&self) -> Option<&dyn ExoticFact> {
+        self.exotic_fact.as_deref()
+    }
+
+    /// Only reached through tract-gpu's arena view, which needs a
+    /// `DeviceSessionHandler` this backend never installs. The signature cannot
+    /// report a failure, so were it reached, a device-side fetch that failed
+    /// would abort instead: on web it cannot succeed at all without `jspi`.
+    fn get_bytes_slice(&self, offset: usize, len: usize) -> Vec<u8> {
+        download_owned_bytes(&self.buffer.inner, offset as u64, len as u64).unwrap()
+    }
+}
+
+fn download_owned_bytes(buffer: &wgpu::Buffer, offset: u64, len: u64) -> TractResult<Vec<u8>> {
+    #[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+    {
+        crate::jspi::download_jspi(buffer, offset, len)
+    }
+    #[cfg(not(all(target_arch = "wasm32", feature = "jspi")))]
+    {
+        with_wgpu_queue(|q| q.download(buffer, offset, len))
+    }
+}
+
+impl Display for WgpuTensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WgpuTensor({:?} {:?})", self.datum_type, self.shape)
+    }
+}

--- a/wgpu/src/tests.rs
+++ b/wgpu/src/tests.rs
@@ -1,0 +1,695 @@
+#![cfg(test)]
+
+use tract_core::internal::*;
+use tract_core::ops::math::mul;
+use tract_core::ops::nn::sigmoid;
+use tract_core::transform::ModelTransform;
+use tract_gpu::tensor::{DeviceTensor, IntoDevice};
+
+use crate::kernels::bin_ops::wgpu_bin_op_dispatch;
+use crate::kernels::element_wise::wgpu_element_wise_dispatch;
+use crate::{WgpuTransform, with_wgpu_queue};
+
+fn close(a: &Tensor, b: &Tensor) -> TractResult<()> {
+    a.close_enough(b, Approximation::Close)
+}
+
+#[test]
+fn upload_download_roundtrip() -> TractResult<()> {
+    with_wgpu_queue(|_| {
+        let t = Tensor::from_shape(&[2, 3], &(0..6).map(|i| i as f32).collect::<Vec<_>>())?;
+        let d = t.clone().into_device()?;
+        let back = d.to_host()?.into_tensor();
+        assert_eq!(t, back);
+        Ok(())
+    })
+}
+
+#[test]
+fn element_wise_sigmoid_matches_cpu() -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        let data: Vec<f32> = (-8..8).map(|i| i as f32 * 0.25).collect();
+        let t = Tensor::from_shape(&[4, 4], &data)?;
+        let cpu = sigmoid()
+            .eval_out_of_plan(tvec!(t.clone().into_tvalue()))?
+            .unwrap()
+            .remove(0)
+            .into_tensor();
+        let input = t.into_device()?;
+        let output = DeviceTensor::uninitialized_dt(DatumType::F32, input.shape())?;
+        wgpu_element_wise_dispatch(&*sigmoid().0, &input, &output)?;
+        q.flush()?;
+        close(&output.to_host()?.into_tensor(), &cpu)
+    })
+}
+
+#[test]
+fn binary_mul_broadcast_matches_cpu() -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        let a = Tensor::from_shape(&[2, 4], &(0..8).map(|i| i as f32 + 1.0).collect::<Vec<_>>())?;
+        let b = Tensor::from_shape(&[1, 4], &[1.0f32, 2.0, 3.0, 4.0])?;
+        let cpu = mul()
+            .eval_out_of_plan(tvec!(a.clone().into_tvalue(), b.clone().into_tvalue()))?
+            .unwrap()
+            .remove(0)
+            .into_tensor();
+        let da = a.into_device()?;
+        let db = b.into_device()?;
+        let out_shape = tract_core::broadcast::multi_broadcast(&[da.shape(), db.shape()])?;
+        let output = DeviceTensor::uninitialized_dt(DatumType::F32, &out_shape)?;
+        wgpu_bin_op_dispatch(&*mul().0, &da, &db, &output)?;
+        q.flush()?;
+        close(&output.to_host()?.into_tensor(), &cpu)
+    })
+}
+
+#[test]
+fn two_op_model_mul_then_sigmoid() -> TractResult<()> {
+    crate::context::wgpu_context();
+    let mut gpu_model = TypedModel::default();
+    let x = gpu_model.add_source("x", f32::fact([2, 4]))?;
+    let two = gpu_model.add_const("two", tensor2(&[[2.0f32]]))?;
+    let y = gpu_model.wire_node("mul", mul(), &[x, two])?[0];
+    let z = gpu_model.wire_node("sig", sigmoid(), &[y])?[0];
+    gpu_model.select_output_outlets(&[z])?;
+
+    let cpu_model = gpu_model.clone();
+    WgpuTransform.transform(&mut gpu_model)?;
+    gpu_model = gpu_model.into_optimized()?;
+    let gpu_plan = TypedSimplePlan::build(
+        gpu_model,
+        &RunOptions { skip_order_opt_ram: true, ..RunOptions::default() },
+    )?;
+
+    let cpu_plan = SimplePlan::new(cpu_model)?;
+    let input =
+        Tensor::from_shape(&[2, 4], &(0..8).map(|i| (i as f32) * 0.5 - 1.0).collect::<Vec<_>>())?;
+    let gpu_out = Arc::new(gpu_plan).run(tvec!(input.clone().into()))?.remove(0).into_tensor();
+    let cpu_out = Arc::new(cpu_plan).run(tvec!(input.into()))?.remove(0).into_tensor();
+    close(&gpu_out, &cpu_out)
+}
+
+fn run_vs_cpu(mut model: TypedModel, input: Tensor) -> TractResult<()> {
+    crate::context::wgpu_context();
+    let cpu_model = model.clone();
+    WgpuTransform.transform(&mut model)?;
+    model = model.into_optimized()?;
+    crate::ensure_wgpu_coverage(&model)?;
+    let gpu_plan = TypedSimplePlan::build(
+        model,
+        &RunOptions { skip_order_opt_ram: true, ..RunOptions::default() },
+    )?;
+    let cpu_plan = SimplePlan::new(cpu_model)?;
+    let gpu_out = Arc::new(gpu_plan).run(tvec!(input.clone().into()))?.remove(0).into_tensor();
+    let cpu_out = Arc::new(cpu_plan).run(tvec!(input.into()))?.remove(0).into_tensor();
+    close(&gpu_out, &cpu_out)
+}
+
+#[test]
+fn reduce_sum_matches_cpu() -> TractResult<()> {
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4, 8]))?;
+    let y = model.wire_node(
+        "sum",
+        tract_core::ops::nn::Reduce::new(tvec![2], tract_core::ops::nn::Reducer::Sum),
+        &[x],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    let input = Tensor::from_shape(
+        &[2, 4, 8],
+        &(0..64).map(|i| (i as f32) * 0.1 - 2.0).collect::<Vec<_>>(),
+    )?;
+    run_vs_cpu(model, input)
+}
+
+#[test]
+fn max_pool_2d_nchw_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::cnn::{MaxPool, PaddingSpec, PoolSpec};
+    use tract_core::ops::nn::DataFormat;
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([1, 1, 4, 4]))?;
+    let y = model.wire_node(
+        "pool",
+        MaxPool {
+            pool_spec: PoolSpec {
+                data_format: DataFormat::NCHW,
+                kernel_shape: tvec![2, 2],
+                padding: PaddingSpec::Valid,
+                dilations: None,
+                strides: Some(tvec![2, 2]),
+                input_channels: 1,
+                output_channels: 1,
+            },
+            with_index_outputs: None,
+        },
+        &[x],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    let input = Tensor::from_shape(&[1, 1, 4, 4], &(0..16).map(|i| i as f32).collect::<Vec<_>>())?;
+    run_vs_cpu(model, input)
+}
+
+#[test]
+fn conv2d_nchw_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::cnn::{Conv, KernelFormat, PaddingSpec, PoolSpec};
+    use tract_core::ops::nn::DataFormat;
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([1, 1, 4, 4]))?;
+    let k = model.add_const(
+        "k",
+        Tensor::from_shape(&[1, 1, 3, 3], &(0..9).map(|i| i as f32 * 0.1).collect::<Vec<_>>())?,
+    )?;
+    let b = model.add_const("b", tensor0(0.0f32))?;
+    let y = model.wire_node(
+        "conv",
+        Conv {
+            pool_spec: PoolSpec {
+                data_format: DataFormat::NCHW,
+                kernel_shape: tvec![3, 3],
+                padding: PaddingSpec::Valid,
+                dilations: None,
+                strides: None,
+                input_channels: 1,
+                output_channels: 1,
+            },
+            kernel_fmt: KernelFormat::OIHW,
+            group: 1,
+            q_params: None,
+        },
+        &[x, k, b],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    let input =
+        Tensor::from_shape(&[1, 1, 4, 4], &(0..16).map(|i| i as f32 * 0.25).collect::<Vec<_>>())?;
+    run_vs_cpu(model, input)
+}
+
+#[test]
+fn relu_via_max_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::math::max;
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let z = model.add_const("zero", tensor2(&[[0.0f32]]))?;
+    let y = model.wire_node("relu", max(), &[x, z])?[0];
+    model.select_output_outlets(&[y])?;
+    let input = Tensor::from_shape(&[2, 4], &(0..8).map(|i| (i as f32) - 3.5).collect::<Vec<_>>())?;
+    run_vs_cpu(model, input)
+}
+
+#[test]
+fn conv_transpose2d_nchw_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::cnn::{Deconv, KernelFormat, PaddingSpec, PoolSpec};
+    use tract_core::ops::nn::DataFormat;
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([1, 1, 2, 2]))?;
+    let k = model.add_const("k", Tensor::from_shape(&[1, 1, 2, 2], &[1.0f32, 0.0, 0.0, 1.0])?)?;
+    let b = model.add_const("b", tensor0(0.0f32))?;
+    let y = model.wire_node(
+        "deconv",
+        Deconv {
+            pool_spec: PoolSpec {
+                data_format: DataFormat::NCHW,
+                kernel_shape: tvec![2, 2],
+                padding: PaddingSpec::Valid,
+                dilations: None,
+                strides: Some(tvec![2, 2]),
+                input_channels: 1,
+                output_channels: 1,
+            },
+            kernel_format: KernelFormat::OIHW,
+            adjustments: tvec![0, 0],
+            group: 1,
+        },
+        &[x, k, b],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    let input = Tensor::from_shape(&[1, 1, 2, 2], &[1.0f32, 2.0, 3.0, 4.0])?;
+    run_vs_cpu(model, input)
+}
+
+#[test]
+fn coverage_accepts_fully_translated_model() -> TractResult<()> {
+    crate::context::wgpu_context();
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let two = model.add_const("two", tensor2(&[[2.0f32]]))?;
+    let y = model.wire_node("mul", mul(), &[x, two])?[0];
+    model.select_output_outlets(&[y])?;
+    WgpuTransform.transform(&mut model)?;
+    model = model.into_optimized()?;
+    crate::ensure_wgpu_coverage(&model)?;
+    Ok(())
+}
+
+#[test]
+fn hybrid_logsoftmax_matches_cpu() -> TractResult<()> {
+    crate::context::wgpu_context();
+    ensure!(
+        crate::hybrid_fallback_available(),
+        "native hybrid fallback should always be available"
+    );
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let y = model.wire_node(
+        "attn_sm",
+        tract_core::ops::nn::Softmax::new(
+            tvec![1],
+            None,
+            tract_core::ops::nn::SoftmaxKind::LogSoftmax,
+        ),
+        &[x],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    let cpu_model = model.clone();
+    let rt =
+        tract_core::runtime::runtime_for_name("wgpu")?.context("wgpu runtime not registered")?;
+    let gpu = rt.prepare(model)?;
+    let cpu_plan = SimplePlan::new(cpu_model)?;
+    let input = Tensor::from_shape(&[2, 4], &[0.1f32, 0.2, 0.3, 0.4, -1.0, 0.0, 1.0, 2.0])?;
+    let gpu_out = gpu.run(tvec!(input.clone().into()))?.remove(0).into_tensor();
+    let cpu_out = Arc::new(cpu_plan).run(tvec!(input.into()))?.remove(0).into_tensor();
+    close(&gpu_out, &cpu_out)
+}
+
+#[test]
+fn coverage_rejects_logsoftmax_by_name() -> TractResult<()> {
+    crate::context::wgpu_context();
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let y = model.wire_node(
+        "attn_sm",
+        tract_core::ops::nn::Softmax::new(
+            tvec![1],
+            None,
+            tract_core::ops::nn::SoftmaxKind::LogSoftmax,
+        ),
+        &[x],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    WgpuTransform.transform(&mut model)?;
+    model = model.into_optimized()?;
+    let err = crate::ensure_wgpu_coverage(&model).expect_err("logsoftmax must be uncovered");
+    let msg = format!("{err:?}");
+    ensure!(msg.contains("LogSoftmax"), "error should name LogSoftmax, got {msg}");
+    ensure!(msg.contains("attn_sm"), "error should name the node, got {msg}");
+    Ok(())
+}
+
+#[test]
+fn rgba8_ingest_to_nchw_f32() -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        // 2x2 packed RGBA8. textureLoad of rgba8unorm yields 0..1 floats.
+        let rgba: [u8; 16] = [
+            255, 0, 0, 255, // (0,0) red
+            0, 255, 0, 255, // (1,0) green
+            0, 0, 255, 255, // (0,1) blue
+            255, 255, 255, 255, // (1,1) white
+        ];
+        let gpu = crate::tensor_from_rgba8(2, 2, &rgba)?;
+        q.flush()?;
+        let host = gpu.to_host()?.into_tensor();
+        let expected = Tensor::from_shape(
+            &[1, 3, 2, 2],
+            &[
+                1.0f32, 0.0, 0.0, 1.0, // R
+                0.0, 1.0, 0.0, 1.0, // G
+                0.0, 0.0, 1.0, 1.0, // B
+            ],
+        )?;
+        close(&host, &expected)
+    })
+}
+
+#[test]
+fn softmax_matches_cpu() -> TractResult<()> {
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let y = model.wire_node(
+        "sm",
+        tract_core::ops::nn::Softmax::new(
+            tvec![1],
+            None,
+            tract_core::ops::nn::SoftmaxKind::Softmax,
+        ),
+        &[x],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    let input = Tensor::from_shape(&[2, 4], &[0.1f32, 0.2, 0.3, 0.4, -1.0, 0.0, 1.0, 2.0])?;
+    run_vs_cpu(model, input)
+}
+
+fn ramp(shape: &[usize], scale: f32, bias: f32) -> TractResult<Tensor> {
+    let n: usize = shape.iter().product();
+    Tensor::from_shape(shape, &(0..n).map(|i| (i as f32) * scale + bias).collect::<Vec<_>>())
+}
+
+fn matmul_model(
+    a_shape: &[usize],
+    b_shape: &[usize],
+    transpose_a: bool,
+    transpose_b: bool,
+    transpose_c: bool,
+) -> TractResult<TypedModel> {
+    use tract_core::ops::einsum::prefix_matmul::PrefixMatMul;
+    let mut model = TypedModel::default();
+    let a = model.add_source("a", f32::fact(a_shape))?;
+    let b = model.add_const("b", ramp(b_shape, 0.05, -0.4)?)?;
+    let op = PrefixMatMul {
+        transpose_a,
+        transpose_b,
+        transpose_c,
+        quantize_output: None,
+        operating_dt: None,
+    };
+    let y = model.wire_node("mm", op, &[a, b])?[0];
+    model.select_output_outlets(&[y])?;
+    Ok(model)
+}
+
+#[test]
+fn matmul_2d_matches_cpu() -> TractResult<()> {
+    let model = matmul_model(&[3, 4], &[4, 5], false, false, false)?;
+    run_vs_cpu(model, ramp(&[3, 4], 0.1, -0.5)?)
+}
+
+#[test]
+fn matmul_transposed_inputs_match_cpu() -> TractResult<()> {
+    let model = matmul_model(&[4, 3], &[5, 4], true, true, false)?;
+    run_vs_cpu(model, ramp(&[4, 3], 0.1, -0.5)?)
+}
+
+#[test]
+fn matmul_transposed_output_matches_cpu() -> TractResult<()> {
+    let model = matmul_model(&[3, 4], &[4, 5], false, false, true)?;
+    run_vs_cpu(model, ramp(&[3, 4], 0.1, -0.5)?)
+}
+
+/// The prefix broadcasts: one weight matrix against a batch of activations.
+#[test]
+fn matmul_broadcast_prefix_matches_cpu() -> TractResult<()> {
+    let model = matmul_model(&[2, 3, 4], &[1, 4, 5], false, false, false)?;
+    run_vs_cpu(model, ramp(&[2, 3, 4], 0.05, -0.3)?)
+}
+
+#[test]
+fn matmul_rank4_prefix_matches_cpu() -> TractResult<()> {
+    let model = matmul_model(&[2, 3, 4, 5], &[2, 1, 5, 6], false, false, false)?;
+    run_vs_cpu(model, ramp(&[2, 3, 4, 5], 0.02, -0.6)?)
+}
+
+/// EinSum is what an ONNX pointwise convolution actually arrives as; the
+/// transform has to rewrite it to PrefixMatMul before it can reach the GPU.
+#[test]
+fn einsum_matmul_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::einsum::EinSum;
+    let mut model = TypedModel::default();
+    let a = model.add_source("a", f32::fact([2, 3, 4]))?;
+    let b = model.add_const("b", ramp(&[4, 5], 0.05, -0.4)?)?;
+    let y =
+        model.wire_node("es", EinSum::new("bij,jk->bik".parse()?, f32::datum_type()), &[a, b])?[0];
+    model.select_output_outlets(&[y])?;
+    run_vs_cpu(model, ramp(&[2, 3, 4], 0.05, -0.3)?)
+}
+
+/// Sizes that are not round, so the kernel's bounds checks matter.
+#[test]
+fn matmul_large_matches_cpu() -> TractResult<()> {
+    let model = matmul_model(&[40, 33], &[33, 48], false, false, false)?;
+    run_vs_cpu(model, ramp(&[40, 33], 0.001, -0.5)?)
+}
+
+#[test]
+fn matmul_large_transposed_matches_cpu() -> TractResult<()> {
+    let model = matmul_model(&[33, 40], &[48, 33], true, true, false)?;
+    run_vs_cpu(model, ramp(&[33, 40], 0.001, -0.5)?)
+}
+
+#[test]
+fn matmul_large_batched_matches_cpu() -> TractResult<()> {
+    let model = matmul_model(&[2, 35, 33], &[1, 33, 40], false, false, false)?;
+    run_vs_cpu(model, ramp(&[2, 35, 33], 0.001, -0.4)?)
+}
+
+/// Bias then activation after a matmul: both should land in the GEMM's epilogue.
+#[test]
+fn matmul_bias_activation_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::einsum::prefix_matmul::PrefixMatMul;
+    let mut model = TypedModel::default();
+    let a = model.add_source("a", f32::fact([6, 5]))?;
+    let b = model.add_const("b", ramp(&[5, 7], 0.05, -0.4)?)?;
+    let bias = model.add_const("bias", ramp(&[1, 7], 0.1, -0.2)?)?;
+    let op = PrefixMatMul {
+        transpose_a: false,
+        transpose_b: false,
+        transpose_c: false,
+        quantize_output: None,
+        operating_dt: None,
+    };
+    let mm = model.wire_node("mm", op, &[a, b])?[0];
+    let biased = model.wire_node("bias_add", tract_core::ops::math::add(), &[mm, bias])?[0];
+    let y = model.wire_node("act", sigmoid(), &[biased])?[0];
+    model.select_output_outlets(&[y])?;
+    run_vs_cpu(model, ramp(&[6, 5], 0.1, -0.5)?)
+}
+
+/// Same for a convolution's per-channel bias.
+#[test]
+fn conv_bias_activation_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::cnn::{Conv, KernelFormat, PaddingSpec, PoolSpec};
+    use tract_core::ops::nn::DataFormat;
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([1, 2, 5, 5]))?;
+    let w = model.add_const("w", ramp(&[3, 2, 3, 3], 0.01, -0.2)?)?;
+    let bias = model.add_const("bias", ramp(&[3], 0.3, -0.4)?)?;
+    let conv = Conv {
+        pool_spec: PoolSpec {
+            data_format: DataFormat::NCHW,
+            kernel_shape: tvec![3, 3],
+            padding: PaddingSpec::Valid,
+            dilations: None,
+            strides: None,
+            input_channels: 2,
+            output_channels: 3,
+        },
+        kernel_fmt: KernelFormat::OIHW,
+        group: 1,
+        q_params: None,
+    };
+    let zero = model.add_const("zero", Tensor::zero::<f32>(&[3])?)?;
+    let c = model.wire_node("conv", conv, &[x, w, zero])?[0];
+    let reshaped = model.wire_node(
+        "bias_r",
+        AxisOp::Reshape(0, tvec!(3.into()), tvec!(1.into(), 3.into(), 1.into(), 1.into())),
+        &[bias],
+    )?[0];
+    let biased = model.wire_node("bias_add", tract_core::ops::math::add(), &[c, reshaped])?[0];
+    let y = model.wire_node("act", sigmoid(), &[biased])?[0];
+    model.select_output_outlets(&[y])?;
+    run_vs_cpu(model, ramp(&[1, 2, 5, 5], 0.05, -0.5)?)
+}
+
+/// Depthwise: one filter per channel, which takes the tiled kernel.
+#[test]
+fn depthwise_conv2d_matches_cpu() -> TractResult<()> {
+    use tract_core::ops::cnn::{Conv, KernelFormat, PaddingSpec, PoolSpec};
+    use tract_core::ops::nn::DataFormat;
+    for (kh, kw, stride, pad) in [
+        (3usize, 3usize, 1usize, PaddingSpec::SameUpper),
+        (3, 3, 2, PaddingSpec::SameUpper),
+        (5, 5, 1, PaddingSpec::SameUpper),
+    ] {
+        let c = 6;
+        let mut model = TypedModel::default();
+        let x = model.add_source("x", f32::fact([1, c, 19, 23]))?;
+        let w = model.add_const("w", ramp(&[c, 1, kh, kw], 0.01, -0.15)?)?;
+        let b = model.add_const("b", Tensor::zero::<f32>(&[c])?)?;
+        let y = model.wire_node(
+            "dw",
+            Conv {
+                pool_spec: PoolSpec {
+                    data_format: DataFormat::NCHW,
+                    kernel_shape: tvec![kh, kw],
+                    padding: pad,
+                    dilations: None,
+                    strides: Some(tvec![stride, stride]),
+                    input_channels: c,
+                    output_channels: c,
+                },
+                kernel_fmt: KernelFormat::OIHW,
+                group: c,
+                q_params: None,
+            },
+            &[x, w, b],
+        )?[0];
+        model.select_output_outlets(&[y])?;
+        run_vs_cpu(model, ramp(&[1, c, 19, 23], 0.003, -0.4)?)?;
+    }
+    Ok(())
+}
+
+/// Does one compute pass run independent dispatches concurrently? A chain of
+/// dependent kernels has to serialize; the same count over disjoint buffers
+/// does not. If both take the same time, nothing overlaps.
+///
+///     cargo test --release -p tract-wgpu -- --ignored --nocapture concurrency
+#[test]
+#[ignore]
+fn dispatch_concurrency() -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        for count in [1, 16, 64, 256] {
+            dispatch_concurrency_at(q, count, 1 << 10)?;
+        }
+        for shift in [8, 12, 16] {
+            dispatch_concurrency_at(q, 64, 1 << shift)?;
+        }
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+fn dispatch_concurrency_at(q: &crate::WgpuQueue, count: usize, len: usize) -> TractResult<()> {
+    {
+        use std::time::Instant;
+        let host = Tensor::from_shape(&[len], &vec![0.25f32; len])?;
+        let inputs: Vec<DeviceTensor> =
+            (0..count).map(|_| host.clone().into_device()).collect::<TractResult<_>>()?;
+        let outputs: Vec<DeviceTensor> = (0..count)
+            .map(|_| DeviceTensor::uninitialized_dt(DatumType::F32, &[len]))
+            .collect::<TractResult<_>>()?;
+        let op = sigmoid();
+
+        let independent = || -> TractResult<()> {
+            for i in 0..count {
+                wgpu_element_wise_dispatch(&*op.0, &inputs[i], &outputs[i])?;
+            }
+            q.flush()
+        };
+        let chained = || -> TractResult<()> {
+            for i in 0..count {
+                let src = if i == 0 { &inputs[0] } else { &outputs[i - 1] };
+                wgpu_element_wise_dispatch(&*op.0, src, &outputs[i])?;
+            }
+            q.flush()
+        };
+
+        for _ in 0..3 {
+            independent()?;
+            chained()?;
+        }
+        let record_only = || -> TractResult<f64> {
+            let t = Instant::now();
+            for i in 0..count {
+                wgpu_element_wise_dispatch(&*op.0, &inputs[i], &outputs[i])?;
+            }
+            let recorded = t.elapsed().as_secs_f64() * 1e3;
+            q.flush()?;
+            Ok(recorded)
+        };
+        let mut best = (f64::MAX, f64::MAX, f64::MAX);
+        for _ in 0..10 {
+            let t = Instant::now();
+            independent()?;
+            best.0 = best.0.min(t.elapsed().as_secs_f64() * 1e3);
+            let t = Instant::now();
+            chained()?;
+            best.1 = best.1.min(t.elapsed().as_secs_f64() * 1e3);
+            best.2 = best.2.min(record_only()?);
+        }
+        eprintln!(
+            "{count} dispatches of {len:>6} elements ({:>4} workgroups each): independent {:.3}ms, chain {:.3}ms, cpu-side recording {:.3}ms",
+            len.div_ceil(64),
+            best.0,
+            best.1,
+            best.2
+        );
+        Ok(())
+    }
+}
+
+/// What a frame pays per node before any kernel runs: allocating the output
+/// tensor, and recording one dispatch against it.
+///
+///     cargo test --release -p tract-wgpu -- --ignored --nocapture per_node_cost
+#[test]
+#[ignore]
+fn per_node_cost() -> TractResult<()> {
+    use std::time::Instant;
+    with_wgpu_queue(|q| {
+        let shape = [1usize, 64, 144, 256];
+        let op = sigmoid();
+        let input = Tensor::zero::<f32>(&shape)?.into_device()?;
+        // Warm the pool so the allocation path is the steady-state one.
+        for _ in 0..64 {
+            let _ = DeviceTensor::uninitialized_dt(DatumType::F32, &shape)?;
+        }
+        let n = 2000;
+        let t = Instant::now();
+        for _ in 0..n {
+            let _out = DeviceTensor::uninitialized_dt(DatumType::F32, &shape)?;
+        }
+        let alloc = t.elapsed().as_secs_f64() * 1e6 / n as f64;
+
+        let out = DeviceTensor::uninitialized_dt(DatumType::F32, &shape)?;
+        let t = Instant::now();
+        for _ in 0..n {
+            wgpu_element_wise_dispatch(&*op.0, &input, &out)?;
+        }
+        let record = t.elapsed().as_secs_f64() * 1e6 / n as f64;
+        q.flush()?;
+
+        let t = Instant::now();
+        for _ in 0..n {
+            let out = DeviceTensor::uninitialized_dt(DatumType::F32, &shape)?;
+            wgpu_element_wise_dispatch(&*op.0, &input, &out)?;
+        }
+        let both = t.elapsed().as_secs_f64() * 1e6 / n as f64;
+        q.flush()?;
+        eprintln!("per node: allocate {alloc:.2}us, record {record:.2}us, together {both:.2}us");
+        Ok(())
+    })
+}
+
+/// What building a bind group costs, against finding one already built.
+///
+///     cargo test --release -p tract-wgpu -- --ignored --nocapture bind_group_cost
+#[test]
+#[ignore]
+fn bind_group_cost() -> TractResult<()> {
+    use crate::kernels::shaders::LayoutKind;
+    use std::time::Instant;
+    with_wgpu_queue(|q| {
+        let ctx = q.context();
+        let n = 2000;
+        let pairs: Vec<(DeviceTensor, DeviceTensor)> = (0..n)
+            .map(|_| {
+                Ok((
+                    DeviceTensor::uninitialized_dt(DatumType::F32, &[1024])?,
+                    DeviceTensor::uninitialized_dt(DatumType::F32, &[1024])?,
+                ))
+            })
+            .collect::<TractResult<_>>()?;
+
+        let t = Instant::now();
+        for (a, b) in &pairs {
+            let _ = ctx.bind_group(
+                LayoutKind::Unary,
+                &[crate::utils::get_wgpu_buffer(a), crate::utils::get_wgpu_buffer(b)],
+                q.uniform(),
+            )?;
+        }
+        let miss = t.elapsed().as_secs_f64() * 1e6 / n as f64;
+
+        let (a, b) = &pairs[0];
+        let t = Instant::now();
+        for _ in 0..n {
+            let _ = ctx.bind_group(
+                LayoutKind::Unary,
+                &[crate::utils::get_wgpu_buffer(a), crate::utils::get_wgpu_buffer(b)],
+                q.uniform(),
+            )?;
+        }
+        let hit = t.elapsed().as_secs_f64() * 1e6 / n as f64;
+        eprintln!("bind group: {miss:.2}us to build, {hit:.2}us to find");
+        Ok(())
+    })
+}

--- a/wgpu/src/transform.rs
+++ b/wgpu/src/transform.rs
@@ -1,0 +1,275 @@
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use tract_core::dyn_clone::clone_box;
+use tract_core::internal::translator::Translate;
+use tract_core::internal::*;
+use tract_core::ops::cnn::conv::rewrite_kernel_conv_in_oihw;
+use tract_core::ops::cnn::{Conv, Deconv, rewrite_conv_with_n_axis};
+use tract_core::ops::einsum::prefix_matmul::{PrefixMatMul, rewrite_einsum_to_prefix_matmul};
+use tract_core::ops::konst::Const;
+use tract_core::ops::nn::Reduce;
+use tract_core::transform::ModelTransform;
+use tract_gpu::fact::{DeviceFact, DeviceTypedFactExt};
+use tract_gpu::rewrite_rules::rewire_syncs::rewire_syncs;
+#[cfg(not(target_arch = "wasm32"))]
+use tract_gpu::sync::sync_model_outputs_if_required;
+use tract_gpu::sync::{DeviceSyncKind, sync_inputs_if_required};
+use tract_gpu::tensor::{DeviceTensor, IntoDevice};
+
+use crate::context::wgpu_context;
+use crate::ops;
+
+/// A registered translator that can convert a core op into a wgpu GPU op.
+pub struct WgpuOpTranslator {
+    pub type_id: TypeId,
+    #[allow(clippy::type_complexity)]
+    pub try_make: fn(&TypedModel, &TypedNode) -> TractResult<Option<Box<dyn TypedOp>>>,
+}
+
+inventory::collect!(WgpuOpTranslator);
+
+/// Register a translator for a core op type. The closure receives `(source, node, op)`
+/// where `op` is already downcast to `$op_type`. Return `Ok(Some(gpu_op))` to translate,
+/// `Ok(None)` to skip.
+#[macro_export]
+macro_rules! register_wgpu_op {
+    ($op_type:ty, |$source:ident, $node:ident, $op:ident| $body:expr) => {
+        inventory::submit! {
+            $crate::transform::WgpuOpTranslator {
+                type_id: std::any::TypeId::of::<$op_type>(),
+                try_make: |$source, $node| {
+                    let Some($op) = $node.op_as::<$op_type>() else {
+                        return Ok(None);
+                    };
+                    $body
+                },
+            }
+        }
+    };
+}
+
+#[derive(Debug, Default)]
+pub struct WgpuTransform;
+
+impl ModelTransform for WgpuTransform {
+    fn name(&self) -> StaticName {
+        "wgpu-transform".into()
+    }
+
+    fn transform(&self, model: &mut TypedModel) -> TractResult<()> {
+        crate::ops::pool::link_translators();
+        wgpu_context();
+        // Pointwise convolutions reach the backend as EinSum, so a segmenter is
+        // mostly matmuls until this runs.
+        rewrite_einsum_to_prefix_matmul(model, false)?;
+        Rewriter::default()
+            .with_rule_for("rewrite_kernel_conv_in_oihw", rewrite_kernel_conv_in_oihw)
+            .with_rule_for("rewrite_conv_with_n_axis", rewrite_conv_with_n_axis)
+            .with_rule_for("split_multi_axis_reduce", split_multi_axis_reduce)
+            .rewrite(&(), model)?;
+        *model = self.translate_model(model)?;
+        Rewriter::default()
+            .with_rule_for("start_elementwise_chain", crate::rewrite_rules::start_elementwise_chain)
+            .with_rule_for("start_binary_chain", crate::rewrite_rules::start_binary_chain)
+            .with_rule_for("grow_elementwise_chain", crate::rewrite_rules::grow_elementwise_chain)
+            .rewrite(&(), model)?;
+        Rewriter::default()
+            .with_rule_for("fuse_gemm_epilogue", crate::rewrite_rules::fuse_gemm_epilogue)
+            .with_rule_for("fuse_conv_epilogue", crate::rewrite_rules::fuse_conv_epilogue)
+            .rewrite(&(), model)?;
+        Rewriter::default()
+            .with_rule_for("fuse_move_axis", crate::rewrite_rules::fuse_move_axis)
+            .rewrite(&(), model)?;
+        Rewriter::default()
+            .with_rule_for("fuse_axis_op", crate::rewrite_rules::fuse_axis_op)
+            .rewrite(&(), model)?;
+        rewire_syncs(model)?;
+        Ok(())
+    }
+}
+
+fn try_make_wgpu_op(
+    source: &TypedModel,
+    node: &TypedNode,
+) -> TractResult<Option<Box<dyn TypedOp>>> {
+    type TranslateFn = fn(&TypedModel, &TypedNode) -> TractResult<Option<Box<dyn TypedOp>>>;
+    static MAP: OnceLock<HashMap<TypeId, Vec<TranslateFn>>> = OnceLock::new();
+    let map = MAP.get_or_init(|| {
+        let mut m: HashMap<TypeId, Vec<TranslateFn>> = HashMap::new();
+        for t in inventory::iter::<WgpuOpTranslator> {
+            m.entry(t.type_id).or_default().push(t.try_make);
+        }
+        m
+    });
+
+    let input_facts = source.node_input_facts(node.id)?;
+    rule_if!(input_facts.iter().all(|f| DeviceTensor::is_supported_dt(f.datum_type)));
+
+    if let Some(op) = tract_gpu::ops::copy_based::try_make_copy_based_op(source, node)? {
+        return Ok(Some(op));
+    }
+
+    if let Some(fns) = map.get(&(*node.op).type_id()) {
+        for f in fns {
+            if let Some(op) = f(source, node)? {
+                return Ok(Some(op));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn convert_const(op: &Const) -> TractResult<Const> {
+    let typed_fact: TypedFact = Arc::clone(op.val()).try_into()?;
+    let wgpu_fact = if let Some(of) = op.exotic_fact() {
+        DeviceFact::from_host(typed_fact.with_exotic_fact(clone_box(of)))?
+    } else {
+        DeviceFact::from_host(typed_fact)?
+    };
+    let wgpu_const = op.val().clone().into_device()?.into_tensor().into_arc_tensor();
+    Const::new_with_exotic_fact(wgpu_const, Box::new(wgpu_fact))
+}
+
+impl Translate<TypedFact, Box<dyn TypedOp>, TypedFact, Box<dyn TypedOp>> for WgpuTransform {
+    fn translate_node(
+        &self,
+        source: &TypedModel,
+        node: &TypedNode,
+        target: &mut TypedModel,
+        mapping: &HashMap<OutletId, OutletId>,
+    ) -> TractResult<TVec<OutletId>> {
+        let input_facts = source.node_input_facts(node.id)?;
+        if let Some(op) = node.op_as::<PrefixMatMul>()
+            && op.quantize_output.is_none()
+            && op.operating_dt.is_none_or(|dt| dt == input_facts[0].datum_type)
+            && input_facts.iter().all(|f| crate::kernels::matmul::is_supported_dt(f.datum_type))
+            && input_facts[0].datum_type == input_facts[1].datum_type
+            && input_facts[0].rank() <= crate::kernels::matmul::MAX_RANK
+        {
+            let device_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToDevice)?;
+            let outlet_ids = target.wire_node(
+                node.name.clone(),
+                ops::matmul::WgpuGemm { op: *op, epilogue: vec![] },
+                &device_inputs,
+            )?;
+            return maybe_sync_outputs(source, node, target, outlet_ids);
+        }
+        if let Some(conv) = node.op_as::<Conv>()
+            && input_facts.iter().all(|f| DeviceTensor::is_supported_dt(f.datum_type))
+            && matches!(input_facts[0].datum_type, DatumType::F16 | DatumType::F32)
+            && conv.pool_spec.kernel_shape.len() == 2
+            && conv.q_params.is_none()
+        {
+            let device_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToDevice)?;
+            let outlet_ids = ops::conv::wire_wgpu_conv(source, node, target, &device_inputs, conv)?;
+            return maybe_sync_outputs(source, node, target, outlet_ids);
+        }
+        if let Some(deconv) = node.op_as::<Deconv>()
+            && input_facts.iter().all(|f| DeviceTensor::is_supported_dt(f.datum_type))
+            && matches!(input_facts[0].datum_type, DatumType::F16 | DatumType::F32)
+            && deconv.pool_spec.kernel_shape.len() == 2
+        {
+            let device_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToDevice)?;
+            let outlet_ids =
+                ops::deconv::wire_wgpu_deconv(source, node, target, &device_inputs, deconv)?;
+            return maybe_sync_outputs(source, node, target, outlet_ids);
+        }
+        if let Some(gpu_op) = crate::kernels::resize::wgpu_resize(source, node)? {
+            let mut input = mapping[&node.inputs[0]];
+            if target.outlet_fact(input)?.as_device_fact().is_none() {
+                input = target.wire_node(
+                    format!("{}.to-device-0", node.name),
+                    tract_gpu::sync::DeviceSync::new(DeviceSyncKind::ToDevice),
+                    &[input],
+                )?[0];
+            }
+            let outlet_ids = target.wire_node(node.name.clone(), gpu_op, &[input])?;
+            return maybe_sync_outputs(source, node, target, outlet_ids);
+        }
+        if let Some(op) = node.op_as::<Const>()
+            && DeviceTensor::is_supported_dt(op.val().datum_type())
+        {
+            let device_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToDevice)?;
+            let outlet_ids =
+                target.wire_node(node.name.clone(), convert_const(op)?, &device_inputs)?;
+            return maybe_sync_outputs(source, node, target, outlet_ids);
+        }
+
+        let target_inputs: TVec<TypedFact> = node
+            .inputs
+            .iter()
+            .map(|i| target.outlet_fact(mapping[i]).cloned())
+            .collect::<TractResult<_>>()?;
+        let target_inputs_post_sync: TVec<TypedFact> = target_inputs
+            .iter()
+            .map(|f| -> TractResult<TypedFact> {
+                if f.as_device_fact().is_some() {
+                    Ok(f.clone())
+                } else {
+                    Ok(tract_gpu::fact::DeviceFact::from_host(f.clone())?.into_exotic_fact())
+                }
+            })
+            .collect::<TractResult<_>>()?;
+        let target_input_post_sync_refs: TVec<&TypedFact> =
+            target_inputs_post_sync.iter().collect();
+        if let Some(gpu_op) = try_make_wgpu_op(source, node)?
+            && gpu_op.output_facts(&target_input_post_sync_refs).is_ok()
+        {
+            let device_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToDevice)?;
+            let outlet_ids = target.wire_node(node.name.clone(), gpu_op, &device_inputs)?;
+            maybe_sync_outputs(source, node, target, outlet_ids)
+        } else {
+            let cpu_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToHost)?;
+            target.wire_node(&node.name, node.op.clone(), &cpu_inputs)
+        }
+    }
+}
+
+/// On wasm, `PollType::Wait` cannot complete a readback. Leave outputs on the
+/// GPU; the caller awaits [`crate::to_host_async`] once after `run()`.
+fn maybe_sync_outputs(
+    src: &TypedModel,
+    node: &TypedNode,
+    target: &mut TypedModel,
+    outlet_ids: TVec<OutletId>,
+) -> TractResult<TVec<OutletId>> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = (src, node, target);
+        Ok(outlet_ids)
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        sync_model_outputs_if_required(src, node, target, outlet_ids)
+    }
+}
+
+fn split_multi_axis_reduce(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &Reduce,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_if!(op.axes.len() > 1);
+    use tract_core::ops::nn::Reducer::*;
+    rule_if!(matches!(op.reducer, Sum | Prod | Min | Max | Any | All));
+    let mut patch = TypedModelPatch::default();
+    let mut wire = patch.tap_model(model, node.inputs[0])?;
+    let mut axes = op.axes.clone();
+    axes.sort();
+    for (i, &axis) in axes.iter().rev().enumerate() {
+        let single = Reduce { axes: tvec![axis], reducer: op.reducer };
+        wire = patch.wire_node(format!("{node_name}.axis_{i}"), single, &[wire])?[0];
+    }
+    patch.shunt_outside(model, node.id.into(), wire)?;
+    Ok(Some(patch))
+}

--- a/wgpu/src/utils.rs
+++ b/wgpu/src/utils.rs
@@ -1,0 +1,16 @@
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::context::WgpuBuffer;
+
+pub fn get_wgpu_buffer(tensor: &DeviceTensor) -> &WgpuBuffer {
+    tensor
+        .device_buffer()
+        .downcast_ref::<WgpuBuffer>()
+        .expect("Non-wgpu buffer accessed during wgpu execution")
+}
+
+/// Element offset of this tensor inside its storage buffer, plus an extra byte offset.
+pub fn element_offset(tensor: &DeviceTensor, extra_bytes: usize) -> usize {
+    let dt = tensor.datum_type().size_of();
+    (tensor.buffer_offset::<usize>() + extra_bytes) / dt
+}


### PR DESCRIPTION
tract reaches a GPU through Metal and CUDA, neither of which a browser can. This adds `tract-wgpu`, a third `tract-gpu` backend built on the `wgpu` crate: one set of WGSL kernels that run on WebGPU in a browser and on Vulkan/Metal/DX12 natively.

Opening as a draft because the code is the easy part of this question — the real one is whether you want a third GPU backend in-tree at all, and on what maintenance terms. I'd rather hear that before polishing anything.

## What it is

A new crate and nothing else. **It changes no existing file**: the diff is `wgpu/`, plus two lines of `Cargo.toml` and the lockfile. No edit to tract-core, tract-gpu, metal or cuda, so nothing that works today can regress.

It covers a full selfie-segmentation model on the GPU with no CPU fallback — convolution (dense, depthwise, transposed), pooling, matmul via `PrefixMatMul`, reduce, softmax, resize, cast, and the element-wise and binary sets, in f32 and f16. There is a `WgpuTransform` like `MetalTransform`, a coverage check that refuses to load a model it would silently split, and an optional hybrid mode that falls back to CPU per-op behind a feature flag.

## Three things WebGPU does not let a `tract-gpu` backend do

These are the parts worth your opinion, because they are contract questions rather than kernel ones.

**The memory pool's single-buffer arena is illegal.** WebGPU refuses a dispatch that binds one buffer both read-only and read-write, which is what an arena does whenever a kernel reads one tensor and writes another in the same allocation. The validation error is `Buffer with 'tract-wgpu-arena' usage ... is used as both a read-only storage and a writable storage`. The backend therefore gives each tensor its own buffer and addresses it as `(buffer, byte offset in a uniform)`.

**`DeviceBuffer::ptr()` has no meaning.** There is no GPU address to hand out. It returns the `wgpu::Buffer`'s handle identity, which is enough for cache keying and nothing else; kernels downcast to the concrete buffer type instead.

**`get_bytes_slice` cannot report a failure.** On a unified-memory backend it is a slice; here it is a device readback that can fail, and the trait returns `Vec<u8>`. Today the path is unreachable — it is only entered through the arena view, which this backend never installs — but it is a trap if the arena ever becomes reachable. On wasm it cannot succeed at all without JSPI.

None of these need a change from you for this PR to work; they are all handled inside the crate. I raise them because if `tract-gpu`'s contract were ever revisited, these are the three places a non-unified-memory backend pushes back.

## Numbers

MobileNet-style selfie segmentation, 144×256, on an M-series Mac.

| | tract-wgpu | reference |
|---|---|---|
| Chrome, GPU-resident | 2.70 ms/frame | onnxruntime-web WebGPU EP, 2.09 ms |
| Chrome, full frame incl. readback | 6.63 ms | onnxruntime-web, 5.40 ms |
| Chrome, background-replacement demo, model only | 1.5–1.7 ms | tract's own 1-thread wasm tier, ~9.5 ms |
| Native | ~3.1–3.7 ms/frame | tract's CPU path on the same box, ~6.1 ms |

**These replace an earlier table that had us ahead of onnxruntime-web on a full frame. That was wrong** — measured against a slower run of theirs, and on our side with a performance bug in the uniform path that I have since fixed. Measured properly in one sitting we are about 1.3× behind them in a browser, and the row that matters for the use case is still the third: inference on a video call must not eat the cores the encoder needs.

Where the gap is, in case it is useful to you: their kernels do **more** GPU work than ours (3.08 ms summed against our ~2.4 ms) and they still land lower, because they issue 122 dispatches to our 140 and recording is about **half** of a WebGPU frame — `record 1.28 ms + submit 0.32 + readback 3.12` on our side. So this backend's remaining problem in a browser is dispatch count and host-side recording, not arithmetic. Native does not show this at all: there the driver wait hides recording, and the same changes that help one target do nothing for the other.

## Testing

`cargo test -p tract-wgpu` is 26 tests against CPU reference, per kernel family. A model-level test compares the whole graph to the CPU plan at `Approximation::Approximate` and asserts full GPU coverage — that one lives in an example crate that is not part of this PR, because it embeds an ONNX file the repo does not carry. If you want the model test in-tree, tell me how you would rather a test model be provisioned and I will wire it that way.

Not covered: no CI runs this. It needs a GPU, and the browser numbers need a browser. I have run it on Apple hardware only — Vulkan and DX12 are what the `wgpu` crate gives us, not something I have verified.

## Not included

The browser demo and its benchmark page are a separate slice, blocked on the same test-model question. A background-replacement demo built on this exists but uses compositing shaders whose provenance I need to settle before offering them.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)

