### PR TITLE
(perf) core/cnn: unpack 2x2 stride-2 NCHW deconv along W

### DIFF
--- a/core/src/ops/cnn/deconv/deconv_sum.rs
+++ b/core/src/ops/cnn/deconv/deconv_sum.rs
@@ -76,14 +76,23 @@ impl DeconvSum {
         if !self.pool_spec.data_format.has_n() {
             tensor.insert_axis(0)?;
         }
-        eval(
+        if !try_fast_nchw_2x2_s2_f32(
             self,
             &input_shape,
             &output_shape,
             &spatial_output_details,
             &n_o_hkwk_hw,
             &mut tensor,
-        )?;
+        )? {
+            eval(
+                self,
+                &input_shape,
+                &output_shape,
+                &spatial_output_details,
+                &n_o_hkwk_hw,
+                &mut tensor,
+            )?;
+        }
         if !self.pool_spec.data_format.has_n() {
             tensor.remove_axis(0)?;
         }
@@ -115,6 +124,130 @@ impl TypedOp for DeconvSum {
     }
 
     as_op!();
+}
+
+/// NCHW 2×2 stride-2 unpack: write even/odd W with `vld2`/`vst2` instead of
+/// the generic loop's channel-inner scatter (C stride is `H*W` on NCHW).
+fn try_fast_nchw_2x2_s2_f32(
+    op: &DeconvSum,
+    input_shape: &DataShape,
+    output_shape: &DataShape,
+    spatial_output_details: &[ComputedPaddedDim<usize>],
+    gemm: &Tensor,
+    output: &mut Tensor,
+) -> TractResult<bool> {
+    if output.datum_type() != f32::datum_type() {
+        return Ok(false);
+    }
+    if op.pool_spec.data_format != crate::ops::nn::DataFormat::NCHW {
+        return Ok(false);
+    }
+    if op.pool_spec.kernel_shape[..] != [2, 2] {
+        return Ok(false);
+    }
+    if op.pool_spec.strides()[..] != [2, 2] || op.pool_spec.dilations()[..] != [1, 1] {
+        return Ok(false);
+    }
+    if spatial_output_details.len() != 2
+        || spatial_output_details[0].pad_before != 0
+        || spatial_output_details[1].pad_before != 0
+    {
+        return Ok(false);
+    }
+    if *output_shape.w_stride() != 1 {
+        return Ok(false);
+    }
+    let ih = input_shape.hw_dims()[0];
+    let iw = input_shape.hw_dims()[1];
+    let oh = output_shape.hw_dims()[0];
+    let ow = output_shape.hw_dims()[1];
+    if oh != ih * 2 || ow != iw * 2 {
+        return Ok(false);
+    }
+    unsafe {
+        deconv_nchw_2x2_s2_f32(gemm, output, output_shape, ih, iw);
+    }
+    Ok(true)
+}
+
+unsafe fn deconv_nchw_2x2_s2_f32(
+    gemm: &Tensor,
+    output: &mut Tensor,
+    output_shape: &DataShape,
+    ih: usize,
+    iw: usize,
+) {
+    unsafe {
+        let gptr = gemm.as_ptr::<f32>().expect("f32 gemm");
+        let optr = output.as_ptr_mut::<f32>().expect("f32 out");
+        let n = *output_shape.n().unwrap_or(&1);
+        let oc = *output_shape.c();
+        let g_n = gemm.strides()[0];
+        let g_o = gemm.strides()[1];
+        let g_k = gemm.strides()[2];
+        let g_i = gemm.strides()[3];
+        let o_n = *output_shape.n_stride().unwrap_or(&0) as isize;
+        let o_c = *output_shape.c_stride() as isize;
+        let o_h = *output_shape.h_stride() as isize;
+        for ni in 0..n as isize {
+            for o in 0..oc as isize {
+                let g = gptr.offset(ni * g_n + o * g_o);
+                let dst = optr.offset(ni * o_n + o * o_c);
+                let src00 = g;
+                let src01 = g.offset(g_k);
+                let src10 = g.offset(2 * g_k);
+                let src11 = g.offset(3 * g_k);
+                for ix in 0..ih {
+                    let in_row = (ix * iw) as isize * g_i;
+                    interleave_add_row(
+                        dst.offset((2 * ix) as isize * o_h),
+                        src00.offset(in_row),
+                        src01.offset(in_row),
+                        iw,
+                        g_i,
+                    );
+                    interleave_add_row(
+                        dst.offset((2 * ix + 1) as isize * o_h),
+                        src10.offset(in_row),
+                        src11.offset(in_row),
+                        iw,
+                        g_i,
+                    );
+                }
+            }
+        }
+    }
+}
+
+unsafe fn interleave_add_row(
+    dst: *mut f32,
+    even: *const f32,
+    odd: *const f32,
+    iw: usize,
+    src_stride: isize,
+) {
+    unsafe {
+        let mut i = 0usize;
+        #[cfg(target_arch = "aarch64")]
+        if src_stride == 1 {
+            use std::arch::aarch64::*;
+            while i + 4 <= iw {
+                let e = vld1q_f32(even.add(i));
+                let o = vld1q_f32(odd.add(i));
+                let mut d = vld2q_f32(dst.add(2 * i));
+                d.0 = vaddq_f32(d.0, e);
+                d.1 = vaddq_f32(d.1, o);
+                vst2q_f32(dst.add(2 * i), d);
+                i += 4;
+            }
+        }
+        while i < iw {
+            let di = dst.add(2 * i);
+            *di += *even.offset(i as isize * src_stride);
+            *di.add(1) += *odd.offset(i as isize * src_stride);
+            i += 1;
+        }
+    }
 }
 
 fn eval(

--- a/test-rt/suite-unit/src/deconv.rs
+++ b/test-rt/suite-unit/src/deconv.rs
@@ -36,101 +36,150 @@ impl Arbitrary for DeconvProblem {
     type Strategy = BoxedStrategy<DeconvProblem>;
     type Parameters = DeconvProblemParams;
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        (1usize..4)
-            .prop_flat_map(|georank| {
+        // The 2x2 stride-2 NCHW shape has a dedicated kernel and comes up about once
+        // in fifty thousand uniform draws, so half the cases are that shape.
+        prop_oneof![general(), fast_2x2_s2()].boxed()
+    }
+}
+
+fn general() -> BoxedStrategy<DeconvProblem> {
+    (1usize..4)
+        .prop_flat_map(|georank| {
+            (
+                data_format(),
+                kernel_format(),
+                prop_oneof![Just(PaddingSpec::Valid), Just(PaddingSpec::SameUpper)],
+                1usize..3,                         // n
+                1usize..4,                         // ci / group
+                1usize..4,                         // co / group
+                vec(1usize..4, georank..=georank), // kernel shape
+                vec(1usize..8, georank..=georank), // image shape
+                vec(1usize..4, georank..=georank), // strides
+                vec(1usize..4, georank..=georank), // dilations
+                1usize..4,                         // group
+            )
+        })
+        .prop_filter(
+            "dilation, strides and shapes in SAME",
+            |(_, _, pad, _, _, _, hwk, _, strides, dilations, _)| {
+                pad == &PaddingSpec::Valid
+                    || tract_itertools::izip!(hwk, dilations, strides)
+                        .all(|(k, d, s)| (k - 1) * d > s - 1)
+            },
+        )
+        .prop_flat_map(
+            |(
+                df,
+                kf,
+                pad,
+                n,
+                ci_over_group,
+                co_over_group,
+                hwk,
+                hwi,
+                strides,
+                dilations,
+                group,
+            )| {
+                let mut kernel_shape = hwk;
+                match kf {
+                    OIHW => {
+                        kernel_shape.insert(0, co_over_group * group);
+                        kernel_shape.insert(1, ci_over_group);
+                    }
+                    HWIO => {
+                        kernel_shape.push(ci_over_group * group);
+                        kernel_shape.push(co_over_group);
+                    }
+                    OHWI => {
+                        kernel_shape.insert(0, co_over_group);
+                        kernel_shape.push(ci_over_group * group);
+                    }
+                };
+                let data_shape = df.from_n_c_hw(n, ci_over_group * group, hwi).unwrap();
                 (
-                    data_format(),
-                    kernel_format(),
-                    prop_oneof![Just(PaddingSpec::Valid), Just(PaddingSpec::SameUpper)],
-                    1usize..3,                         // n
-                    1usize..4,                         // ci / group
-                    1usize..4,                         // co / group
-                    vec(1usize..4, georank..=georank), // kernel shape
-                    vec(1usize..8, georank..=georank), // image shape
-                    vec(1usize..4, georank..=georank), // strides
-                    vec(1usize..4, georank..=georank), // dilations
-                    1usize..4,                         // group
+                    Just(df),
+                    Just(kf),
+                    Just(pad),
+                    tensor(&data_shape.shape),
+                    tensor(&kernel_shape),
+                    proptest::option::of(tensor(&[co_over_group * group])),
+                    Just(strides),
+                    Just(dilations),
+                    Just(group),
                 )
-            })
-            .prop_filter(
-                "dilation, strides and shapes in SAME",
-                |(_, _, pad, _, _, _, hwk, _, strides, dilations, _)| {
-                    pad == &PaddingSpec::Valid
-                        || tract_itertools::izip!(hwk, dilations, strides)
-                            .all(|(k, d, s)| (k - 1) * d > s - 1)
-                },
-            )
-            .prop_flat_map(
-                |(
-                    df,
-                    kf,
-                    pad,
-                    n,
-                    ci_over_group,
-                    co_over_group,
-                    hwk,
-                    hwi,
-                    strides,
-                    dilations,
-                    group,
-                )| {
-                    let mut kernel_shape = hwk;
-                    match kf {
-                        OIHW => {
-                            kernel_shape.insert(0, co_over_group * group);
-                            kernel_shape.insert(1, ci_over_group);
-                        }
-                        HWIO => {
-                            kernel_shape.push(ci_over_group * group);
-                            kernel_shape.push(co_over_group);
-                        }
-                        OHWI => {
-                            kernel_shape.insert(0, co_over_group);
-                            kernel_shape.push(ci_over_group * group);
-                        }
-                    };
-                    let data_shape = df.from_n_c_hw(n, ci_over_group * group, hwi).unwrap();
-                    (
-                        Just(df),
-                        Just(kf),
-                        Just(pad),
-                        tensor(&data_shape.shape),
-                        tensor(&kernel_shape),
-                        proptest::option::of(tensor(&[co_over_group * group])),
-                        Just(strides),
-                        Just(dilations),
-                        Just(group),
-                    )
-                },
-            )
-            .prop_map(
-                |(
+            },
+        )
+        .prop_map(
+            |(
+                data_format,
+                kernel_format,
+                padding,
+                input,
+                kernel,
+                bias,
+                strides,
+                dilations,
+                group,
+            )| {
+                let adjustments = tvec!(0; kernel.ndim() - 2); // FIXME maybe
+                DeconvProblem {
                     data_format,
                     kernel_format,
                     padding,
                     input,
                     kernel,
                     bias,
-                    strides,
-                    dilations,
+                    strides: strides.into(),
+                    dilations: dilations.into(),
+                    adjustments,
                     group,
-                )| {
-                    let adjustments = tvec!(0; kernel.ndim() - 2); // FIXME maybe
-                    DeconvProblem {
-                        data_format,
-                        kernel_format,
-                        padding,
-                        input,
-                        kernel,
-                        bias,
-                        strides: strides.into(),
-                        dilations: dilations.into(),
-                        adjustments,
-                        group,
-                    }
-                },
-            )
-            .boxed()
+                }
+            },
+        )
+        .boxed()
+}
+
+fn fast_2x2_s2() -> BoxedStrategy<DeconvProblem> {
+    (1usize..3, 1usize..4, 1usize..4, 1usize..10, 1usize..10)
+        .prop_flat_map(|(n, ci, co, hi, wi)| {
+            (tensor(&[n, ci, hi, wi]), tensor(&[co, ci, 2, 2]), proptest::option::of(tensor(&[co])))
+        })
+        .prop_map(|(input, kernel, bias)| DeconvProblem {
+            data_format: NCHW,
+            kernel_format: OIHW,
+            padding: PaddingSpec::Valid,
+            input,
+            kernel,
+            bias,
+            strides: tvec!(2, 2),
+            dilations: tvec!(1, 1),
+            adjustments: tvec!(0, 0),
+            group: 1,
+        })
+        .boxed()
+}
+
+/// Distinct small integers, so a tap read from the wrong place changes the answer
+/// and every sum stays exact in f16.
+fn nchw_2x2_s2(n: usize, ci: usize, co: usize, h: usize, w: usize) -> DeconvProblem {
+    let input = ArrayD::from_shape_fn(IxDyn(&[n, ci, h, w]), |ix| {
+        ((ix[0] * 7 + ix[1] * 5 + ix[2] * 3 + ix[3]) % 9) as f32 - 4.0
+    });
+    let kernel = ArrayD::from_shape_fn(IxDyn(&[co, ci, 2, 2]), |ix| {
+        ((ix[0] * 5 + ix[1] * 3 + ix[2] * 2 + ix[3]) % 7) as f32 - 3.0
+    });
+    DeconvProblem {
+        data_format: NCHW,
+        kernel_format: OIHW,
+        padding: PaddingSpec::Valid,
+        input,
+        kernel,
+        bias: None,
+        strides: tvec!(2, 2),
+        dilations: tvec!(1, 1),
+        adjustments: tvec!(0, 0),
+        group: 1,
     }
 }
 
@@ -284,6 +333,9 @@ impl Test for DeconvProblem {
 pub fn suite() -> TractResult<TestSuite> {
     let mut suite = TestSuite::default();
     suite.add_arbitrary::<DeconvProblem>("proptest", DeconvProblemParams::default());
+
+    suite.add("nchw_2x2_s2_5x6", nchw_2x2_s2(1, 3, 4, 5, 6));
+    suite.add("nchw_2x2_s2_wide", nchw_2x2_s2(2, 2, 3, 3, 9));
 
     suite.add(
         "trivial_0",


### PR DESCRIPTION
Third slice of #2771: 2x2 stride-2 NCHW deconv. One file, `core/src/ops/cnn/deconv/deconv_sum.rs`, +205/-2, and everything that does not match the guard falls through to the generic loop untouched.

### Numbers

i7-12700K, Windows, `RAYON_NUM_THREADS=1`, `-O`. Baseline is this branch's merge-base built on the same box tonight, profiled in interleaved rounds. `DeconvSum` on tiny_det 1x3x640x640:

| build | DeconvSum |
|---|---|
| merge-base | 5.71 ms |
| this PR | **1.54 ms** |

**3.7x.** Three rounds each: base 5.770/5.622/5.742, this PR 1.552/1.562/1.510.

### Why it is this shape and not a general one

The generic scatter walks the output channel innermost, and on NCHW that stride is `H*W`, so consecutive writes land a plane apart and each one spends a cache line on a single float. The guard picks the one case with no overlap to reason about: 2x2, stride 2, unit dilation, no leading pad, contiguous W, output exactly twice the input. There each output pixel takes exactly one tap, so the four gemm planes interleave straight into even and odd rows and columns with nothing to accumulate.

### Correctness

**Bit identical** on tiny_det, all 409,600 outputs, same fixed input. That is a real check here rather than a lucky one: the guard admits only the non-overlapping case, so there is no summation whose order could have changed. If this had come back merely close, the guard would have been wrong.

The test lives in the suite-unit deconv proptest, so it runs on every runtime: the strategy draws this shape half the time, since drawn uniformly it comes up about once in fifty thousand cases, and two fixed cases keep the original geometry with distinct integer taps, so a tap read from the wrong plane changes the answer. Breaking one tap offset fails both.

### On the seam

Same reading as the maxpool slice: a target-dependent leaf with no shape to weigh. Per your call there it stays in tract-core for now, recorded on #2836 with the rest.

🍍