### PR TITLE
cuda: Not had no kernel, so a graph negating a bool left the device f…

### DIFF
--- a/cuda/src/kernels/cu/element_wise.cu
+++ b/cuda/src/kernels/cu/element_wise.cu
@@ -170,5 +170,8 @@ DEFINE_UNARY_KERNEL(element_wise_bitnot, i16, int16_t, op_bitnot);
 DEFINE_UNARY_KERNEL(element_wise_bitnot, i32, int32_t, op_bitnot);
 DEFINE_UNARY_KERNEL(element_wise_bitnot, i64, int64_t, op_bitnot);
 
-static __device__ __forceinline__ bool op_bitnot_bool(bool x) { return !x; }
-DEFINE_UNARY_KERNEL(element_wise_bitnot, bool, bool, op_bitnot_bool);
+/* Core keeps Not and BitNot apart because BitNot also takes the integers, but
+   on bool they are the one operation. */
+static __device__ __forceinline__ bool op_not_bool(bool x) { return !x; }
+DEFINE_UNARY_KERNEL(element_wise_bitnot, bool, bool, op_not_bool);
+DEFINE_UNARY_KERNEL(element_wise_not, bool, bool, op_not_bool);

--- a/cuda/src/kernels/element_wise.rs
+++ b/cuda/src/kernels/element_wise.rs
@@ -38,6 +38,7 @@ const ALL_OP_NAMES: &[&str] = &[
     "sign",
     "hardswish",
     "bitnot",
+    "not",
 ];
 
 pub fn all_functions() -> Vec<String> {
@@ -55,10 +56,10 @@ pub fn all_functions() -> Vec<String> {
 pub fn is_supported(mini_op: &dyn ElementWiseMiniOp, dt: DatumType) -> bool {
     let name = mini_op.name().to_lowercase();
     ALL_OP_NAMES.contains(&name.as_str())
-        && if name == "bitnot" {
-            dt.is_integer() || dt.is::<bool>()
-        } else {
-            matches!(dt, DatumType::F32 | DatumType::F16)
+        && match name.as_str() {
+            "bitnot" => dt.is_integer() || dt.is::<bool>(),
+            "not" => dt.is::<bool>(),
+            _ => matches!(dt, DatumType::F32 | DatumType::F16),
         }
 }
 
@@ -164,6 +165,22 @@ mod tests {
         test_case::<f32>(&nn::Sigmoid {}, &[4, 4])?;
         test_case::<f16>(&nn::Sigmoid {}, &[4, 4])?;
         Ok(())
+    }
+
+    /// The bool ops the `Float` helper above cannot reach. `Not` is the one the
+    /// attention mask needs: without it the mask chain leaves the device for a
+    /// single negation and comes back.
+    #[test]
+    fn test_element_wise_not() -> TractResult<()> {
+        with_cuda_stream(|stream| {
+            let input = tensor1(&[true, false, true, true]).into_device()?;
+            let output = unsafe { DeviceTensor::uninitialized_dt(DatumType::Bool, input.shape())? };
+            dispatch_eval(stream, &tract_core::ops::logic::Not {}, &input, &output)?;
+            stream.synchronize()?;
+            let out = output.to_host()?.into_tensor();
+            assert_eq!(out.as_plain().unwrap().as_slice::<bool>()?, &[false, true, false, false]);
+            Ok(())
+        })
     }
 
     #[test]

--- a/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
+++ b/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
@@ -12,7 +12,7 @@ for rt in $TRACT_RUNTIMES
 do
 	gpu_assert=""
 	case "$rt" in
-		--cuda) gpu_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub,Not";;
+		--cuda) gpu_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub";;
 		--metal) gpu_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub,Not";;
 	esac
 
@@ -72,7 +72,7 @@ do
 	case "$rt" in
 		--cuda)
 			pp_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
-			enc_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,PulsedRange,Not"
+			enc_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,PulsedRange"
 			;;
 		--metal)
 			pp_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"


### PR DESCRIPTION
…or it and came back -- on the pulsed nemotron encoder the attention mask went device to host and back every turn for one negation of ten kilobytes, which was also the last host op in that graph. Take the bool kernel BitNot already has, and drop Not from the cuda side of the harness's assert-op-only list, which was allowing it. This is not a speed win: the round trip costs 0.23 ms of accelerator time a turn at batch 43 and the extra dispatch costs 0.38, so the turn is 1% slower and capacity flat at 186 to 187 streams. It closes the island; metal still has the same gap.