### PR TITLE
Add missing sign checks on loader dims casts (onnx/tflite)

### DIFF
--- a/onnx/src/tensor.rs
+++ b/onnx/src/tensor.rs
@@ -160,7 +160,17 @@ pub fn load_tensor(
     let dt = DataType::try_from(t.data_type)
         .map_err(|e| format_err!("unknown ONNX TensorProto.DataType ({}): {e}", t.data_type))?
         .try_into()?;
-    let shape: Vec<usize> = t.dims.iter().map(|&i| i as usize).collect();
+    let shape = t
+        .dims
+        .iter()
+        .map(|&i| {
+            if i < 0 {
+                bail!("Negative dimension in ONNX TensorProto dims: {i}")
+            } else {
+                Ok(i as usize)
+            }
+        })
+        .collect::<TractResult<Vec<usize>>>()?;
     // detect if the tensor is rather in an external file than inside the onnx file directly
     let is_external = t.data_location.is_some()
         && t.data_location == Some(tensor_proto::DataLocation::External as i32);

--- a/tflite/src/tensors.rs
+++ b/tflite/src/tensors.rs
@@ -113,7 +113,19 @@ pub fn flat_tensor_to_tract_fact<'m>(
             dt = dt.quantize(QParams::ZpScale { zero_point: zp.get(0) as _, scale: scale.get(0) })
         }
     }
-    let mut fact = dt.fact(flat.shape().unwrap().iter().map(|d| d as usize).collect_vec());
+    let shape = flat
+        .shape()
+        .unwrap()
+        .iter()
+        .map(|d| {
+            if d < 0 {
+                bail!("Negative dimension in TFLite tensor shape: {d}")
+            } else {
+                Ok(d as usize)
+            }
+        })
+        .collect::<TractResult<Vec<usize>>>()?;
+    let mut fact = dt.fact(shape);
     let buffer_ix = flat.buffer() as usize;
     if buffer_ix != 0 {
         let buffer = model.buffers().unwrap().get(flat.buffer() as usize);


### PR DESCRIPTION
Both `onnx::tensor::load_tensor` and `tflite::tensors::flat_tensor_to_tract_fact` cast loader dims (`i64` / `i32`) straight to `usize` without a sign check. A crafted model with a negative dim turns into a huge `usize` and blows up the next allocation -- panic / host DoS.

Same pattern as the one already in `tensorflow/src/tensor.rs:44` -- bail on negative dims before the cast.

### Files

| file | change |
|---|---|
| `onnx/src/tensor.rs` | bail on `i < 0` in the dims map |
| `tflite/src/tensors.rs` | bail on `d < 0` in the shape map |

### Why safe

Negative dims are invalid in both formats. Mitigation sits at the loader boundary only -- no behavior change on well-formed models.
