### PR TITLE
bench: a timed-out run failed the job only in smoke mode

### DIFF
--- a/cli/src/bench_suite.rs
+++ b/cli/src/bench_suite.rs
@@ -116,12 +116,16 @@ impl RuntimeKind {
     }
 
     /// `(global, subcommand)` flags. `--timeout` is a whole-process watchdog
-    /// (load+optimize+run); the GPU arms keep it wide to clear a large-model load.
+    /// (load+optimize+run). The child never fetches: `stage` hands it bytes the parent
+    /// already downloaded (a memfd on Linux, a local file elsewhere), so the window
+    /// covers compute only and does not have to clear a cold download. The slowest
+    /// healthy GPU case measures ~42s, so 180 keeps 4x margin while bounding a wedged
+    /// transform at 3min instead of 10.
     fn flags(&self) -> (&'static [&'static str], &'static [&'static str]) {
         match self {
             RuntimeKind::Cpu => (&["--timeout", "180"], &[]),
-            RuntimeKind::Metal => (&["--metal", "--timeout", "600"], &["--warmup-loops", "1"]),
-            RuntimeKind::Cuda => (&["--cuda", "--timeout", "600"], &["--warmup-loops", "1"]),
+            RuntimeKind::Metal => (&["--metal", "--timeout", "180"], &["--warmup-loops", "1"]),
+            RuntimeKind::Cuda => (&["--cuda", "--timeout", "180"], &["--warmup-loops", "1"]),
         }
     }
 }
@@ -296,7 +300,7 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
 
     let start = Instant::now();
     let mut results: Vec<RunResult> = vec![];
-    let mut smoke_failures: Vec<String> = vec![];
+    let mut failures: Vec<String> = vec![];
 
     for (bench_idx, bench) in manifest.benches.iter().enumerate() {
         if filter.is_some_and(|f| !bench.name.contains(f)) {
@@ -409,19 +413,19 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
                 }
                 Err(e) => {
                     eprintln!("  !! {} {} failed: {e:#}", bench.name, variant);
-                    smoke_failures.push(format!("{} [{variant}]", bench.name));
+                    failures.push(format!("{} [{variant}]", bench.name));
                 }
             }
         }
     }
 
     if smoke {
-        eprintln!("smoke: {} run(s) ok, {} failed", results.len(), smoke_failures.len());
+        eprintln!("smoke: {} run(s) ok, {} failed", results.len(), failures.len());
         ensure!(
-            smoke_failures.is_empty(),
+            failures.is_empty(),
             "smoke: {} run(s) failed to load/run:\n  {}",
-            smoke_failures.len(),
-            smoke_failures.join("\n  ")
+            failures.len(),
+            failures.join("\n  ")
         );
         return Ok(());
     }
@@ -443,6 +447,16 @@ pub fn handle(matches: &clap::ArgMatches) -> TractResult<()> {
     metrics.push(("bundle.bench_runtime".to_string(), start.elapsed().as_secs() as f64));
     write_metrics(output, &metrics)?;
     eprintln!("wrote {} metrics to {output}", metrics.len());
+    // A run that died -- notably a `--timeout` watchdog kill (exit 124) on a wedged
+    // transform -- used to be collected here and never looked at, so a hung bench
+    // reported success and cost only wall clock. The metrics are written first, so the
+    // cases that did run still land and the report still has something to compare.
+    ensure!(
+        failures.is_empty(),
+        "{} bench run(s) failed:\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
     Ok(())
 }
 


### PR DESCRIPTION
`smoke_failures` collected every failed run, but the `ensure!` that reads it sits inside the `if smoke` block. In bench mode the failures were pushed onto a vector nobody ever checked: the suite printed `!! <bench> <variant> failed`, wrote metrics for whatever did run, and exited 0.

So a `--timeout` watchdog kill -- a child wedged in a transform, exit 124 -- was reported as a successful bench. The only visible symptom was the job taking 20 minutes longer than usual, which is how an infinite loop in the GPU fuse_axis_op rewrite (fixed separately) sat in CI for five days on all three GPU runners while every run stayed green.

Rename the vector (it was never smoke-specific) and assert it in bench mode too, after the metrics are written so the runs that did succeed still land and the PR comparison still has something to chew on.

Also drop the GPU watchdog from 600s to 180s. It was sized to clear a large-model load, but the child never loads from origin: `stage` hands it bytes the parent already fetched -- a memfd on Linux, a local file elsewhere -- so the window covers compute only. The slowest healthy GPU case in a full run measures ~42s, so 180 keeps 4x margin and bounds a wedged transform at 3min rather than 10. CPU stays at 180s; `trunet pulse1_f16` runs close to it and wants its own measurement first.

Verified against a build carrying the fuse_axis_op bug: the suite now kills the wedged child at 180s, writes the 9 CPU metrics, and exits 1 naming `llama-3_2-1B-q40ef32-516 [cuda]`. A passing bench still exits 0.

Claude-Session: https://claude.ai/code/session_01A3aqFWtqYHC4hGyzSQGQXS