### PR TITLE
(perf) core/nn: integer nearest upsample in one pass

### DIFF
--- a/core/src/ops/nn/resize.rs
+++ b/core/src/ops/nn/resize.rs
@@ -1,5 +1,4 @@
 use crate::internal::*;
-use crate::ops::array::Tile;
 
 /// Maps an output coordinate back to the input axis. The ONNX coordinate
 /// transformation modes that have a well-defined inverse without an input ROI.
@@ -469,6 +468,160 @@ impl TypedOp for Resize {
     }
 }
 
+/// Integer nearest upsample, one scale per input axis. Output axis `a` has
+/// length `input[a] * scales[a]` and `out[.., i, ..] = in[.., i / scales[a], ..]`.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct NearestUpsample {
+    pub scales: TVec<usize>,
+}
+
+impl Op for NearestUpsample {
+    fn name(&self) -> StaticName {
+        "NearestUpsample".into()
+    }
+
+    fn info(&self) -> TractResult<Vec<String>> {
+        Ok(vec![format!("scales:{:?}", self.scales)])
+    }
+
+    op_as_typed_op!();
+}
+
+impl EvalOp for NearestUpsample {
+    op_out_of_plan!();
+
+    fn eval(&self, _ctx: &EvalContext, inputs: TVec<TValue>) -> TractResult<TVec<TValue>> {
+        let input = args_1!(inputs);
+        ensure!(input.rank() == self.scales.len());
+        let out_shape: TVec<usize> =
+            input.shape().iter().zip(self.scales.iter()).map(|(d, s)| d * s).collect();
+        if input.datum_type() == f32::datum_type()
+            && let Some(out) = nearest_hw_f32(&input, &self.scales, &out_shape)?
+        {
+            return Ok(tvec!(out.into_tvalue()));
+        }
+        dispatch_copy!(nearest_generic(input.datum_type())(&input, &self.scales, &out_shape))
+    }
+}
+
+impl TypedOp for NearestUpsample {
+    fn output_facts(&self, inputs: &[&TypedFact]) -> TractResult<TVec<TypedFact>> {
+        ensure!(inputs[0].rank() == self.scales.len());
+        let shape: TVec<TDim> =
+            inputs[0].shape.iter().zip(self.scales.iter()).map(|(d, s)| d.clone() * *s).collect();
+        Ok(tvec!(inputs[0].datum_type.fact(shape)))
+    }
+
+    as_op!();
+}
+
+fn nearest_hw_f32(
+    input: &Tensor,
+    scales: &[usize],
+    out_shape: &[usize],
+) -> TractResult<Option<Tensor>> {
+    if scales.len() < 2 {
+        return Ok(None);
+    }
+    if scales[..scales.len() - 2].iter().any(|&s| s != 1) {
+        return Ok(None);
+    }
+    let sh = scales[scales.len() - 2];
+    let sw = scales[scales.len() - 1];
+    if sh == 1 && sw == 1 {
+        return Ok(None);
+    }
+    if *input.strides().last().unwrap_or(&1) != 1 {
+        return Ok(None);
+    }
+    let h = input.shape()[input.rank() - 2];
+    let w = input.shape()[input.rank() - 1];
+    let planes = input.len() / (h * w);
+    let mut output = unsafe { Tensor::uninitialized::<f32>(out_shape)? };
+    unsafe {
+        let ip = input.as_ptr::<f32>()?;
+        let op = output.as_ptr_mut::<f32>()?;
+        let ow = w * sw;
+        for p in 0..planes {
+            let src = ip.add(p * h * w);
+            let dst = op.add(p * h * sh * ow);
+            for y in 0..h {
+                let srow = src.add(y * w);
+                let drow = dst.add(y * sh * ow);
+                expand_row_f32(srow, drow, w, sw);
+                for ry in 1..sh {
+                    std::ptr::copy_nonoverlapping(drow, drow.add(ry * ow), ow);
+                }
+            }
+        }
+    }
+    Ok(Some(output))
+}
+
+unsafe fn expand_row_f32(src: *const f32, dst: *mut f32, w: usize, sw: usize) {
+    unsafe {
+        if sw == 2 {
+            let mut x = 0usize;
+            #[cfg(target_arch = "aarch64")]
+            {
+                use std::arch::aarch64::*;
+                while x + 4 <= w {
+                    let v = vld1q_f32(src.add(x));
+                    vst2q_f32(dst.add(2 * x), float32x4x2_t(v, v));
+                    x += 4;
+                }
+            }
+            while x < w {
+                let v = *src.add(x);
+                *dst.add(2 * x) = v;
+                *dst.add(2 * x + 1) = v;
+                x += 1;
+            }
+            return;
+        }
+        for x in 0..w {
+            let v = *src.add(x);
+            for rx in 0..sw {
+                *dst.add(x * sw + rx) = v;
+            }
+        }
+    }
+}
+
+fn nearest_generic<T: Datum + Copy>(
+    input: &Tensor,
+    scales: &[usize],
+    out_shape: &[usize],
+) -> TractResult<TVec<TValue>> {
+    let plain = input.try_as_plain()?;
+    let src = plain.as_slice::<T>()?;
+    let mut output = unsafe { Tensor::uninitialized::<T>(out_shape)? };
+    let rank = out_shape.len();
+    let mut in_strides = vec![1usize; rank];
+    for i in (0..rank - 1).rev() {
+        in_strides[i] = in_strides[i + 1] * input.shape()[i + 1];
+    }
+    let mut out_strides = vec![1usize; rank];
+    for i in (0..rank - 1).rev() {
+        out_strides[i] = out_strides[i + 1] * out_shape[i + 1];
+    }
+    {
+        let mut out_plain = output.try_as_plain_mut()?;
+        let dst = out_plain.as_slice_mut::<T>()?;
+        for (i, slot) in dst.iter_mut().enumerate() {
+            let mut rem = i;
+            let mut src_ix = 0usize;
+            for ax in 0..rank {
+                let c = rem / out_strides[ax];
+                rem %= out_strides[ax];
+                src_ix += (c / scales[ax]) * in_strides[ax];
+            }
+            *slot = src[src_ix];
+        }
+    }
+    Ok(tvec!(output.into_tvalue()))
+}
+
 /// An axis length to build a probe plan on. `HalfPixel`, `Asymmetric` and
 /// `TfHalfPixelForNn` map coordinates without consulting the axis lengths, so a
 /// symbolic axis can still be probed on a stand-in; the others cannot.
@@ -489,73 +642,8 @@ pub fn lower_nearest_integer_upsample(
     node: &TypedNode,
     int_scales: &[usize],
 ) -> TractResult<Option<TypedModelPatch>> {
-    let input_fact = model.outlet_fact(node.inputs[0])?;
-    let input_shape = &input_fact.shape;
-
-    let mut patch = TypedModelPatch::default();
-    let mut wire = patch.tap_model(model, node.inputs[0])?;
-
-    let mut from_dims: TVec<TDim> = tvec![];
-    let mut to_dims: TVec<TDim> = tvec![];
-    let mut tile_multipliers: TVec<TDim> = tvec![];
-    let mut first_upsampled = None;
-
-    for (i, &scale) in int_scales.iter().enumerate() {
-        from_dims.push(input_shape[i].clone());
-        to_dims.push(input_shape[i].clone());
-        tile_multipliers.push(1.into());
-        if scale > 1 {
-            if first_upsampled.is_none() {
-                first_upsampled = Some(i);
-            }
-            to_dims.push(1.into());
-            tile_multipliers.push(scale.into());
-        }
-    }
-
-    if to_dims.len() > from_dims.len() {
-        let first = first_upsampled.unwrap();
-        wire = patch.wire_node(
-            format!("{}.reshape_pre", node.name),
-            AxisOp::Reshape(first, from_dims[first..].into(), to_dims[first..].into()),
-            &[wire],
-        )?[0];
-    }
-
-    wire = patch.wire_node(
-        format!("{}.tile", node.name),
-        Tile { multipliers: tile_multipliers },
-        &[wire],
-    )?[0];
-
-    let tiled_shape: TVec<TDim> = to_dims
-        .iter()
-        .zip(int_scales.iter().flat_map(|&s| if s > 1 { vec![1usize, s] } else { vec![1] }))
-        .map(|(d, s)| d.clone() * s)
-        .collect();
-    let mut final_dims: TVec<TDim> = tvec![];
-    let mut idx = 0;
-    for &scale in int_scales {
-        if scale > 1 {
-            final_dims.push(tiled_shape[idx].clone() * tiled_shape[idx + 1].clone());
-            idx += 2;
-        } else {
-            final_dims.push(tiled_shape[idx].clone());
-            idx += 1;
-        }
-    }
-
-    if tiled_shape.len() > final_dims.len() {
-        let first = first_upsampled.unwrap();
-        wire = patch.wire_node(
-            format!("{}.reshape_post", node.name),
-            AxisOp::Reshape(first, tiled_shape[first..].into(), final_dims[first..].into()),
-            &[wire],
-        )?[0];
-    }
-
-    patch.shunt_outside(model, node.id.into(), wire)?;
-    Ok(Some(patch))
+    let op = NearestUpsample { scales: int_scales.iter().cloned().collect() };
+    TypedModelPatch::replace_single_op(model, node, &node.inputs[..1], op).map(Some)
 }
 
 #[cfg(test)]
@@ -577,6 +665,23 @@ mod tests {
                 + cubic_kernel(2.0 - t, a);
             assert!((sum - 1.0).abs() < 1e-5, "kernel weights must sum to 1.0, got {sum} at t={t}");
         }
+    }
+
+    #[test]
+    fn nearest_upsample_2x2_replicates_pixels() {
+        let src = Tensor::from_shape(&[1, 1, 2, 2], &[1.0f32, 2.0, 3.0, 4.0]).unwrap();
+        let op = NearestUpsample { scales: tvec![1, 1, 2, 2] };
+        let out = op.eval(&EvalContext::out_of_plan(), tvec!(src.into_tvalue())).unwrap().remove(0);
+        let v = out.to_plain_array_view::<f32>().unwrap();
+        assert_eq!(v.shape(), &[1, 1, 4, 4]);
+        assert_eq!(v[[0, 0, 0, 0]], 1.0);
+        assert_eq!(v[[0, 0, 0, 1]], 1.0);
+        assert_eq!(v[[0, 0, 1, 0]], 1.0);
+        assert_eq!(v[[0, 0, 1, 1]], 1.0);
+        assert_eq!(v[[0, 0, 2, 2]], 4.0);
+        assert_eq!(v[[0, 0, 3, 3]], 4.0);
+        assert_eq!(v[[0, 0, 0, 2]], 2.0);
+        assert_eq!(v[[0, 0, 2, 0]], 3.0);
     }
 
     fn cubic_resize(input: Tensor, scales: &[f32]) -> Tensor {

--- a/nnef/src/ops/core/resize.rs
+++ b/nnef/src/ops/core/resize.rs
@@ -1,5 +1,8 @@
 use crate::internal::*;
-use tract_core::ops::nn::resize::{CoordTransformer, Interpolator, Nearest, Resize};
+use crate::ser::ints;
+use tract_core::ops::nn::resize::{
+    CoordTransformer, Interpolator, Nearest, NearestUpsample, Resize,
+};
 
 pub fn register(registry: &mut Registry) {
     registry.register_primitive(
@@ -9,6 +12,7 @@ pub fn register(registry: &mut Registry) {
         load,
     );
     registry.register_dumper(dump);
+    registry.register_dumper(dump_nearest_upsample);
     registry.register_primitive(
         "nearest_upsample",
         &upsample_parameters(),
@@ -51,6 +55,33 @@ fn dump(ast: &mut IntoAst, node: &TypedNode, op: &Resize) -> TractResult<Option<
             ("coord_transformer", string(op.coord_transformer.as_str())),
             ("interpolator", string(op.interpolator.as_str())),
             ("nearest_mode", string(op.nearest.as_str())),
+        ],
+    )))
+}
+
+fn dump_nearest_upsample(
+    ast: &mut IntoAst,
+    node: &TypedNode,
+    op: &NearestUpsample,
+) -> TractResult<Option<Arc<RValue>>> {
+    let input = ast.mapping[&node.inputs[0]].clone();
+    if op.scales.len() >= 2 && op.scales[..2] == [1, 1] {
+        return Ok(Some(invocation(
+            "nearest_upsample",
+            &[input],
+            &[("factor", ints(&op.scales[2..]))],
+        )));
+    }
+    let scales: Vec<f32> = op.scales.iter().map(|&s| s as f32).collect();
+    let scales = ast.konst(format!("{}_scales", node.name), &rctensor1(&scales))?;
+    Ok(Some(invocation(
+        "tract_core_resize",
+        &[input],
+        &[
+            ("scales", (*scales).clone()),
+            ("coord_transformer", string(CoordTransformer::Asymmetric.as_str())),
+            ("interpolator", string(Interpolator::Nearest.as_str())),
+            ("nearest_mode", string(Nearest::Floor.as_str())),
         ],
     )))
 }


### PR DESCRIPTION
First slice of #2771: the nearest upsample lowering, on its own. It replaces the Reshape/Tile/MultiBroadcastTo/Reshape chain with a single `NearestUpsample` op, so the broadcast intermediate is never materialised.

One file, `core/src/ops/nn/resize.rs`. None of the kernels from #2771 are here. This is the lowering only, it does not depend on the rest of that PR and the rest of that PR does not depend on it.

### Numbers

i7-12700K, Windows, `RAYON_NUM_THREADS=1`, `-O`. Baseline is this branch's merge-base, built and measured on the same box tonight.

Five interleaved rounds, alternating the two binaries with no build between them. Worth saying why: running all the baseline first and all the branch second moved the *same* branch binary by 25 ms, so that ordering measures the machine as much as the patch.

| | base | this PR |
|---|---|---|
| tiny_det 1x3x640x640 | 337.5 ms | **310.0 ms** |

1.09x. Base runs span 336.4 to 339.0, PR runs 304.2 to 314.5, no overlap.

### tiny_det, ops that moved

| op | base | this PR | delta |
|---|---|---|---|
| MultiBroadcastTo | 43.906 | 16.647 | **-27.3** |
| Reduce&lt;Sum&gt; | 4.460 | 1.436 | -3.0 |
| MoveAxis | 0.509 | - | gone |
| NearestUpsample | - | 2.933 | new |

Everything else is inside a 1.3 ms band.

### Structural

- 6 `Resize.N.tile` MultiBroadcastTo nodes become 6 `Resize.N.nearest` NearestUpsample nodes
- The one surviving MultiBroadcastTo is `ConvTranspose.0.broadcast_bias`, as before
- 3 `Conv.*.restore_out_*` MoveAxis nodes go entirely

The node counts drop past the ops that changed: IntoShape 80 to 69, OptAddUnicast 30 to 26, OptMulByScalar 31 to 27, OptMaxByScalar 15 to 11, OptAddByScalar 11 to 7. Not inserting the unit axes in the first place lets the optimiser fold about 27 nodes it could not fold around the reshape pair.

### Two changes from the version on #2771

The doc comment described what the op replaces; it states the contract now. The generic fallback opened with `.to_vec()` on the whole input, which is unnecessary once the `PlainView` from `try_as_plain` is given a name, so that copy is gone.

### Numerics

The op itself is exact. On a model containing nothing but the nearest `Resize`, this branch and the merge-base are **bit identical**, and both are bit identical to an independent `numpy.repeat` reference.

End to end on tiny_det the outputs are not bit identical: **max abs 2.9e-6** on a sigmoid map in 0 to 0.999, mean abs 1.0e-7. None of that comes from `NearestUpsample`, which only copies. It comes from the folding the change unblocks, since reassociating a chain moves the last few bits. For scale, the figure quoted on #2771 for the whole series was 2.4e-5.

### One thing to know before it is benchmarked elsewhere

`expand_row_f32` has a NEON store-interleave for scale 2 and falls to scalar on x86, so the number above is the scalar path. An AVX2 row expand is a leaf kernel, and per your rule of thumb that belongs in `routines` rather than here, so I have left it for a later slice instead of widening this one.

🍍