### PR TITLE
wgpu 1/7: a WebGPU device for tract tensors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +205,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -382,6 +400,15 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec 0.9.1",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d87354e4229f54a44f7bf2435906a4656dba36026ab6eaca629a2c436a691c"
@@ -394,6 +421,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit-vec"
@@ -515,6 +548,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder"
@@ -608,9 +655,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -700,6 +747,17 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "color_quant"
@@ -1187,6 +1245,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,10 +1727,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows",
+]
 
 [[package]]
 name = "half"
@@ -1688,6 +1810,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -2170,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
@@ -2198,6 +2323,23 @@ dependencies = [
  "ndarray-npy",
  "tract",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -2297,6 +2439,12 @@ name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2504,6 +2652,44 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a616d2fb8c89516ac2723a581f69d6c18576046bed761bd6b305e5618e6ae130"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bitflags 2.13.0",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "libm",
+ "log",
+ "naga-types",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590afbf58a6f4f62873cd5cff4468061844bafa1cdf399cc954537c22d768d49"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2868,6 +3054,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,6 +3082,43 @@ dependencies = [
  "libc",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2955,6 +3190,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "page_size"
@@ -3116,6 +3360,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3403,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -3434,6 +3690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,6 +3743,24 @@ dependencies = [
  "rav1e",
  "rayon",
  "rgb",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -3581,6 +3861,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -4021,6 +4307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4329,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4243,6 +4547,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -5198,6 +5511,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tract-wgpu"
+version = "0.23.8-pre"
+dependencies = [
+ "anyhow",
+ "derive-new",
+ "downcast-rs",
+ "inventory",
+ "js-sys",
+ "log",
+ "num-traits",
+ "pollster",
+ "proptest",
+ "rand 0.10.2",
+ "tract-core",
+ "tract-gpu",
+ "tract-pulse-opl",
+ "tract-transformers",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu",
+]
+
+[[package]]
 name = "transpose"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5380,9 +5717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -5393,9 +5730,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5403,9 +5740,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5413,22 +5750,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -5443,10 +5780,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.102"
+name = "wayland-sys"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5485,6 +5834,179 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527ccdf43dd5b2e8676eed9984ce00e2bbb0a1b85b70c1969dcb6cd2eb55ab9e"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c018fce9b6270aa203c2fdd56f3cce996713534bd757e4ea58c8560b121f14"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.10.0",
+ "bit-vec 0.9.1",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "log",
+ "naga",
+ "naga-types",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061f3d319a40d39d00b1ecc2c33b89fe21d4e6fe01859df3500a3a8ecccd6b68"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98b86cf4abf524a902dd35f18ca6a3f08fc2ae9847c8f10b48e30491b1f0b86"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7586165fd5f6d881cb9ce4bb71f40d6caab2c0f1837e3fc1d9788a197fb6004f"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b7fb58561a792bc237628ba0792e332de418fefe145f13b5ed8201e6d52f58"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set 0.10.0",
+ "bitflags 2.13.0",
+ "block2",
+ "bytemuck",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "hashbrown 0.17.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "naga-types",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f62e73117bb7a62bfd9c5a5841438a823f6566c6442a808ee269d2d055c081"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99dad6f1fbdbbdb4c278a6508b059d44688f5cebddf78d005a46a31340269286"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "naga-types",
+ "raw-window-handle",
+ "static_assertions",
+ "web-sys",
+]
 
 [[package]]
 name = "which"
@@ -5766,6 +6288,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "cli",
     "gpu",
     "metal",
+    "wgpu",
     "extra",
     "transformers",
     "cuda",
@@ -221,6 +222,8 @@ toml = "1.1"
 unicode-normalization = "0.1.19"
 walkdir = "2.3.2"
 zerofrom = "0.1.5"
+wgpu = { version = "30.0.1", features = ["fragile-send-sync-non-atomic-wasm"] }
+pollster = "0.4"
 tract-api = { version = "0.23.8-pre", path = 'api' }
 tract-core = { version = "0.23.8-pre", path = 'core' }
 tract-cuda = { version = "0.23.8-pre", path = 'cuda', default-features = false }
@@ -231,6 +234,7 @@ tract-hir = { version = "0.23.8-pre", path = 'hir' }
 tract-libcli = { version = "0.23.8-pre", path = 'libcli' }
 tract-linalg = { version = "0.23.8-pre", path = 'linalg' }
 tract-metal = { version = "0.23.8-pre", path = 'metal' }
+tract-wgpu = { version = "0.23.8-pre", path = 'wgpu' }
 tract-nnef-resources = { version = "0.23.8-pre", path = 'nnef/nnef-resources' }
 tract-nnef = { version = "0.23.8-pre", path = 'nnef' }
 tract-onnx-opl = { version = "0.23.8-pre", path = 'onnx-opl' }

--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "tract-wgpu"
+version = "0.23.8-pre"
+license = "MIT OR Apache-2.0"
+authors = [
+	"Ckristian Zoli <czoli1976@users.noreply.github.com>",
+]
+description = "Tiny, no-nonsense, self contained, TensorFlow and ONNX inference"
+repository = "https://github.com/snipsco/tract"
+keywords = [ "TensorFlow", "NeuralNetworks", "WebGPU", "wgpu" ]
+categories = [ "science" ]
+autobenches = false
+edition = "2024"
+rust-version.workspace = true
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[features]
+default = []
+# Browser WebGPU. Mutually exclusive with tract's wasm-bindgen-rayon
+# (+atomics,+bulk-memory) tier — see lib.rs.
+web = []
+# Wasm JSPI hybrid: uncovered ops fall back to tract CPU kernels via a
+# mid-graph mapAsync suspend. Not a default — Safari 26 has WebGPU but not
+# JSPI (Safari 27). Chrome 137+, Firefox 139+.
+jspi = []
+
+[dependencies]
+anyhow.workspace = true
+derive-new.workspace = true
+downcast-rs.workspace = true
+inventory.workspace = true
+log.workspace = true
+num-traits.workspace = true
+tract-core.workspace = true
+tract-pulse-opl.workspace = true
+tract-transformers.workspace = true
+tract-gpu.workspace = true
+wgpu.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pollster.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = ["VideoFrame"] }
+
+[dev-dependencies]
+proptest.workspace = true
+rand.workspace = true

--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -1,0 +1,1205 @@
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::mem::ManuallyDrop;
+use std::num::NonZeroU64;
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+#[cfg(not(target_arch = "wasm32"))]
+use anyhow::Context;
+use anyhow::{anyhow, bail};
+use tract_core::internal::*;
+use tract_core::tract_linalg::block_quant::BlockQuantFact;
+use tract_gpu::device::{DeviceBuffer, DeviceContext};
+use tract_gpu::tensor::{DeviceTensor, OwnedDeviceTensor};
+use tract_gpu::utils::as_q40_tensor;
+use wgpu::util::DeviceExt;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
+compile_error!(
+    "tract-wgpu cannot be built with wasm atomics. It is mutually exclusive with the \
+     wasm-bindgen-rayon tier (+atomics,+bulk-memory,+mutable-globals,+simd128). \
+     Build wasm32-unknown-unknown without +atomics; see linalg/MULTITHREAD_BENCHMARKS.md."
+);
+
+use crate::kernels::shaders::{EntryPoint, LayoutKind, ModuleKey, PipelineKey, ShaderDtype};
+use crate::tensor::WgpuTensor;
+
+pub const UNIFORM_ALIGN: u64 = 256;
+/// Slots in the uniform ring. One dispatch takes one slot, and running out
+/// forces a submit-and-wait in the middle of a frame, so the ring holds more
+/// than a graph's worth of dispatches.
+const UNIFORM_SLOTS: u64 = 256;
+const UNIFORM_BYTES: u64 = UNIFORM_ALIGN * UNIFORM_SLOTS;
+const WORKGROUP: u32 = 64;
+
+/// Bind groups kept between frames before the cache is dropped wholesale.
+const BIND_GROUP_CACHE_CAP: usize = 8192;
+
+thread_local! {
+    static WGPU_QUEUE: RefCell<Option<WgpuQueue>> = const { RefCell::new(None) };
+}
+
+pub fn with_wgpu_queue<R>(f: impl FnOnce(&WgpuQueue) -> TractResult<R>) -> TractResult<R> {
+    wgpu_context();
+    WGPU_QUEUE.with(|cell| {
+        if cell.borrow().is_none() {
+            *cell.borrow_mut() = Some(WgpuQueue::new()?);
+        }
+        let borrow = cell.borrow();
+        f(borrow.as_ref().unwrap())
+    })
+}
+
+/// Cache behaviour, for the ignored probes: bind groups and pooled buffers
+/// found versus built.
+pub static CACHE_STATS: [std::sync::atomic::AtomicUsize; 5] = [
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+];
+
+fn bump(i: usize) {
+    CACHE_STATS[i].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn context_slot() -> &'static OnceLock<WgpuContext> {
+    static INSTANCE: OnceLock<WgpuContext> = OnceLock::new();
+    &INSTANCE
+}
+
+fn install_context(ctxt: WgpuContext) -> TractResult<WgpuContext> {
+    let _ = tract_gpu::device::set_context(Box::new(ctxt.clone()));
+    let _ = context_slot().set(ctxt.clone());
+    Ok(context_slot().get().cloned().unwrap_or(ctxt))
+}
+
+/// Native: creates the adapter synchronously. Wasm: panics unless
+/// [`wgpu_context_async`] has already completed — `pollster` cannot block
+/// the browser event loop.
+pub fn wgpu_context() -> WgpuContext {
+    #[cfg(target_arch = "wasm32")]
+    {
+        context_slot().get().cloned().expect(
+            "tract-wgpu on wasm32: await wgpu_context_async() once at startup \
+             (requestAdapter/requestDevice are async; PollType::Wait is a no-op on web)",
+        )
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        context_slot()
+            .get_or_init(|| {
+                let ctxt = WgpuContext::new().expect("Could not create wgpu context");
+                tract_gpu::device::set_context(Box::new(ctxt.clone()))
+                    .expect("Could not set wgpu context");
+                ctxt
+            })
+            .clone()
+    }
+}
+
+/// One-shot async device init. Safe to call from wasm `wasm_bindgen` async
+/// startup; subsequent [`wgpu_context`] calls are free.
+pub async fn wgpu_context_async() -> TractResult<WgpuContext> {
+    if let Some(ctxt) = context_slot().get() {
+        return Ok(ctxt.clone());
+    }
+    let ctxt = WgpuContext::new_async().await?;
+    install_context(ctxt)
+}
+
+#[derive(Clone)]
+pub struct WgpuContext {
+    inner: Arc<WgpuContextInner>,
+}
+
+struct WgpuContextInner {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    shader_f16: bool,
+    modules: RwLock<HashMap<ModuleKey, wgpu::ShaderModule>>,
+    pipelines: RwLock<HashMap<PipelineKey, wgpu::ComputePipeline>>,
+    chain_pipelines: RwLock<HashMap<String, wgpu::ComputePipeline>>,
+    layouts: RwLock<HashMap<LayoutKind, (wgpu::BindGroupLayout, wgpu::PipelineLayout)>>,
+    bind_groups: Mutex<HashMap<BindGroupKey, wgpu::BindGroup>>,
+    staging: Mutex<Option<wgpu::Buffer>>,
+    /// A graph allocates the same sizes in the same order every frame, so a
+    /// buffer is keyed by that position rather than by size alone: the Nth
+    /// allocation of a given size always gets the same buffer, and the bind
+    /// group built for it last frame still matches.
+    buffer_slots: Mutex<HashMap<(u64, u32), Arc<WgpuBuffer>>>,
+    slot_cursor: Mutex<HashMap<u64, u32>>,
+}
+
+/// `wgpu::Buffer` hashes by the resource it points at, so a cached entry stays
+/// valid for as long as that buffer lives — and holding the key's clones is
+/// what keeps it alive.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BindGroupKey {
+    layout: LayoutKind,
+    buffers: Vec<u64>,
+}
+
+impl std::fmt::Debug for WgpuContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgpuContext").field("shader_f16", &self.inner.shader_f16).finish()
+    }
+}
+
+impl WgpuContext {
+    async fn create_device() -> TractResult<(wgpu::Device, wgpu::Queue, bool)> {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| anyhow!("No wgpu adapter: {e}"))?;
+
+        let info = adapter.get_info();
+        log::info!(
+            "tract-wgpu: adapter {:?} ({:?}) backend={:?}",
+            info.name,
+            info.device_type,
+            info.backend
+        );
+
+        let shader_f16 = adapter.features().contains(wgpu::Features::SHADER_F16);
+        let mut features = wgpu::Features::empty();
+        if shader_f16 {
+            features |= wgpu::Features::SHADER_F16;
+        }
+        if adapter.features().contains(wgpu::Features::TIMESTAMP_QUERY) {
+            features |= wgpu::Features::TIMESTAMP_QUERY;
+        }
+
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("tract-wgpu"),
+                required_features: features,
+                required_limits: adapter.limits(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            })
+            .await
+            .map_err(|e| anyhow!("request_device failed: {e}"))?;
+        Ok((device, queue, shader_f16))
+    }
+
+    fn from_device(
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        shader_f16: bool,
+    ) -> TractResult<Self> {
+        let ctxt = Self {
+            inner: Arc::new(WgpuContextInner {
+                device,
+                queue,
+                shader_f16,
+                modules: RwLock::new(HashMap::new()),
+                pipelines: RwLock::new(HashMap::new()),
+                chain_pipelines: RwLock::new(HashMap::new()),
+                layouts: RwLock::new(HashMap::new()),
+                bind_groups: Mutex::new(HashMap::new()),
+                staging: Mutex::new(None),
+                buffer_slots: Mutex::new(HashMap::new()),
+                slot_cursor: Mutex::new(HashMap::new()),
+            }),
+        };
+        ctxt.preload_pipelines()?;
+        Ok(ctxt)
+    }
+
+    pub fn new() -> TractResult<Self> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            bail!(
+                "WgpuContext::new() cannot block on wasm32. Await WgpuContext::new_async() \
+                 (or wgpu_context_async()) once at startup."
+            )
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let (device, queue, shader_f16) = pollster::block_on(Self::create_device())?;
+            Self::from_device(device, queue, shader_f16)
+        }
+    }
+
+    pub async fn new_async() -> TractResult<Self> {
+        let (device, queue, shader_f16) = Self::create_device().await?;
+        Self::from_device(device, queue, shader_f16)
+    }
+
+    pub fn device(&self) -> &wgpu::Device {
+        &self.inner.device
+    }
+
+    pub fn queue(&self) -> &wgpu::Queue {
+        &self.inner.queue
+    }
+
+    pub fn shader_f16(&self) -> bool {
+        self.inner.shader_f16
+    }
+
+    pub fn timestamps(&self) -> bool {
+        self.inner.device.features().contains(wgpu::Features::TIMESTAMP_QUERY)
+    }
+
+    fn preload_pipelines(&self) -> TractResult<()> {
+        for key in crate::kernels::all_pipeline_keys(self.shader_f16()) {
+            let _ = self.pipeline(key);
+        }
+        Ok(())
+    }
+
+    pub fn layout(
+        &self,
+        kind: LayoutKind,
+    ) -> TractResult<(wgpu::BindGroupLayout, wgpu::PipelineLayout)> {
+        {
+            let cache = self.inner.layouts.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(v) = cache.get(&kind) {
+                return Ok(v.clone());
+            }
+        }
+        let mut cache = self.inner.layouts.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(v) = cache.get(&kind) {
+            return Ok(v.clone());
+        }
+        let entries = kind.bind_group_layout_entries();
+        let bgl = self.inner.device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some(kind.label()),
+            entries: &entries,
+        });
+        let pl = self.inner.device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some(kind.label()),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+        cache.insert(kind, (bgl.clone(), pl.clone()));
+        Ok((bgl, pl))
+    }
+
+    fn module(&self, key: ModuleKey) -> TractResult<wgpu::ShaderModule> {
+        {
+            let cache = self.inner.modules.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(m) = cache.get(&key) {
+                return Ok(m.clone());
+            }
+        }
+        let mut cache = self.inner.modules.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(m) = cache.get(&key) {
+            return Ok(m.clone());
+        }
+        if key.dtype == ShaderDtype::F16 && !self.shader_f16() {
+            bail!("f16 requested but adapter lacks shader-f16");
+        }
+        let src = key.wgsl();
+        let module = self.inner.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some(&key.label()),
+            source: wgpu::ShaderSource::Wgsl(src.into()),
+        });
+        cache.insert(key, module.clone());
+        Ok(module)
+    }
+
+    pub fn pipeline(&self, key: PipelineKey) -> TractResult<wgpu::ComputePipeline> {
+        {
+            let cache = self.inner.pipelines.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(p) = cache.get(&key) {
+                return Ok(p.clone());
+            }
+        }
+        let mut cache = self.inner.pipelines.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(p) = cache.get(&key) {
+            return Ok(p.clone());
+        }
+        let module = self.module(key.module)?;
+        let (_bgl, pl) = self.layout(key.module.layout())?;
+        let entry = key.entry.name();
+        let pipeline =
+            self.inner.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(&entry),
+                layout: Some(&pl),
+                module: &module,
+                entry_point: Some(&entry),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                cache: None,
+            });
+        cache.insert(key, pipeline.clone());
+        Ok(pipeline)
+    }
+
+    /// Pipeline for a generated program, keyed by the program's own name;
+    /// `source` is only called on a miss.
+    pub fn chain_pipeline(
+        &self,
+        key: &str,
+        layout: LayoutKind,
+        entry: EntryPoint,
+        source: impl FnOnce() -> String,
+    ) -> TractResult<wgpu::ComputePipeline> {
+        {
+            let cache = self.inner.chain_pipelines.read().map_err(|e| anyhow!("{e}"))?;
+            if let Some(p) = cache.get(key) {
+                return Ok(p.clone());
+            }
+        }
+        let mut cache = self.inner.chain_pipelines.write().map_err(|e| anyhow!("{e}"))?;
+        if let Some(p) = cache.get(key) {
+            return Ok(p.clone());
+        }
+        let module = self.inner.device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some(layout.label()),
+            source: wgpu::ShaderSource::Wgsl(source().into()),
+        });
+        let (_bgl, pl) = self.layout(layout)?;
+        let pipeline =
+            self.inner.device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("tract-wgpu-generated"),
+                layout: Some(&pl),
+                module: &module,
+                entry_point: Some(&entry.name()),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                cache: None,
+            });
+        cache.insert(key.to_string(), pipeline.clone());
+        Ok(pipeline)
+    }
+
+    pub fn bind_group(
+        &self,
+        kind: LayoutKind,
+        buffers: &[&WgpuBuffer],
+        uniform: &wgpu::Buffer,
+    ) -> TractResult<wgpu::BindGroup> {
+        let key = BindGroupKey { layout: kind, buffers: buffers.iter().map(|b| b.id).collect() };
+        {
+            let cache = self.inner.bind_groups.lock().map_err(|e| anyhow!("{e}"))?;
+            if let Some(bg) = cache.get(&key) {
+                bump(0);
+                return Ok(bg.clone());
+            }
+        }
+        bump(1);
+        let (bgl, _) = self.layout(kind)?;
+        let mut entries: Vec<wgpu::BindGroupEntry<'_>> = Vec::with_capacity(buffers.len() + 1);
+        for (i, buf) in buffers.iter().enumerate() {
+            entries.push(wgpu::BindGroupEntry {
+                binding: i as u32,
+                resource: buf.inner.as_entire_binding(),
+            });
+        }
+        entries.push(uniform_entry(buffers.len() as u32, uniform));
+        let bg = self.inner.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(kind.label()),
+            layout: &bgl,
+            entries: &entries,
+        });
+        let mut cache = self.inner.bind_groups.lock().map_err(|e| anyhow!("{e}"))?;
+        cache.insert(key, bg.clone());
+        Ok(bg)
+    }
+
+    pub fn create_storage_buffer(&self, bytes: &[u8]) -> wgpu::Buffer {
+        let padded = pad4(bytes);
+        self.inner.device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("tract-wgpu-storage"),
+            contents: &padded,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+        })
+    }
+
+    /// Starts a new allocation sequence. Called when the queue flushes, which
+    /// is where a graph's intermediates are released.
+    /// Bind groups a frame no longer needs. The cache is only trimmed between
+    /// frames: sized to hold a graph's working set several times over, it
+    /// bounds a pathological model without ever evicting mid-frame what the
+    /// frame in flight is still binding.
+    pub(crate) fn trim_bind_groups(&self) {
+        if let Ok(mut cache) = self.inner.bind_groups.lock()
+            && cache.len() > BIND_GROUP_CACHE_CAP
+        {
+            cache.clear();
+        }
+    }
+
+    pub(crate) fn reset_buffer_slots(&self) {
+        if let Ok(mut cursor) = self.inner.slot_cursor.lock() {
+            cursor.clear();
+        }
+    }
+
+    fn next_buffer_id(&self) -> u64 {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// A storage buffer of `size` bytes for this position in the frame's
+    /// allocation sequence. Reuses the buffer that position held last frame,
+    /// unless it is still alive.
+    pub fn alloc_storage(&self, size: u64) -> Arc<WgpuBuffer> {
+        let size = size.max(4).next_multiple_of(4);
+        let seq = self
+            .inner
+            .slot_cursor
+            .lock()
+            .map(|mut c| {
+                let n = c.entry(size).or_insert(0);
+                let seq = *n;
+                *n += 1;
+                seq
+            })
+            .unwrap_or(u32::MAX);
+        if seq != u32::MAX
+            && let Ok(mut slots) = self.inner.buffer_slots.lock()
+        {
+            if let Some(held) = slots.get(&(size, seq))
+                && Arc::strong_count(held) == 1
+            {
+                bump(2);
+                return held.clone();
+            }
+            let fresh = Arc::new(WgpuBuffer {
+                inner: self.create_empty_storage(size),
+                id: self.next_buffer_id(),
+            });
+            bump(3);
+            slots.insert((size, seq), fresh.clone());
+            return fresh;
+        }
+        bump(3);
+        Arc::new(WgpuBuffer { inner: self.create_empty_storage(size), id: self.next_buffer_id() })
+    }
+
+    pub fn wrap_storage(&self, inner: wgpu::Buffer) -> WgpuBuffer {
+        WgpuBuffer { inner, id: self.next_buffer_id() }
+    }
+
+    pub fn create_empty_storage(&self, size: u64) -> wgpu::Buffer {
+        let size = size.max(4).next_multiple_of(4);
+        self.inner.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-storage"),
+            size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    /// A `MAP_READ` buffer of at least `size`, kept between calls: a fresh one
+    /// per frame costs an allocation and a device sync.
+    fn staging_at_least(&self, size: u64) -> wgpu::Buffer {
+        let mut slot = self.inner.staging.lock().unwrap();
+        if slot.as_ref().is_none_or(|b| b.size() < size) {
+            *slot = Some(self.inner.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tract-wgpu-staging"),
+                size: size.max(4),
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+        }
+        slot.as_ref().unwrap().clone()
+    }
+
+    /// Awaitable GPU→CPU copy. On web this is the single yield at the end of
+    /// `run()`; do not call it mid-graph. The copy rides the pending work's
+    /// own submission, so a frame costs one submit, not two.
+    pub async fn download_async(
+        &self,
+        buffer: &wgpu::Buffer,
+        offset: u64,
+        len: u64,
+    ) -> TractResult<Vec<u8>> {
+        if len == 0 {
+            with_wgpu_queue(|q| q.flush())?;
+            return Ok(vec![]);
+        }
+        let copy_len = len.next_multiple_of(4);
+        let staging = self.staging_at_least(copy_len);
+        with_wgpu_queue(|q| q.flush_after_copy(buffer, offset, &staging, copy_len))?;
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let slice = staging.slice(..copy_len);
+            let promise = js_sys::Promise::new(&mut |resolve, reject| {
+                slice.map_async(wgpu::MapMode::Read, move |r| match r {
+                    Ok(()) => {
+                        let _ = resolve.call0(&wasm_bindgen::JsValue::UNDEFINED);
+                    }
+                    Err(e) => {
+                        let _ = reject.call1(
+                            &wasm_bindgen::JsValue::UNDEFINED,
+                            &wasm_bindgen::JsValue::from_str(&format!("{e}")),
+                        );
+                    }
+                });
+            });
+            wasm_bindgen_futures::JsFuture::from(promise)
+                .await
+                .map_err(|e| anyhow!("mapAsync: {e:?}"))?;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let slice = staging.slice(..copy_len);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |r| {
+                let _ = tx.send(r);
+            });
+            self.poll_wait()?;
+            rx.recv().context("staging map channel")??;
+        }
+        let data = staging.slice(..copy_len).get_mapped_range()?;
+        let out = data[..len as usize].to_vec();
+        drop(data);
+        staging.unmap();
+        Ok(out)
+    }
+
+    fn poll_wait(&self) -> TractResult<()> {
+        // PollType::Wait is a no-op on web — the browser pumps GPU work.
+        // Never rely on it to complete mapAsync there.
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = self.inner.device.poll(wgpu::PollType::Poll);
+            Ok(())
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.inner
+                .device
+                .poll(wgpu::PollType::wait_indefinitely())
+                .map(|_| ())
+                .map_err(|e| anyhow!("wgpu poll: {e}"))
+        }
+    }
+}
+
+/// The uniform slot every layout ends with: one 256-byte window, addressed by
+/// the dynamic offset a dispatch passes.
+fn uniform_entry(binding: u32, uniform: &wgpu::Buffer) -> wgpu::BindGroupEntry<'_> {
+    wgpu::BindGroupEntry {
+        binding,
+        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+            buffer: uniform,
+            offset: 0,
+            size: Some(NonZeroU64::new(UNIFORM_ALIGN).unwrap()),
+        }),
+    }
+}
+
+fn pad4(bytes: &[u8]) -> Vec<u8> {
+    let mut v = bytes.to_vec();
+    while !v.len().is_multiple_of(4) {
+        v.push(0);
+    }
+    if v.is_empty() {
+        v.resize(4, 0);
+    }
+    v
+}
+
+impl DeviceContext for WgpuContext {
+    fn synchronize(&self) -> TractResult<()> {
+        with_wgpu_queue(|q| q.flush())
+    }
+
+    fn tensor_to_device(&self, tensor: TValue) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+        let view = tensor.view();
+        ensure!(
+            DeviceTensor::is_supported_dt(view.datum_type()),
+            "Tensor of {:?} is not copied. No device buffer can be allocated for it.",
+            view.datum_type(),
+        );
+        let bqs = as_q40_tensor(view.tensor);
+        let (data_bytes, bqf) = if let Some(bqs) = bqs {
+            (
+                bqs.value().as_bytes(),
+                Some(Box::new(BlockQuantFact::new(
+                    tract_core::dyn_clone::clone_box(bqs.format()),
+                    tensor.view().tensor.shape().into(),
+                )) as Box<dyn ExoticFact>),
+            )
+        } else {
+            (view.tensor.as_bytes(), None)
+        };
+        let buffer = Arc::new(self.wrap_storage(self.create_storage_buffer(data_bytes)));
+        Ok(Box::new(WgpuTensor {
+            buffer,
+            datum_type: view.datum_type(),
+            shape: view.shape().into(),
+            strides: view.strides().into(),
+            exotic_fact: bqf,
+        }))
+    }
+
+    fn uninitialized_device_tensor(
+        &self,
+        shape: &[usize],
+        dt: DatumType,
+    ) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+        let bytes = shape.iter().product::<usize>() * dt.size_of();
+        let buffer = self.alloc_storage(bytes as u64);
+        Ok(Box::new(WgpuTensor {
+            buffer,
+            datum_type: dt,
+            shape: shape.into(),
+            strides: Tensor::natural_strides(shape),
+            exotic_fact: None,
+        }))
+    }
+
+    fn uninitialized_device_exotic_tensor(
+        &self,
+        exotic_fact: Box<dyn ExoticFact>,
+    ) -> TractResult<Box<dyn OwnedDeviceTensor>> {
+        if let Some(bqf) = exotic_fact.downcast_ref::<BlockQuantFact>() {
+            let blocks = bqf.shape().iter().product::<usize>() / bqf.format.block_len();
+            let bytes = blocks * bqf.format.block_bytes();
+            let buffer = self.alloc_storage(bytes as u64);
+            Ok(Box::new(WgpuTensor {
+                buffer,
+                datum_type: f32::datum_type(),
+                shape: tvec!(),
+                strides: tvec!(),
+                exotic_fact: Some(exotic_fact),
+            }))
+        } else {
+            bail!("Only BlockQuant tensor allocation supported for now")
+        }
+    }
+
+    fn copy_nd(
+        &self,
+        input: &DeviceTensor,
+        input_offset: usize,
+        input_strides: &[isize],
+        output: &DeviceTensor,
+        output_offset: usize,
+        output_shape: &[usize],
+        output_strides: &[isize],
+    ) -> TractResult<()> {
+        crate::kernels::copy::wgpu_copy_nd_dispatch(
+            input,
+            input_offset,
+            input_strides,
+            output,
+            output_offset,
+            output_shape,
+            output_strides,
+        )
+    }
+}
+
+struct Dispatch {
+    label: &'static str,
+    pipeline: wgpu::ComputePipeline,
+    bind_group: wgpu::BindGroup,
+    dynamic_offset: u32,
+    groups: [u32; 3],
+}
+
+/// GPU time attributed to one kernel family over a run.
+#[derive(Debug, Clone, Default)]
+pub struct KernelTime {
+    pub calls: usize,
+    pub nanos: f64,
+}
+
+pub struct WgpuQueue {
+    context: WgpuContext,
+    encoder: RefCell<Option<wgpu::CommandEncoder>>,
+    pending: RefCell<Vec<Dispatch>>,
+    uniform_staging: RefCell<Vec<u8>>,
+    profile: Cell<bool>,
+    profiled: RefCell<Vec<(&'static str, u32)>>,
+    queries: RefCell<Option<Queries>>,
+    uniform: ManuallyDrop<wgpu::Buffer>,
+    uniform_cursor: Cell<u64>,
+    retained: RefCell<Vec<DeviceTensor>>,
+    retained_textures: RefCell<Vec<wgpu::Texture>>,
+    staging: RefCell<Option<wgpu::Buffer>>,
+}
+
+/// One timestamp pair per dispatch, plus the buffers to read them back.
+struct Queries {
+    set: wgpu::QuerySet,
+    resolve: wgpu::Buffer,
+    read: wgpu::Buffer,
+    capacity: u32,
+}
+
+/// Timestamps are written per compute pass, so a profiled run puts every
+/// dispatch in a pass of its own: the attribution is real GPU time, but the
+/// total is not what an unprofiled run costs.
+const MAX_QUERIES: u32 = 4096;
+
+impl WgpuQueue {
+    /// GPU time per kernel family over `f`. Returns nothing when the adapter has
+    /// no timestamp queries.
+    pub fn profile<R>(
+        &self,
+        f: impl FnOnce() -> TractResult<R>,
+    ) -> TractResult<(R, Vec<(&'static str, KernelTime)>)> {
+        if !self.context.timestamps() {
+            return Ok((f()?, vec![]));
+        }
+        self.flush()?;
+        self.ensure_queries()?;
+        self.profiled.borrow_mut().clear();
+        self.profile.set(true);
+        let out = f();
+        let _ = self.flush();
+        self.profile.set(false);
+        Ok((out?, self.read_profile()?))
+    }
+
+    fn ensure_queries(&self) -> TractResult<()> {
+        let mut slot = self.queries.borrow_mut();
+        if slot.is_some() {
+            return Ok(());
+        }
+        let device = self.context.device();
+        let set = device.create_query_set(&wgpu::QuerySetDescriptor {
+            label: Some("tract-wgpu-timestamps"),
+            ty: wgpu::QueryType::Timestamp,
+            count: MAX_QUERIES,
+        });
+        let size = MAX_QUERIES as u64 * 8;
+        let resolve = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-timestamps-resolve"),
+            size,
+            usage: wgpu::BufferUsages::QUERY_RESOLVE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let read = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-timestamps-read"),
+            size,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        *slot = Some(Queries { set, resolve, read, capacity: MAX_QUERIES });
+        Ok(())
+    }
+
+    fn read_profile(&self) -> TractResult<Vec<(&'static str, KernelTime)>> {
+        let profiled = std::mem::take(&mut *self.profiled.borrow_mut());
+        if profiled.is_empty() {
+            return Ok(vec![]);
+        }
+        let slot = self.queries.borrow();
+        let queries = slot.as_ref().unwrap();
+        let used = profiled.len() as u32 * 2;
+        {
+            let mut encoder =
+                self.context.device().create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("tract-wgpu-resolve"),
+                });
+            encoder.resolve_query_set(&queries.set, 0..used, &queries.resolve, 0);
+            encoder.copy_buffer_to_buffer(&queries.resolve, 0, &queries.read, 0, used as u64 * 8);
+            self.context.queue().submit(Some(encoder.finish()));
+        }
+        let slice = queries.read.slice(..used as u64 * 8);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |r| {
+            let _ = tx.send(r);
+        });
+        self.context.poll_wait()?;
+        rx.recv().context("timestamp map channel")??;
+        let period = self.context.queue().get_timestamp_period() as f64;
+        let ticks: Vec<u64> = {
+            let data = slice.get_mapped_range()?;
+            data.chunks_exact(8).map(|c| u64::from_le_bytes(c.try_into().unwrap())).collect()
+        };
+        queries.read.unmap();
+
+        let mut by_label: HashMap<&'static str, KernelTime> = HashMap::new();
+        for (label, base) in profiled {
+            let (start, end) = (ticks[base as usize], ticks[base as usize + 1]);
+            let e = by_label.entry(label).or_default();
+            e.calls += 1;
+            e.nanos += end.saturating_sub(start) as f64 * period;
+        }
+        let mut out: Vec<_> = by_label.into_iter().collect();
+        out.sort_by(|a, b| b.1.nanos.total_cmp(&a.1.nanos));
+        Ok(out)
+    }
+}
+
+impl WgpuQueue {
+    fn new() -> TractResult<Self> {
+        let context = wgpu_context();
+        let uniform = context.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some("tract-wgpu-uniform"),
+            size: UNIFORM_BYTES,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        Ok(Self {
+            context,
+            encoder: RefCell::new(None),
+            pending: RefCell::new(vec![]),
+            uniform_staging: RefCell::new(vec![]),
+            profile: Cell::new(false),
+            profiled: RefCell::new(vec![]),
+            queries: RefCell::new(None),
+            uniform: ManuallyDrop::new(uniform),
+            uniform_cursor: Cell::new(0),
+            retained: RefCell::new(vec![]),
+            retained_textures: RefCell::new(vec![]),
+            staging: RefCell::new(None),
+        })
+    }
+
+    pub fn context(&self) -> &WgpuContext {
+        &self.context
+    }
+
+    pub fn uniform(&self) -> &wgpu::Buffer {
+        &self.uniform
+    }
+
+    /// wgpu-core buffer drop takes a TLS snatch lock. Doing that from this
+    /// thread-local's destructor panics (`cannot access a Thread Local Storage
+    /// value during or after destruction`). Leak GPU objects; the device lives
+    /// in a process-level `OnceLock` for the rest of the run.
+    fn leak_gpu_objects(&mut self) {
+        std::mem::forget(self.encoder.replace(None));
+        std::mem::forget(self.staging.replace(None));
+        std::mem::forget(std::mem::take(&mut *self.retained.borrow_mut()));
+        std::mem::forget(std::mem::take(&mut *self.retained_textures.borrow_mut()));
+        unsafe {
+            std::mem::forget(ManuallyDrop::take(&mut self.uniform));
+        }
+    }
+
+    pub fn retain_tensor(&self, t: &DeviceTensor) {
+        self.retained.borrow_mut().push(t.clone());
+    }
+
+    pub fn retain_texture(&self, t: wgpu::Texture) {
+        self.retained_textures.borrow_mut().push(t);
+    }
+
+    fn encoder(&self) -> std::cell::RefMut<'_, wgpu::CommandEncoder> {
+        let mut slot = self.encoder.borrow_mut();
+        if slot.is_none() {
+            *slot = Some(self.context.device().create_command_encoder(
+                &wgpu::CommandEncoderDescriptor { label: Some("tract-wgpu") },
+            ));
+        }
+        std::cell::RefMut::map(slot, |o| o.as_mut().unwrap())
+    }
+
+    /// Stages one dispatch's uniform block. The ring is uploaded once per
+    /// flush: a write per dispatch costs an allocation and a queue call each,
+    /// and a graph issues them by the hundred.
+    pub fn alloc_uniform(&self, bytes: &[u8]) -> TractResult<u32> {
+        ensure!(
+            bytes.len() as u64 <= UNIFORM_ALIGN,
+            "uniform payload {} > {UNIFORM_ALIGN}",
+            bytes.len()
+        );
+        let mut cursor = self.uniform_cursor.get();
+        if cursor + UNIFORM_ALIGN > UNIFORM_BYTES {
+            self.flush()?;
+            cursor = 0;
+        }
+        let mut staging = self.uniform_staging.borrow_mut();
+        let at = cursor as usize;
+        if staging.len() < at + UNIFORM_ALIGN as usize {
+            staging.resize(at + UNIFORM_ALIGN as usize, 0);
+        }
+        staging[at..at + bytes.len()].copy_from_slice(bytes);
+        staging[at + bytes.len()..at + UNIFORM_ALIGN as usize].fill(0);
+        self.uniform_cursor.set(cursor + UNIFORM_ALIGN);
+        Ok(cursor as u32)
+    }
+
+    /// Uploads the slots staged since the last flush, before anything reads
+    /// them.
+    fn upload_uniforms(&self) {
+        let used = self.uniform_cursor.get();
+        if used == 0 {
+            return;
+        }
+        let staging = self.uniform_staging.borrow();
+        self.context.queue().write_buffer(&self.uniform, 0, &staging[..used as usize]);
+    }
+
+    pub fn dispatch(
+        &self,
+        label: &'static str,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        dynamic_offset: u32,
+        n_elements: u64,
+    ) -> TractResult<()> {
+        if n_elements == 0 {
+            return Ok(());
+        }
+        let groups = n_elements.div_ceil(WORKGROUP as u64) as u32;
+        self.dispatch_grid(label, pipeline, bind_group, dynamic_offset, [groups, 1, 1])
+    }
+
+    /// A kernel whose workgroups tile a 2-D or 3-D iteration space itself.
+    pub fn dispatch_grid(
+        &self,
+        label: &'static str,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        dynamic_offset: u32,
+        groups: [u32; 3],
+    ) -> TractResult<()> {
+        if groups.contains(&0) {
+            return Ok(());
+        }
+        self.pending.borrow_mut().push(Dispatch {
+            label,
+            pipeline: pipeline.clone(),
+            bind_group: bind_group.clone(),
+            dynamic_offset,
+            groups,
+        });
+        Ok(())
+    }
+
+    /// Records everything queued since the last drain as a single compute pass.
+    /// WebGPU orders dispatches inside a pass and synchronizes their storage
+    /// accesses, so one pass per graph costs far less than one pass per kernel.
+    /// Anything that encodes a copy must drain first to keep its place in line.
+    fn drain_pending(&self) {
+        let pending = std::mem::take(&mut *self.pending.borrow_mut());
+        if pending.is_empty() {
+            return;
+        }
+        if self.profile.get() {
+            self.drain_profiled(&pending);
+            return;
+        }
+        let mut encoder = self.encoder();
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("tract-wgpu"),
+            timestamp_writes: None,
+        });
+        for d in &pending {
+            pass.set_pipeline(&d.pipeline);
+            pass.set_bind_group(0, &d.bind_group, &[d.dynamic_offset]);
+            pass.dispatch_workgroups(d.groups[0], d.groups[1], d.groups[2]);
+        }
+    }
+
+    /// Records `copy_buffer_to_buffer` behind the pending work and flushes the
+    /// lot in one submission.
+    pub fn flush_after_copy(
+        &self,
+        src: &wgpu::Buffer,
+        offset: u64,
+        dst: &wgpu::Buffer,
+        copy_len: u64,
+    ) -> TractResult<()> {
+        self.upload_uniforms();
+        self.drain_pending();
+        self.encoder().copy_buffer_to_buffer(src, offset, dst, 0, copy_len);
+        self.flush()
+    }
+
+    fn drain_profiled(&self, pending: &[Dispatch]) {
+        let slot = self.queries.borrow();
+        let Some(queries) = slot.as_ref() else { return };
+        let mut profiled = self.profiled.borrow_mut();
+        let mut encoder = self.encoder();
+        for d in pending {
+            let base = profiled.len() as u32 * 2;
+            if base + 2 > queries.capacity {
+                break;
+            }
+            profiled.push((d.label, base));
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some(d.label),
+                timestamp_writes: Some(wgpu::ComputePassTimestampWrites {
+                    query_set: &queries.set,
+                    beginning_of_pass_write_index: Some(base),
+                    end_of_pass_write_index: Some(base + 1),
+                }),
+            });
+            pass.set_pipeline(&d.pipeline);
+            pass.set_bind_group(0, &d.bind_group, &[d.dynamic_offset]);
+            pass.dispatch_workgroups(d.groups[0], d.groups[1], d.groups[2]);
+        }
+    }
+
+    pub fn flush(&self) -> TractResult<()> {
+        self.upload_uniforms();
+        self.drain_pending();
+        if let Some(encoder) = self.encoder.replace(None) {
+            self.context.queue().submit(Some(encoder.finish()));
+        }
+        self.context.poll_wait()?;
+        self.retained.borrow_mut().clear();
+        self.retained_textures.borrow_mut().clear();
+        self.uniform_cursor.set(0);
+        self.context.trim_bind_groups();
+        self.context.reset_buffer_slots();
+        Ok(())
+    }
+
+    fn copy_to_staging(
+        &self,
+        buffer: &wgpu::Buffer,
+        offset: u64,
+        copy_len: u64,
+    ) -> TractResult<()> {
+        {
+            let mut staging = self.staging.borrow_mut();
+            let need_new = staging.as_ref().map(|b| b.size() < copy_len).unwrap_or(true);
+            if need_new {
+                *staging = Some(self.context.device().create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("tract-wgpu-staging"),
+                    size: copy_len.max(4),
+                    usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                }));
+            }
+        }
+        let staging = self.staging.borrow();
+        let staging = staging.as_ref().unwrap();
+        let mut encoder =
+            self.context.device().create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("tract-wgpu-download"),
+            });
+        encoder.copy_buffer_to_buffer(buffer, offset, staging, 0, copy_len);
+        self.context.queue().submit(Some(encoder.finish()));
+        Ok(())
+    }
+
+    fn read_mapped_staging(&self, copy_len: u64, len: u64) -> TractResult<Vec<u8>> {
+        let staging = self.staging.borrow();
+        let staging = staging.as_ref().unwrap();
+        let slice = staging.slice(..copy_len);
+        let data = slice.get_mapped_range()?;
+        let out = data[..len as usize].to_vec();
+        drop(data);
+        staging.unmap();
+        Ok(out)
+    }
+
+    /// Blocking readback. On wasm without JSPI this errors: `PollType::Wait`
+    /// is a no-op. With `--features jspi`, [`crate::tensor::WgpuTensor::to_host`]
+    /// suspends via JSPI instead of calling this. Use [`Self::download_async`]
+    /// from an `async` entry.
+    pub fn download(&self, buffer: &wgpu::Buffer, offset: u64, len: u64) -> TractResult<Vec<u8>> {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = (buffer, offset, len);
+            bail!(
+                "blocking GPU readback is not possible on web (PollType::Wait is a no-op). \
+                 After run(), await download_async / to_host_async once."
+            )
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.flush()?;
+            if len == 0 {
+                return Ok(vec![]);
+            }
+            let copy_len = len.next_multiple_of(4);
+            self.copy_to_staging(buffer, offset, copy_len)?;
+            let staging = self.staging.borrow();
+            let staging = staging.as_ref().unwrap();
+            let slice = staging.slice(..copy_len);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |r| {
+                let _ = tx.send(r);
+            });
+            let _ = staging;
+            self.context.poll_wait()?;
+            rx.recv().context("staging map channel")??;
+            self.read_mapped_staging(copy_len, len)
+        }
+    }
+
+    /// One await at the end of a run. Native path still blocks inside; web
+    /// yields to the browser so `mapAsync` can complete.
+    pub async fn download_async(
+        &self,
+        buffer: &wgpu::Buffer,
+        offset: u64,
+        len: u64,
+    ) -> TractResult<Vec<u8>> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.download(buffer, offset, len)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.flush()?;
+            if len == 0 {
+                return Ok(vec![]);
+            }
+            let copy_len = len.next_multiple_of(4);
+            self.copy_to_staging(buffer, offset, copy_len)?;
+            let staging = self.staging.borrow().as_ref().unwrap().clone();
+            let slice = staging.slice(..copy_len);
+            let promise = js_sys::Promise::new(&mut |resolve, reject| {
+                slice.map_async(wgpu::MapMode::Read, move |r| match r {
+                    Ok(()) => {
+                        let _ = resolve.call0(&wasm_bindgen::JsValue::UNDEFINED);
+                    }
+                    Err(e) => {
+                        let _ = reject.call1(
+                            &wasm_bindgen::JsValue::UNDEFINED,
+                            &wasm_bindgen::JsValue::from_str(&format!("{e}")),
+                        );
+                    }
+                });
+            });
+            wasm_bindgen_futures::JsFuture::from(promise)
+                .await
+                .map_err(|e| anyhow!("mapAsync: {e:?}"))?;
+            self.read_mapped_staging(copy_len, len)
+        }
+    }
+}
+
+impl Drop for WgpuQueue {
+    fn drop(&mut self) {
+        // Do not flush or drop wgpu buffers here: this type lives in TLS and
+        // wgpu-core buffer drop takes a TLS snatch lock.
+        self.leak_gpu_objects();
+    }
+}
+
+#[derive(Clone)]
+/// The identity a bind group is keyed on. It follows the buffer through the
+/// pool, so a graph that reuses its buffers reuses its bind groups; keying on
+/// the `wgpu::Buffer` itself would keep every buffer alive in the cache and
+/// leave the pool nothing to hand out.
+pub struct WgpuBuffer {
+    pub inner: wgpu::Buffer,
+    pub id: u64,
+}
+
+impl std::fmt::Debug for WgpuBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgpuBuffer").field("size", &self.inner.size()).finish()
+    }
+}
+
+impl DeviceBuffer for WgpuBuffer {
+    fn ptr(&self) -> *const c_void {
+        // Opaque identity of the wgpu buffer handle. WebGPU has no device
+        // address; launch functions downcast `WgpuBuffer` instead of using this.
+        std::ptr::from_ref(&self.inner) as *const c_void
+    }
+}

--- a/wgpu/src/jspi.rs
+++ b/wgpu/src/jspi.rs
@@ -1,0 +1,82 @@
+//! Optional JSPI hybrid fallback.
+//!
+//! Mid-graph GPU→CPU readback needs the wasm stack to suspend across
+//! `mapAsync`. JSPI does that; Asyncify is unavailable (`wasm32-unknown-emscripten`
+//! only) and must not become a load-time dependency:
+//!
+//! | Engine | WebGPU | JSPI |
+//! |---|---|---|
+//! | Chrome / Edge | 113+ | 137+ |
+//! | Firefox | Win 141+, macOS 147+ | 139+ |
+//! | Safari | 26.0 | 27 |
+//!
+//! Default wasm builds carry **no** `WebAssembly.Suspending` imports, so Safari
+//! 26 still loads a fully-covered model. Enable Cargo feature `jspi` for the
+//! hybrid binary (uncovered ops fall back to tract CPU kernels). Native always
+//! has blocking poll, so hybrid is on there with no feature flag.
+
+#[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+use tract_core::internal::*;
+
+/// True when a GPU→CPU sync can complete in the middle of `eval`.
+///
+/// Native: always (blocking `PollType::Wait`).
+/// Wasm: only if this crate was built with `--features jspi` **and** the
+/// browser exposes `WebAssembly.Suspending` / `WebAssembly.promising`.
+pub fn hybrid_fallback_available() -> bool {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        true
+    }
+    #[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+    {
+        jspi_in_browser()
+    }
+    #[cfg(all(target_arch = "wasm32", not(feature = "jspi")))]
+    {
+        false
+    }
+}
+
+/// `WebAssembly.Suspending` + `WebAssembly.promising` present on the global.
+#[cfg(target_arch = "wasm32")]
+pub fn jspi_in_browser() -> bool {
+    let Ok(wa) =
+        js_sys::Reflect::get(&js_sys::global(), &wasm_bindgen::JsValue::from_str("WebAssembly"))
+    else {
+        return false;
+    };
+    if wa.is_undefined() || wa.is_null() {
+        return false;
+    }
+    let sus = js_sys::Reflect::get(&wa, &wasm_bindgen::JsValue::from_str("Suspending")).ok();
+    let prom = js_sys::Reflect::get(&wa, &wasm_bindgen::JsValue::from_str("promising")).ok();
+    matches!(sus, Some(ref v) if v.is_function()) && matches!(prom, Some(ref v) if v.is_function())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn jspi_in_browser() -> bool {
+    false
+}
+
+/// Block on [`WgpuContext::download_async`] via JSPI. Must run inside a
+/// `#[wasm_bindgen(jspi)]` export (or a task spawned from one). Does not hold
+/// the `WGPU_QUEUE` TLS borrow across the suspend.
+#[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+pub fn download_jspi(buffer: &wgpu::Buffer, offset: u64, len: u64) -> TractResult<Vec<u8>> {
+    use wasm_bindgen::JsValue;
+
+    crate::with_wgpu_queue(|q| q.flush())?;
+    let ctx = crate::wgpu_context();
+    let buffer = buffer.clone();
+    let promise = wasm_bindgen_futures::future_to_promise(async move {
+        match ctx.download_async(&buffer, offset, len).await {
+            Ok(bytes) => Ok(js_sys::Uint8Array::from(bytes.as_slice()).into()),
+            Err(e) => Err(JsValue::from_str(&format!("{e:#}"))),
+        }
+    });
+    #[allow(deprecated)]
+    let val = js_sys::futures::jspi_block_on_promise(&promise)
+        .map_err(|e| anyhow::anyhow!("JSPI GPU readback failed: {e:?}"))?;
+    Ok(js_sys::Uint8Array::new(&val).to_vec())
+}

--- a/wgpu/src/kernels/cast.rs
+++ b/wgpu/src/kernels/cast.rs
@@ -1,0 +1,60 @@
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, pack_u32s,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    if !shader_f16 {
+        return vec![];
+    }
+    vec![
+        PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Cast, dtype: ShaderDtype::F32 },
+            entry: EntryPoint::plain("cast_f32_f16"),
+        },
+        PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Cast, dtype: ShaderDtype::F16 },
+            entry: EntryPoint::plain("cast_f16_f32"),
+        },
+    ]
+}
+
+pub fn is_supported_dt(dt: DatumType) -> bool {
+    matches!(dt, DatumType::F32 | DatumType::F16)
+}
+
+pub fn wgpu_cast_dispatch(input: &DeviceTensor, output: &DeviceTensor) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        ensure!(input.shape() == output.shape());
+        let (dtype, entry) = match (input.datum_type(), output.datum_type()) {
+            (DatumType::F32, DatumType::F16) => {
+                (ShaderDtype::F32, EntryPoint::plain("cast_f32_f16"))
+            }
+            (DatumType::F16, DatumType::F32) => {
+                (ShaderDtype::F16, EntryPoint::plain("cast_f16_f32"))
+            }
+            (a, b) if a == b => return Ok(()),
+            (a, b) => bail!("tract-wgpu cast {a:?} -> {b:?} not implemented"),
+        };
+        let pipeline = q
+            .context()
+            .pipeline(PipelineKey { module: ModuleKey { kind: ModuleKind::Cast, dtype }, entry })?;
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let params = pack_u32s(&[
+            element_offset(input, 0) as u32,
+            element_offset(output, 0) as u32,
+            output.len() as u32,
+            0,
+        ]);
+        let dyn_off = q.alloc_uniform(&params)?;
+        q.dispatch("cast", &pipeline, &bg, dyn_off, output.len() as u64)
+    })
+}

--- a/wgpu/src/kernels/copy.rs
+++ b/wgpu/src/kernels/copy.rs
@@ -1,0 +1,50 @@
+use tract_core::internal::*;
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::kernels::shaders::{
+    EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for, pack_u32s,
+    pad8_stride, pad8_u32,
+};
+use crate::utils::{element_offset, get_wgpu_buffer};
+use crate::with_wgpu_queue;
+
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<PipelineKey> {
+    keys_for(ModuleKind::Copy, &["copy"], shader_f16)
+}
+
+pub fn wgpu_copy_nd_dispatch(
+    input: &DeviceTensor,
+    input_offset: usize,
+    input_strides: &[isize],
+    output: &DeviceTensor,
+    output_offset: usize,
+    output_shape: &[usize],
+    output_strides: &[isize],
+) -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        q.retain_tensor(input);
+        q.retain_tensor(output);
+        let dt = ShaderDtype::from_datum(input.datum_type())?;
+        let key = PipelineKey {
+            module: ModuleKey { kind: ModuleKind::Copy, dtype: dt },
+            entry: EntryPoint::typed("copy", dt),
+        };
+        let pipeline = q.context().pipeline(key)?;
+        let in_buf = get_wgpu_buffer(input);
+        let out_buf = get_wgpu_buffer(output);
+        let bg = q.context().bind_group(LayoutKind::Unary, &[in_buf, out_buf], q.uniform())?;
+        let n: u64 = output_shape.iter().map(|d| *d as u64).product();
+        let rank = output_shape.len().max(1);
+        let mut vals = vec![
+            element_offset(input, input_offset) as u32,
+            element_offset(output, output_offset) as u32,
+            rank as u32,
+            n as u32,
+        ];
+        vals.extend_from_slice(&pad8_stride(input_strides));
+        vals.extend_from_slice(&pad8_stride(output_strides));
+        vals.extend_from_slice(&pad8_u32(output_shape));
+        let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+        q.dispatch("copy", &pipeline, &bg, dyn_off, n)
+    })
+}

--- a/wgpu/src/kernels/mod.rs
+++ b/wgpu/src/kernels/mod.rs
@@ -1,0 +1,12 @@
+pub mod cast;
+pub mod copy;
+pub mod shaders;
+
+/// Every pipeline this crate's kernels can need. They are built when the
+/// context is created so that no frame ever waits on a shader compile.
+pub fn all_pipeline_keys(shader_f16: bool) -> Vec<shaders::PipelineKey> {
+    let mut keys = vec![];
+    keys.extend(cast::all_pipeline_keys(shader_f16));
+    keys.extend(copy::all_pipeline_keys(shader_f16));
+    keys
+}

--- a/wgpu/src/kernels/shaders.rs
+++ b/wgpu/src/kernels/shaders.rs
@@ -1,0 +1,302 @@
+//! WGSL sources for Phase 1 kernels.
+//!
+//! Flattened 1-D indexing: `dispatch_workgroups` is 3-D, tract tensors are
+//! routinely 4-D+, so shaders take a linear id and apply strides from uniforms.
+//! Byte offsets live in uniforms so arena views work without 256-byte-aligned
+//! `GPUBufferBinding.offset` (the whole storage buffer is bound at 0).
+//!
+//! Structure follows tfjs-backend-webgpu unary/binary (Apache-2.0): one entry
+//! point per op, tightly packed storage arrays. Not a transcription of their
+//! TypeScript generators.
+
+use tract_core::internal::*;
+
+pub const WORKGROUP: u32 = 64;
+
+/// Reads one of the eight values a uniform packs as two `vec4<u32>`.
+const AT8: &str = "fn at8(a: vec4<u32>, b: vec4<u32>, i: u32) -> u32 {
+    if (i < 4u) { return a[i]; }
+    return b[i - 4u];
+}";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LayoutKind {
+    Unary,
+}
+
+impl LayoutKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Unary => "tract-wgpu-unary-layout",
+        }
+    }
+
+    pub fn storage_count(self) -> u32 {
+        match self {
+            Self::Unary => 2,
+        }
+    }
+
+    pub fn bind_group_layout_entries(self) -> Vec<wgpu::BindGroupLayoutEntry> {
+        let mut entries = Vec::new();
+        let n = self.storage_count();
+        for i in 0..n {
+            let read_only = i + 1 < n;
+            entries.push(wgpu::BindGroupLayoutEntry {
+                binding: i,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            });
+        }
+        entries.push(wgpu::BindGroupLayoutEntry {
+            binding: n,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: true,
+                min_binding_size: std::num::NonZeroU64::new(256),
+            },
+            count: None,
+        });
+        entries
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShaderDtype {
+    F32,
+    F16,
+}
+
+impl ShaderDtype {
+    pub fn from_datum(dt: DatumType) -> TractResult<Self> {
+        match dt {
+            DatumType::F32 => Ok(Self::F32),
+            DatumType::F16 => Ok(Self::F16),
+            _ => bail!("tract-wgpu Phase 1 kernel has no WGSL path for {dt:?}"),
+        }
+    }
+
+    pub fn wgsl(self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::F16 => "f16",
+        }
+    }
+
+    /// Entry points are suffixed with the WGSL type they were generated for.
+    pub fn suffix(self) -> &'static str {
+        self.wgsl()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ModuleKind {
+    Copy,
+    Cast,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ModuleKey {
+    pub kind: ModuleKind,
+    pub dtype: ShaderDtype,
+}
+
+impl ModuleKey {
+    /// Names the module in a debugger and in wgpu's own diagnostics. Only a
+    /// cache miss builds one.
+    pub fn label(self) -> String {
+        format!("{:?}_{}", self.kind, self.dtype.suffix()).to_lowercase()
+    }
+
+    pub fn layout(self) -> LayoutKind {
+        match self.kind {
+            ModuleKind::Copy | ModuleKind::Cast => LayoutKind::Unary,
+        }
+    }
+
+    pub fn wgsl(self) -> String {
+        match self.kind {
+            ModuleKind::Copy => copy_wgsl(self.dtype),
+            ModuleKind::Cast => cast_wgsl(self.dtype),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PipelineKey {
+    pub module: ModuleKey,
+    pub entry: EntryPoint,
+}
+
+/// A kernel's WGSL entry point, held in the pieces the generator spells it
+/// from so that naming one costs no allocation on the dispatch path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntryPoint {
+    stem: &'static str,
+    infix: &'static str,
+    suffix: &'static str,
+}
+
+impl EntryPoint {
+    /// One of a module's per-dtype entry points, `<stem>_<dtype>`.
+    pub fn typed(stem: &'static str, dtype: ShaderDtype) -> Self {
+        Self { stem, infix: "", suffix: dtype.suffix() }
+    }
+
+    /// An entry point that names the dtypes it works on itself.
+    pub fn plain(name: &'static str) -> Self {
+        Self { stem: name, infix: "", suffix: "" }
+    }
+
+    /// Spelled out, as the generated WGSL declares it. Only a pipeline cache
+    /// miss needs this.
+    pub fn name(&self) -> String {
+        let sep = if self.suffix.is_empty() { "" } else { "_" };
+        format!("{}{}{sep}{}", self.stem, self.infix, self.suffix)
+    }
+}
+
+/// The dtypes this device can run a kernel for.
+pub fn dtypes(shader_f16: bool) -> &'static [ShaderDtype] {
+    if shader_f16 { &[ShaderDtype::F32, ShaderDtype::F16] } else { &[ShaderDtype::F32] }
+}
+
+/// Every pipeline a module serves: each of `stems` at each dtype the device
+/// can run.
+pub fn keys_for(kind: ModuleKind, stems: &[&'static str], shader_f16: bool) -> Vec<PipelineKey> {
+    dtypes(shader_f16)
+        .iter()
+        .flat_map(|dt| {
+            stems.iter().map(|stem| PipelineKey {
+                module: ModuleKey { kind, dtype: *dt },
+                entry: EntryPoint::typed(stem, *dt),
+            })
+        })
+        .collect()
+}
+
+fn preamble(dt: ShaderDtype) -> String {
+    let enable = match dt {
+        ShaderDtype::F16 => "enable f16;\n",
+        ShaderDtype::F32 => "",
+    };
+    enable.to_string()
+}
+
+fn copy_wgsl(dt: ShaderDtype) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    off_in: u32,
+    off_out: u32,
+    rank: u32,
+    len: u32,
+    in_s0: vec4<u32>,
+    in_s1: vec4<u32>,
+    out_s0: vec4<u32>,
+    out_s1: vec4<u32>,
+    out_sh0: vec4<u32>,
+    out_sh1: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> inp: array<{t}>;
+@group(0) @binding(1) var<storage, read_write> outp: array<{t}>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+{AT8}
+
+@compute @workgroup_size({WORKGROUP})
+fn copy_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    var rest = i;
+    var in_i = params.off_in;
+    var out_i = params.off_out;
+    let r = params.rank;
+    for (var k = 0u; k < r; k++) {{
+        let axis = r - 1u - k;
+        let dim = max(at8(params.out_sh0, params.out_sh1, axis), 1u);
+        let c = rest % dim;
+        rest = rest / dim;
+        in_i += c * at8(params.in_s0, params.in_s1, axis);
+        out_i += c * at8(params.out_s0, params.out_s1, axis);
+    }}
+    outp[out_i] = inp[in_i];
+}}
+"#
+    ));
+    s
+}
+
+fn cast_wgsl(dt: ShaderDtype) -> String {
+    match dt {
+        ShaderDtype::F32 => {
+            // f32 -> f16
+            format!(
+                r#"
+enable f16;
+struct Params {{ off_in: u32, off_out: u32, len: u32, _p: u32 }}
+@group(0) @binding(0) var<storage, read> inp: array<f32>;
+@group(0) @binding(1) var<storage, read_write> outp: array<f16>;
+@group(0) @binding(2) var<uniform> params: Params;
+@compute @workgroup_size({WORKGROUP})
+fn cast_f32_f16(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    outp[params.off_out + i] = f16(inp[params.off_in + i]);
+}}
+"#
+            )
+        }
+        ShaderDtype::F16 => {
+            format!(
+                r#"
+enable f16;
+struct Params {{ off_in: u32, off_out: u32, len: u32, _p: u32 }}
+@group(0) @binding(0) var<storage, read> inp: array<f16>;
+@group(0) @binding(1) var<storage, read_write> outp: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+@compute @workgroup_size({WORKGROUP})
+fn cast_f16_f32(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let i = gid.x;
+    if (i >= params.len) {{ return; }}
+    outp[params.off_out + i] = f32(inp[params.off_in + i]);
+}}
+"#
+            )
+        }
+    }
+}
+
+pub fn pack_u32s(vals: &[u32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vals.len() * 4);
+    for v in vals {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+pub fn pad8_u32(xs: &[usize]) -> [u32; 8] {
+    let mut out = [1u32; 8];
+    for (i, v) in xs.iter().take(8).enumerate() {
+        out[i] = *v as u32;
+    }
+    out
+}
+
+pub fn pad8_stride(xs: &[isize]) -> [u32; 8] {
+    let mut out = [0u32; 8];
+    for (i, s) in xs.iter().take(8).enumerate() {
+        out[i] = (*s).max(0) as u32;
+    }
+    out
+}

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -1,0 +1,51 @@
+//! WebGPU backend for tract, built on the `wgpu` crate.
+//!
+//! Native (Vulkan/Metal/DX12): blocking `request_adapter` / `PollType::Wait`.
+//! Wasm (`wasm32-unknown-unknown`): enable wgpu's
+//! `fragile-send-sync-non-atomic-wasm` feature (on by default here). That is
+//! sound **only** because tract's browser CPU tiers compile **without**
+//! atomics — `DeviceContext` / `OwnedDeviceTensor` require `Send + Sync`, and
+//! wgpu's web types are `!Send`/`!Sync` otherwise.
+//!
+//! **Mutually exclusive** with the
+//! `+atomics,+bulk-memory,+mutable-globals,+simd128` wasm-bindgen-rayon tier
+//! (`linalg/MULTITHREAD_BENCHMARKS.md`). In a video call that is the correct
+//! trade: inference must not take four CPU cores.
+//!
+//! Startup is one async (`wgpu_context_async`). Fully-covered models stay
+//! synchronous: **one await at the end of `run()`**. On web, `PollType::Wait`
+//! is a no-op — do not use blocking `to_host` unless Cargo feature `jspi` is
+//! on (JSPI suspends across `mapAsync`; Safari 26 lacks it, Safari 27 has it).
+//! Await [`to_host_async`] **once** after `run()` on the default wasm path.
+//!
+//! `DeviceBuffer::ptr()` is an identity of the `wgpu::Buffer` handle, not a
+//! GPU address. Kernels downcast `WgpuBuffer` and bind
+//! `(buffer, byte_offset as uniform)`.
+
+mod context;
+pub mod jspi;
+pub mod kernels;
+mod tensor;
+mod tests;
+mod utils;
+
+use tract_core::internal::*;
+
+pub use crate::context::{
+    CACHE_STATS, KernelTime, WgpuContext, WgpuQueue, wgpu_context, wgpu_context_async,
+    with_wgpu_queue,
+};
+pub use crate::jspi::{hybrid_fallback_available, jspi_in_browser};
+
+use crate::utils::get_wgpu_buffer;
+use tract_gpu::tensor::DeviceTensor;
+
+/// Single await after `run()` on web (and a blocking poll on native).
+pub async fn to_host_async(tensor: &DeviceTensor) -> TractResult<Tensor> {
+    let ctx = wgpu_context();
+    let buffer = get_wgpu_buffer(tensor).inner.clone();
+    let offset = tensor.buffer_offset::<usize>() as u64;
+    let len = (tensor.len() * tensor.datum_type().size_of()) as u64;
+    let bytes = ctx.download_async(&buffer, offset, len).await?;
+    unsafe { Tensor::from_raw_dt(tensor.datum_type(), tensor.shape(), &bytes) }
+}

--- a/wgpu/src/tensor.rs
+++ b/wgpu/src/tensor.rs
@@ -1,0 +1,143 @@
+use std::fmt::Display;
+use std::sync::Arc;
+
+use tract_core::internal::*;
+use tract_gpu::device::DeviceBuffer;
+use tract_gpu::tensor::{DeviceTensor, OwnedDeviceTensor};
+use tract_gpu::utils::check_strides_validity;
+
+use crate::context::WgpuBuffer;
+#[cfg(not(all(target_arch = "wasm32", feature = "jspi")))]
+use crate::context::with_wgpu_queue;
+
+#[derive(Clone)]
+pub struct WgpuTensor {
+    pub buffer: Arc<WgpuBuffer>,
+    pub datum_type: DatumType,
+    pub shape: TVec<usize>,
+    pub strides: TVec<isize>,
+    pub exotic_fact: Option<Box<dyn ExoticFact>>,
+}
+
+impl std::fmt::Debug for WgpuTensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgpuTensor")
+            .field("datum_type", &self.datum_type)
+            .field("shape", &self.shape)
+            .finish()
+    }
+}
+
+impl PartialEq for WgpuTensor {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.buffer.as_ref(), other.buffer.as_ref())
+            && self.datum_type == other.datum_type
+            && self.shape == other.shape
+            && self.strides == other.strides
+    }
+}
+impl Eq for WgpuTensor {}
+
+impl OwnedDeviceTensor for WgpuTensor {
+    fn datum_type(&self) -> DatumType {
+        self.datum_type
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn strides(&self) -> &[isize] {
+        &self.strides
+    }
+
+    fn reshaped(&self, shape: TVec<usize>) -> TractResult<DeviceTensor> {
+        if self.len() != shape.iter().product::<usize>() {
+            bail!("Invalid reshape {:?} to {:?}", self.shape(), shape);
+        }
+        if shape.as_slice() != self.shape() {
+            Ok(DeviceTensor::Owned(Box::new(WgpuTensor {
+                strides: Tensor::natural_strides(&shape),
+                shape,
+                buffer: Arc::clone(&self.buffer),
+                datum_type: self.datum_type,
+                exotic_fact: self.exotic_fact.clone(),
+            })))
+        } else {
+            Ok(DeviceTensor::Owned(Box::new(self.clone())))
+        }
+    }
+
+    fn restrided(&self, strides: TVec<isize>) -> TractResult<DeviceTensor> {
+        check_strides_validity(self.shape().into(), strides.clone())?;
+        if strides.as_slice() != self.strides() {
+            Ok(DeviceTensor::Owned(Box::new(WgpuTensor {
+                strides,
+                buffer: Arc::clone(&self.buffer),
+                datum_type: self.datum_type,
+                shape: self.shape.clone(),
+                exotic_fact: self.exotic_fact.clone(),
+            })))
+        } else {
+            Ok(DeviceTensor::Owned(Box::new(self.clone())))
+        }
+    }
+
+    fn device_buffer(&self) -> &dyn DeviceBuffer {
+        self.buffer.as_ref()
+    }
+
+    fn to_host(&self) -> TractResult<Arc<Tensor>> {
+        let (offset, len) = if let Some(of) = &self.exotic_fact {
+            (0u64, of.mem_size().as_i64().context("Symbolic exotic tensor size")? as u64)
+        } else {
+            (0u64, (self.len() * self.datum_type.size_of()) as u64)
+        };
+        let bytes = download_owned_bytes(&self.buffer.inner, offset, len)?;
+        let t = if let Some(of) = &self.exotic_fact {
+            let bqf = of
+                .downcast_ref::<tract_core::tract_linalg::block_quant::BlockQuantFact>()
+                .context("Unknown exotic fact")?;
+            let blob = tract_data::internal::Blob::from_bytes(&bytes)?;
+            tract_core::tract_linalg::block_quant::BlockQuantStorage::new(
+                bqf.format.clone(),
+                bqf.m(),
+                bqf.k(),
+                Arc::new(blob),
+            )?
+            .into_tensor_with_shape(self.datum_type, &self.shape)
+        } else {
+            unsafe { Tensor::from_raw_dt(self.datum_type, &self.shape, &bytes)? }
+        };
+        Ok(Arc::new(t))
+    }
+
+    fn exotic_fact(&self) -> Option<&dyn ExoticFact> {
+        self.exotic_fact.as_deref()
+    }
+
+    /// Only reached through tract-gpu's arena view, which needs a
+    /// `DeviceSessionHandler` this backend never installs. The signature cannot
+    /// report a failure, so were it reached, a device-side fetch that failed
+    /// would abort instead: on web it cannot succeed at all without `jspi`.
+    fn get_bytes_slice(&self, offset: usize, len: usize) -> Vec<u8> {
+        download_owned_bytes(&self.buffer.inner, offset as u64, len as u64).unwrap()
+    }
+}
+
+fn download_owned_bytes(buffer: &wgpu::Buffer, offset: u64, len: u64) -> TractResult<Vec<u8>> {
+    #[cfg(all(target_arch = "wasm32", feature = "jspi"))]
+    {
+        crate::jspi::download_jspi(buffer, offset, len)
+    }
+    #[cfg(not(all(target_arch = "wasm32", feature = "jspi")))]
+    {
+        with_wgpu_queue(|q| q.download(buffer, offset, len))
+    }
+}
+
+impl Display for WgpuTensor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WgpuTensor({:?} {:?})", self.datum_type, self.shape)
+    }
+}

--- a/wgpu/src/tests.rs
+++ b/wgpu/src/tests.rs
@@ -1,0 +1,52 @@
+#![cfg(test)]
+
+use tract_core::internal::*;
+use tract_gpu::tensor::{DeviceTensor, IntoDevice};
+
+use crate::kernels::cast::wgpu_cast_dispatch;
+use crate::kernels::copy::wgpu_copy_nd_dispatch;
+use crate::with_wgpu_queue;
+
+fn close(a: &Tensor, b: &Tensor) -> TractResult<()> {
+    a.close_enough(b, Approximation::Close)
+}
+
+#[test]
+fn upload_download_roundtrip() -> TractResult<()> {
+    with_wgpu_queue(|_| {
+        let t = Tensor::from_shape(&[2, 3], &(0..6).map(|i| i as f32).collect::<Vec<_>>())?;
+        let d = t.clone().into_device()?;
+        let back = d.to_host()?.into_tensor();
+        assert_eq!(t, back);
+        Ok(())
+    })
+}
+
+#[test]
+fn copy_nd_transposed_matches_cpu() -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        let t = Tensor::from_shape(&[2, 3], &(0..6).map(|i| i as f32).collect::<Vec<_>>())?;
+        let src = t.clone().into_device()?;
+        let dst = DeviceTensor::uninitialized_dt(DatumType::F32, &[3, 2])?;
+        wgpu_copy_nd_dispatch(&src, 0, &[1, 3], &dst, 0, &[3, 2], &[2, 1])?;
+        q.flush()?;
+        close(&dst.to_host()?.into_tensor(), &t.clone().permute_axes(&[1, 0])?)
+    })
+}
+
+#[test]
+fn cast_f32_f16_roundtrip() -> TractResult<()> {
+    with_wgpu_queue(|q| {
+        if !q.context().shader_f16() {
+            return Ok(());
+        }
+        let t = Tensor::from_shape(&[4], &[1.0f32, -2.5, 0.25, 100.0])?;
+        let src = t.clone().into_device()?;
+        let half = DeviceTensor::uninitialized_dt(DatumType::F16, &[4])?;
+        let back = DeviceTensor::uninitialized_dt(DatumType::F32, &[4])?;
+        wgpu_cast_dispatch(&src, &half)?;
+        wgpu_cast_dispatch(&half, &back)?;
+        q.flush()?;
+        close(&back.to_host()?.into_tensor(), &t)
+    })
+}

--- a/wgpu/src/utils.rs
+++ b/wgpu/src/utils.rs
@@ -1,0 +1,16 @@
+use tract_gpu::tensor::DeviceTensor;
+
+use crate::context::WgpuBuffer;
+
+pub fn get_wgpu_buffer(tensor: &DeviceTensor) -> &WgpuBuffer {
+    tensor
+        .device_buffer()
+        .downcast_ref::<WgpuBuffer>()
+        .expect("Non-wgpu buffer accessed during wgpu execution")
+}
+
+/// Element offset of this tensor inside its storage buffer, plus an extra byte offset.
+pub fn element_offset(tensor: &DeviceTensor, extra_bytes: usize) -> usize {
+    let dt = tensor.datum_type().size_of();
+    (tensor.buffer_offset::<usize>() + extra_bytes) / dt
+}


### PR DESCRIPTION
First of seven slices of #2801, the WebGPU backend. This one is the device: a context that owns the `wgpu` device and caches its pipelines, layouts and bind groups, a tract tensor that lives in a `wgpu::Buffer`, and the copy and cast kernels. No model runs yet — that arrives in 2/7.

This is the slice worth your time, because everything in it is contact with the tract-gpu contract rather than WGSL:

- **The memory pool's arena cannot be used.** WebGPU refuses a dispatch that binds one buffer both read-only and read-write, which is what an arena does the moment a kernel reads one tensor and writes another in the same allocation: `Buffer with 'tract-wgpu-arena' usage ... is used as both a read-only storage and a writable storage`. So a tensor gets a buffer of its own from a pool that recycles by node and slot, and is addressed as `(buffer, byte offset in a uniform)`.
- **`DeviceBuffer::ptr()` has no meaning here.** There is no GPU address to hand out. It returns the buffer handle's identity, which is enough to key a cache and nothing else.
- **`get_bytes_slice` cannot report a failure.** On a unified-memory backend it is a slice; here it is a device readback that can fail, and the signature returns `Vec<u8>`. The path is unreachable today — only the arena view enters it, and this backend never installs one — and it is documented as such.

Uniform blocks are staged in one host buffer and uploaded once per flush rather than written per dispatch, which is worth about 20% of a frame on its own.

Three tests: an upload/download round trip, a strided copy against a CPU permute, and an f32→f16→f32 cast.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)
