### PR TITLE
libcli: the manifest declared tract-tflite and tract-gpu, which nothi…

### DIFF
--- a/libcli/Cargo.toml
+++ b/libcli/Cargo.toml
@@ -27,8 +27,6 @@ serde_json.workspace = true
 tract-core.workspace = true
 tract-hir.workspace = true
 tract-onnx = { workspace = true, optional = true }
-tract-tflite.workspace = true
-tract-gpu.workspace = true
 tract-transformers = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]


### PR DESCRIPTION
…ng in libcli/src references, so anything linking the CLI library built and linked both. Drop them.