### PR TITLE
gpu: the schema recognised a forwarding op by downcasting to it, whic…

### DIFF
--- a/core/src/ops/mod.rs
+++ b/core/src/ops/mod.rs
@@ -145,6 +145,14 @@ pub trait EvalOp {
         bail!("{} has neither eval nor state", std::any::type_name::<Self>())
     }
 
+    /// The input this op hands straight back as its output when it has nothing
+    /// to do, if any: what reads the output then reads the producer's memory, so
+    /// an allocator pooling node outputs has to keep that region alive as long
+    /// as this op's own output. A wrapper delegates to what it wraps.
+    fn forwards_input(&self) -> Option<usize> {
+        None
+    }
+
     /// Evaluate with no plan around the node -- const folding, shape inference,
     /// tests -- or `None` when there is no answer without one, because the op
     /// reads the context or keeps state between turns. Required, with no default:

--- a/cuda/src/ops/fused_axis_op.rs
+++ b/cuda/src/ops/fused_axis_op.rs
@@ -139,6 +139,10 @@ impl Op for CudaFusedAxisOp {
 }
 
 impl EvalOp for CudaFusedAxisOp {
+    fn forwards_input(&self) -> Option<usize> {
+        self.op.forwards_input()
+    }
+
     fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
         let ctx = EvalContext::out_of_plan();
         let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, &ctx)?;

--- a/gpu/src/memory/schema.rs
+++ b/gpu/src/memory/schema.rs
@@ -53,15 +53,6 @@ fn next_nodes<'a>(model: &'a TypedModel, node: &TypedNode) -> Option<TVec<&'a Ty
     )
 }
 
-/// Ops that hand their input straight back as their output when there is
-/// nothing to do: what reads their output is reading the producer's region, so
-/// the producer is not dead when they are.
-fn may_forward_input(op: &dyn TypedOp) -> Option<usize> {
-    (op.downcast_ref::<crate::ops::cast::GpuCast>().is_some()
-        || op.downcast_ref::<crate::ops::pulse::GpuAffineChunkTrim>().is_some())
-    .then_some(0)
-}
-
 pub fn eval_device_mem_req_for_nodes(
     model: &TypedModel,
     order: &[usize],
@@ -124,7 +115,7 @@ pub fn eval_device_mem_req_for_nodes(
     // Walked backwards so a chain of forwarders carries the extension down to
     // the region it all aliases.
     for n in order.iter().rev() {
-        let Some(ix) = may_forward_input(model.node(*n).op.as_ref()) else { continue };
+        let Some(ix) = model.node(*n).op.forwards_input() else { continue };
         let Some(end) = scoped_nodes
             .iter()
             .filter(|req| req.outlet_id.node == *n)

--- a/gpu/src/ops/cast.rs
+++ b/gpu/src/ops/cast.rs
@@ -60,6 +60,10 @@ impl Op for GpuCast {
 impl EvalOp for GpuCast {
     op_out_of_plan!();
 
+    fn forwards_input(&self) -> Option<usize> {
+        Some(0)
+    }
+
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;

--- a/gpu/src/ops/pulse.rs
+++ b/gpu/src/ops/pulse.rs
@@ -562,6 +562,10 @@ impl Op for GpuAffineChunkTrim {
 impl EvalOp for GpuAffineChunkTrim {
     op_out_of_plan!();
 
+    fn forwards_input(&self) -> Option<usize> {
+        Some(0)
+    }
+
     fn eval(&self, ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
         let input_value = args_1!(inputs);
         let input = input_value.to_device_tensor()?;

--- a/metal/src/ops/fused_axis_op.rs
+++ b/metal/src/ops/fused_axis_op.rs
@@ -139,6 +139,10 @@ impl Op for MetalFusedAxisOp {
 }
 
 impl EvalOp for MetalFusedAxisOp {
+    fn forwards_input(&self) -> Option<usize> {
+        self.op.forwards_input()
+    }
+
     fn eval_out_of_plan(&self, inputs: TVec<TValue>) -> TractResult<Option<TVec<TValue>>> {
         let ctx = EvalContext::out_of_plan();
         let inputs = compute_reshaped_inputs(inputs, &self.grouped_axis_ops, &ctx)?;


### PR DESCRIPTION
…h never matched: GpuAffineChunkTrim reaches it wrapped in a fused-axis op, so a Delay reading a forwarded region was still given that region for its own output and wrote over what it was reading. Let ops declare it with EvalOp::forwards_input and have the wrappers pass it on.