### PR TITLE
(perf) wgpu 8/8: a blocked matmul over repacked weights

### DIFF
--- a/wgpu/src/context.rs
+++ b/wgpu/src/context.rs
@@ -441,7 +441,11 @@ impl WgpuContext {
     }
 
     pub fn wrap_storage(&self, inner: wgpu::Buffer) -> WgpuBuffer {
-        WgpuBuffer { inner, id: self.next_buffer_id() }
+        WgpuBuffer { inner, id: self.next_buffer_id(), pooled: false }
+    }
+
+    fn wrap_pooled_storage(&self, inner: wgpu::Buffer) -> WgpuBuffer {
+        WgpuBuffer { inner, id: self.next_buffer_id(), pooled: true }
     }
 
     pub fn create_empty_storage(&self, size: u64) -> wgpu::Buffer {
@@ -687,6 +691,10 @@ pub struct WgpuQueue {
     /// thread that owns the frame: a buffer must not be handed to another
     /// thread while a dispatch this one recorded still reads it.
     buffer_slots: RefCell<HashMap<(u64, u32), Arc<WgpuBuffer>>>,
+    /// The blocked matmul's weights, transposed once. Keyed by everything the
+    /// packing depends on, and only ever by an unpooled buffer, whose id no
+    /// later tensor can take.
+    repacked: RefCell<HashMap<RepackKey, DeviceTensor>>,
     slot_cursor: RefCell<HashMap<u64, u32>>,
     profile: Cell<bool>,
     profiled: RefCell<Vec<(&'static str, u32)>>,
@@ -818,6 +826,7 @@ impl WgpuQueue {
             pending: RefCell::new(vec![]),
             uniform_staging: RefCell::new(vec![]),
             buffer_slots: RefCell::new(HashMap::new()),
+            repacked: RefCell::new(HashMap::new()),
             slot_cursor: RefCell::new(HashMap::new()),
             profile: Cell::new(false),
             profiled: RefCell::new(vec![]),
@@ -848,6 +857,7 @@ impl WgpuQueue {
         std::mem::forget(std::mem::take(&mut *self.retained.borrow_mut()));
         std::mem::forget(std::mem::take(&mut *self.retained_textures.borrow_mut()));
         std::mem::forget(std::mem::take(&mut *self.buffer_slots.borrow_mut()));
+        std::mem::forget(std::mem::take(&mut *self.repacked.borrow_mut()));
         unsafe {
             std::mem::forget(ManuallyDrop::take(&mut self.uniform));
         }
@@ -872,10 +882,19 @@ impl WgpuQueue {
             bump(2);
             return held.clone();
         }
-        let fresh = Arc::new(self.context.wrap_storage(self.context.create_empty_storage(size)));
+        let fresh =
+            Arc::new(self.context.wrap_pooled_storage(self.context.create_empty_storage(size)));
         bump(3);
         slots.insert((size, seq), fresh.clone());
         fresh
+    }
+
+    pub fn repacked(&self, key: &RepackKey) -> Option<DeviceTensor> {
+        self.repacked.borrow().get(key).cloned()
+    }
+
+    pub fn store_repacked(&self, key: RepackKey, packed: DeviceTensor) {
+        self.repacked.borrow_mut().insert(key, packed);
     }
 
     pub fn retain_tensor(&self, t: &DeviceTensor) {
@@ -1175,6 +1194,16 @@ impl Drop for WgpuQueue {
     }
 }
 
+/// Identifies one blocked-matmul weight packing: the buffer it was read from,
+/// where in that buffer, and the shape it was written as.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RepackKey {
+    pub buffer: u64,
+    pub offset: usize,
+    pub k: usize,
+    pub n: usize,
+}
+
 #[derive(Clone)]
 /// The identity a bind group is keyed on. It follows the buffer through the
 /// pool, so a graph that reuses its buffers reuses its bind groups; keying on
@@ -1183,6 +1212,10 @@ impl Drop for WgpuQueue {
 pub struct WgpuBuffer {
     pub inner: wgpu::Buffer,
     pub id: u64,
+    /// Whether this buffer came from the frame pool, which hands it to the next
+    /// tensor that fits once nothing holds it. Its `id` is stable only while it
+    /// lives, so a cache must not key on a pooled buffer.
+    pub pooled: bool,
 }
 
 impl std::fmt::Debug for WgpuBuffer {

--- a/wgpu/src/kernels/matmul.rs
+++ b/wgpu/src/kernels/matmul.rs
@@ -8,9 +8,10 @@
 use tract_core::internal::*;
 use tract_gpu::tensor::DeviceTensor;
 
+use crate::context::RepackKey;
 use crate::kernels::shaders::{
     ChainStep, EntryPoint, LayoutKind, ModuleKey, ModuleKind, PipelineKey, ShaderDtype, keys_for,
-    matmul_module, pack_u32s, program_key, rpad8_dims, rpad8_strides,
+    matmul_blocked_module, matmul_module, pack_u32s, program_key, rpad8_dims, rpad8_strides,
 };
 use crate::utils::{element_offset, get_wgpu_buffer};
 use crate::with_wgpu_queue;
@@ -89,6 +90,64 @@ pub struct Transposes {
     pub c: bool,
 }
 
+/// `b` transposed once, kept for the frames that read it again. Only reached
+/// for an unpooled `b`, so the key cannot outlive the buffer it names.
+fn repacked_b(
+    q: &crate::context::WgpuQueue,
+    b: &DeviceTensor,
+    k: usize,
+    n: usize,
+) -> TractResult<DeviceTensor> {
+    let key = RepackKey { buffer: get_wgpu_buffer(b).id, offset: element_offset(b, 0), k, n };
+    if let Some(packed) = q.repacked(&key) {
+        return Ok(packed);
+    }
+    let packed = DeviceTensor::uninitialized_dt(b.datum_type(), &[k, n])?;
+    // b is (n, k) with k fastest; write it out with n fastest
+    crate::kernels::copy::wgpu_copy_nd_dispatch(
+        b,
+        0,
+        &[1, k as isize],
+        &packed,
+        0,
+        &[k, n],
+        &[n as isize, 1],
+    )?;
+    q.store_repacked(key, packed.clone());
+    Ok(packed)
+}
+
+/// Whether the blocked kernel can serve this product: it reads both operands as
+/// `vec4`, so the tile must divide the shape and the fastest axis of each
+/// operand must be the one it widens. `b` is repacked once and read back by
+/// buffer id, which only a buffer outside the frame pool keeps.
+#[allow(clippy::too_many_arguments)]
+fn blocked_applies(
+    prefix: usize,
+    m: usize,
+    k: usize,
+    n: usize,
+    a: &DeviceTensor,
+    b: &DeviceTensor,
+    out: &DeviceTensor,
+    t: Transposes,
+) -> bool {
+    let rank = a.rank();
+    !get_wgpu_buffer(b).pooled
+        && prefix == 1
+        && m.is_multiple_of(4)
+        && n.is_multiple_of(4)
+        && k.is_multiple_of(4)
+        && t.a
+        && t.b
+        && t.c
+        && a.strides()[rank - 1] == 1
+        && a.strides()[rank - 2] == m as isize
+        && out.strides()[out.rank() - 1] == 1
+        && element_offset(a, 0).is_multiple_of(4)
+        && element_offset(out, 0).is_multiple_of(4)
+}
+
 pub fn wgpu_matmul_dispatch(
     t: Transposes,
     epilogue: &[ChainStep],
@@ -128,6 +187,48 @@ pub fn wgpu_matmul_dispatch(
             "matmul output shape {out_shape:?} does not match its inputs"
         );
         let prefix: usize = out_shape[..out_shape.len() - 2].iter().product();
+
+        if blocked_applies(prefix, m, k, n, a, b, output, t) {
+            let packed = repacked_b(q, b, k, n)?;
+            let pipeline = q.context().chain_pipeline(
+                &program_key("matmul_blocked", dt, epilogue, extras.len()),
+                layout,
+                EntryPoint::typed("matmul_blocked", dt),
+                || matmul_blocked_module(dt, epilogue, extras.len()),
+            )?;
+            q.retain_tensor(&packed);
+            let mut buffers: Vec<&crate::context::WgpuBuffer> =
+                vec![get_wgpu_buffer(a), get_wgpu_buffer(&packed)];
+            buffers.extend(extras.iter().map(|t| get_wgpu_buffer(t)));
+            buffers.push(get_wgpu_buffer(output));
+            let bg = q.context().bind_group(layout, &buffers, q.uniform())?;
+            let mut vals = vec![
+                m as u32,
+                k as u32,
+                n as u32,
+                (element_offset(a, 0) / 4) as u32,
+                (element_offset(&packed, 0) / 4) as u32,
+                (element_offset(output, 0) / 4) as u32,
+                0,
+                0,
+            ];
+            let mut off_extra = [0u32; 4];
+            let mut mode_extra = [0u32; 4];
+            for (i, t) in extras.iter().enumerate() {
+                off_extra[i] = element_offset(t, 0) as u32;
+                mode_extra[i] = epilogue_mode(t, n)?;
+            }
+            vals.extend_from_slice(&off_extra);
+            vals.extend_from_slice(&mode_extra);
+            let dyn_off = q.alloc_uniform(&pack_u32s(&vals))?;
+            return q.dispatch(
+                "matmul_blocked",
+                &pipeline,
+                &bg,
+                dyn_off,
+                ((m / 4) * (n / 4)) as u64,
+            );
+        }
 
         let mut buffers: Vec<&crate::context::WgpuBuffer> =
             vec![get_wgpu_buffer(a), get_wgpu_buffer(b)];

--- a/wgpu/src/kernels/shaders.rs
+++ b/wgpu/src/kernels/shaders.rs
@@ -1788,3 +1788,90 @@ pub fn broadcast_strides(shape: &[usize], strides: &[isize], out_shape: &[usize]
     }
     out
 }
+
+pub fn matmul_blocked_module(dt: ShaderDtype, epilogue: &[ChainStep], extras: usize) -> String {
+    let t = dt.wgsl();
+    let suf = dt.suffix();
+    let out_binding = 2 + extras;
+    let uniform_binding = 3 + extras;
+    let extra_bindings = (0..extras)
+        .map(|i| {
+            format!("@group(0) @binding({}) var<storage, read> extra{i}: array<{t}>;\n", 2 + i)
+        })
+        .collect::<String>();
+    let lib = format!("{}{}", unary_ops_wgsl("f32"), binary_ops_wgsl("f32"));
+    let epi = epilogue_body(epilogue, "col");
+    let mut s = preamble(dt);
+    s.push_str(&format!(
+        r#"
+struct Params {{
+    m: u32,
+    k: u32,
+    n: u32,
+    off_a: u32,
+    off_b: u32,
+    off_out: u32,
+    _p0: u32,
+    _p1: u32,
+    off_extra: vec4<u32>,
+    mode_extra: vec4<u32>,
+}}
+
+@group(0) @binding(0) var<storage, read> a4: array<vec4<f32>>;
+@group(0) @binding(1) var<storage, read> b4: array<vec4<f32>>;
+{extra_bindings}@group(0) @binding({out_binding}) var<storage, read_write> c4: array<vec4<f32>>;
+@group(0) @binding({uniform_binding}) var<uniform> params: Params;
+{lib}
+
+fn epi(v_in: f32, col: u32) -> f32 {{
+    var v = v_in;
+{epi}
+    return v;
+}}
+
+@compute @workgroup_size({WORKGROUP})
+fn matmul_blocked_{suf}(@builtin(global_invocation_id) gid: vec3<u32>) {{
+    let m4 = params.m / 4u;
+    let n4 = params.n / 4u;
+    let tile = gid.x;
+    let row_tile = tile % m4;
+    let col_tile = tile / m4;
+    if (col_tile >= n4) {{ return; }}
+    var acc0 = vec4<f32>(0.0);
+    var acc1 = vec4<f32>(0.0);
+    var acc2 = vec4<f32>(0.0);
+    var acc3 = vec4<f32>(0.0);
+    for (var kk = 0u; kk < params.k; kk += 4u) {{
+        let ab = params.off_a + kk * m4 + row_tile;
+        let bb = params.off_b + kk * n4 + col_tile;
+        let a0 = a4[ab];
+        let a1 = a4[ab + m4];
+        let a2 = a4[ab + 2u * m4];
+        let a3 = a4[ab + 3u * m4];
+        let b0 = b4[bb];
+        let b1 = b4[bb + n4];
+        let b2 = b4[bb + 2u * n4];
+        let b3 = b4[bb + 3u * n4];
+        acc0 += a0 * b0.x + a1 * b1.x + a2 * b2.x + a3 * b3.x;
+        acc1 += a0 * b0.y + a1 * b1.y + a2 * b2.y + a3 * b3.y;
+        acc2 += a0 * b0.z + a1 * b1.z + a2 * b2.z + a3 * b3.z;
+        acc3 += a0 * b0.w + a1 * b1.w + a2 * b2.w + a3 * b3.w;
+    }}
+    let col0 = col_tile * 4u;
+    let cc = params.off_out + col0 * m4 + row_tile;
+    c4[cc] = vec4<f32>(
+        epi(acc0.x, col0), epi(acc0.y, col0), epi(acc0.z, col0), epi(acc0.w, col0));
+    c4[cc + m4] = vec4<f32>(
+        epi(acc1.x, col0 + 1u), epi(acc1.y, col0 + 1u),
+        epi(acc1.z, col0 + 1u), epi(acc1.w, col0 + 1u));
+    c4[cc + 2u * m4] = vec4<f32>(
+        epi(acc2.x, col0 + 2u), epi(acc2.y, col0 + 2u),
+        epi(acc2.z, col0 + 2u), epi(acc2.w, col0 + 2u));
+    c4[cc + 3u * m4] = vec4<f32>(
+        epi(acc3.x, col0 + 3u), epi(acc3.y, col0 + 3u),
+        epi(acc3.z, col0 + 3u), epi(acc3.w, col0 + 3u));
+}}
+"#
+    ));
+    s
+}


### PR DESCRIPTION
Stacked on #2810 — its commits are included here, so read this one's top commit only.

A thread computes a 4x4 tile instead of a single value and reads both operands as `vec4`. That needs the second operand's `k` axis fastest, so it is transposed once on first use and kept.

**Measured on the selfie-segmentation model, natively (Metal): median 11.1% faster per frame, winning 15 of 16 interleaved A/B pairs** (3.213 ms vs 3.578 ms on a quiet machine). The one loss is a pair where both arms ran 3x slow under load. This is a *native* number — the browser is record-bound rather than GPU-bound on this model, and I have not measured a browser win here, so please don't read one into it.

The cache this needs is the interesting part. Weights are only worth transposing because they are read again every frame, which makes the packing worth keeping — but a cache keyed on a buffer is a trap when buffers are pooled and their ids recycled. So the packing lives on the queue that owns the frame rather than on the shared context (it holds a tensor from that thread's pool), the key names the buffer, its offset and the shape it was packed to, and `blocked_applies` takes the path only for a buffer the pool cannot recycle. That last condition is what makes "weights are constant" an invariant rather than a comment.

Conformance: `cargo test -p test-wgpu` — 4071 passed, 0 failed.

🍍

🤖 Generated with [Claude Code](https://claude.com/claude-code)