### PR TITLE
gpu: fuse_axis_op only shunted outlet 0, hanging on multi-output ops

### DIFF
--- a/cuda/src/rewrite_rules/fuse_axis_op.rs
+++ b/cuda/src/rewrite_rules/fuse_axis_op.rs
@@ -81,8 +81,8 @@ fn split_succs(
         op_ins[idx] = axis_out;
 
         let op_outs = patch.wire_node(succ.name.clone(), succ.op.clone(), &op_ins)?;
-        for out in op_outs {
-            patch.shunt_outside(model, succ.id.into(), out)?;
+        for (slot, out) in op_outs.into_iter().enumerate() {
+            patch.shunt_outside(model, OutletId::new(succ.id, slot), out)?;
         }
     }
 
@@ -143,7 +143,9 @@ pub fn fuse_axis_op(
                 CudaFusedAxisOp { grouped_axis_ops, op: Box::new(op.clone()) },
                 &tap_inputs,
             )?;
-            patch.shunt_outside(model, node.id.into(), out[0])?;
+            for (slot, o) in out.iter().enumerate() {
+                patch.shunt_outside(model, OutletId::new(node.id, slot), *o)?;
+            }
             return Ok(Some(patch));
         } else {
             // Nothing to do right now; we’ll fuse on a later pass.
@@ -157,7 +159,9 @@ pub fn fuse_axis_op(
         CudaFusedAxisOp { grouped_axis_ops, op: node.op.clone() },
         &tap_inputs,
     )?;
-    patch.shunt_outside(model, node.id.into(), out[0])?;
+    for (slot, o) in out.iter().enumerate() {
+        patch.shunt_outside(model, OutletId::new(node.id, slot), *o)?;
+    }
     Ok(Some(patch))
 }
 

--- a/metal/src/rewrite_rules/fuse_axis_op.rs
+++ b/metal/src/rewrite_rules/fuse_axis_op.rs
@@ -75,8 +75,8 @@ fn split_succs(
         op_ins[idx] = axis_out;
 
         let op_outs = patch.wire_node(succ.name.clone(), succ.op.clone(), &op_ins)?;
-        for out in op_outs {
-            patch.shunt_outside(model, succ.id.into(), out)?;
+        for (slot, out) in op_outs.into_iter().enumerate() {
+            patch.shunt_outside(model, OutletId::new(succ.id, slot), out)?;
         }
     }
 
@@ -137,7 +137,9 @@ pub fn fuse_axis_op(
                 MetalFusedAxisOp { grouped_axis_ops, op: Box::new(op.clone()) },
                 &tap_inputs,
             )?;
-            patch.shunt_outside(model, node.id.into(), out[0])?;
+            for (slot, o) in out.iter().enumerate() {
+                patch.shunt_outside(model, OutletId::new(node.id, slot), *o)?;
+            }
             return Ok(Some(patch));
         } else {
             // Nothing to do right now; we’ll fuse on a later pass.
@@ -151,7 +153,9 @@ pub fn fuse_axis_op(
         MetalFusedAxisOp { grouped_axis_ops, op: node.op.clone() },
         &tap_inputs,
     )?;
-    patch.shunt_outside(model, node.id.into(), out[0])?;
+    for (slot, o) in out.iter().enumerate() {
+        patch.shunt_outside(model, OutletId::new(node.id, slot), *o)?;
+    }
     Ok(Some(patch))
 }
 


### PR DESCRIPTION
CudaRmsNorm/MetalRmsNorm with `scaled: true` and a residual has two outputs: the normalized result on slot 0, the residual sum on slot 1. fuse_axis_op shunted `node.id.into()` — outlet 0 — and dropped the rest.

Once slot 0 had been fused, slot 1 kept the original node alive, so the rule kept matching it: every pass rebuilt the fused node, redirected an outlet with no consumers, and returned a patch that changed nothing. Rewriter::rewrite only stops when a pass applies zero patches, so a no-op patch reads as progress and it spins forever — no log output, no memory growth, no GPU work.

Shunt every output slot instead, at all three sites in each backend.

llama-3_2-{1B,3B}-q40ef32-516 on cuda went from hanging (killed by the bench watchdog at 600s) to 6.5s and 8.5s. These two cases have been timing out in the bench suite on metal and cuda since 2026-09-03.

Claude-Session: https://claude.ai/code/session_01A3aqFWtqYHC4hGyzSQGQXS