### PR TITLE
wgpu 7/7: take a frame in, hand a mask back

### DIFF
--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -373,6 +373,7 @@ impl WgpuContext {
         buffers: &[&WgpuBuffer],
         uniform: &wgpu::Buffer,
     ) -> TractResult<wgpu::BindGroup> {
+        ensure!(kind != LayoutKind::Ingest, "Ingest layout binds a texture; use bind_group_ingest");
         let key = BindGroupKey {
             layout: kind,
             buffers: buffers.iter().map(|b| b.id).collect(),
@@ -403,6 +404,45 @@ impl WgpuContext {
         let mut cache = self.inner.bind_groups.lock().map_err(|e| anyhow!("{e}"))?;
         cache.insert(key, bg.clone());
         Ok(bg)
+    }
+
+    /// One storage buffer read, one storage texture written.
+    pub fn bind_group_export(
+        &self,
+        input: &wgpu::Buffer,
+        view: &wgpu::TextureView,
+        uniform: &wgpu::Buffer,
+    ) -> TractResult<wgpu::BindGroup> {
+        let (bgl, _) = self.layout(LayoutKind::Export)?;
+        let entries = [
+            wgpu::BindGroupEntry { binding: 0, resource: input.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: wgpu::BindingResource::TextureView(view) },
+            uniform_entry(2, uniform),
+        ];
+        Ok(self.inner.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(LayoutKind::Export.label()),
+            layout: &bgl,
+            entries: &entries,
+        }))
+    }
+
+    pub fn bind_group_ingest(
+        &self,
+        view: &wgpu::TextureView,
+        output: &wgpu::Buffer,
+        uniform: &wgpu::Buffer,
+    ) -> TractResult<wgpu::BindGroup> {
+        let (bgl, _) = self.layout(LayoutKind::Ingest)?;
+        let entries = [
+            wgpu::BindGroupEntry { binding: 0, resource: wgpu::BindingResource::TextureView(view) },
+            wgpu::BindGroupEntry { binding: 1, resource: output.as_entire_binding() },
+            uniform_entry(2, uniform),
+        ];
+        Ok(self.inner.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(LayoutKind::Ingest.label()),
+            layout: &bgl,
+            entries: &entries,
+        }))
     }
 
     pub fn create_storage_buffer(&self, bytes: &[u8]) -> wgpu::Buffer {

--- a/wgpu/src/kernels/ingest.rs
+++ b/wgpu/src/kernels/ingest.rs
@@ -1,0 +1,186 @@
+//! RGBA8 texture → NCHW f32 ingest.
+//!
+//! Native: [`Queue::write_texture`] (bytes_per_row 256-aligned).
+//! Wasm: same CPU-bytes path, plus [`Queue::copy_external_image_to_texture`]
+//! for `VideoFrame` / `ImageBitmap` (wgpu 30 web `create_external_texture`
+//! is unimplemented). One GPU copy; the frame never lands as an f32 CPU tensor.
+
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::{wgpu_context, with_wgpu_queue};
+
+pub fn all_pipeline_keys(_shader_f16: bool) -> Vec<PipelineKey> {
+    vec![PipelineKey {
+        module: ModuleKey { kind: ModuleKind::Ingest, dtype: ShaderDtype::F32 },
+        entry: EntryPoint::plain("rgba_to_nchw_f32"),
+    }]
+}
+
+fn ingest_usages() -> wgpu::TextureUsages {
+    wgpu::TextureUsages::TEXTURE_BINDING
+        | wgpu::TextureUsages::COPY_DST
+        | wgpu::TextureUsages::RENDER_ATTACHMENT
+}
+
+fn create_rgba8_texture(device: &wgpu::Device, width: u32, height: u32) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("tract-wgpu-ingest-rgba"),
+        size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: ingest_usages(),
+        view_formats: &[],
+    })
+}
+
+fn pad_rgba_rows(width: u32, height: u32, rgba: &[u8]) -> TractResult<(Vec<u8>, u32)> {
+    let row = width.checked_mul(4).context("width overflow")?;
+    ensure!(
+        rgba.len() == row as usize * height as usize,
+        "RGBA8 length {} != {width}x{height}x4",
+        rgba.len()
+    );
+    let padded_row = row.next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+    if padded_row == row {
+        return Ok((rgba.to_vec(), row));
+    }
+    let mut out = vec![0u8; padded_row as usize * height as usize];
+    for y in 0..height as usize {
+        let src = y * row as usize;
+        let dst = y * padded_row as usize;
+        out[dst..dst + row as usize].copy_from_slice(&rgba[src..src + row as usize]);
+    }
+    Ok((out, padded_row))
+}
+
+fn dispatch_rgba_to_nchw(
+    q: &crate::WgpuQueue,
+    texture: wgpu::Texture,
+    width: u32,
+    height: u32,
+    output: &DeviceTensor,
+) -> TractResult<()> {
+    q.retain_tensor(output);
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let pipeline = q.context().pipeline(PipelineKey {
+        module: ModuleKey { kind: ModuleKind::Ingest, dtype: ShaderDtype::F32 },
+        entry: EntryPoint::plain("rgba_to_nchw_f32"),
+    })?;
+    let out_buf = get_wgpu_buffer(output);
+    let bg = q.context().bind_group_ingest(&view, &out_buf.inner, q.uniform())?;
+    let params = pack_u32s(&[element_offset(output, 0) as u32, width, height, 0]);
+    let dyn_off = q.alloc_uniform(&params)?;
+    q.dispatch("ingest", &pipeline, &bg, dyn_off, width as u64 * height as u64)?;
+    q.retain_texture(texture);
+    Ok(())
+}
+
+fn output_tensor(width: u32, height: u32) -> TractResult<DeviceTensor> {
+    DeviceTensor::uninitialized_dt(DatumType::F32, &[1, 3, height as usize, width as usize])
+}
+
+/// Upload tightly packed RGBA8 (`width * height * 4` bytes) and convert to
+/// NCHW f32 `[1, 3, H, W]` (alpha dropped). Works native and on wasm.
+pub fn tensor_from_rgba8(width: u32, height: u32, rgba: &[u8]) -> TractResult<DeviceTensor> {
+    ensure!(width > 0 && height > 0, "ingest size must be > 0");
+    wgpu_context();
+    with_wgpu_queue(|q| {
+        let (padded, bpr) = pad_rgba_rows(width, height, rgba)?;
+        let texture = create_rgba8_texture(q.context().device(), width, height);
+        q.context().queue().write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &padded,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(bpr),
+                rows_per_image: Some(height),
+            },
+            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        );
+        let output = output_tensor(width, height)?;
+        dispatch_rgba_to_nchw(q, texture, width, height, &output)?;
+        Ok(output)
+    })
+}
+
+/// One-GPU-copy ingest from a WebCodecs `VideoFrame` / canvas / bitmap.
+/// Requires wgpu's web backend (`copy_external_image_to_texture`).
+#[cfg(target_arch = "wasm32")]
+pub fn tensor_from_external_image(
+    source: wgpu::ExternalImageSource,
+    width: u32,
+    height: u32,
+) -> TractResult<DeviceTensor> {
+    ensure!(width > 0 && height > 0, "ingest size must be > 0");
+    wgpu_context();
+    with_wgpu_queue(|q| {
+        let texture = create_rgba8_texture(q.context().device(), width, height);
+        q.context().queue().copy_external_image_to_texture(
+            &wgpu::CopyExternalImageSourceInfo {
+                source,
+                origin: wgpu::Origin2d::ZERO,
+                flip_y: false,
+            },
+            wgpu::CopyExternalImageDestInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+                color_space: wgpu::PredefinedColorSpace::Srgb,
+                premultiplied_alpha: false,
+            },
+            wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        );
+        let output = output_tensor(width, height)?;
+        dispatch_rgba_to_nchw(q, texture, width, height, &output)?;
+        Ok(output)
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn tensor_from_video_frame(frame: web_sys::VideoFrame) -> TractResult<DeviceTensor> {
+    let width = frame.display_width();
+    let height = frame.display_height();
+    tensor_from_external_image(wgpu::ExternalImageSource::VideoFrame(frame), width, height)
+}
+
+/// Writes a single-channel tensor into a texture the caller owns, so a mask can
+/// be composited on the GPU instead of read back.
+pub fn tensor_to_texture(
+    mask: &DeviceTensor,
+    texture: &wgpu::Texture,
+    width: u32,
+    height: u32,
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        ensure!(
+            mask.len() >= (width * height) as usize,
+            "mask of {} values is too small for {width}x{height}",
+            mask.len()
+        );
+        q.retain_tensor(mask);
+        let dt = ShaderDtype::from_datum(mask.datum_type())?;
+        let pipeline = q.context().pipeline(PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Export, dtype: dt },
+            entry: EntryPoint::typed("export", dt),
+        })?;
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let bg = q.context().bind_group_export(&get_wgpu_buffer(mask).inner, &view, q.uniform())?;
+        let params = pack_u32s(&[element_offset(mask, 0) as u32, width, height, 0]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.retain_texture(texture.clone());
+        q.dispatch("export", &pipeline, &bg, dyn_off, (width * height) as u64)
+    })
+}

--- a/wgpu/src/kernels/mod.rs
+++ b/wgpu/src/kernels/mod.rs
@@ -5,6 +5,7 @@ pub mod conv;
 pub mod copy;
 pub mod deconv;
 pub mod element_wise;
+pub mod ingest;
 pub mod matmul;
 pub mod pool;
 pub mod reduce;
@@ -22,6 +23,7 @@ pub fn all_pipeline_keys(shader_f16: bool) -> Vec<shaders::PipelineKey> {
     keys.extend(copy::all_pipeline_keys(shader_f16));
     keys.extend(deconv::all_pipeline_keys(shader_f16));
     keys.extend(element_wise::all_pipeline_keys(shader_f16));
+    keys.extend(ingest::all_pipeline_keys(shader_f16));
     keys.extend(matmul::all_pipeline_keys(shader_f16));
     keys.extend(pool::all_pipeline_keys(shader_f16));
     keys.extend(reduce::all_pipeline_keys(shader_f16));

--- a/wgpu/src/kernels/shaders.rs
+++ b/wgpu/src/kernels/shaders.rs
@@ -24,6 +24,9 @@ pub enum LayoutKind {
     Unary,
     Binary,
     Resize,
+    Ingest,
+    /// Writes a tensor into a storage texture the caller owns.
+    Export,
     /// A fused elementwise chain: `n` storage buffers, the last one the output.
     Chain(u8),
 }
@@ -34,6 +37,8 @@ impl LayoutKind {
             Self::Unary => "tract-wgpu-unary-layout",
             Self::Binary => "tract-wgpu-binary-layout",
             Self::Resize => "tract-wgpu-resize-layout",
+            Self::Ingest => "tract-wgpu-ingest-layout",
+            Self::Export => "tract-wgpu-export-layout",
             Self::Chain(_) => "tract-wgpu-chain-layout",
         }
     }
@@ -43,11 +48,81 @@ impl LayoutKind {
             Self::Unary => 2,
             Self::Binary => 3,
             Self::Resize => 4,
+            Self::Ingest => 1,
+            Self::Export => 1,
             Self::Chain(n) => n as u32,
         }
     }
 
     pub fn bind_group_layout_entries(self) -> Vec<wgpu::BindGroupLayoutEntry> {
+        if self == Self::Export {
+            return vec![
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::StorageTexture {
+                        access: wgpu::StorageTextureAccess::WriteOnly,
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: std::num::NonZeroU64::new(256),
+                    },
+                    count: None,
+                },
+            ];
+        }
+        if self == Self::Ingest {
+            return vec![
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: std::num::NonZeroU64::new(256),
+                    },
+                    count: None,
+                },
+            ];
+        }
         let mut entries = Vec::new();
         let n = self.storage_count();
         for i in 0..n {
@@ -117,6 +192,8 @@ pub enum ModuleKind {
     Deconv,
     Resize,
     Softmax,
+    Ingest,
+    Export,
     MatMul,
 }
 
@@ -145,6 +222,8 @@ impl ModuleKey {
                 LayoutKind::Binary
             }
             ModuleKind::Resize => LayoutKind::Resize,
+            ModuleKind::Ingest => LayoutKind::Ingest,
+            ModuleKind::Export => LayoutKind::Export,
         }
     }
 
@@ -160,6 +239,8 @@ impl ModuleKey {
             ModuleKind::Deconv => deconv_wgsl(self.dtype),
             ModuleKind::Resize => resize_wgsl(self.dtype),
             ModuleKind::Softmax => softmax_wgsl(self.dtype),
+            ModuleKind::Ingest => ingest_wgsl(self.dtype),
+            ModuleKind::Export => export_wgsl(self.dtype),
             ModuleKind::MatMul => matmul_wgsl(self.dtype),
         }
     }
@@ -1724,6 +1805,73 @@ fn matmul_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
 "#
     ));
     s
+}
+
+/// A single-channel tensor into a texture the caller can sample: the mask
+/// leaves the graph as a GPU resource rather than as bytes on the host.
+fn export_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    width: u32,
+    height: u32,
+    _p: u32,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var dst: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn export_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.width * params.height;
+    if (i >= n) {{ return; }}
+    let x = i % params.width;
+    let y = i / params.width;
+    let v = clamp(f32(inp[params.off_in + i]), 0.0, 1.0);
+    textureStore(dst, vec2<i32>(i32(x), i32(y)), vec4<f32>(v, v, v, 1.0));
+}}
+"#
+    ));
+    s
+}
+
+fn ingest_wgsl(dt: ShaderDtype) -> String {
+    let _ = dt;
+    format!(
+        r#"
+struct Params {{
+    off_out: u32,
+    width: u32,
+    height: u32,
+    _p: u32,
+}}
+
+@group(0) @binding(0) var src: texture_2d<f32>;
+@group(0) @binding(1) var<storage, read_write> outp: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size({WORKGROUP})
+fn rgba_to_nchw_f32(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    let n = params.width * params.height;
+    if (i >= n) {{ return; }}
+    let x = i % params.width;
+    let y = i / params.width;
+    let px = textureLoad(src, vec2<i32>(i32(x), i32(y)), 0);
+    let hw = params.width * params.height;
+    let o = params.off_out + i;
+    outp[o] = px.r;
+    outp[o + hw] = px.g;
+    outp[o + 2u * hw] = px.b;
+}}
+"#
+    )
 }
 
 pub fn pack_u32s(vals: &[u32]) -> Vec<u8> {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -42,7 +42,45 @@ pub use crate::context::{
 };
 pub use crate::coverage::{UncoveredOp, ensure_wgpu_coverage, uncovered_ops};
 pub use crate::jspi::{hybrid_fallback_available, jspi_in_browser};
+#[cfg(target_arch = "wasm32")]
+pub use crate::kernels::ingest::{tensor_from_external_image, tensor_from_video_frame};
+pub use crate::kernels::ingest::{tensor_from_rgba8, tensor_to_texture};
 
+/// The `GPUDevice` this backend runs on, so a compositor in the page can be
+/// built against the same device and read the mask where it already is.
+#[cfg(target_arch = "wasm32")]
+pub fn webgpu_device() -> Option<wasm_bindgen::JsValue> {
+    use wasm_bindgen::JsCast;
+    wgpu_context().device().as_webgpu().map(|d| d.clone().unchecked_into())
+}
+
+/// A texture this backend can write a mask into, handed to the page as a
+/// `GPUTexture`.
+#[cfg(target_arch = "wasm32")]
+pub fn mask_texture(
+    width: u32,
+    height: u32,
+) -> TractResult<(wgpu::Texture, wasm_bindgen::JsValue)> {
+    use wasm_bindgen::JsCast;
+    let texture = wgpu_context().device().create_texture(&wgpu::TextureDescriptor {
+        label: Some("tract-wgpu-mask"),
+        size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::STORAGE_BINDING
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let handle = texture
+        .as_webgpu()
+        .context("mask texture is not a WebGPU texture")?
+        .clone()
+        .unchecked_into();
+    Ok((texture, handle))
+}
 pub use crate::transform::WgpuTransform;
 
 use crate::utils::get_wgpu_buffer;

--- a/wgpu/src/tests.rs
+++ b/wgpu/src/tests.rs
@@ -202,3 +202,28 @@ fn a_move_rides_the_op_that_reads_it() -> TractResult<()> {
     ensure!(fused == 1, "the move should ride its consumer, got {fused} fused nodes");
     Ok(())
 }
+
+#[test]
+fn rgba8_ingest_to_nchw_f32() -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        // 2x2 packed RGBA8. textureLoad of rgba8unorm yields 0..1 floats.
+        let rgba: [u8; 16] = [
+            255, 0, 0, 255, // (0,0) red
+            0, 255, 0, 255, // (1,0) green
+            0, 0, 255, 255, // (0,1) blue
+            255, 255, 255, 255, // (1,1) white
+        ];
+        let gpu = crate::tensor_from_rgba8(2, 2, &rgba)?;
+        q.flush()?;
+        let host = gpu.to_host()?.into_tensor();
+        let expected = Tensor::from_shape(
+            &[1, 3, 2, 2],
+            &[
+                1.0f32, 0.0, 0.0, 1.0, // R
+                0.0, 1.0, 0.0, 1.0, // G
+                0.0, 0.0, 1.0, 1.0, // B
+            ],
+        )?;
+        close(&host, &expected)
+    })
+}


### PR DESCRIPTION
7/7 of #2801. The two kernels a camera needs. **Stacked on #2809 — read this one's top commit only.**

RGBA8 pixels become an NCHW f32 tensor without a trip through the CPU, and a result is written into a storage texture the page already owns. Together they let a browser run a frame end to end without ever reading a tensor back, which is the case the whole backend exists for: on a video call, inference must not take the cores the encoder needs.

Drop this one if you would rather the browser plumbing stayed out of tree until there is a demo in tree to justify it — nothing in 1/7 through 6/7 depends on it.

One test: an RGBA8 buffer ingested and compared against the same conversion on the CPU.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)
