### PR TITLE
(perf) core/cnn: vectorise NCHW MaxPool 2x2

### DIFF
--- a/core/src/ops/cnn/maxpool.rs
+++ b/core/src/ops/cnn/maxpool.rs
@@ -147,6 +147,13 @@ impl OptMaxPool {
         geo: &ConcretePoolGeometry,
     ) -> TractResult<TVec<TValue>> {
         let input_dt = input.datum_type();
+
+        if self.with_index_outputs.is_none()
+            && let Some(values) = self.try_nchw_2x2_f32::<T>(input, geo)?
+        {
+            return Ok(tvec!(values.into_tvalue()));
+        }
+
         let input_plain = input.try_as_plain()?;
         let input: ArrayViewD<T> = input_plain.to_array_view()?;
         let input_ptr = input.as_ptr();
@@ -196,6 +203,154 @@ impl OptMaxPool {
             ))
         } else {
             Ok(tvec!(values.into_tvalue()))
+        }
+    }
+
+    /// 2x2 f32 NCHW, walked (n, c, y, x) so W is contiguous and the stride-1
+    /// interior vectorises along x. Every other pool keeps `visit_output`.
+    fn try_nchw_2x2_f32<T: Datum>(
+        &self,
+        input: &Tensor,
+        geo: &ConcretePoolGeometry,
+    ) -> TractResult<Option<Tensor>> {
+        let patch = &geo.patch;
+        if T::datum_type() != f32::datum_type()
+            || self.pool_spec.data_format != crate::ops::nn::DataFormat::NCHW
+            || patch.rank() != 2
+            || *geo.input_shape.w_stride() != 1
+            || patch.spec.kernel_shape[..] != [2, 2]
+            || patch.spec.dilations[..] != [1, 1]
+        {
+            return Ok(None);
+        }
+        let mut values =
+            unsafe { Tensor::uninitialized_dt(input.datum_type(), &geo.output_shape.shape)? };
+        unsafe {
+            maxpool_2x2_f32(input.as_ptr::<f32>()?, values.as_ptr_mut::<f32>()?, geo);
+        }
+        Ok(Some(values))
+    }
+}
+
+unsafe fn maxpool_2x2_f32(iptr: *const f32, optr: *mut f32, geo: &ConcretePoolGeometry) {
+    unsafe {
+        let ish = &geo.input_shape;
+        let osh = &geo.output_shape;
+        let (h, w) = (ish.hw_dims()[0] as isize, ish.hw_dims()[1] as isize);
+        let (oh, ow) = (geo.patch.output_shape[0], geo.patch.output_shape[1]);
+        let sh = geo.patch.spec.strides[0] as isize;
+        let sw = geo.patch.spec.strides[1] as isize;
+        let pt = geo.patch.pad_before[0] as isize;
+        let pl = geo.patch.pad_before[1] as isize;
+        let ih_stride = *ish.h_stride() as isize;
+        let oh_stride = *osh.h_stride() as isize;
+        let n = *ish.n().unwrap_or(&1) as isize;
+        let in_stride = *ish.n_stride().unwrap_or(&0) as isize;
+        let on_stride = *osh.n_stride().unwrap_or(&0) as isize;
+        let c = *ish.c() as isize;
+        let ic_stride = *ish.c_stride() as isize;
+        let oc_stride = *osh.c_stride() as isize;
+        // Fully-valid 2×2 windows (both taps in-bounds). SameUpper 2×2 s=1
+        // keeps H/W and pads after, so the last row/col are partial.
+        let simd_s1 = sh == 1 && sw == 1;
+        let y0 = pt.max(0) as usize;
+        let y1 = ((h - 1 + pt).max(0) as usize).min(oh);
+        let x0 = pl.max(0) as usize;
+        let x1 = ((w - 1 + pl).max(0) as usize).min(ow);
+        for nn in 0..n {
+            for cc in 0..c {
+                let in_base = nn * in_stride + cc * ic_stride;
+                let out_base = nn * on_stride + cc * oc_stride;
+                if simd_s1 && y1 > y0 && x1 > x0 {
+                    maxpool_2x2_s1_valid_f32(
+                        iptr.offset(in_base + (y0 as isize - pt) * ih_stride + (x0 as isize - pl)),
+                        optr.offset(out_base + y0 as isize * oh_stride + x0 as isize),
+                        y1 - y0,
+                        x1 - x0,
+                        ih_stride,
+                        oh_stride,
+                    );
+                }
+                for oy in 0..oh {
+                    let interior_y = simd_s1 && oy >= y0 && oy < y1;
+                    for ox in 0..ow {
+                        if interior_y && ox >= x0 && ox < x1 {
+                            continue;
+                        }
+                        let mut m = f32::MIN;
+                        for ky in 0..2 {
+                            let iy = oy as isize * sh + ky - pt;
+                            if iy < 0 || iy >= h {
+                                continue;
+                            }
+                            let row = iptr.offset(in_base + iy * ih_stride);
+                            for kx in 0..2 {
+                                let ix = ox as isize * sw + kx - pl;
+                                if ix < 0 || ix >= w {
+                                    continue;
+                                }
+                                m = m.max(*row.offset(ix));
+                            }
+                        }
+                        *optr.offset(out_base + oy as isize * oh_stride + ox as isize) = m;
+                    }
+                }
+            }
+        }
+    }
+}
+
+unsafe fn maxpool_2x2_s1_valid_f32(
+    iptr: *const f32,
+    optr: *mut f32,
+    oh: usize,
+    ow: usize,
+    ih_stride: isize,
+    oh_stride: isize,
+) {
+    unsafe {
+        for oy in 0..oh {
+            let row0 = iptr.offset(oy as isize * ih_stride);
+            let row1 = iptr.offset((oy as isize + 1) * ih_stride);
+            let dst = optr.offset(oy as isize * oh_stride);
+            let mut ox = 0usize;
+            #[cfg(target_arch = "aarch64")]
+            {
+                use std::arch::aarch64::*;
+                while ox + 4 <= ow {
+                    let a = vld1q_f32(row0.add(ox));
+                    let b = vld1q_f32(row0.add(ox + 1));
+                    let c = vld1q_f32(row1.add(ox));
+                    let d = vld1q_f32(row1.add(ox + 1));
+                    vst1q_f32(dst.add(ox), vmaxq_f32(vmaxq_f32(a, b), vmaxq_f32(c, d)));
+                    ox += 4;
+                }
+            }
+            #[cfg(target_arch = "x86_64")]
+            {
+                if is_x86_feature_detected!("avx") {
+                    use std::arch::x86_64::*;
+                    while ox + 8 <= ow {
+                        let a = _mm256_loadu_ps(row0.add(ox));
+                        let b = _mm256_loadu_ps(row0.add(ox + 1));
+                        let c = _mm256_loadu_ps(row1.add(ox));
+                        let d = _mm256_loadu_ps(row1.add(ox + 1));
+                        _mm256_storeu_ps(
+                            dst.add(ox),
+                            _mm256_max_ps(_mm256_max_ps(a, b), _mm256_max_ps(c, d)),
+                        );
+                        ox += 8;
+                    }
+                }
+            }
+            while ox < ow {
+                let m = (*row0.add(ox))
+                    .max(*row0.add(ox + 1))
+                    .max(*row1.add(ox))
+                    .max(*row1.add(ox + 1));
+                *dst.add(ox) = m;
+                ox += 1;
+            }
         }
     }
 }

--- a/test-rt/suite-unit/src/lib.rs
+++ b/test-rt/suite-unit/src/lib.rs
@@ -20,6 +20,7 @@ pub mod elmwise;
 pub mod gather_elements;
 pub mod gelu_approximate;
 pub mod matmul_q40;
+pub mod max_pool;
 pub mod q_binary;
 pub mod q_elmwise;
 pub mod q_flavours;
@@ -40,6 +41,7 @@ pub fn suite() -> TractResult<TestSuite> {
     suite.add("downsample", downsample::suite()?);
     suite.add("gather_elements", gather_elements::suite()?);
     suite.add("matmul_q40", matmul_q40::suite()?);
+    suite.add("max_pool", max_pool::suite()?);
     suite.add("q_flavours", q_flavours::suite()?);
     suite.add("rms_norm", rms_norm::suite()?);
     suite.add("apply_rope", apply_rope::suite()?);

--- a/test-rt/suite-unit/src/max_pool.rs
+++ b/test-rt/suite-unit/src/max_pool.rs
@@ -1,0 +1,261 @@
+use infra::Test;
+use infra::TestResult;
+use infra::TestSuite;
+use proptest::collection::vec;
+use proptest::prelude::*;
+use std::ops::Range;
+use tract_core::internal::*;
+use tract_core::ops::cnn::*;
+use tract_core::ops::nn::*;
+use tract_ndarray::{prelude::*, *};
+
+use crate::data_format;
+use crate::tensor;
+
+#[derive(Debug, Clone, Default)]
+pub struct MaxPoolProblemParams {}
+
+#[derive(Debug, Clone)]
+pub struct MaxPoolProblem {
+    pub data_format: DataFormat,
+    pub padding: PaddingSpec,
+    pub input: ArrayD<f32>,
+    pub kernel_shape: TVec<usize>,
+    pub strides: TVec<usize>,
+    pub dilations: TVec<usize>,
+}
+
+impl Arbitrary for MaxPoolProblem {
+    type Strategy = BoxedStrategy<MaxPoolProblem>;
+    type Parameters = MaxPoolProblemParams;
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // Drawn with everything else, a 2x2 unit-dilation NCHW 2D pool is about one case in a
+        // thousand, so it gets a branch of its own: that layout has a dedicated loop whose
+        // 8-lane body only runs on rows longer than 8.
+        prop_oneof![
+            problems(
+                data_format().boxed(),
+                1..4,
+                (1usize..4).boxed(),
+                (1usize..3).boxed(),
+                (1usize..4).boxed(),
+                0..6,
+            ),
+            problems(
+                Just(DataFormat::NCHW).boxed(),
+                2..3,
+                Just(2usize).boxed(),
+                Just(1usize).boxed(),
+                prop_oneof![Just(1usize), 1usize..4].boxed(),
+                0..16,
+            ),
+        ]
+        .boxed()
+    }
+}
+
+fn problems(
+    data_format: BoxedStrategy<DataFormat>,
+    georank: Range<usize>,
+    kernel: BoxedStrategy<usize>,
+    dilation: BoxedStrategy<usize>,
+    stride: BoxedStrategy<usize>,
+    margin: Range<usize>,
+) -> BoxedStrategy<MaxPoolProblem> {
+    (data_format, georank)
+        .prop_flat_map(move |(df, georank)| {
+            (
+                Just(df),
+                0usize..4, // Valid, SameUpper, SameLower, Explicit
+                1usize..3, // n
+                1usize..4, // c
+                vec(kernel.clone(), georank..=georank),
+                vec(dilation.clone(), georank..=georank),
+                vec(stride.clone(), georank..=georank),
+                vec(margin.clone(), georank..=georank),
+                vec((0usize..8, 0usize..8), georank..=georank), // explicit pads, folded below
+            )
+        })
+        .prop_flat_map(|(df, padding, n, c, kernel_shape, dilations, strides, margins, pads)| {
+            let fields: Vec<usize> =
+                kernel_shape.iter().zip(&dilations).map(|(k, d)| (k - 1) * d + 1).collect();
+            // Sides at least as long as their kernel field, and explicit pads shorter than it,
+            // leave no window entirely in the padding, where runtimes disagree on the answer
+            // (f32::MIN on the CPU, -inf in the Metal kernel).
+            let hw: Vec<usize> = fields.iter().zip(&margins).map(|(f, m)| f + m).collect();
+            let padding = match padding {
+                0 => PaddingSpec::Valid,
+                1 => PaddingSpec::SameUpper,
+                2 => PaddingSpec::SameLower,
+                _ => {
+                    let (before, after) =
+                        pads.iter().zip(&fields).map(|((b, a), f)| (b % f, a % f)).unzip();
+                    PaddingSpec::Explicit(before, after)
+                }
+            };
+            let shape = df.from_n_c_hw(n, c, hw).unwrap();
+            (
+                Just(df),
+                Just(padding),
+                tensor(&shape.shape),
+                Just(kernel_shape),
+                Just(strides),
+                Just(dilations),
+            )
+        })
+        .prop_map(|(data_format, padding, input, kernel_shape, strides, dilations)| {
+            MaxPoolProblem {
+                data_format,
+                padding,
+                input,
+                kernel_shape: kernel_shape.into(),
+                strides: strides.into(),
+                dilations: dilations.into(),
+            }
+        })
+        .boxed()
+}
+
+impl MaxPoolProblem {
+    fn tract(&self) -> TractResult<TypedModel> {
+        let mut model = TypedModel::default();
+        let src = model.add_source("src", f32::fact(self.input.shape()))?;
+        let c = *self.data_format.shape(self.input.shape())?.c();
+        let pool_spec = PoolSpec::new(
+            self.data_format,
+            self.kernel_shape.clone(),
+            self.padding.clone(),
+            Some(self.dilations.clone()),
+            Some(self.strides.clone()),
+            c,
+            c,
+        );
+        let output = model.wire_node("max_pool", MaxPool::new(pool_spec, None), &[src])?;
+        model.select_output_outlets(&output)?;
+        Ok(model)
+    }
+
+    /// Output length and padding before, per spatial axis, as ONNX defines them.
+    fn geometry(&self) -> TractResult<TVec<(usize, usize)>> {
+        let input_shape = self.data_format.shape(self.input.shape())?;
+        tract_itertools::izip!(
+            input_shape.hw_dims(),
+            &self.kernel_shape,
+            &self.strides,
+            &self.dilations
+        )
+        .enumerate()
+        .map(|(axis, (&i, &k, &s, &d))| {
+            let field = (k - 1) * d + 1;
+            Ok(match &self.padding {
+                PaddingSpec::Valid => ((i - field) / s + 1, 0),
+                PaddingSpec::Explicit(before, after) => {
+                    ((i + before[axis] + after[axis] - field) / s + 1, before[axis])
+                }
+                PaddingSpec::SameUpper | PaddingSpec::SameLower => {
+                    let o = i.div_ceil(s);
+                    let total = ((o - 1) * s + field).saturating_sub(i);
+                    let before = if self.padding == PaddingSpec::SameUpper {
+                        total / 2
+                    } else {
+                        total - total / 2
+                    };
+                    (o, before)
+                }
+                other => bail!("no reference for {other:?}"),
+            })
+        })
+        .collect()
+    }
+
+    fn reference(&self) -> TractResult<ArrayD<f32>> {
+        let input_shape = self.data_format.shape(self.input.shape())?;
+        let n = input_shape.n().copied().unwrap_or(1);
+        let c = *input_shape.c();
+        let geometry = self.geometry()?;
+        let output_hw: TVec<usize> = geometry.iter().map(|g| g.0).collect();
+        let output_shape = self.data_format.from_n_c_hw(n, c, &*output_hw)?;
+        let mut output = ArrayD::<f32>::zeros(&*output_shape.shape);
+        for n in 0..n {
+            for c in 0..c {
+                for out in indices(&*output_hw) {
+                    let mut max: Option<f32> = None;
+                    for tap in indices(&*self.kernel_shape) {
+                        let pos: Option<TVec<usize>> = tract_itertools::izip!(
+                            out.slice(),
+                            tap.slice(),
+                            &geometry,
+                            &self.strides,
+                            &self.dilations,
+                            input_shape.hw_dims()
+                        )
+                        .map(|(o, t, (_, before), s, d, i)| {
+                            (o * s + t * d).checked_sub(*before).filter(|p| p < i)
+                        })
+                        .collect();
+                        if let Some(pos) = pos {
+                            let v = self.input[&*self.data_format.from_n_c_hw(n, c, &*pos)?.shape];
+                            max = Some(max.map_or(v, |m| m.max(v)));
+                        }
+                    }
+                    let max = max
+                        .with_context(|| format!("window {out:?} lies entirely in the padding"))?;
+                    output[&*self.data_format.from_n_c_hw(n, c, out.slice())?.shape] = max;
+                }
+            }
+        }
+        Ok(output)
+    }
+}
+
+impl Test for MaxPoolProblem {
+    fn run_with_approx(
+        &self,
+        id: &str,
+        runtime: &dyn Runtime,
+        approx: Approximation,
+    ) -> TestResult {
+        let reference = self.reference().context("Running reference")?.into_tensor();
+        let mut model = self.tract().context("Generating model")?;
+        model.properties.insert("tract-rt-test.id".to_string(), rctensor0(id.to_string()));
+        let mut output = runtime.prepare(model)?.run(tvec![self.input.clone().into_tvalue()])?;
+        let output = output.remove(0).into_tensor();
+        output.close_enough(&reference, approx)
+    }
+}
+
+/// Distinct within any window, so a tap read from the wrong place changes the answer, and all
+/// exact in f16.
+fn nchw(
+    shape: [usize; 4],
+    kernel: [usize; 2],
+    strides: [usize; 2],
+    padding: PaddingSpec,
+) -> MaxPoolProblem {
+    let len = shape.iter().product::<usize>();
+    let values = (0..len).map(|i| ((i * 7919) % 2039) as f32 - 1019.0).collect();
+    MaxPoolProblem {
+        data_format: DataFormat::NCHW,
+        padding,
+        input: ArrayD::from_shape_vec(IxDyn(&shape), values).unwrap(),
+        kernel_shape: kernel.iter().copied().collect(),
+        strides: strides.iter().copied().collect(),
+        dilations: tvec!(1, 1),
+    }
+}
+
+pub fn suite() -> TractResult<TestSuite> {
+    let mut suite = TestSuite::default();
+    suite.add_arbitrary::<MaxPoolProblem>("proptest", MaxPoolProblemParams::default());
+
+    suite.add("nchw_2x2_s1_valid_8x8", nchw([1, 3, 8, 8], [2, 2], [1, 1], PaddingSpec::Valid));
+    suite.add("nchw_2x2_s1_valid_17x19", nchw([1, 16, 17, 19], [2, 2], [1, 1], PaddingSpec::Valid));
+    suite.add(
+        "nchw_2x2_s1_same_upper_9x9",
+        nchw([2, 4, 9, 9], [2, 2], [1, 1], PaddingSpec::SameUpper),
+    );
+    suite.add("nchw_2x2_s2_valid_16x16", nchw([1, 8, 16, 16], [2, 2], [2, 2], PaddingSpec::Valid));
+    suite.add("nchw_3x3_s1_valid_11x13", nchw([1, 4, 11, 13], [3, 3], [1, 1], PaddingSpec::Valid));
+
+    Ok(suite)
+}

--- a/test-rt/test-f16/suite.rs
+++ b/test-rt/test-f16/suite.rs
@@ -1,6 +1,8 @@
 use infra::Test;
 use suite_unit::bin_einsum::{BinEinsumProblem, BinEinsumProblemParams};
 use suite_unit::conv_q::{QConvProblem, QConvProblemParams};
+use suite_unit::max_pool::{MaxPoolProblem, MaxPoolProblemParams};
+use tract_core::ops::cnn::PaddingSpec;
 
 pub fn suite() -> &'static infra::TestSuite {
     lazy_static::lazy_static! {
@@ -24,6 +26,11 @@ fn mk_suite() -> infra::TestSuite {
         QConvProblemParams::default(),
         compatible_conv_q,
     );
+    unit.get_sub_mut("max_pool").add_arbitrary_with_filter::<MaxPoolProblem>(
+        "proptest",
+        MaxPoolProblemParams::default(),
+        compatible_max_pool,
+    );
 
     infra::TestSuite::default().with("onnx", onnx).with("unit", unit)
 }
@@ -32,6 +39,12 @@ fn ignore_unit(t: &[String], case: &dyn Test) -> bool {
     #[allow(clippy::collapsible_if)]
     if let Some(qcp) = case.downcast_ref::<QConvProblem>() {
         if !compatible_conv_q(qcp) {
+            return true;
+        }
+    }
+    #[allow(clippy::collapsible_if)]
+    if let Some(mp) = case.downcast_ref::<MaxPoolProblem>() {
+        if !compatible_max_pool(mp) {
             return true;
         }
     }
@@ -99,4 +112,9 @@ test_unsqueeze
 
 fn compatible_conv_q(qcp: &QConvProblem) -> bool {
     qcp.qp.iter().all(|t| t.len() == 1)
+}
+
+/// nnef_f16 goes through the NNEF dumper, which bails on SameLower.
+fn compatible_max_pool(mp: &MaxPoolProblem) -> bool {
+    mp.padding != PaddingSpec::SameLower
 }

--- a/test-rt/test-nnef-cycle/suite.rs
+++ b/test-rt/test-nnef-cycle/suite.rs
@@ -1,6 +1,8 @@
 use infra::Test;
 use suite_unit::bin_einsum::{BinEinsumProblem, BinEinsumProblemParams};
 use suite_unit::conv_q::{QConvProblem, QConvProblemParams};
+use suite_unit::max_pool::{MaxPoolProblem, MaxPoolProblemParams};
+use tract_core::ops::cnn::PaddingSpec;
 
 pub fn suite() -> &'static infra::TestSuite {
     lazy_static::lazy_static! {
@@ -25,6 +27,11 @@ fn mk_suite() -> infra::TestSuite {
         "proptest",
         QConvProblemParams::default(),
         compatible_conv_q,
+    );
+    unit.get_sub_mut("max_pool").add_arbitrary_with_filter::<MaxPoolProblem>(
+        "proptest",
+        MaxPoolProblemParams::default(),
+        compatible_max_pool,
     );
 
     infra::TestSuite::default().with("onnx", onnx).with("unit", unit)
@@ -88,9 +95,17 @@ fn ignore_unit(t: &[String], tc: &dyn Test) -> bool {
     if let Some(qcp) = tc.downcast_ref::<QConvProblem>() {
         return !compatible_conv_q(qcp);
     }
+    if let Some(mp) = tc.downcast_ref::<MaxPoolProblem>() {
+        return !compatible_max_pool(mp);
+    }
     false
 }
 
 fn compatible_conv_q(qcp: &QConvProblem) -> bool {
     qcp.qp.iter().all(|qp| qp.len() == 1)
+}
+
+/// The NNEF dumper bails on SameLower, as test_maxpool_2d_same_lower above shows.
+fn compatible_max_pool(mp: &MaxPoolProblem) -> bool {
+    mp.padding != PaddingSpec::SameLower
 }

--- a/test-rt/test-tflite/suite.rs
+++ b/test-rt/test-tflite/suite.rs
@@ -3,7 +3,9 @@ use regex::Regex;
 use suite_unit::bin_einsum::{BinEinsumProblem, BinEinsumProblemParams};
 use suite_unit::conv_f32::{ConvProblem, ConvProblemParams};
 use suite_unit::conv_q::{QConvProblem, QConvProblemParams};
+use suite_unit::max_pool::{MaxPoolProblem, MaxPoolProblemParams};
 use tract_core::internal::*;
+use tract_core::ops::cnn::PaddingSpec;
 
 pub fn suite() -> &'static infra::TestSuite {
     lazy_static::lazy_static! {
@@ -31,6 +33,11 @@ fn mk_suite() -> infra::TestSuite {
         "proptest",
         QConvProblemParams { conv: cv, tflite_rules: true, ..QConvProblemParams::default() },
         compatible_conv_q,
+    );
+    unit.get_sub_mut("max_pool").add_arbitrary_with_filter::<MaxPoolProblem>(
+        "proptest",
+        MaxPoolProblemParams::default(),
+        compatible_max_pool,
     );
 
     let einsum_params = BinEinsumProblemParams { max_dims: 4, ..BinEinsumProblemParams::default() };
@@ -163,6 +170,12 @@ fn ignore_unit(t: &[String], case: &dyn Test) -> bool {
             return true;
         }
     }
+    #[allow(clippy::collapsible_if)]
+    if let Some(mp) = case.downcast_ref::<MaxPoolProblem>() {
+        if !compatible_max_pool(mp) {
+            return true;
+        }
+    }
 
     if t[0] == "bin_einsum" && t[1] == "proptest" {
         return true;
@@ -193,6 +206,16 @@ fn compatible_conv_f32(qcp: &ConvProblem) -> bool {
     qcp.group == 1
         && (qcp.kernel.ndim() == 4 || qcp.kernel.ndim() == 3)
         && qcp.dilations.iter().all(|d| *d == 1)
+}
+
+/// What `pool_2d_options` can express: 2D, VALID or SAME (upper), and a batch axis, since
+/// the rewriter moves NCHW to NHWC but nothing adds a missing N. It drops a dilation
+/// silently rather than refusing it.
+fn compatible_max_pool(mp: &MaxPoolProblem) -> bool {
+    mp.data_format.has_n()
+        && mp.kernel_shape.len() == 2
+        && mp.dilations.iter().all(|d| *d == 1)
+        && (mp.padding == PaddingSpec::Valid || mp.padding == PaddingSpec::SameUpper)
 }
 
 fn compatible_conv_q(qcp: &QConvProblem) -> bool {


### PR DESCRIPTION
Second slice of #2771: NCHW MaxPool 2x2. The kernel lives in `core/src/ops/cnn/maxpool.rs` and is purely additive: only 2x2 f32 NCHW pools with unit dilation take the new path, and every other pool runs the existing `visit_output` code untouched. The test is a `max_pool` proptest in test-rt/suite-unit.

I took this one second on purpose, because it is the smallest diff that puts the core/linalg seam in front of us. So I measured that question rather than argue it.

### The number, and it is not where I expected

i7-12700K, Windows, `RAYON_NUM_THREADS=1`, `-O`. Three binaries off the same merge-base, built and measured on the same box, profiled in interleaved rounds. `OptMaxPool` on tiny_det 1x3x640x640:

| build | OptMaxPool | vs base |
|---|---|---|
| merge-base | 8.82 ms | |
| loop reorder only, 2x2 f32 specialisation removed | 10.46 ms | **+1.6, slower** |
| this PR | **2.55 ms** | **-6.3, 3.5x** |

Three rounds each, spreads of 0.06 ms or less: base 8.694/8.918/8.855, loop-only 10.383/10.565/10.418, this PR 2.525/2.581/2.557. End to end tiny_det moves about -6 ms, which matches the op.

**The NCHW loop reorder on its own is a regression.** All of the win comes from the leaf kernel, so the reorder now only runs under it. An earlier push also sent every other NCHW 2D pool through the reordered loop, and the bench caught it on inceptionv1q: inception v1's pool shapes nearly doubled (u8 7.65 to 14.69 ms). That loop is gone, those pools are back at main's speed (7.88 ms against 7.65), and tiny_det keeps its win (10.44 to 3.07 ms in the same rounds).

### Where the kernel belongs

That makes this change a target-dependent leaf kernel and nothing else: one kernel wins outright when it applies, with no shape to weigh, no pool and no tier ladder. You settled it: it stays in tract-core for now as temporary platform-dependent code, recorded on #2836 with the other kernels to move to `routines`.

### Something to fix when it moves

The AVX block calls `_mm256_*` behind a runtime `is_x86_feature_detected!` but the enclosing function carries no `#[target_feature(enable = "avx")]`, unlike every other x86 kernel in linalg (`x86_64/by_scalar.rs:17` and the rest). The intrinsics will not inline like that, so 2.55 ms is probably not the floor. It is noted on #2836, so it gets fixed on the way to `routines`.

### Correctness

Base and this PR are **bit identical** on tiny_det, every one of 409,600 outputs, same fixed input. Max is exact, so there is no reassociation to hide behind: a difference here would be a defect, not rounding.

The test is a proptest in test-rt/suite-unit, so it runs on every runtime: all four layouts, 1D to 3D, Valid, SameUpper, SameLower and explicit pads, strides and dilations. Half the cases are 2x2 NCHW with rows up to 17, because drawn uniformly that shape almost never comes up and the AVX body needs rows longer than 8. Dropping one tap from the AVX max makes it fail, so it does reach the vector body. The five shapes from the original test are fixed cases. NNEF cannot express SameLower, so nnef-cycle and f16 filter it out, and tflite keeps what its pool options can express.

### One divergence I found and closed

The 2x2 border loop seeded its running max with `f32::NEG_INFINITY`, where the fold it replaces uses `T::min_value()`. A window with no in-bounds tap would have written `-inf` where the existing code writes `f32::MIN`. Nothing in tiny_det produces one, and the first test could not catch it because its own reference seeded the same way. Both are `f32::MIN` now, so the border matches the fold exactly.

### Still divergent, and I do not think it can be fixed cheaply

`_mm256_max_ps` and `vmaxq_f32` take the second operand when either is NaN, while the scalar fold's `<` drops NaN entirely. So a NaN input can come out differently on the SIMD path. Guarding it would cost the kernel its point. Flagging rather than fixing, since a NaN reaching a maxpool means something upstream already went wrong.

### Correction to my last comment

I wrote `DepthwiseMF32`. It is `DepthwiseWF32`.

🍍