### PR TITLE
The new self-hosted i9-9900k box was not in the bench fleet. Add it t…

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -162,6 +162,9 @@ jobs:
           - target: i9-11900kb_rtx-4060
             runner: cuda-lovelace
             triple: x86_64-unknown-linux-gnu
+          - target: i9-9900k
+            runner: i99900k
+            triple: x86_64-unknown-linux-gnu
           - target: jetson-orin-nx
             runner: orin-nx-16g
             triple: aarch64-unknown-linux-gnu-stretch
@@ -543,6 +546,9 @@ jobs:
           - target: i9-11900kb_rtx-4060
             runner: cuda-lovelace
             triple: x86_64-unknown-linux-gnu
+          - target: i9-9900k
+            runner: i99900k
+            triple: x86_64-unknown-linux-gnu
           - target: jetson-orin-nx
             runner: orin-nx-16g
             triple: aarch64-unknown-linux-gnu-stretch
@@ -656,6 +662,9 @@ jobs:
             triple: aarch64-apple-darwin
           - target: i9-11900kb_rtx-4060
             runner: cuda-lovelace
+            triple: x86_64-unknown-linux-gnu
+          - target: i9-9900k
+            runner: i99900k
             triple: x86_64-unknown-linux-gnu
           - target: jetson-orin-nx
             runner: orin-nx-16g

--- a/.travis/bench-thresholds.toml
+++ b/.travis/bench-thresholds.toml
@@ -40,6 +40,7 @@ bench_runtime = 10
 [devices]
 "apple-m1-max"        = "m1max"
 "i9-11900kb_rtx-4060" = "i9-4060"
+"i9-9900k"            = "9900k"
 "jetson-orin-nx"      = "orin"
 "cortex-a55"          = "a55"
 "cortex-a53"          = "a53"


### PR DESCRIPTION
…o the bench, hwbench and smoke matrices as device i9-9900k on runner i99900k, reusing the x86_64-unknown-linux-gnu build, and give it a short column label in bench-thresholds.toml.