### PR TITLE
wgpu 2/7: element-wise and binary ops, and the transform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,6 +4684,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-wgpu"
+version = "0.1.0"
+dependencies = [
+ "home",
+ "infra",
+ "lazy_static",
+ "log",
+ "pastey 0.2.3",
+ "regex",
+ "suite-onnx",
+ "suite-pulse",
+ "suite-unit",
+ "tract-core",
+ "tract-gpu",
+ "tract-onnx-opl",
+ "tract-wgpu",
+]
+
+[[package]]
 name = "tf-inceptionv3"
 version = "0.20.7-pre"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "test-rt/test-f16",
     "test-rt/test-metal",
     "test-rt/test-cuda",
+    "test-rt/test-wgpu",
     "test-rt/test-unit-core",
     "test-rt/test-pulse-core",
     "test-rt/test-onnx-core",

--- a/test-rt/test-wgpu/Cargo.toml
+++ b/test-rt/test-wgpu/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "test-wgpu"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[build-dependencies]
+home.workspace = true
+lazy_static.workspace = true
+regex.workspace = true
+infra = { path = "../infra" }
+tract-core.workspace = true
+suite-onnx = { path = "../suite-onnx" }
+suite-unit = { path = "../suite-unit" }
+suite-pulse = { path = "../suite-pulse" }
+tract-onnx-opl.workspace = true
+pastey.workspace = true
+
+[dev-dependencies]
+home.workspace = true
+regex.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+tract-core.workspace = true
+tract-wgpu.workspace = true
+tract-gpu.workspace = true
+tract-onnx-opl.workspace = true
+infra = { path = "../infra" }
+suite-onnx = { path = "../suite-onnx" }
+suite-unit = { path = "../suite-unit" }
+suite-pulse = { path = "../suite-pulse" }
+pastey.workspace = true

--- a/test-rt/test-wgpu/build.rs
+++ b/test-rt/test-wgpu/build.rs
@@ -1,0 +1,11 @@
+#[path = "suite.rs"]
+mod suite;
+
+fn main() {
+    suite::suite().test_runtime(
+        "tests",
+        "suite::suite()",
+        "runtime()",
+        "Approximation::Approximate",
+    );
+}

--- a/test-rt/test-wgpu/src/lib.rs
+++ b/test-rt/test-wgpu/src/lib.rs
@@ -1,0 +1,64 @@
+#![cfg(all(test, not(target_arch = "wasm32")))]
+
+use infra::device_runtime::{DeviceTestBackend, DeviceTestRuntime};
+use pastey::paste;
+use tract_core::internal::*;
+use tract_core::runtime::runtime_for_name;
+use tract_core::transform::ModelTransform;
+
+#[path = "../suite.rs"]
+mod suite;
+
+#[derive(Debug)]
+struct WgpuBackend;
+
+impl DeviceTestBackend for WgpuBackend {
+    fn transform(&self, model: &mut TypedModel) -> TractResult<()> {
+        tract_wgpu::WgpuTransform.transform(model)
+    }
+
+    /// The memory pool's arena binds one buffer both read-only and read-write
+    /// in a dispatch, which WebGPU refuses, so this backend never installs it
+    /// and every runtime below runs with `use_arena` false.
+    fn with_arena(
+        &self,
+        plan: TypedSimplePlan,
+        _memory_hint: &SymbolValues,
+    ) -> TractResult<TypedSimplePlan> {
+        Ok(plan)
+    }
+
+    fn check(&self) -> TractResult<()> {
+        runtime_for_name("wgpu")?.context("No wgpu runtime found")?;
+        Ok(())
+    }
+}
+
+macro_rules! wgpu_test_suite {
+    ($id: ident, $optimize: expr, $transpose_inputs: ident) => {
+        paste! {
+            mod [<$id>] {
+                use super::*;
+
+                fn runtime() -> &'static DeviceTestRuntime<WgpuBackend> {
+                    lazy_static::lazy_static! {
+                        static ref RT: DeviceTestRuntime<WgpuBackend> = DeviceTestRuntime {
+                            name: stringify!([<$id>]),
+                            backend: WgpuBackend,
+                            optimize: $optimize,
+                            transpose_inputs: $transpose_inputs,
+                            use_arena: false,
+                        };
+                    };
+                    &RT
+                }
+
+                include!(concat!(env!("OUT_DIR"), "/tests/tests.rs"));
+            }
+        }
+    };
+}
+
+wgpu_test_suite!(wgpu_translate, false, false);
+wgpu_test_suite!(optimized_wgpu, true, false);
+wgpu_test_suite!(optimized_wgpu_transpose, true, true);

--- a/test-rt/test-wgpu/suite.rs
+++ b/test-rt/test-wgpu/suite.rs
@@ -1,0 +1,16 @@
+pub fn suite() -> &'static infra::TestSuite {
+    lazy_static::lazy_static! {
+        static ref SUITE: infra::TestSuite  = mk_suite();
+    };
+    &SUITE
+}
+
+/// Every case the shared suites define. The backend declines to translate what
+/// it has no kernel for, so an unsupported op runs on the CPU rather than
+/// needing an entry here.
+fn mk_suite() -> infra::TestSuite {
+    infra::TestSuite::default()
+        .with("onnx", suite_onnx::suite().clone())
+        .with("unit", suite_unit::suite().unwrap().clone())
+        .with("pulse", suite_pulse::suite().unwrap().clone())
+}

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -125,12 +125,6 @@ struct WgpuContextInner {
     layouts: RwLock<HashMap<LayoutKind, (wgpu::BindGroupLayout, wgpu::PipelineLayout)>>,
     bind_groups: Mutex<HashMap<BindGroupKey, wgpu::BindGroup>>,
     staging: Mutex<Option<wgpu::Buffer>>,
-    /// A graph allocates the same sizes in the same order every frame, so a
-    /// buffer is keyed by that position rather than by size alone: the Nth
-    /// allocation of a given size always gets the same buffer, and the bind
-    /// group built for it last frame still matches.
-    buffer_slots: Mutex<HashMap<(u64, u32), Arc<WgpuBuffer>>>,
-    slot_cursor: Mutex<HashMap<u64, u32>>,
 }
 
 /// `wgpu::Buffer` hashes by the resource it points at, so a cached entry stays
@@ -140,6 +134,7 @@ struct WgpuContextInner {
 struct BindGroupKey {
     layout: LayoutKind,
     buffers: Vec<u64>,
+    uniform: wgpu::Buffer,
 }
 
 impl std::fmt::Debug for WgpuContext {
@@ -208,8 +203,6 @@ impl WgpuContext {
                 layouts: RwLock::new(HashMap::new()),
                 bind_groups: Mutex::new(HashMap::new()),
                 staging: Mutex::new(None),
-                buffer_slots: Mutex::new(HashMap::new()),
-                slot_cursor: Mutex::new(HashMap::new()),
             }),
         };
         ctxt.preload_pipelines()?;
@@ -380,7 +373,11 @@ impl WgpuContext {
         buffers: &[&WgpuBuffer],
         uniform: &wgpu::Buffer,
     ) -> TractResult<wgpu::BindGroup> {
-        let key = BindGroupKey { layout: kind, buffers: buffers.iter().map(|b| b.id).collect() };
+        let key = BindGroupKey {
+            layout: kind,
+            buffers: buffers.iter().map(|b| b.id).collect(),
+            uniform: uniform.clone(),
+        };
         {
             let cache = self.inner.bind_groups.lock().map_err(|e| anyhow!("{e}"))?;
             if let Some(bg) = cache.get(&key) {
@@ -433,52 +430,14 @@ impl WgpuContext {
         }
     }
 
-    pub(crate) fn reset_buffer_slots(&self) {
-        if let Ok(mut cursor) = self.inner.slot_cursor.lock() {
-            cursor.clear();
-        }
-    }
-
     fn next_buffer_id(&self) -> u64 {
         static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
         NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     }
 
-    /// A storage buffer of `size` bytes for this position in the frame's
-    /// allocation sequence. Reuses the buffer that position held last frame,
-    /// unless it is still alive.
     pub fn alloc_storage(&self, size: u64) -> Arc<WgpuBuffer> {
-        let size = size.max(4).next_multiple_of(4);
-        let seq = self
-            .inner
-            .slot_cursor
-            .lock()
-            .map(|mut c| {
-                let n = c.entry(size).or_insert(0);
-                let seq = *n;
-                *n += 1;
-                seq
-            })
-            .unwrap_or(u32::MAX);
-        if seq != u32::MAX
-            && let Ok(mut slots) = self.inner.buffer_slots.lock()
-        {
-            if let Some(held) = slots.get(&(size, seq))
-                && Arc::strong_count(held) == 1
-            {
-                bump(2);
-                return held.clone();
-            }
-            let fresh = Arc::new(WgpuBuffer {
-                inner: self.create_empty_storage(size),
-                id: self.next_buffer_id(),
-            });
-            bump(3);
-            slots.insert((size, seq), fresh.clone());
-            return fresh;
-        }
-        bump(3);
-        Arc::new(WgpuBuffer { inner: self.create_empty_storage(size), id: self.next_buffer_id() })
+        with_wgpu_queue(|q| Ok(q.alloc_storage(size)))
+            .expect("wgpu queue unavailable for allocation")
     }
 
     pub fn wrap_storage(&self, inner: wgpu::Buffer) -> WgpuBuffer {
@@ -721,6 +680,14 @@ pub struct WgpuQueue {
     encoder: RefCell<Option<wgpu::CommandEncoder>>,
     pending: RefCell<Vec<Dispatch>>,
     uniform_staging: RefCell<Vec<u8>>,
+    /// A graph allocates the same sizes in the same order every frame, so a
+    /// buffer is keyed by that position rather than by size alone: the Nth
+    /// allocation of a given size always gets the same buffer, and the bind
+    /// group built for it last frame still matches. Both maps belong to the
+    /// thread that owns the frame: a buffer must not be handed to another
+    /// thread while a dispatch this one recorded still reads it.
+    buffer_slots: RefCell<HashMap<(u64, u32), Arc<WgpuBuffer>>>,
+    slot_cursor: RefCell<HashMap<u64, u32>>,
     profile: Cell<bool>,
     profiled: RefCell<Vec<(&'static str, u32)>>,
     queries: RefCell<Option<Queries>>,
@@ -850,6 +817,8 @@ impl WgpuQueue {
             encoder: RefCell::new(None),
             pending: RefCell::new(vec![]),
             uniform_staging: RefCell::new(vec![]),
+            buffer_slots: RefCell::new(HashMap::new()),
+            slot_cursor: RefCell::new(HashMap::new()),
             profile: Cell::new(false),
             profiled: RefCell::new(vec![]),
             queries: RefCell::new(None),
@@ -878,9 +847,35 @@ impl WgpuQueue {
         std::mem::forget(self.staging.replace(None));
         std::mem::forget(std::mem::take(&mut *self.retained.borrow_mut()));
         std::mem::forget(std::mem::take(&mut *self.retained_textures.borrow_mut()));
+        std::mem::forget(std::mem::take(&mut *self.buffer_slots.borrow_mut()));
         unsafe {
             std::mem::forget(ManuallyDrop::take(&mut self.uniform));
         }
+    }
+
+    /// A storage buffer of `size` bytes for this position in the frame's
+    /// allocation sequence. Reuses the buffer that position held last frame,
+    /// unless it is still alive.
+    pub fn alloc_storage(&self, size: u64) -> Arc<WgpuBuffer> {
+        let size = size.max(4).next_multiple_of(4);
+        let seq = {
+            let mut cursor = self.slot_cursor.borrow_mut();
+            let n = cursor.entry(size).or_insert(0);
+            let seq = *n;
+            *n += 1;
+            seq
+        };
+        let mut slots = self.buffer_slots.borrow_mut();
+        if let Some(held) = slots.get(&(size, seq))
+            && Arc::strong_count(held) == 1
+        {
+            bump(2);
+            return held.clone();
+        }
+        let fresh = Arc::new(self.context.wrap_storage(self.context.create_empty_storage(size)));
+        bump(3);
+        slots.insert((size, seq), fresh.clone());
+        fresh
     }
 
     pub fn retain_tensor(&self, t: &DeviceTensor) {
@@ -1050,7 +1045,7 @@ impl WgpuQueue {
         self.retained_textures.borrow_mut().clear();
         self.uniform_cursor.set(0);
         self.context.trim_bind_groups();
-        self.context.reset_buffer_slots();
+        self.slot_cursor.borrow_mut().clear();
         Ok(())
     }
 

--- a/wgpu/src/coverage.rs
+++ b/wgpu/src/coverage.rs
@@ -1,0 +1,56 @@
+//! Load-time coverage check.
+//!
+//! Without JSPI a mid-graph GPU→CPU readback cannot complete in a browser.
+//! [`ensure_wgpu_coverage`] still fails with named ops for that case.
+//! The wgpu `Runtime::prepare` path skips it when
+//! [`crate::hybrid_fallback_available`] (native blocking poll, or wasm built
+//! with `--features jspi` on a JSPI browser): uncovered ops run on tract's
+//! CPU kernels instead.
+
+use tract_core::internal::*;
+use tract_core::ops::konst::Const;
+use tract_core::ops::source::TypedSource;
+use tract_gpu::fact::DeviceTypedFactExt;
+use tract_gpu::sync::DeviceSync;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UncoveredOp {
+    pub node: String,
+    pub op: String,
+}
+
+fn is_glue(node: &TypedNode) -> bool {
+    node.op_is::<TypedSource>() || node.op_is::<Const>() || node.op_is::<DeviceSync>()
+}
+
+/// Nodes the backend cannot run, in eval order. Glue (Source, Const, DeviceSync)
+/// is ignored; everything else must produce `DeviceFact` outputs.
+pub fn uncovered_ops(model: &TypedModel) -> TractResult<Vec<UncoveredOp>> {
+    let mut out = Vec::new();
+    for id in model.eval_order()? {
+        let node = &model.nodes()[id];
+        if is_glue(node) {
+            continue;
+        }
+        let facts = model.node_output_facts(id)?;
+        if facts.iter().all(|f| f.as_device_fact().is_some()) {
+            continue;
+        }
+        out.push(UncoveredOp { node: node.name.to_string(), op: node.op.name().to_string() });
+    }
+    Ok(out)
+}
+
+/// Reject a model that would need a mid-graph CPU fallback.
+pub fn ensure_wgpu_coverage(model: &TypedModel) -> TractResult<()> {
+    let bad = uncovered_ops(model)?;
+    if bad.is_empty() {
+        return Ok(());
+    }
+    let list =
+        bad.iter().map(|u| format!("{} (node {:?})", u.op, u.node)).collect::<Vec<_>>().join(", ");
+    bail!(
+        "tract-wgpu cannot run this model; no GPU kernel for: {list}. \
+         Mid-graph CPU fallback is not supported without JSPI."
+    )
+}

--- a/wgpu/src/kernels/bin_ops.rs
+++ b/wgpu/src/kernels/bin_ops.rs
@@ -1,0 +1,113 @@
+use tract_core::internal::*;
+use tract_core::ops::binary::BinMiniOp;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    BINARY_OPS, EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, Width,
+    broadcast_strides, dtypes, op_in_set, pack_u32s, pad8_u32,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{register_wgpu_op, with_wgpu_queue};
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    let mut keys = Vec::new();
+    for dt in dtypes(shader_f16) {
+        for name in BINARY_OPS {
+            for width in [Width::Scalar, Width::Vec4, Width::Vec4Splat] {
+                keys.push(PipelineKey {
+                    module: ModuleKey { kind: ModuleKind::Binary, dtype: *dt },
+                    entry: EntryPoint::wide(name, width, *dt),
+                });
+            }
+        }
+    }
+    keys
+}
+
+/// A wider thread only pays when the left operand runs with the output and the
+/// right one either does too or is constant across the four values.
+fn width_for(lhs: &DeviceTensor, rhs: &DeviceTensor, output: &DeviceTensor) -> Width {
+    let out_shape = output.shape();
+    let last = *out_shape.last().unwrap_or(&1);
+    if !output.len().is_multiple_of(4) || !last.is_multiple_of(4) {
+        return Width::Scalar;
+    }
+    let natural = Tensor::natural_strides(out_shape);
+    let runs_with_output = |t: &DeviceTensor| t.shape() == out_shape && t.strides() == &natural[..];
+    if !runs_with_output(lhs) {
+        return Width::Scalar;
+    }
+    if runs_with_output(rhs) {
+        Width::Vec4
+    } else if rhs.rank() == out_shape.len() && rhs.shape().last() == Some(&1) && last != 1 {
+        Width::Vec4Splat
+    } else {
+        Width::Scalar
+    }
+}
+
+pub fn is_supported(mini_op: &dyn BinMiniOp, dt: DatumType) -> bool {
+    let name = mini_op.name().to_lowercase();
+    BINARY_OPS.contains(&name.as_str()) && matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+pub fn wgpu_bin_op_dispatch(
+    mini_op: &dyn BinMiniOp,
+    lhs: &DeviceTensor,
+    rhs: &DeviceTensor,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(lhs);
+        q.retain_tensor(rhs);
+        q.retain_tensor(output);
+        ensure!(lhs.rank() == rhs.rank());
+        let dt = ShaderDtype::from_datum(lhs.datum_type())?;
+        let name = op_in_set(BINARY_OPS, mini_op.name())
+            .with_context(|| format!("tract-wgpu has no binary kernel for {}", mini_op.name()))?;
+        let width = width_for(lhs, rhs, output);
+        let key = PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Binary, dtype: dt },
+            entry: EntryPoint::wide(name, width, dt),
+        };
+        let pipeline = q.context().pipeline(key)?;
+        let lhs_buf = get_wgpu_buffer(lhs);
+        let rhs_buf = get_wgpu_buffer(rhs);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(
+            LayoutKind::Binary,
+            &[lhs_buf, rhs_buf, out_buf],
+            q.uniform(),
+        )?;
+
+        let out_shape = output.shape();
+        let lhs_s = broadcast_strides(lhs.shape(), lhs.strides(), out_shape);
+        let rhs_s = broadcast_strides(rhs.shape(), rhs.strides(), out_shape);
+        let shp = pad8_u32(out_shape);
+        let mut vals = vec![
+            element_offset(lhs, 0) as u32,
+            element_offset(rhs, 0) as u32,
+            element_offset(output, 0) as u32,
+            out_shape.len() as u32,
+            output.len() as u32,
+            0,
+            0,
+            0,
+        ];
+        vals.extend_from_slice(&lhs_s);
+        vals.extend_from_slice(&rhs_s);
+        vals.extend_from_slice(&shp);
+        let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+        let threads = if width == Width::Scalar { output.len() } else { output.len() / 4 };
+        q.dispatch("binary", &pipeline, &bg, dyn_off, threads as u64)
+    })
+}
+
+pub fn wgpu_bin_op(mini_op: Box<dyn BinMiniOp>) -> tract_gpu::ops::binary::GpuBinOp {
+    tract_gpu::ops::binary::GpuBinOp::new(mini_op, "Wgpu", wgpu_bin_op_dispatch)
+}
+
+register_wgpu_op!(tract_core::ops::binary::TypedBinOp, |source, node, op| {
+    rule_if!(is_supported(&*op.0, source.node_input_facts(node.id)?[0].datum_type));
+    Ok(Some(Box::new(wgpu_bin_op(op.0.clone()))))
+});

--- a/wgpu/src/kernels/cast.rs
+++ b/wgpu/src/kernels/cast.rs
@@ -5,7 +5,7 @@ use crate::kernels::shaders::{
     EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, pack_u32s,
 };
 use crate::utils::{element_offset, get_wgpu_buffer};
-use crate::with_wgpu_queue;
+use crate::{register_wgpu_op, with_wgpu_queue};
 
 pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
     if !shader_f16 {
@@ -58,3 +58,8 @@ pub fn wgpu_cast_dispatch(input: &DeviceTensor, output: &DeviceTensor) -> TractR
         q.dispatch("cast", &pipeline, &bg, dyn_off, output.len() as u64)
     })
 }
+
+register_wgpu_op!(tract_core::ops::cast::Cast, |_source, _node, op| {
+    Ok(tract_gpu::ops::cast::GpuCast::new(op.to, "Wgpu", wgpu_cast_dispatch, is_supported_dt)
+        .map(|c| Box::new(c) as _))
+});

--- a/wgpu/src/kernels/element_wise.rs
+++ b/wgpu/src/kernels/element_wise.rs
@@ -1,0 +1,62 @@
+use tract_core::internal::*;
+use tract_core::ops::element_wise::ElementWiseMiniOp;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    ELEMENT_WISE_OPS, EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype,
+    keys_for, op_in_set, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{register_wgpu_op, with_wgpu_queue};
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::ElementWise, ELEMENT_WISE_OPS, shader_f16)
+}
+
+pub fn is_supported(mini_op: &dyn ElementWiseMiniOp, dt: DatumType) -> bool {
+    let name = mini_op.name().to_lowercase();
+    ELEMENT_WISE_OPS.contains(&name.as_str()) && matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+pub fn wgpu_element_wise_dispatch(
+    mini_op: &dyn ElementWiseMiniOp,
+    input: &DeviceTensor,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        ensure!(output.shape() == input.shape() && output.datum_type() == input.datum_type());
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let name = op_in_set(ELEMENT_WISE_OPS, &mini_op.name()).with_context(|| {
+            format!("tract-wgpu has no element-wise kernel for {}", mini_op.name())
+        })?;
+        let key = PipelineKey {
+            module: ModuleKey { kind: ModuleKind::ElementWise, dtype: dt },
+            entry: EntryPoint::typed(name, dt),
+        };
+        let pipeline = q.context().pipeline(key)?;
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(output, 0) as u32,
+            output.len() as u32,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("element_wise", &pipeline, &bg, dyn_off, output.len() as u64)
+    })
+}
+
+pub fn wgpu_element_wise_op(
+    mini_op: Box<dyn ElementWiseMiniOp>,
+) -> tract_gpu::ops::element_wise::GpuElementWise {
+    tract_gpu::ops::element_wise::GpuElementWise::new(mini_op, "Wgpu", wgpu_element_wise_dispatch)
+}
+
+register_wgpu_op!(tract_core::ops::element_wise::ElementWiseOp, |source, node, op| {
+    rule_if!(is_supported(&*op.0, source.node_input_facts(node.id)?[0].datum_type));
+    Ok(Some(Box::new(wgpu_element_wise_op(op.0.clone()))))
+});

--- a/wgpu/src/kernels/mod.rs
+++ b/wgpu/src/kernels/mod.rs
@@ -1,12 +1,16 @@
+pub mod bin_ops;
 pub mod cast;
 pub mod copy;
+pub mod element_wise;
 pub mod shaders;
 
 /// Every pipeline this crate's kernels can need. They are built when the
 /// context is created so that no frame ever waits on a shader compile.
 pub fn all_pipeline_keys(shader_f16: bool) -> Vec<shaders::PipelineKey> {
     let mut keys = vec![];
+    keys.extend(bin_ops::all_pipeline_keys(shader_f16));
     keys.extend(cast::all_pipeline_keys(shader_f16));
     keys.extend(copy::all_pipeline_keys(shader_f16));
+    keys.extend(element_wise::all_pipeline_keys(shader_f16));
     keys
 }

--- a/wgpu/src/kernels/shaders.rs
+++ b/wgpu/src/kernels/shaders.rs
@@ -22,18 +22,21 @@ const AT8: &str = "fn at8(a: vec4<u32>, b: vec4<u32>, i: u32) -> u32 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LayoutKind {
     Unary,
+    Binary,
 }
 
 impl LayoutKind {
     pub fn label(self) -> &'static str {
         match self {
             Self::Unary => "tract-wgpu-unary-layout",
+            Self::Binary => "tract-wgpu-binary-layout",
         }
     }
 
     pub fn storage_count(self) -> u32 {
         match self {
             Self::Unary => 2,
+            Self::Binary => 3,
         }
     }
 
@@ -97,6 +100,8 @@ impl ShaderDtype {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ModuleKind {
+    ElementWise,
+    Binary,
     Copy,
     Cast,
 }
@@ -116,12 +121,15 @@ impl ModuleKey {
 
     pub fn layout(self) -> LayoutKind {
         match self.kind {
-            ModuleKind::Copy | ModuleKind::Cast => LayoutKind::Unary,
+            ModuleKind::ElementWise | ModuleKind::Copy | ModuleKind::Cast => LayoutKind::Unary,
+            ModuleKind::Binary => LayoutKind::Binary,
         }
     }
 
     pub fn wgsl(self) -> String {
         match self.kind {
+            ModuleKind::ElementWise => element_wise_wgsl(self.dtype),
+            ModuleKind::Binary => binary_wgsl(self.dtype),
             ModuleKind::Copy => copy_wgsl(self.dtype),
             ModuleKind::Cast => cast_wgsl(self.dtype),
         }
@@ -132,6 +140,24 @@ impl ModuleKey {
 pub struct PipelineKey {
     pub module: ModuleKey,
     pub entry: EntryPoint,
+}
+
+/// How many values of the last axis one thread of a kernel handles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Width {
+    Scalar,
+    Vec4,
+    Vec4Splat,
+}
+
+impl Width {
+    fn infix(self) -> &'static str {
+        match self {
+            Self::Scalar => "",
+            Self::Vec4 => "_v4",
+            Self::Vec4Splat => "_v4s",
+        }
+    }
 }
 
 /// A kernel's WGSL entry point, held in the pieces the generator spells it
@@ -147,6 +173,11 @@ impl EntryPoint {
     /// One of a module's per-dtype entry points, `<stem>_<dtype>`.
     pub fn typed(stem: &'static str, dtype: ShaderDtype) -> Self {
         Self { stem, infix: "", suffix: dtype.suffix() }
+    }
+
+    /// A per-dtype entry point in its `width`-value-per-thread form.
+    pub fn wide(stem: &'static str, width: Width, dtype: ShaderDtype) -> Self {
+        Self { stem, infix: width.infix(), suffix: dtype.suffix() }
     }
 
     /// An entry point that names the dtypes it works on itself.
@@ -181,6 +212,12 @@ pub fn keys_for(kind: ModuleKind, stems: &[&'static str], shader_f16: bool) -> V
         .collect()
 }
 
+/// The set's own `&'static str` for `name`, matched the way an op reaches us
+/// from tract: case-insensitively, and without allocating to lowercase it.
+pub fn op_in_set(set: &'static [&'static str], name: &str) -> Option<&'static str> {
+    set.iter().copied().find(|op| op.eq_ignore_ascii_case(name))
+}
+
 fn preamble(dt: ShaderDtype) -> String {
     let enable = match dt {
         ShaderDtype::F16 => "enable f16;\n",
@@ -188,6 +225,282 @@ fn preamble(dt: ShaderDtype) -> String {
     };
     enable.to_string()
 }
+
+fn binary_ops_vec4_wgsl(t: &str) -> String {
+    let mut s = String::new();
+    for name in BINARY_OPS {
+        s.push_str(&format!(
+            "fn op_{name}_v(a: vec4<{t}>, b: vec4<{t}>) -> vec4<{t}> {{ return vec4<{t}>(op_{name}(a.x, b.x), op_{name}(a.y, b.y), op_{name}(a.z, b.z), op_{name}(a.w, b.w)); }}\n"
+        ));
+    }
+    s
+}
+
+/// Every unary `op_*` a kernel may call, plus the erf polynomial they share.
+fn unary_ops_wgsl(t: &str) -> String {
+    format!(
+        r#"fn approx_erf(x: f32) -> f32 {{
+    let a1 = 0.0705230784;
+    let a2 = 0.0422820123;
+    let a3 = 0.0092705272;
+    let a4 = 0.0001520143;
+    let a5 = 0.0002765672;
+    let a6 = 0.0000430638;
+    let ax = abs(x);
+    var y = a6 * ax;
+    y = (a5 + y) * ax;
+    y = (a4 + y) * ax;
+    y = (a3 + y) * ax;
+    y = (a2 + y) * ax;
+    y = (a1 + y) * ax;
+    y = 1.0 - (1.0 / pow(y + 1.0, 16.0));
+    return sign(x) * y;
+}}
+
+fn op_abs(x: {t}) -> {t} {{ return abs(x); }}
+fn op_exp(x: {t}) -> {t} {{ return exp(x); }}
+fn op_ln(x: {t}) -> {t} {{ return log(x); }}
+fn op_sqrt(x: {t}) -> {t} {{ return sqrt(x); }}
+fn op_rsqrt(x: {t}) -> {t} {{ return inverseSqrt(x); }}
+fn op_sigmoid(x: {t}) -> {t} {{
+    let y = {t}(1.0) / ({t}(1.0) + exp(-abs(x)));
+    if (x < {t}(0.0)) {{ return {t}(1.0) - y; }}
+    return y;
+}}
+fn op_square(x: {t}) -> {t} {{ return x * x; }}
+fn op_recip(x: {t}) -> {t} {{ return {t}(1.0) / x; }}
+fn op_ceil(x: {t}) -> {t} {{ return ceil(x); }}
+fn op_floor(x: {t}) -> {t} {{ return floor(x); }}
+fn op_round(x: {t}) -> {t} {{ return sign(x) * floor(abs(x) + {t}(0.5)); }}
+fn op_roundhalftoeven(x: {t}) -> {t} {{ return round(x); }}
+fn op_cos(x: {t}) -> {t} {{ return cos(x); }}
+fn op_sin(x: {t}) -> {t} {{ return sin(x); }}
+fn op_tan(x: {t}) -> {t} {{ return tan(x); }}
+fn op_acos(x: {t}) -> {t} {{ return acos(x); }}
+fn op_asin(x: {t}) -> {t} {{ return asin(x); }}
+fn op_atan(x: {t}) -> {t} {{ return atan(x); }}
+fn op_cosh(x: {t}) -> {t} {{ return cosh(x); }}
+fn op_sinh(x: {t}) -> {t} {{ return sinh(x); }}
+fn op_tanh(x: {t}) -> {t} {{ return tanh(x); }}
+fn op_acosh(x: {t}) -> {t} {{ return acosh(x); }}
+fn op_asinh(x: {t}) -> {t} {{ return asinh(x); }}
+fn op_atanh(x: {t}) -> {t} {{ return atanh(x); }}
+fn op_erf(x: {t}) -> {t} {{ return {t}(approx_erf(f32(x))); }}
+fn op_neg(x: {t}) -> {t} {{ return -x; }}
+fn op_sign(x: {t}) -> {t} {{ return sign(x); }}
+fn op_hardswish(x: {t}) -> {t} {{
+    let h = max({t}(0.0), min({t}(1.0), x / {t}(6.0) + {t}(0.5)));
+    return x * h;
+}}
+fn op_silu(x: {t}) -> {t} {{ return x / ({t}(1.0) + exp(-x)); }}
+"#
+    )
+}
+
+/// Every binary `op_*` a kernel may call.
+fn binary_ops_wgsl(t: &str) -> String {
+    format!(
+        r#"fn op_add(a: {t}, b: {t}) -> {t} {{ return a + b; }}
+fn op_sub(a: {t}, b: {t}) -> {t} {{ return a - b; }}
+fn op_mul(a: {t}, b: {t}) -> {t} {{ return a * b; }}
+fn op_div(a: {t}, b: {t}) -> {t} {{ return a / b; }}
+fn op_min(a: {t}, b: {t}) -> {t} {{ return min(a, b); }}
+fn op_max(a: {t}, b: {t}) -> {t} {{ return max(a, b); }}
+fn op_pow(a: {t}, b: {t}) -> {t} {{ return pow(a, b); }}
+"#
+    )
+}
+
+fn element_wise_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let lib = unary_ops_wgsl(t);
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_out: u32,
+    len: u32,
+    _pad: u32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+{lib}
+"#
+    ));
+    for name in ELEMENT_WISE_OPS {
+        s.push_str(&format!(
+            r#"
+@compute @workgroup_size({WORKGROUP})
+fn {name}_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    outp[params.off_out + i] = op_{name}(inp[params.off_in + i]);
+}}
+"#
+        ));
+    }
+    s
+}
+
+pub const ELEMENT_WISE_OPS: &[&str] = &[
+    "abs",
+    "exp",
+    "ln",
+    "sigmoid",
+    "square",
+    "sqrt",
+    "rsqrt",
+    "recip",
+    "ceil",
+    "floor",
+    "round",
+    "roundhalftoeven",
+    "cos",
+    "acos",
+    "acosh",
+    "cosh",
+    "sin",
+    "asin",
+    "asinh",
+    "sinh",
+    "tan",
+    "atan",
+    "atanh",
+    "tanh",
+    "erf",
+    "neg",
+    "sign",
+    "hardswish",
+    "silu",
+];
+
+fn binary_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let lib = binary_ops_wgsl(t);
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_lhs: u32,
+    off_rhs: u32,
+    off_out: u32,
+    rank: u32,
+    len: u32,
+    _p0: u32,
+    _p1: u32,
+    _p2: u32,
+    lhs_s0: vec4<u32>,
+    lhs_s1: vec4<u32>,
+    rhs_s0: vec4<u32>,
+    rhs_s1: vec4<u32>,
+    out_sh0: vec4<u32>,
+    out_sh1: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> lhs: array<{t}>;
+@group(0) @binding(1) var<storage, read> rhs: array<{t}>;
+@group(0) @binding(2) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+{AT8}
+
+fn gather_idx(linear: u32, is_lhs: bool) -> u32 {{
+    var rest = linear;
+    var idx = 0u;
+    let r = params.rank;
+    for (var k = 0u; k < r; k++) {{
+        let axis = r - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        let stride = select(
+            at8(params.rhs_s0, params.rhs_s1, axis),
+            at8(params.lhs_s0, params.lhs_s1, axis),
+            is_lhs,
+        );
+        idx += c * stride;
+    }}
+    return idx;
+}}
+
+{lib}"#
+    ));
+    for name in BINARY_OPS {
+        s.push_str(&format!(
+            r#"
+@compute @workgroup_size({WORKGROUP})
+fn {name}_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    let li = params.off_lhs + gather_idx(i, true);
+    let ri = params.off_rhs + gather_idx(i, false);
+    outp[params.off_out + i] = op_{name}(lhs[li], rhs[ri]);
+}}
+"#
+        ));
+    }
+    s.push_str(&binary_vec4_entries(t, suf));
+    s
+}
+
+/// The four-wide binary entries. `_v4` is both operands element for element
+/// with the output; `_v4s` is a right operand that broadcasts over the last
+/// axis, so one value covers the four a thread handles. Anything else gathers
+/// per element and gains nothing from a wider thread.
+fn binary_vec4_entries(t: &str, suf: &str) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        r#"
+fn lhs4(i: u32) -> vec4<{t}> {{
+    let b = params.off_lhs + i * 4u;
+    return vec4<{t}>(lhs[b], lhs[b + 1u], lhs[b + 2u], lhs[b + 3u]);
+}}
+
+fn rhs4(i: u32) -> vec4<{t}> {{
+    let b = params.off_rhs + i * 4u;
+    return vec4<{t}>(rhs[b], rhs[b + 1u], rhs[b + 2u], rhs[b + 3u]);
+}}
+
+fn store4(i: u32, v: vec4<{t}>) {{
+    let b = params.off_out + i * 4u;
+    outp[b] = v.x;
+    outp[b + 1u] = v.y;
+    outp[b + 2u] = v.z;
+    outp[b + 3u] = v.w;
+}}
+"#
+    ));
+    s.push_str(&binary_ops_vec4_wgsl(t));
+    for name in BINARY_OPS {
+        s.push_str(&format!(
+            r#"
+@compute @workgroup_size({WORKGROUP})
+fn {name}_v4_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i * 4u >= params.len) {{ return; }}
+    store4(i, op_{name}_v(lhs4(i), rhs4(i)));
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn {name}_v4s_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i * 4u >= params.len) {{ return; }}
+    let r = vec4<{t}>(rhs[params.off_rhs + gather_idx(i * 4u, false)]);
+    store4(i, op_{name}_v(lhs4(i), r));
+}}
+"#
+        ));
+    }
+    s
+}
+
+pub const BINARY_OPS: &[&str] = &["mul", "add", "div", "sub", "pow", "min", "max"];
 
 fn copy_wgsl(dt: ShaderDtype) -> String {
     let t = dt.wgsl();
@@ -297,6 +610,19 @@ pub fn pad8_stride(xs: &[isize]) -> [u32; 8] {
     let mut out = [0u32; 8];
     for (i, s) in xs.iter().take(8).enumerate() {
         out[i] = (*s).max(0) as u32;
+    }
+    out
+}
+
+/// Strides in elements, zeroed on broadcast axes (`shape[i] == 1 && out[i] != 1`).
+pub fn broadcast_strides(shape: &[usize], strides: &[isize], out_shape: &[usize]) -> [u32; 8] {
+    let mut out = [0u32; 8];
+    for i in 0..out_shape.len().min(8) {
+        if i < shape.len() && shape[i] == 1 && out_shape[i] != 1 {
+            out[i] = 0;
+        } else if i < strides.len() {
+            out[i] = strides[i].max(0) as u32;
+        }
     }
     out
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -23,19 +23,25 @@
 //! `(buffer, byte_offset as uniform)`.
 
 mod context;
+pub mod coverage;
 pub mod jspi;
 pub mod kernels;
 mod tensor;
 mod tests;
+mod transform;
 mod utils;
 
 use tract_core::internal::*;
+use tract_core::transform::ModelTransform;
 
 pub use crate::context::{
     CACHE_STATS, KernelTime, WgpuContext, WgpuQueue, wgpu_context, wgpu_context_async,
     with_wgpu_queue,
 };
+pub use crate::coverage::{UncoveredOp, ensure_wgpu_coverage, uncovered_ops};
 pub use crate::jspi::{hybrid_fallback_available, jspi_in_browser};
+
+pub use crate::transform::WgpuTransform;
 
 use crate::utils::get_wgpu_buffer;
 use tract_gpu::tensor::DeviceTensor;
@@ -49,3 +55,54 @@ pub async fn to_host_async(tensor: &DeviceTensor) -> TractResult<Tensor> {
     let bytes = ctx.download_async(&buffer, offset, len).await?;
     unsafe { Tensor::from_raw_dt(tensor.datum_type(), tensor.shape(), &bytes) }
 }
+
+#[derive(Debug)]
+struct WgpuRuntime;
+
+impl Runtime for WgpuRuntime {
+    fn name(&self) -> StaticName {
+        "wgpu".into()
+    }
+
+    fn prepare_with_options(
+        &self,
+        mut model: TypedModel,
+        options: &RunOptions,
+    ) -> TractResult<Box<dyn Runnable>> {
+        WgpuTransform.transform(&mut model)?;
+        model = model.into_optimized()?;
+        if hybrid_fallback_available() {
+            let bad = uncovered_ops(&model)?;
+            if !bad.is_empty() {
+                let list = bad
+                    .iter()
+                    .map(|u| format!("{} (node {:?})", u.op, u.node))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                log::warn!(
+                    "tract-wgpu hybrid fallback: running on CPU for {list}. \
+                     Covered ops stay on GPU."
+                );
+            }
+        } else {
+            ensure_wgpu_coverage(&model)?;
+        }
+
+        let options = RunOptions { skip_order_opt_ram: true, ..options.clone() };
+        let mut runnable = TypedSimplePlan::build(model, &options)?;
+        if let Some(hints) = options.memory_sizing_hints {
+            let turn_handler =
+                tract_gpu::turn_handler::DeviceTurnHandler::from_plan(&runnable, &hints)
+                    .context("While sizing memory arena. Missing hint ?")?;
+            runnable = runnable.with_turn_handler(turn_handler);
+        }
+
+        Ok(Box::new(Arc::new(runnable)))
+    }
+
+    fn check(&self) -> TractResult<()> {
+        Ok(())
+    }
+}
+
+register_runtime!(WgpuRuntime = WgpuRuntime);

--- a/wgpu/src/tests.rs
+++ b/wgpu/src/tests.rs
@@ -1,11 +1,13 @@
 #![cfg(test)]
 
 use tract_core::internal::*;
+use tract_core::ops::math::mul;
+use tract_core::transform::ModelTransform;
 use tract_gpu::tensor::{DeviceTensor, IntoDevice};
 
 use crate::kernels::cast::wgpu_cast_dispatch;
 use crate::kernels::copy::wgpu_copy_nd_dispatch;
-use crate::with_wgpu_queue;
+use crate::{WgpuTransform, with_wgpu_queue};
 
 fn close(a: &Tensor, b: &Tensor) -> TractResult<()> {
     a.close_enough(b, Approximation::Close)
@@ -49,4 +51,72 @@ fn cast_f32_f16_roundtrip() -> TractResult<()> {
         q.flush()?;
         close(&back.to_host()?.into_tensor(), &t)
     })
+}
+
+#[test]
+fn coverage_accepts_fully_translated_model() -> TractResult<()> {
+    crate::context::wgpu_context();
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let two = model.add_const("two", tensor2(&[[2.0f32]]))?;
+    let y = model.wire_node("mul", mul(), &[x, two])?[0];
+    model.select_output_outlets(&[y])?;
+    WgpuTransform.transform(&mut model)?;
+    model = model.into_optimized()?;
+    crate::ensure_wgpu_coverage(&model)?;
+    Ok(())
+}
+
+#[test]
+fn hybrid_logsoftmax_matches_cpu() -> TractResult<()> {
+    crate::context::wgpu_context();
+    ensure!(
+        crate::hybrid_fallback_available(),
+        "native hybrid fallback should always be available"
+    );
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let y = model.wire_node(
+        "attn_sm",
+        tract_core::ops::nn::Softmax::new(
+            tvec![1],
+            None,
+            tract_core::ops::nn::SoftmaxKind::LogSoftmax,
+        ),
+        &[x],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    let cpu_model = model.clone();
+    let rt =
+        tract_core::runtime::runtime_for_name("wgpu")?.context("wgpu runtime not registered")?;
+    let gpu = rt.prepare(model)?;
+    let cpu_plan = SimplePlan::new(cpu_model)?;
+    let input = Tensor::from_shape(&[2, 4], &[0.1f32, 0.2, 0.3, 0.4, -1.0, 0.0, 1.0, 2.0])?;
+    let gpu_out = gpu.run(tvec!(input.clone().into()))?.remove(0).into_tensor();
+    let cpu_out = Arc::new(cpu_plan).run(tvec!(input.into()))?.remove(0).into_tensor();
+    close(&gpu_out, &cpu_out)
+}
+
+#[test]
+fn coverage_rejects_logsoftmax_by_name() -> TractResult<()> {
+    crate::context::wgpu_context();
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let y = model.wire_node(
+        "attn_sm",
+        tract_core::ops::nn::Softmax::new(
+            tvec![1],
+            None,
+            tract_core::ops::nn::SoftmaxKind::LogSoftmax,
+        ),
+        &[x],
+    )?[0];
+    model.select_output_outlets(&[y])?;
+    WgpuTransform.transform(&mut model)?;
+    model = model.into_optimized()?;
+    let err = crate::ensure_wgpu_coverage(&model).expect_err("logsoftmax must be uncovered");
+    let msg = format!("{err:?}");
+    ensure!(msg.contains("LogSoftmax"), "error should name LogSoftmax, got {msg}");
+    ensure!(msg.contains("attn_sm"), "error should name the node, got {msg}");
+    Ok(())
 }

--- a/wgpu/src/transform.rs
+++ b/wgpu/src/transform.rs
@@ -1,0 +1,174 @@
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use tract_core::dyn_clone::clone_box;
+use tract_core::internal::translator::Translate;
+use tract_core::internal::*;
+use tract_core::ops::konst::Const;
+use tract_core::transform::ModelTransform;
+use tract_gpu::fact::{DeviceFact, DeviceTypedFactExt};
+use tract_gpu::rewrite_rules::rewire_syncs::rewire_syncs;
+#[cfg(not(target_arch = "wasm32"))]
+use tract_gpu::sync::sync_model_outputs_if_required;
+use tract_gpu::sync::{DeviceSyncKind, sync_inputs_if_required};
+use tract_gpu::tensor::IntoDevice;
+
+use crate::context::wgpu_context;
+
+/// A registered translator that can convert a core op into a wgpu GPU op.
+pub struct WgpuOpTranslator {
+    pub type_id: TypeId,
+    #[allow(clippy::type_complexity)]
+    pub try_make: fn(&TypedModel, &TypedNode) -> TractResult<Option<Box<dyn TypedOp>>>,
+}
+
+inventory::collect!(WgpuOpTranslator);
+
+/// Register a translator for a core op type. The closure receives `(source, node, op)`
+/// where `op` is already downcast to `$op_type`. Return `Ok(Some(gpu_op))` to translate,
+/// `Ok(None)` to skip.
+#[macro_export]
+macro_rules! register_wgpu_op {
+    ($op_type:ty, |$source:ident, $node:ident, $op:ident| $body:expr) => {
+        inventory::submit! {
+            $crate::transform::WgpuOpTranslator {
+                type_id: std::any::TypeId::of::<$op_type>(),
+                try_make: |$source, $node| {
+                    let Some($op) = $node.op_as::<$op_type>() else {
+                        return Ok(None);
+                    };
+                    $body
+                },
+            }
+        }
+    };
+}
+
+#[derive(Debug, Default)]
+pub struct WgpuTransform;
+
+impl ModelTransform for WgpuTransform {
+    fn name(&self) -> StaticName {
+        "wgpu-transform".into()
+    }
+
+    fn transform(&self, model: &mut TypedModel) -> TractResult<()> {
+        wgpu_context();
+        *model = self.translate_model(model)?;
+        rewire_syncs(model)?;
+        Ok(())
+    }
+}
+
+fn try_make_wgpu_op(
+    source: &TypedModel,
+    node: &TypedNode,
+) -> TractResult<Option<Box<dyn TypedOp>>> {
+    type TranslateFn = fn(&TypedModel, &TypedNode) -> TractResult<Option<Box<dyn TypedOp>>>;
+    static MAP: OnceLock<HashMap<TypeId, Vec<TranslateFn>>> = OnceLock::new();
+    let map = MAP.get_or_init(|| {
+        let mut m: HashMap<TypeId, Vec<TranslateFn>> = HashMap::new();
+        for t in inventory::iter::<WgpuOpTranslator> {
+            m.entry(t.type_id).or_default().push(t.try_make);
+        }
+        m
+    });
+
+    let input_facts = source.node_input_facts(node.id)?;
+    rule_if!(input_facts.iter().all(|f| crate::utils::is_supported_fact(f)));
+
+    if let Some(op) = tract_gpu::ops::copy_based::try_make_copy_based_op(source, node)? {
+        return Ok(Some(op));
+    }
+
+    if let Some(fns) = map.get(&(*node.op).type_id()) {
+        for f in fns {
+            if let Some(op) = f(source, node)? {
+                return Ok(Some(op));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn convert_const(op: &Const) -> TractResult<Const> {
+    let typed_fact: TypedFact = Arc::clone(op.val()).try_into()?;
+    let wgpu_fact = if let Some(of) = op.exotic_fact() {
+        DeviceFact::from_host(typed_fact.with_exotic_fact(clone_box(of)))?
+    } else {
+        DeviceFact::from_host(typed_fact)?
+    };
+    let wgpu_const = op.val().clone().into_device()?.into_tensor().into_arc_tensor();
+    Const::new_with_exotic_fact(wgpu_const, Box::new(wgpu_fact))
+}
+
+impl Translate<TypedFact, Box<dyn TypedOp>, TypedFact, Box<dyn TypedOp>> for WgpuTransform {
+    fn translate_node(
+        &self,
+        source: &TypedModel,
+        node: &TypedNode,
+        target: &mut TypedModel,
+        mapping: &HashMap<OutletId, OutletId>,
+    ) -> TractResult<TVec<OutletId>> {
+        if let Some(op) = node.op_as::<Const>()
+            && crate::utils::is_supported_dt(op.val().datum_type())
+            && op.exotic_fact().is_none()
+        {
+            let device_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToDevice)?;
+            let outlet_ids =
+                target.wire_node(node.name.clone(), convert_const(op)?, &device_inputs)?;
+            return maybe_sync_outputs(source, node, target, outlet_ids);
+        }
+
+        let target_inputs: TVec<TypedFact> = node
+            .inputs
+            .iter()
+            .map(|i| target.outlet_fact(mapping[i]).cloned())
+            .collect::<TractResult<_>>()?;
+        let target_inputs_post_sync: TVec<TypedFact> = target_inputs
+            .iter()
+            .map(|f| -> TractResult<TypedFact> {
+                if f.as_device_fact().is_some() {
+                    Ok(f.clone())
+                } else {
+                    Ok(tract_gpu::fact::DeviceFact::from_host(f.clone())?.into_exotic_fact())
+                }
+            })
+            .collect::<TractResult<_>>()?;
+        let target_input_post_sync_refs: TVec<&TypedFact> =
+            target_inputs_post_sync.iter().collect();
+        if let Some(gpu_op) = try_make_wgpu_op(source, node)?
+            && gpu_op.output_facts(&target_input_post_sync_refs).is_ok()
+        {
+            let device_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToDevice)?;
+            let outlet_ids = target.wire_node(node.name.clone(), gpu_op, &device_inputs)?;
+            maybe_sync_outputs(source, node, target, outlet_ids)
+        } else {
+            let cpu_inputs =
+                sync_inputs_if_required(target, node, mapping, DeviceSyncKind::ToHost)?;
+            target.wire_node(&node.name, node.op.clone(), &cpu_inputs)
+        }
+    }
+}
+
+/// On wasm, `PollType::Wait` cannot complete a readback. Leave outputs on the
+/// GPU; the caller awaits [`crate::to_host_async`] once after `run()`.
+fn maybe_sync_outputs(
+    src: &TypedModel,
+    node: &TypedNode,
+    target: &mut TypedModel,
+    outlet_ids: TVec<OutletId>,
+) -> TractResult<TVec<OutletId>> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = (src, node, target);
+        Ok(outlet_ids)
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        sync_model_outputs_if_required(src, node, target, outlet_ids)
+    }
+}

--- a/wgpu/src/utils.rs
+++ b/wgpu/src/utils.rs
@@ -1,6 +1,25 @@
+use tract_core::internal::{DatumType, TypedFact};
 use tract_gpu::tensor::DeviceTensor;
 
 use crate::context::WgpuBuffer;
+
+/// The datum types this backend has kernels for.
+///
+/// `DeviceTensor::is_supported_dt` is wider — it covers everything a device
+/// tensor can hold, which suits the backends whose kernels are generated per
+/// type. Every WGSL kernel here is f32 or f16, so a node carrying anything else
+/// has to stay on the CPU: taking it and failing at dispatch is worse than not
+/// taking it.
+pub fn is_supported_dt(dt: DatumType) -> bool {
+    matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+/// Whether a node input can reach a kernel. No kernel here decodes a
+/// block-quantized tensor, so an exotic fact keeps the node on the CPU however
+/// its datum type reads.
+pub fn is_supported_fact(f: &TypedFact) -> bool {
+    is_supported_dt(f.datum_type) && f.exotic_fact().is_none()
+}
 
 pub fn get_wgpu_buffer(tensor: &DeviceTensor) -> &WgpuBuffer {
     tensor


### PR DESCRIPTION
2/7 of #2801. Adds the element-wise and binary kernels, the `WgpuTransform` that translates a model onto them, and the coverage check. **Stacked on #2811 — its commit is included here, so read this one's top commit only.**

With this a model of element-wise ops runs end to end on the GPU.

The policy question worth your opinion is what to do with an op the backend has no kernel for. On Metal a fallback is a cheap trip through unified memory; on WebGPU it is a readback and an upload, which is far more expensive than the op it rescues. So the default refuses to load a model it would silently split, and names the ops that made it refuse; a `jspi` Cargo feature turns that into a per-op CPU fallback for the browsers that can suspend across a buffer mapping. Happy to change the default if you would rather it always limp than refuse.

Where the operands run with the output a thread handles four values at once — the kernel is bandwidth-bound, so a wider load is the whole win.

Ten tests, including a two-op model against the CPU plan and both coverage outcomes.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)
