### PR TITLE
wgpu 6/7: fusion — chains, epilogues and axis ops

### DIFF
--- a/wgpu/src/kernels/chain.rs
+++ b/wgpu/src/kernels/chain.rs
@@ -1,0 +1,87 @@
+//! Dispatch for a fused elementwise chain.
+
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    ChainOperand, ChainStep, EntryPoint, LayoutKind, ShaderDtype, broadcast_strides, chain_key,
+    chain_wgsl, pack_u32s, pad8_u32,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+/// Extra operands a chain can read besides its head, bounded by what the
+/// 256-byte uniform slot holds.
+pub const MAX_EXTRA_INPUTS: usize = 3;
+
+pub fn wgpu_chain_dispatch(
+    steps: &[ChainStep],
+    inputs: &[&DeviceTensor],
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        ensure!(inputs.len() <= MAX_EXTRA_INPUTS + 1, "chain has too many inputs");
+        for t in inputs {
+            q.retain_tensor(t);
+        }
+        q.retain_tensor(output);
+        let dt = ShaderDtype::from_datum(output.datum_type())?;
+        let layout = LayoutKind::Chain(inputs.len() as u8 + 1);
+        let out_shape = output.shape();
+        let natural = Tensor::natural_strides(out_shape);
+        let contiguous: Vec<bool> =
+            inputs.iter().map(|t| t.shape() == out_shape && t.strides() == &natural[..]).collect();
+        // Four values a thread: the kernel is bandwidth-bound, so a wider load
+        // is the whole win. The four sit next to each other along the last
+        // axis, so an operand that broadcasts over that axis is one value for
+        // all of them and can be splatted; anything else still has to gather,
+        // and then a wider thread buys nothing.
+        let last = *out_shape.last().unwrap_or(&1);
+        let kinds: Option<Vec<ChainOperand>> = (output.len().is_multiple_of(4)
+            && last.is_multiple_of(4))
+        .then(|| {
+            inputs
+                .iter()
+                .zip(contiguous.iter())
+                .map(|(t, c)| {
+                    if *c {
+                        Some(ChainOperand::Contiguous)
+                    } else if t.rank() == out_shape.len()
+                        && t.shape().last() == Some(&1)
+                        && out_shape.last() != Some(&1)
+                    {
+                        Some(ChainOperand::Splat)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Option<Vec<_>>>()
+        })
+        .flatten();
+        let key = chain_key(dt, steps, &contiguous, kinds.as_deref());
+        let pipeline =
+            q.context().chain_pipeline(&key, layout, EntryPoint::plain("chain"), || {
+                chain_wgsl(dt, steps, &contiguous, kinds.as_deref())
+            })?;
+
+        let mut buffers: Vec<&crate::context::WgpuBuffer> =
+            inputs.iter().map(|t| get_wgpu_buffer(t)).collect();
+        buffers.push(get_wgpu_buffer(output));
+        let bg = q.context().bind_group(layout, &buffers, q.uniform())?;
+
+        let mut offsets = [0u32; 4];
+        for (i, t) in inputs.iter().enumerate() {
+            offsets[i] = element_offset(t, 0) as u32;
+        }
+        let mut vals =
+            vec![element_offset(output, 0) as u32, output.len() as u32, out_shape.len() as u32, 0];
+        vals.extend_from_slice(&offsets);
+        vals.extend_from_slice(&pad8_u32(out_shape));
+        for t in inputs {
+            vals.extend_from_slice(&broadcast_strides(t.shape(), t.strides(), out_shape));
+        }
+        let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+        let threads = if kinds.is_some() { output.len() / 4 } else { output.len() };
+        q.dispatch("chain", &pipeline, &bg, dyn_off, threads as u64)
+    })
+}

--- a/wgpu/src/kernels/mod.rs
+++ b/wgpu/src/kernels/mod.rs
@@ -1,5 +1,6 @@
 pub mod bin_ops;
 pub mod cast;
+pub mod chain;
 pub mod conv;
 pub mod copy;
 pub mod deconv;

--- a/wgpu/src/kernels/shaders.rs
+++ b/wgpu/src/kernels/shaders.rs
@@ -263,6 +263,232 @@ pub enum ChainStep {
     Binary { op: String, rhs: usize, swapped: bool },
 }
 
+/// Names the generated program, and so keys its pipeline. `contiguous` says
+/// which inputs share the output's layout and can skip index arithmetic.
+/// How a chain operand is read: element for element with the output, one value
+/// splatted across the four a thread handles, or gathered through its strides.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainOperand {
+    Contiguous,
+    Splat,
+    Gather,
+}
+
+pub fn chain_key(
+    dt: ShaderDtype,
+    steps: &[ChainStep],
+    contiguous: &[bool],
+    kinds: Option<&[ChainOperand]>,
+) -> String {
+    let mut key = format!("chain_{}", dt.suffix());
+    match kinds {
+        Some(kinds) => {
+            key.push_str("_v4");
+            for k in kinds {
+                key.push(match k {
+                    ChainOperand::Contiguous => 'c',
+                    ChainOperand::Splat => 's',
+                    ChainOperand::Gather => 'g',
+                });
+            }
+        }
+        None => {
+            for c in contiguous {
+                key.push(if *c { 'c' } else { 'b' });
+            }
+        }
+    }
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => key.push_str(&format!("_{op}")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                key.push_str(&format!("_{op}{rhs}{}", if *swapped { "r" } else { "" }))
+            }
+        }
+    }
+    key
+}
+
+/// The chain over `vec4`s: a thread takes four values at a time, which is
+/// where the win is on a bandwidth-bound kernel. The four are adjacent along
+/// the last axis, so an operand broadcasting over that axis is read once and
+/// splatted.
+fn chain_vec4_wgsl(dt: ShaderDtype, steps: &[ChainStep], kinds: &[ChainOperand]) -> String {
+    let t = dt.wgsl();
+    let inputs = kinds.len();
+    let mut s = preamble(dt);
+    s.push_str("struct Params {\n    off_out: u32,\n    len: u32,\n    rank: u32,\n    _p: u32,\n    off_in: vec4<u32>,\n    out_sh0: vec4<u32>,\n    out_sh1: vec4<u32>,\n");
+    for i in 0..inputs {
+        s.push_str(&format!("    s{i}_0: vec4<u32>,\n    s{i}_1: vec4<u32>,\n"));
+    }
+    s.push_str("}\n\n");
+    for (i, kind) in kinds.iter().enumerate() {
+        let ty = match kind {
+            ChainOperand::Contiguous => format!("array<vec4<{t}>>"),
+            _ => format!("array<{t}>"),
+        };
+        s.push_str(&format!("@group(0) @binding({i}) var<storage, read> in{i}: {ty};\n"));
+    }
+    s.push_str(&format!(
+        "@group(0) @binding({inputs}) var<storage, read_write> outp: array<vec4<{t}>>;\n"
+    ));
+    s.push_str(&format!("@group(0) @binding({}) var<uniform> params: Params;\n\n", inputs + 1));
+    s.push_str(AT8);
+    s.push_str("\n\n");
+    s.push_str(&unary_ops_wgsl(t));
+    s.push_str(&binary_ops_wgsl(t));
+    s.push_str(&unary_ops_vec4_wgsl(t));
+    s.push_str(&binary_ops_vec4_wgsl(t));
+    for (i, kind) in kinds.iter().enumerate() {
+        if *kind == ChainOperand::Contiguous {
+            continue;
+        }
+        s.push_str(&format!(
+            r#"
+fn gather{i}(linear: u32) -> u32 {{
+    var rest = linear;
+    var idx = 0u;
+    for (var k = 0u; k < params.rank; k++) {{
+        let axis = params.rank - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        idx += c * at8(params.s{i}_0, params.s{i}_1, axis);
+    }}
+    return idx;
+}}
+"#
+        ));
+    }
+    s.push_str(&format!(
+        r#"
+@compute @workgroup_size({WORKGROUP})
+fn chain(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let base = i * 4u;
+    if (base >= params.len) {{ return; }}
+    var v = in0[params.off_in[0u] / 4u + i];
+"#
+    ));
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => s.push_str(&format!("    v = op_{op}_v(v);\n")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                match kinds[*rhs] {
+                    ChainOperand::Contiguous => s.push_str(&format!(
+                        "    let b{rhs} = in{rhs}[params.off_in[{rhs}u] / 4u + i];\n"
+                    )),
+                    _ => s.push_str(&format!(
+                        "    let b{rhs} = vec4<{t}>(in{rhs}[params.off_in[{rhs}u] + gather{rhs}(base)]);\n"
+                    )),
+                }
+                if *swapped {
+                    s.push_str(&format!("    v = op_{op}_v(b{rhs}, v);\n"));
+                } else {
+                    s.push_str(&format!("    v = op_{op}_v(v, b{rhs});\n"));
+                }
+            }
+        }
+    }
+    s.push_str("    outp[params.off_out / 4u + i] = v;\n}\n");
+    s
+}
+
+/// A whole elementwise chain as one kernel: the running value stays in
+/// registers, so only the chain's own inputs and its final output touch memory.
+/// Extra operands broadcast against the output shape; the head and the output
+/// share it.
+pub fn chain_wgsl(
+    dt: ShaderDtype,
+    steps: &[ChainStep],
+    contiguous: &[bool],
+    kinds: Option<&[ChainOperand]>,
+) -> String {
+    if let Some(kinds) = kinds {
+        return chain_vec4_wgsl(dt, steps, kinds);
+    }
+    let t = dt.wgsl();
+    let inputs = contiguous.len();
+    let mut s = preamble(dt);
+    s.push_str("struct Params {\n    off_out: u32,\n    len: u32,\n    rank: u32,\n    _p: u32,\n    off_in: vec4<u32>,\n    out_sh0: vec4<u32>,\n    out_sh1: vec4<u32>,\n");
+    for i in 0..inputs {
+        s.push_str(&format!("    s{i}_0: vec4<u32>,\n    s{i}_1: vec4<u32>,\n"));
+    }
+    s.push_str("}\n\n");
+    for i in 0..inputs {
+        s.push_str(&format!("@group(0) @binding({i}) var<storage, read> in{i}: array<{t}>;\n"));
+    }
+    s.push_str(&format!(
+        "@group(0) @binding({inputs}) var<storage, read_write> outp: array<{t}>;\n"
+    ));
+    s.push_str(&format!("@group(0) @binding({}) var<uniform> params: Params;\n\n", inputs + 1));
+    s.push_str(AT8);
+    s.push_str("\n\n");
+    s.push_str(&unary_ops_wgsl(t));
+    s.push_str(&binary_ops_wgsl(t));
+    for (i, contig) in contiguous.iter().enumerate() {
+        if *contig {
+            s.push_str(&format!("\nfn gather{i}(linear: u32) -> u32 {{ return linear; }}\n"));
+            continue;
+        }
+        s.push_str(&format!(
+            r#"
+fn gather{i}(linear: u32) -> u32 {{
+    var rest = linear;
+    var idx = 0u;
+    for (var k = 0u; k < params.rank; k++) {{
+        let axis = params.rank - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        idx += c * at8(params.s{i}_0, params.s{i}_1, axis);
+    }}
+    return idx;
+}}
+"#
+        ));
+    }
+    s.push_str(&format!(
+        r#"
+@compute @workgroup_size({WORKGROUP})
+fn chain(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    var v = in0[params.off_in[0] + gather0(i)];
+"#
+    ));
+    for step in steps {
+        match step {
+            ChainStep::Unary(op) => s.push_str(&format!("    v = op_{op}(v);\n")),
+            ChainStep::Binary { op, rhs, swapped } => {
+                s.push_str(&format!(
+                    "    let b{rhs} = in{rhs}[params.off_in[{rhs}] + gather{rhs}(i)];\n"
+                ));
+                if *swapped {
+                    s.push_str(&format!("    v = op_{op}(b{rhs}, v);\n"));
+                } else {
+                    s.push_str(&format!("    v = op_{op}(v, b{rhs});\n"));
+                }
+            }
+        }
+    }
+    s.push_str("    outp[params.off_out + i] = v;\n}\n");
+    s
+}
+
+/// A four-wide wrapper for each op, so a kernel that moves whole `vec4`s can
+/// still call them. The bodies stay scalar: the win here is the wider load and
+/// store, not the arithmetic.
+fn unary_ops_vec4_wgsl(t: &str) -> String {
+    let mut s = String::new();
+    for name in ELEMENT_WISE_OPS {
+        s.push_str(&format!(
+            "fn op_{name}_v(x: vec4<{t}>) -> vec4<{t}> {{ return vec4<{t}>(op_{name}(x.x), op_{name}(x.y), op_{name}(x.z), op_{name}(x.w)); }}\n"
+        ));
+    }
+    s
+}
+
 fn binary_ops_vec4_wgsl(t: &str) -> String {
     let mut s = String::new();
     for name in BINARY_OPS {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -27,6 +27,7 @@ pub mod coverage;
 pub mod jspi;
 pub mod kernels;
 pub mod ops;
+mod rewrite_rules;
 mod tensor;
 mod tests;
 mod transform;

--- a/wgpu/src/ops/chain.rs
+++ b/wgpu/src/ops/chain.rs
@@ -1,0 +1,61 @@
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensorExt;
+
+use crate::kernels::chain::wgpu_chain_dispatch;
+use crate::kernels::shaders::ChainStep;
+
+/// A run of elementwise ops evaluated as one kernel. Input 0 is the head of the
+/// chain and carries the output shape; the rest are the second operands of the
+/// binary links, and broadcast against it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WgpuElementWiseChain {
+    pub steps: Vec<ChainStep>,
+}
+
+impl Op for WgpuElementWiseChain {
+    fn name(&self) -> StaticName {
+        "WgpuElementWiseChain".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(self
+            .steps
+            .iter()
+            .map(|s| match s {
+                ChainStep::Unary(op) => op.clone(),
+                ChainStep::Binary { op, rhs, swapped } => {
+                    format!("{op}(#{rhs}){}", if *swapped { " swapped" } else { "" })
+                }
+            })
+            .collect())
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuElementWiseChain {
+    op_out_of_plan!();
+
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let inputs =
+            inputs.iter().map(|it| it.to_device_tensor()).collect::<TractResult<TVec<_>>>()?;
+        let head = inputs[0];
+        let output =
+            tract_gpu::turn_handler::make_tensor_for_node(ctx, head.datum_type(), head.shape())?;
+        if output.len() > 0 {
+            wgpu_chain_dispatch(&self.steps, &inputs, &output)?;
+        }
+        Ok(tvec!(output.into_tensor().into_tvalue()))
+    }
+}
+
+impl TypedOp for WgpuElementWiseChain {
+    as_op!();
+
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        tract_gpu::utils::facts_to_device_facts(inputs, |facts| {
+            Ok(tvec!(facts[0].datum_type.fact(facts[0].shape.clone())))
+        })
+        .with_context(|| "Error while computing facts for WgpuElementWiseChain")
+    }
+}

--- a/wgpu/src/ops/fused_axis_op.rs
+++ b/wgpu/src/ops/fused_axis_op.rs
@@ -1,0 +1,189 @@
+//! Applies a chain of shape-only axis ops to an op's inputs as views, so a
+//! `Reshape` / `Add` / `Rm` (and a `Move` its consumer can restride) costs no
+//! kernel and no copy. Mirrors `MetalFusedAxisOp`.
+
+use derive_new::new;
+use tract_core::internal::tract_smallvec::ToSmallVec;
+use tract_core::internal::*;
+use tract_gpu::ops::change_axes::GpuAxisOp;
+use tract_gpu::tensor::{DeviceTensor, DeviceTensorExt};
+
+#[derive(Clone, Debug, new, PartialEq, Eq)]
+pub struct WgpuFusedAxisOp {
+    /// List of axis ops to apply for each op inputs
+    /// Length of the list is equal to number of inputs
+    pub grouped_axis_ops: TVec<TVec<GpuAxisOp>>,
+    pub op: Box<dyn TypedOp>,
+}
+
+#[derive(Debug, Clone, new)]
+pub struct WgpuFusedAxisOpState {
+    pub op_state: Box<dyn OpState>,
+}
+
+fn compute_reshaped_inputs(
+    inputs: TVec<TValue>,
+    grouped_axis_ops: &TVec<TVec<GpuAxisOp>>,
+    ctx: &EvalContext,
+) -> TractResult<TVec<TValue>> {
+    // Apply Axis Ops per input
+
+    inputs
+        .into_iter()
+        .zip(grouped_axis_ops.iter())
+        .map(|(input, axis_ops)| {
+            if axis_ops.is_empty() {
+                return Ok(input);
+            };
+            let m_input = input.to_device_tensor()?;
+            let reshaped_input = axis_ops.iter().try_fold(
+                m_input.clone(),
+                |t, axis_op| -> TractResult<DeviceTensor> {
+                    let new_shape = match &axis_op.inner {
+                        AxisOp::Reshape(skip, from, to) => {
+                            let from = from.iter().map(|d| d.eval(ctx.symbols)).collect();
+                            let to = to.iter().map(|d| d.eval(ctx.symbols)).collect();
+                            let mut shape: TVec<usize> = t.shape().into();
+                            AxisOp::Reshape(*skip, from, to)
+                                .change_shape_array(&mut shape, false)?;
+                            shape
+                        }
+                        AxisOp::Add(_) | AxisOp::Rm(_) | AxisOp::Move(..) => {
+                            let mut shape: TVec<usize> = t.shape().into();
+                            axis_op.inner.change_shape_array(&mut shape, false)?;
+                            shape
+                        }
+                    };
+                    if let AxisOp::Move(from, to) = axis_op.inner {
+                        let mut out_strides: TVec<isize> = t.strides().to_smallvec();
+                        let removed_stride = out_strides.remove(from);
+                        out_strides.insert(to, removed_stride);
+                        let tmp_t = t.reshaped(new_shape)?;
+                        tmp_t.restrided(out_strides)
+                    } else {
+                        t.reshaped(new_shape)
+                    }
+                },
+            )?;
+
+            Ok(reshaped_input.into_tensor().into())
+        })
+        .collect::<TractResult<TVec<_>>>()
+}
+
+impl OpState for WgpuFusedAxisOpState {
+    fn init_tensor_fact(&self) -> Option<(String, TypedFact)> {
+        self.op_state.init_tensor_fact()
+    }
+
+    fn has_init_tensor_fact(&self) -> bool {
+        self.op_state.has_init_tensor_fact()
+    }
+
+    fn load_from(
+        &mut self,
+        turn: &mut TurnState,
+        states: &mut dyn Iterator<Item = tract_core::value::TValue>,
+    ) -> TractResult<()> {
+        self.op_state.load_from(turn, states)
+    }
+
+    fn save_to(&self, states: &mut Vec<TValue>) -> TractResult<()> {
+        self.op_state.save_to(states)
+    }
+
+    fn resolve_symbols(&mut self, turn: &mut TurnState) -> TractResult<()> {
+        self.op_state.resolve_symbols(turn)
+    }
+
+    fn eval(
+        &mut self,
+        ctx: &EvalContext,
+        op: &dyn Op,
+        inputs: TVec<TValue>,
+    ) -> TractResult<TVec<TValue>> {
+        let fused_axis_op = op.downcast_ref::<WgpuFusedAxisOp>().unwrap();
+        let inputs = compute_reshaped_inputs(inputs, &fused_axis_op.grouped_axis_ops, ctx)?;
+        // Runner inner op
+        self.op_state.eval(ctx, fused_axis_op.op.as_op(), inputs)
+    }
+
+    fn reset_lanes(&mut self, lanes: &[LaneId]) -> TractResult<()> {
+        self.op_state.reset_lanes(lanes)
+    }
+}
+
+impl Op for WgpuFusedAxisOp {
+    fn name(&self) -> StaticName {
+        self.op.name()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        let mut info = self.op.info()?;
+        for (idx, axis_ops) in self.grouped_axis_ops.iter().enumerate() {
+            if !axis_ops.is_empty() {
+                info.push(format!(
+                    "Fused axis Op on Input #{idx}: {}",
+                    axis_ops
+                        .iter()
+                        .map(|axis_op| Ok(format!(
+                            "{} - {}",
+                            axis_op.name(),
+                            axis_op.info()?.join(" | ")
+                        )))
+                        .collect::<TractResult<TVec<_>>>()?
+                        .join(" | ")
+                ));
+            }
+        }
+        Ok(info)
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for WgpuFusedAxisOp {
+    fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
+        let ctx = EvalContext::out_of_plan();
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, &ctx)?;
+        self.op.eval_out_of_plan(inputs)
+    }
+
+    fn state(&self, ctx: &EvalContext) -> TractResult<Option<Box<dyn OpState>>> {
+        if let Some(state) = self.op.state(ctx)? {
+            Ok(Some(Box::new(WgpuFusedAxisOpState { op_state: state })))
+        } else {
+            Ok(None)
+        }
+    }
+    fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, ctx)?;
+        // Runner inner op
+        self.op.eval(ctx, inputs)
+    }
+}
+
+impl TypedOp for WgpuFusedAxisOp {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        ensure!(
+            inputs.len() == self.grouped_axis_ops.len(),
+            "Number of inputs and fused axis ops are not aligned"
+        );
+        // Apply AxisOp
+        let inputs = inputs
+            .iter()
+            .zip(self.grouped_axis_ops.iter())
+            .map(|(i, axis_ops)| {
+                axis_ops.iter().try_fold((*i).clone(), |reshaped_i, axis_op| {
+                    Ok(axis_op.output_facts(&[&reshaped_i])?[0].clone())
+                })
+            })
+            .collect::<TractResult<TVec<_>>>()?;
+
+        let inputs_ref = inputs.iter().collect::<TVec<_>>();
+        // Apply Op
+        self.op.output_facts(&inputs_ref)
+    }
+
+    as_op!();
+}

--- a/wgpu/src/ops/mod.rs
+++ b/wgpu/src/ops/mod.rs
@@ -1,4 +1,6 @@
+pub mod chain;
 pub mod conv;
 pub mod deconv;
+pub mod fused_axis_op;
 pub mod matmul;
 pub mod pool;

--- a/wgpu/src/rewrite_rules/fuse_axis_op.rs
+++ b/wgpu/src/rewrite_rules/fuse_axis_op.rs
@@ -1,0 +1,248 @@
+use crate::ops::fused_axis_op::WgpuFusedAxisOp;
+use tract_core::internal::*;
+use tract_core::tract_data::itertools::Itertools;
+use tract_gpu::fact::DeviceTypedFactExt;
+use tract_gpu::ops::change_axes::GpuAxisOp;
+use tract_gpu::rule_ensure;
+use tract_gpu::sync::DeviceSync;
+
+fn is_supported_axis_op(op: &GpuAxisOp) -> bool {
+    matches!(op.inner, AxisOp::Add(_) | AxisOp::Rm(_) | AxisOp::Reshape(..))
+}
+
+/// Ops that read every input through explicit strides, so a `Move` in front of
+/// one is a permutation of those strides rather than a copy.
+fn can_fuse_move(model: &TypedModel, axis_node: &TypedNode) -> bool {
+    model.single_succ(axis_node.id).unwrap().is_some_and(|node| {
+        node.op_is::<crate::ops::matmul::WgpuGemm>()
+            || node.op_is::<crate::ops::chain::WgpuElementWiseChain>()
+            || node.op_is::<tract_gpu::ops::concat::GpuConcat>()
+            || node.op_is::<tract_gpu::ops::apply_rope::GpuApplyRope>()
+            || node.op_is::<tract_gpu::ops::scaled_masked_softmax::GpuScaledMaskedSoftmax>()
+            || node.op_is::<tract_gpu::ops::slice::GpuSlice>()
+            || node.op_is::<tract_gpu::ops::broadcast::GpuMultiBroadcastTo>()
+            || node.op_is::<tract_gpu::ops::dyn_kv_cache::GpuDynKVCache>()
+    })
+}
+
+pub fn collect_chain_of_axis_ops<'a>(
+    model: &'a TypedModel,
+    mut cursor: &'a TypedNode,
+) -> TractResult<Option<(TVec<GpuAxisOp>, &'a TypedNode)>> {
+    let mut acc_axis_ops = tvec![];
+    let mut head_of_chain = cursor;
+
+    while let Some(axis_op) = cursor.op_as::<GpuAxisOp>().filter(|o| {
+        is_supported_axis_op(o)
+            || (matches!(o.inner, AxisOp::Move(..)) && can_fuse_move(model, cursor))
+    }) {
+        acc_axis_ops.push(axis_op.clone());
+        head_of_chain = cursor;
+
+        if let Some(prev) = model.single_prec(cursor.id)? {
+            cursor = prev;
+        } else {
+            break;
+        }
+    }
+
+    Ok(if acc_axis_ops.is_empty() {
+        None
+    } else {
+        Some((acc_axis_ops.into_iter().rev().collect(), head_of_chain))
+    })
+}
+
+fn split_succs(
+    model: &TypedModel,
+    axis_node: &TypedNode,
+    axis_node_name: &str,
+    axis_op: &GpuAxisOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    let succs = model.all_succ(axis_node.id)?.context("Expected node with successors")?;
+
+    let mut patch = TypedModelPatch::default();
+    let input = patch.tap_model(model, axis_node.inputs[0])?;
+
+    for (i, succ) in succs.iter().enumerate() {
+        let axis_out =
+            patch.wire_node(format!("{axis_node_name}.{i}"), axis_op.clone(), &[input])?[0];
+
+        let mut op_ins = patch.taps(model, &succ.inputs)?;
+
+        let (idx, _) = succ
+            .inputs
+            .iter()
+            .enumerate()
+            .find(|(_, inlet)| inlet.node == axis_node.id)
+            .context("Axis node not found in its successor inputs")?;
+
+        op_ins[idx] = axis_out;
+
+        let op_outs = patch.wire_node(succ.name.clone(), succ.op.clone(), &op_ins)?;
+        for out in op_outs {
+            patch.shunt_outside(model, succ.id.into(), out)?;
+        }
+    }
+
+    Ok(Some(patch))
+}
+
+pub fn fuse_axis_op(
+    _ctx: &(),
+    model: &TypedModel,
+    axis_node: &TypedNode,
+    axis_node_name: &str,
+    axis_op: &GpuAxisOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    // Only support certain axis ops (or a Move, which is handled specially below)
+    rule_ensure!(is_supported_axis_op(axis_op) || matches!(axis_op.inner, AxisOp::Move(..)));
+
+    let Some(node) = model.single_succ(axis_node.id)? else {
+        return split_succs(model, axis_node, axis_node_name, axis_op);
+    };
+
+    // A sync must stay a node of its own: `rewire_syncs` looks for it by type,
+    // and the load-time coverage check reads it as glue.
+    rule_ensure!(!node.op_is::<DeviceSync>());
+
+    // Disallow fusing when the successor is already an axis/fused op or a sync,
+    // *unless* it's a Move AxisOp (we allow that via the early-quit branch).
+    let is_axis_like = node.op_is::<GpuAxisOp>() || node.op_is::<WgpuFusedAxisOp>();
+    let is_allowed_move =
+        node.op_as::<GpuAxisOp>().is_some_and(|op| matches!(op.inner, AxisOp::Move(..)));
+
+    rule_ensure!(!is_axis_like || is_allowed_move);
+
+    let node_name = &node.name;
+
+    rule_if_some!(in_nodes = model.all_prec(node.id)?);
+
+    let mut grouped_axis_ops: TVec<TVec<GpuAxisOp>> = tvec![];
+    let mut tap_inputs = tvec![];
+    let mut patch = TypedModelPatch::default();
+
+    for (in_idx, in_node) in in_nodes.into_iter().enumerate() {
+        match collect_chain_of_axis_ops(model, in_node)? {
+            Some((acc_axis_ops, head_of_chain)) => {
+                grouped_axis_ops.push(acc_axis_ops);
+                tap_inputs.push(patch.tap_model(model, head_of_chain.inputs[0])?);
+            }
+            None => {
+                grouped_axis_ops.push(tvec![]);
+                tap_inputs.push(patch.tap_model(model, node.inputs[in_idx])?);
+            }
+        }
+    }
+
+    // If the successor is a Move, we may fuse it now or defer.
+    if let Some(op) = node.op_as::<GpuAxisOp>()
+        && matches!(op.inner, AxisOp::Move(..))
+    {
+        let should_defer_move = !grouped_axis_ops[0].is_empty() && !can_fuse_move(model, node);
+        if should_defer_move {
+            let out = patch.wire_node(
+                format!("{node_name}.fused_axis_op"),
+                WgpuFusedAxisOp { grouped_axis_ops, op: Box::new(op.clone()) },
+                &tap_inputs,
+            )?;
+            patch.shunt_outside(model, node.id.into(), out[0])?;
+            return Ok(Some(patch));
+        } else {
+            // Nothing to do right now; we’ll fuse on a later pass.
+            return Ok(None);
+        }
+    }
+
+    // General case: fuse using the successor's op.
+    let out = patch.wire_node(
+        format!("{node_name}.fused_axis_op"),
+        WgpuFusedAxisOp { grouped_axis_ops, op: node.op.clone() },
+        &tap_inputs,
+    )?;
+    patch.shunt_outside(model, node.id.into(), out[0])?;
+    Ok(Some(patch))
+}
+
+pub fn fuse_move_axis(
+    _ctx: &(),
+    model: &TypedModel,
+    axis_node: &TypedNode,
+    axis_node_name: &str,
+    axis_op: &GpuAxisOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_ensure!(matches!(axis_op.inner, AxisOp::Move(..)));
+
+    let in_fact = model.node_input_facts(axis_node.id)?[0];
+    let in_shape =
+        in_fact.as_device_fact().map(|mf| mf.shape.clone()).unwrap_or(in_fact.shape.clone());
+
+    let out_fact = model.node_output_facts(axis_node.id)?[0];
+    let out_shape =
+        out_fact.as_device_fact().map(|mf| mf.shape.clone()).unwrap_or(out_fact.shape.clone());
+
+    // Checks if MoveAxis has no impact on shape + layout
+    if in_shape == out_shape
+        && let (Some(in_strides), AxisOp::Move(from, to)) =
+            (in_shape.as_concrete().map(Tensor::natural_strides), axis_op.inner.clone())
+    {
+        let mut out_strides = in_strides.clone();
+        let remove_stride = out_strides.remove(from);
+        out_strides.insert(to, remove_stride);
+        if in_strides == out_strides {
+            return TypedModelPatch::shunt_one_op(model, axis_node);
+        }
+    }
+
+    // Reshape are always fusable. Change Move by Reshape if possible
+    let simpl_op = GpuAxisOp::simplify_axis_op(axis_op.inner.clone(), in_shape.dims());
+    if simpl_op != *axis_op {
+        return Ok(Some(TypedModelPatch::replace_single_op(
+            model,
+            axis_node,
+            &[axis_node.inputs[0]],
+            simpl_op,
+        )?));
+    }
+
+    // Fuse consecutive MoveAxis if possible
+    rule_if_some!(cursor = model.single_succ(axis_node.id)?);
+    if let (AxisOp::Move(from_1, to_1), AxisOp::Move(from_2, to_2)) = (
+        axis_op.inner.clone(),
+        cursor.op_as::<GpuAxisOp>().map(|ax_op| ax_op.inner.clone()).unwrap_or(AxisOp::Add(0)),
+    ) {
+        let max_rank = [from_1, from_2, to_1, to_2].iter().max().unwrap() + 1;
+        let mut perm: TVec<usize> = (0..max_rank).collect_vec().into();
+
+        AxisOp::Move(from_1, to_1).change_shape_array(&mut perm, false)?;
+        AxisOp::Move(from_2, to_2).change_shape_array(&mut perm, false)?;
+        let new_axis_ops = perm_to_ops(&perm);
+        if new_axis_ops.len() == 1 {
+            let mut patch = TypedModelPatch::default();
+            let inputs = patch.taps(model, &axis_node.inputs)?;
+            let out = patch.wire_node(
+                format!("{axis_node_name}.fused_move_axis"),
+                GpuAxisOp::new(new_axis_ops[0].clone()),
+                &inputs,
+            )?;
+            patch.shunt_outside(model, cursor.id.into(), out[0])?;
+            return Ok(Some(patch));
+        }
+    }
+
+    // Add(x) -> Move(x, y)
+    rule_if_some!(cursor = model.single_prec(axis_node.id)?);
+    if let (AxisOp::Move(from_1, to_1), AxisOp::Add(ax)) = (
+        axis_op.inner.clone(),
+        cursor.op_as::<GpuAxisOp>().map(|ax_op| ax_op.inner.clone()).unwrap_or(AxisOp::Rm(0)),
+    ) && ax == from_1
+    {
+        let mut patch = TypedModelPatch::default();
+        let inputs = patch.taps(model, &cursor.inputs)?;
+        let out =
+            patch.wire_node(cursor.name.clone(), GpuAxisOp::new(AxisOp::Add(to_1)), &inputs)?;
+        patch.shunt_outside(model, axis_node.id.into(), out[0])?;
+        return Ok(Some(patch));
+    }
+    Ok(None)
+}

--- a/wgpu/src/rewrite_rules/fuse_elementwise.rs
+++ b/wgpu/src/rewrite_rules/fuse_elementwise.rs
@@ -1,0 +1,112 @@
+use tract_core::internal::*;
+use tract_gpu::ops::binary::GpuBinOp;
+use tract_gpu::ops::element_wise::GpuElementWise;
+use tract_gpu::rule_ensure;
+
+use crate::kernels::chain::MAX_EXTRA_INPUTS;
+use crate::kernels::shaders::{BINARY_OPS, ChainStep, ELEMENT_WISE_OPS};
+use crate::ops::chain::WgpuElementWiseChain;
+
+/// The op's name as the generated WGSL spells it, if there is one.
+fn unary_name(node: &TypedNode) -> Option<String> {
+    let op = node.op_as::<GpuElementWise>()?;
+    let name = op.mini_op.name().to_lowercase();
+    ELEMENT_WISE_OPS.contains(&name.as_str()).then_some(name)
+}
+
+fn binary_name(node: &TypedNode) -> Option<String> {
+    let op = node.op_as::<GpuBinOp>()?;
+    let name = op.mini_op.name().to_lowercase();
+    BINARY_OPS.contains(&name.as_str()).then_some(name)
+}
+
+/// A single elementwise op, as the one step it becomes. `slot` is the input the
+/// running value arrives on, so the other one is the step's extra operand.
+fn one_step(node: &TypedNode, slot: usize, rhs: usize) -> Option<(ChainStep, Option<OutletId>)> {
+    if let Some(op) = unary_name(node) {
+        return Some((ChainStep::Unary(op), None));
+    }
+    let op = binary_name(node)?;
+    let other = node.inputs[1 - slot];
+    Some((ChainStep::Binary { op, rhs, swapped: slot == 1 }, Some(other)))
+}
+
+pub fn grow_elementwise_chain(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &WgpuElementWiseChain,
+) -> TractResult<Option<TypedModelPatch>> {
+    fuse_into_successor(model, node, node_name, op.steps.clone(), node.inputs.len() - 1)
+}
+
+pub fn start_elementwise_chain(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    _op: &GpuElementWise,
+) -> TractResult<Option<TypedModelPatch>> {
+    let Some(name) = unary_name(node) else { return Ok(None) };
+    fuse_into_successor(model, node, node_name, vec![ChainStep::Unary(name)], 0)
+}
+
+pub fn start_binary_chain(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    _op: &GpuBinOp,
+) -> TractResult<Option<TypedModelPatch>> {
+    // The head of a chain carries its shape, so it has to be the operand that
+    // is not broadcast.
+    let facts = model.node_input_facts(node.id)?;
+    let out_shape = model.node_output_facts(node.id)?[0].shape.clone();
+    rule_ensure!(facts[0].shape == out_shape);
+    let Some(name) = binary_name(node) else { return Ok(None) };
+    fuse_into_successor(
+        model,
+        node,
+        node_name,
+        vec![ChainStep::Binary { op: name, rhs: 1, swapped: false }],
+        1,
+    )
+}
+
+/// Merges `node` and its single consumer into one chain kernel. Growth stops at
+/// a value anyone else reads, at a step that would change the running shape,
+/// and at the uniform slot's operand budget.
+fn fuse_into_successor(
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    mut steps: Vec<ChainStep>,
+    extras: usize,
+) -> TractResult<Option<TypedModelPatch>> {
+    let Some(succ) = model.single_succ(node.id)? else { return Ok(None) };
+    rule_ensure!(!succ.op_is::<WgpuElementWiseChain>());
+    rule_ensure!(unary_name(succ).is_some() || binary_name(succ).is_some());
+    rule_ensure!(succ.inputs.iter().filter(|i| i.node == node.id).count() == 1);
+    rule_ensure!(
+        model.node_output_facts(succ.id)?[0].shape == model.node_output_facts(node.id)?[0].shape
+    );
+    rule_ensure!(extras < MAX_EXTRA_INPUTS);
+
+    let slot = succ.inputs.iter().position(|i| i.node == node.id).unwrap();
+    let Some((step, extra)) = one_step(succ, slot, extras + 1) else { return Ok(None) };
+    steps.push(step);
+
+    let mut patch = TypedModelPatch::default();
+    let mut inputs = vec![];
+    for inlet in node.inputs.iter() {
+        inputs.push(patch.tap_model(model, *inlet)?);
+    }
+    if let Some(extra) = extra {
+        inputs.push(patch.tap_model(model, extra)?);
+    }
+    let out =
+        patch.wire_node(format!("{node_name}.chain"), WgpuElementWiseChain { steps }, &inputs)?;
+    patch.shunt_outside(model, succ.id.into(), out[0])?;
+    Ok(Some(patch))
+}

--- a/wgpu/src/rewrite_rules/fuse_epilogue.rs
+++ b/wgpu/src/rewrite_rules/fuse_epilogue.rs
@@ -1,0 +1,122 @@
+use tract_core::internal::*;
+use tract_gpu::fact::DeviceTypedFactExt;
+use tract_gpu::ops::binary::GpuBinOp;
+use tract_gpu::ops::element_wise::GpuElementWise;
+use tract_gpu::rule_ensure;
+
+use crate::kernels::shaders::{BINARY_OPS, ChainStep, ELEMENT_WISE_OPS};
+use crate::ops::chain::WgpuElementWiseChain;
+use crate::ops::conv::WgpuConv;
+use crate::ops::matmul::WgpuGemm;
+
+/// Epilogue operands ride in one `vec4` of offsets.
+const MAX_EPILOGUE_OPERANDS: usize = 3;
+
+fn shape_of(model: &TypedModel, outlet: OutletId) -> TractResult<TVec<TDim>> {
+    let fact = model.outlet_fact(outlet)?;
+    Ok(fact
+        .as_device_fact()
+        .map(|f| f.shape.dims().into())
+        .unwrap_or_else(|| fact.shape.dims().into()))
+}
+
+/// A GEMM's epilogue can only read an operand that is one value, or one per
+/// output column — that is what a convolution bias becomes here.
+fn addressable(model: &TypedModel, outlet: OutletId, columns: &TDim) -> TractResult<bool> {
+    let shape = shape_of(model, outlet)?;
+    let len = shape.iter().product::<TDim>();
+    Ok(len == 1.to_dim() || len == *columns)
+}
+
+fn steps_of(node: &TypedNode, slot: usize, rhs: usize) -> Option<(Vec<ChainStep>, usize)> {
+    if let Some(chain) = node.op_as::<WgpuElementWiseChain>() {
+        return Some((chain.steps.clone(), node.inputs.len() - 1));
+    }
+    if let Some(op) = node.op_as::<GpuElementWise>() {
+        let name = op.mini_op.name().to_lowercase();
+        return ELEMENT_WISE_OPS
+            .contains(&name.as_str())
+            .then(|| (vec![ChainStep::Unary(name)], 0));
+    }
+    let op = node.op_as::<GpuBinOp>()?;
+    let name = op.mini_op.name().to_lowercase();
+    BINARY_OPS
+        .contains(&name.as_str())
+        .then(|| (vec![ChainStep::Binary { op: name, rhs, swapped: slot == 1 }], 1))
+}
+
+/// Folds the elementwise ops that follow a convolution into it, the same way.
+pub fn fuse_conv_epilogue(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &WgpuConv,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_ensure!(op.epilogue.is_empty());
+    let channels = op.op.pool_spec.output_channels.to_dim();
+    absorb(model, node, node_name, channels, |steps| WgpuConv {
+        op: op.op.clone(),
+        epilogue: steps,
+    })
+}
+
+/// Folds the elementwise ops that follow a GEMM into the GEMM itself, so a
+/// bias and its activation cost no extra pass over the result.
+pub fn fuse_gemm_epilogue(
+    _ctx: &(),
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    op: &WgpuGemm,
+) -> TractResult<Option<TypedModelPatch>> {
+    rule_ensure!(op.epilogue.is_empty());
+    let out_shape = shape_of(model, node.id.into())?;
+    rule_ensure!(out_shape.len() >= 2);
+    let columns = if op.op.transpose_c {
+        out_shape[out_shape.len() - 2].clone()
+    } else {
+        out_shape[out_shape.len() - 1].clone()
+    };
+    absorb(model, node, node_name, columns, |steps| WgpuGemm { op: op.op, epilogue: steps })
+}
+
+fn absorb<O: TypedOp>(
+    model: &TypedModel,
+    node: &TypedNode,
+    node_name: &str,
+    columns: TDim,
+    build: impl FnOnce(Vec<ChainStep>) -> O,
+) -> TractResult<Option<TypedModelPatch>> {
+    let Some(succ) = model.single_succ(node.id)? else { return Ok(None) };
+    rule_ensure!(succ.inputs.iter().filter(|i| i.node == node.id).count() == 1);
+    rule_ensure!(shape_of(model, succ.id.into())? == shape_of(model, node.id.into())?);
+
+    let slot = succ.inputs.iter().position(|i| i.node == node.id).unwrap();
+    let Some((steps, operands)) = steps_of(succ, slot, 1) else { return Ok(None) };
+    rule_ensure!(operands <= MAX_EPILOGUE_OPERANDS);
+
+    let extras: TVec<OutletId> = succ
+        .inputs
+        .iter()
+        .enumerate()
+        .filter(|(i, inlet)| {
+            !(succ.op_is::<WgpuElementWiseChain>() && *i == 0) && inlet.node != node.id
+        })
+        .map(|(_, inlet)| *inlet)
+        .collect();
+    rule_ensure!(extras.len() == operands);
+    for extra in &extras {
+        rule_ensure!(addressable(model, *extra, &columns)?);
+    }
+
+    let mut patch = TypedModelPatch::default();
+    let mut inputs = vec![patch.tap_model(model, node.inputs[0])?];
+    inputs.push(patch.tap_model(model, node.inputs[1])?);
+    for extra in extras {
+        inputs.push(patch.tap_model(model, extra)?);
+    }
+    let out = patch.wire_node(format!("{node_name}.epilogue"), build(steps), &inputs)?;
+    patch.shunt_outside(model, succ.id.into(), out[0])?;
+    Ok(Some(patch))
+}

--- a/wgpu/src/rewrite_rules/mod.rs
+++ b/wgpu/src/rewrite_rules/mod.rs
@@ -1,0 +1,7 @@
+mod fuse_axis_op;
+mod fuse_elementwise;
+mod fuse_epilogue;
+
+pub use fuse_axis_op::{fuse_axis_op, fuse_move_axis};
+pub use fuse_elementwise::{grow_elementwise_chain, start_binary_chain, start_elementwise_chain};
+pub use fuse_epilogue::{fuse_conv_epilogue, fuse_gemm_epilogue};

--- a/wgpu/src/tests.rs
+++ b/wgpu/src/tests.rs
@@ -120,3 +120,85 @@ fn coverage_rejects_logsoftmax_by_name() -> TractResult<()> {
     ensure!(msg.contains("attn_sm"), "error should name the node, got {msg}");
     Ok(())
 }
+
+/// The suites check what a fused graph computes; these check that it fused.
+fn transformed(mut model: TypedModel) -> TractResult<TypedModel> {
+    crate::context::wgpu_context();
+    WgpuTransform.transform(&mut model)?;
+    model.into_optimized()
+}
+
+#[test]
+fn elementwise_run_becomes_one_chain() -> TractResult<()> {
+    use tract_core::ops::nn::sigmoid;
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 4]))?;
+    let a = model.wire_node("a", sigmoid(), &[x])?[0];
+    let b = model.wire_node("b", tract_core::ops::math::tanh(), &[a])?[0];
+    let c = model.wire_node("c", sigmoid(), &[b])?[0];
+    model.select_output_outlets(&[c])?;
+    let model = transformed(model)?;
+    let chains = model
+        .nodes()
+        .iter()
+        .filter_map(|n| n.op_as::<crate::ops::chain::WgpuElementWiseChain>())
+        .collect::<Vec<_>>();
+    ensure!(chains.len() == 1, "three element-wise ops should leave one chain, got {chains:?}");
+    ensure!(chains[0].steps.len() == 3, "chain should hold all three steps");
+    Ok(())
+}
+
+#[test]
+fn bias_and_activation_become_a_gemm_epilogue() -> TractResult<()> {
+    use tract_core::ops::einsum::prefix_matmul::PrefixMatMul;
+    use tract_core::ops::nn::sigmoid;
+    let mut model = TypedModel::default();
+    let a = model.add_source("a", f32::fact([6, 5]))?;
+    let b = model.add_const("b", Tensor::zero::<f32>(&[5, 7])?)?;
+    let bias = model.add_const("bias", Tensor::zero::<f32>(&[1, 7])?)?;
+    let mm = model.wire_node(
+        "mm",
+        PrefixMatMul {
+            transpose_a: false,
+            transpose_b: false,
+            transpose_c: false,
+            quantize_output: None,
+            operating_dt: None,
+        },
+        &[a, b],
+    )?[0];
+    let biased = model.wire_node("bias_add", tract_core::ops::math::add(), &[mm, bias])?[0];
+    let y = model.wire_node("act", sigmoid(), &[biased])?[0];
+    model.select_output_outlets(&[y])?;
+    let model = transformed(model)?;
+    let gemms = model
+        .nodes()
+        .iter()
+        .filter_map(|n| n.op_as::<crate::ops::matmul::WgpuGemm>())
+        .collect::<Vec<_>>();
+    ensure!(gemms.len() == 1, "expected one gemm, got {}", gemms.len());
+    ensure!(
+        gemms[0].epilogue.len() == 2,
+        "bias and activation should ride the gemm, got {:?}",
+        gemms[0].epilogue
+    );
+    Ok(())
+}
+
+#[test]
+fn a_move_rides_the_op_that_reads_it() -> TractResult<()> {
+    use tract_core::ops::nn::sigmoid;
+    let mut model = TypedModel::default();
+    let x = model.add_source("x", f32::fact([2, 3, 4]))?;
+    let m = model.wire_node("mv", AxisOp::Move(0, 2), &[x])?[0];
+    let y = model.wire_node("act", sigmoid(), &[m])?[0];
+    model.select_output_outlets(&[y])?;
+    let model = transformed(model)?;
+    let fused = model
+        .nodes()
+        .iter()
+        .filter(|n| n.op_is::<crate::ops::fused_axis_op::WgpuFusedAxisOp>())
+        .count();
+    ensure!(fused == 1, "the move should ride its consumer, got {fused} fused nodes");
+    Ok(())
+}

--- a/wgpu/src/transform.rs
+++ b/wgpu/src/transform.rs
@@ -71,6 +71,21 @@ impl ModelTransform for WgpuTransform {
             .with_rule_for("split_multi_axis_reduce", split_multi_axis_reduce)
             .rewrite(&(), model)?;
         *model = self.translate_model(model)?;
+        Rewriter::default()
+            .with_rule_for("start_elementwise_chain", crate::rewrite_rules::start_elementwise_chain)
+            .with_rule_for("start_binary_chain", crate::rewrite_rules::start_binary_chain)
+            .with_rule_for("grow_elementwise_chain", crate::rewrite_rules::grow_elementwise_chain)
+            .rewrite(&(), model)?;
+        Rewriter::default()
+            .with_rule_for("fuse_gemm_epilogue", crate::rewrite_rules::fuse_gemm_epilogue)
+            .with_rule_for("fuse_conv_epilogue", crate::rewrite_rules::fuse_conv_epilogue)
+            .rewrite(&(), model)?;
+        Rewriter::default()
+            .with_rule_for("fuse_move_axis", crate::rewrite_rules::fuse_move_axis)
+            .rewrite(&(), model)?;
+        Rewriter::default()
+            .with_rule_for("fuse_axis_op", crate::rewrite_rules::fuse_axis_op)
+            .rewrite(&(), model)?;
         rewire_syncs(model)?;
         Ok(())
     }


### PR DESCRIPTION
6/7 of #2801. The graph-level work, and where the frame time actually goes. Slices 1–5 are merged; this is now a single commit on current main.

Three passes: a run of element-wise ops becomes one kernel; the ops trailing a GEMM or a convolution become that kernel's epilogue instead of another full pass over the result; and a shape-only axis op in front of an op that reads through strides becomes a change of strides rather than a copy.

The axis-op rules and `WgpuFusedAxisOp` follow metal's closely, with one divergence: a `DeviceSync` must stay a node of its own, because `rewire_syncs` and the coverage check both look for it by type, and fusing into it makes the model appear uncovered. Metal may well have the same latent hazard.

That closeness is worth naming: metal and cuda each already carry ~450 lines of `fuse_axis_op.rs` + `fused_axis_op.rs`, and this makes a third near-identical copy. It belongs in tract-gpu, parameterised by the backend's "reads through strides" op list. I did not do it here because it would touch cuda, which I have no way to run. Say the word and it becomes its own PR, before or after this one.

Three in-crate tests assert the fusions fire (one chain from a run of element-wise ops, a two-entry GEMM epilogue, a Move absorbed into `WgpuFusedAxisOp`); what the fused graphs compute is covered by the shared conformance suite from #2805.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)