### PR TITLE
cuda: a pulsed attention window reaches its GEMM's second operand thr…

### DIFF
--- a/cuda/src/kernels/cu/mm_mv.cu
+++ b/cuda/src/kernels/cu/mm_mv.cu
@@ -10,15 +10,25 @@ mul_mat_vec(const T *__restrict__ x, const T *__restrict__ y,
             const int32_t stride_col_dst, const int32_t channel_ratio,
             const int32_t stride_channel_x, const int32_t stride_channel_y,
             const int32_t stride_channel_dst,
-            const int32_t *__restrict__ x_ring) {
+            const int32_t *__restrict__ x_ring,
+            const int32_t ring_rotates_k) {
   const int row = blockIdx.x;
   const int channel_dst = blockIdx.y;
   const int channel_x = channel_dst / channel_ratio;
   const int channel_y = channel_dst;
   const int tid = threadIdx.x;
 
+  // How far this channel's window has turned, in pairs of columns, when the
+  // ring turns along the contracted axis rather than along the rows.
+  int ring_off2 = 0;
   if (x_ring == nullptr) {
     x += channel_x * stride_channel_x + row * stride_row;
+  } else if (ring_rotates_k) {
+    // x holds each channel's contracted axis as a ring of whole slots, and more
+    // channels than the grid covers: the table gives how far the window has
+    // turned and where this channel's rows start.
+    ring_off2 = x_ring[2 * channel_dst];
+    x += (x_ring[2 * channel_dst + 1] + row) * stride_row;
   } else {
     // x holds each channel's gridDim.x rows as a ring, and more channels than
     // the grid covers: the table gives this channel's first row and where its
@@ -48,7 +58,11 @@ mul_mat_vec(const T *__restrict__ x, const T *__restrict__ y,
     const float2 *x2 = (const float2 *)x;
     const float2 *y2 = (const float2 *)y;
     for (int col2 = tid; col2 < ncols2; col2 += block_size) {
-      const float2 tmpx = x2[col2];
+      int col2_x = col2 + ring_off2;
+      if (col2_x >= ncols2) {
+        col2_x -= ncols2;
+      }
+      const float2 tmpx = x2[col2_x];
 
 #pragma unroll
       for (int j = 0; j < ncols_dst; ++j) {
@@ -63,7 +77,11 @@ mul_mat_vec(const T *__restrict__ x, const T *__restrict__ y,
     half2 sumh2[ncols_dst] = {{0.0f, 0.0f}};
 
     for (int col2 = tid; col2 < ncols2; col2 += block_size) {
-      const half2 tmpx = x2[col2];
+      int col2_x = col2 + ring_off2;
+      if (col2_x >= ncols2) {
+        col2_x -= ncols2;
+      }
+      const half2 tmpx = x2[col2_x];
 
 #pragma unroll
       for (int j = 0; j < ncols_dst; ++j) {
@@ -113,11 +131,12 @@ mul_mat_vec(const T *__restrict__ x, const T *__restrict__ y,
           const int32_t stride_col_dst, const int32_t channel_ratio,                   \
           const int32_t stride_channel_x, const int32_t stride_channel_y,              \
           const int32_t stride_channel_dst,                                    \
-          const int32_t *__restrict__ x_ring) {                                \
+          const int32_t *__restrict__ x_ring,                                  \
+          const int32_t ring_rotates_k) {                                      \
     mul_mat_vec<T, ncols_dst, block_size>(                                     \
         x, y, dst, ncols2, nchannels_y, stride_row, stride_col_y2,             \
         stride_col_dst, channel_ratio, stride_channel_x, stride_channel_y,     \
-        stride_channel_dst, x_ring);                                           \
+        stride_channel_dst, x_ring, ring_rotates_k);                           \
   }
 
 #define INSTANTIATE_MAT_VEC_FOR_BS(name, T, blocksize)                         \

--- a/cuda/src/kernels/matmul/mod.rs
+++ b/cuda/src/kernels/matmul/mod.rs
@@ -187,6 +187,15 @@ impl CublasDispatchParams {
     }
 }
 
+/// Which axis of a weights ring the kernel turns as it reads: the rows of the
+/// window, or the axis the GEMM contracts. The window's own axis is one or the
+/// other once the layout the ring is held in has been applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RingAxis {
+    Rows,
+    Contracted,
+}
+
 fn kernel_name_mat_vec(dt: DatumType, n_cols: usize, block_size: usize) -> TractResult<String> {
     Ok(format!("ggml_matvec_{}_ncols_{}_bs_{}", DeviceTensor::tname(dt)?, n_cols, block_size))
 }
@@ -197,7 +206,7 @@ fn dispatch_ggml_matvec(
     activs: &DeviceTensor,
     output: &DeviceTensor,
     params: GemmParams,
-    w_ring: Option<&DeviceTensor>,
+    w_ring: Option<(&DeviceTensor, RingAxis)>,
 ) -> TractResult<()> {
     ensure!(params.act_batch % params.w_batch == 0);
 
@@ -227,11 +236,12 @@ fn dispatch_ggml_matvec(
     launch_args.push_i32(params.w_strides[0]);
     launch_args.push_i32(params.act_strides[0]);
     launch_args.push_i32(params.out_strides[0]);
-    let ring_view = w_ring.map(get_cuda_view);
+    let ring_view = w_ring.map(|(table, _)| get_cuda_view(table));
     match ring_view.as_ref() {
         Some(view) => launch_args.push_view(view),
         None => launch_args.push_null_ptr(),
     }
+    launch_args.push_i32(matches!(w_ring, Some((_, RingAxis::Contracted))) as i32);
 
     let cfg = LaunchConfig {
         grid_dim: (params.n as _, params.act_batch as _, 1),
@@ -584,6 +594,7 @@ impl GgmlGemm {
     /// window starts at within its lane, and the row its lane starts at -- so
     /// the kernel addresses the weights through the table rather than through
     /// `w_shape`'s channel stride. Matvec shapes only.
+    #[allow(clippy::too_many_arguments)]
     pub fn dispatch_matvec_ring(
         &self,
         stream: &TractCudaStream,
@@ -592,6 +603,7 @@ impl GgmlGemm {
         out: &DeviceTensor,
         w_shape: &[usize],
         ring_table: &DeviceTensor,
+        ring_axis: RingAxis,
     ) -> TractResult<()> {
         let (act_shape, _) = get_concrete_shapes(activs, ring)?;
         ensure!(out.shape() == self.output_shape(&act_shape, w_shape).as_slice());
@@ -606,7 +618,7 @@ impl GgmlGemm {
             "A weights ring needs the matvec kernel, which {w_shape:?}x{act_shape:?} does not reach"
         );
         ensure!(params.act_batch == params.w_batch, "A weights ring is addressed per channel");
-        dispatch_ggml_matvec(stream, ring, activs, out, params, Some(ring_table))
+        dispatch_ggml_matvec(stream, ring, activs, out, params, Some((ring_table, ring_axis)))
     }
 
     pub fn dispatch_eval(
@@ -824,6 +836,74 @@ mod tests {
                 &out,
                 &[channels, n, k],
                 &tensor1(&table).into_device()?,
+                RingAxis::Rows,
+            )?;
+            stream.synchronize()?;
+            out.to_host()?.close_enough(&expected.to_host()?.into_tensor(), true)
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_ring_k_test_case(
+        (seats, per_seat, lanes, m, n, slots, slot_cols): (
+            usize,
+            usize,
+            usize,
+            usize,
+            usize,
+            usize,
+            usize,
+        ),
+    ) -> TractResult<()> {
+        crate::with_cuda_stream(|stream| {
+            let (channels, k) = (seats * per_seat, slots * slot_cols);
+            let act = Tensor::from_shape(
+                &[channels, m, k],
+                &(0..channels * m * k).map(|f| f as f32 / (channels * m * k) as f32).collect_vec(),
+            )?;
+            let window = Tensor::from_shape(
+                &[channels, n, k],
+                &(0..channels * n * k).map(|f| f as f32 / (channels * n * k) as f32).collect_vec(),
+            )?;
+            let expected = GgmlGemm.eval(
+                stream,
+                &act.clone().into_device()?,
+                &window.clone().into_device()?,
+            )?;
+
+            // The ring turns on the contracted axis: lane `l` holds channel
+            // `c`'s window with every row's columns rotated by `rot = l + 1`
+            // whole slots of them, which is what the table's rotation means.
+            let window = window.as_plain().unwrap().as_slice::<f32>()?.to_vec();
+            let mut ring = Tensor::zero::<f32>(&[lanes * channels, n, k])?;
+            let mut ring_plain = ring.as_plain_mut().unwrap();
+            let ring_slice = ring_plain.as_slice_mut::<f32>()?;
+            let mut table: Vec<i32> = vec![0; 2 * channels];
+            for c in 0..channels {
+                let lane = c % lanes;
+                let rot = lane + 1;
+                for row in 0..n {
+                    for slot in 0..slots {
+                        let from = (c * n + row) * k + slot * slot_cols;
+                        let to = ((lane * channels + c) * n + row) * k
+                            + ((slot + rot) % slots) * slot_cols;
+                        ring_slice[to..to + slot_cols]
+                            .copy_from_slice(&window[from..from + slot_cols]);
+                    }
+                }
+                table[2 * c] = (rot * slot_cols / 2) as i32;
+                table[2 * c + 1] = ((lane * channels + c) * n) as i32;
+            }
+
+            let out = unsafe { DeviceTensor::uninitialized_dt(F32, expected.shape())? };
+            GgmlGemm.dispatch_matvec_ring(
+                stream,
+                &act.into_device()?,
+                &ring.clone().into_device()?,
+                &out,
+                &[channels, n, k],
+                &tensor1(&table).into_device()?,
+                RingAxis::Contracted,
             )?;
             stream.synchronize()?;
             out.to_host()?.close_enough(&expected.to_host()?.into_tensor(), true)
@@ -836,6 +916,15 @@ mod tests {
         run_ring_test_case((1, 8, 1, 4, 128, 15, 4))?;
         run_ring_test_case((3, 8, 5, 4, 128, 15, 4))?;
         run_ring_test_case((2, 2, 3, 8, 64, 7, 1))?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_mat_vec_ring_on_contracted_axis() -> TractResult<()> {
+        run_ring_k_test_case((1, 1, 1, 1, 1, 2, 2))?;
+        run_ring_k_test_case((43, 8, 1, 4, 128, 15, 4))?;
+        run_ring_k_test_case((43, 8, 5, 4, 128, 15, 4))?;
+        run_ring_k_test_case((2, 2, 3, 8, 7, 7, 2))?;
         Ok(())
     }
 

--- a/cuda/src/ops/ring_gemm.rs
+++ b/cuda/src/ops/ring_gemm.rs
@@ -1,3 +1,4 @@
+use tract_core::internal::natural_strides;
 use tract_core::internal::*;
 use tract_gpu::device::get_context;
 use tract_gpu::ops::change_axes::GpuAxisOp;
@@ -7,7 +8,7 @@ use tract_gpu::tensor::{DeviceTensor, DeviceTensorExt, IntoDevice};
 use tract_gpu::turn_handler::make_tensor_for_node;
 use tract_pulse_opl::ops::Delay;
 
-use crate::kernels::matmul::GgmlGemm;
+use crate::kernels::matmul::{GgmlGemm, RingAxis};
 use crate::ops::CudaGgmlGemm;
 
 /// A pulsed window and the GEMM reading it, fused: the window stays a ring of
@@ -19,8 +20,9 @@ use crate::ops::CudaGgmlGemm;
 /// and so the layout the ring is held in. The inputs are the GEMM's activations
 /// and the turn's slot, in that order, the window being the GEMM's second
 /// operand. Sound only for a window the rotation of a ring can stand for: a
-/// `Delay` of no delay and a zeroed pad, a slot per turn, and a layout whose
-/// window axis spans one channel in runs of whole slots.
+/// `Delay` of no delay and a zeroed pad, a slot per turn, and a layout under
+/// which a slot is either a run of whole rows of the window or an even run of
+/// the columns of every one of its rows -- the two axes a ring can turn on.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CudaRingGemm {
     pub delay: Delay,
@@ -122,18 +124,35 @@ impl CudaRingGemmState {
         let max_lanes = ctx.seating.max_lanes();
         let mut slots_shape: TVec<usize> = slot.shape().into();
         slots_shape[axis] = op.slots();
-        if max_lanes > 1 {
-            ensure!(axis > 0, "A ring on axis 0 leaves no axis 0 for the lanes");
-            slots_shape[0] = max_lanes;
-        }
+        // The layout the window reaches its GEMM in, for the streams this turn
+        // seats.
         let held = chain_shape(&slots_shape, &op.window_axis_ops, ctx.symbols)?;
-        let ring = Tensor::zero_dt(slot.datum_type(), &held)?.into_device()?;
-        let (unchained, strides) =
-            unchain_strides(ring.shape(), ring.strides(), &op.window_axis_ops, ctx.symbols)?;
+        let (unchained, mut strides) =
+            unchain_strides(&held, &natural_strides(&held), &op.window_axis_ops, ctx.symbols)?;
         ensure!(
             unchained == slots_shape,
             "The ring's layout leads to {unchained:?}, not {slots_shape:?}"
         );
+        // A laned ring holds a lane per seat the turn may ever seat, and the
+        // chain can fold the lane axis into another, so it holds one stream's
+        // worth of that layout per lane rather than being chained at its full
+        // width. A ring one stream owns is that layout whole.
+        let ring_shape: TVec<usize> = if max_lanes > 1 {
+            ensure!(axis > 0, "A ring on axis 0 leaves no axis 0 for the lanes");
+            let lane_span = held.iter().product::<usize>() / slots_shape[0];
+            ensure!(
+                slots_shape[0] == 1 || strides[0] as usize == lane_span,
+                "A ring held as {held:?} gives a stream stride of {}, not the {lane_span} a \
+                 whole stream of it spans",
+                strides[0]
+            );
+            slots_shape[0] = max_lanes;
+            strides[0] = lane_span as isize;
+            tvec!(max_lanes, lane_span)
+        } else {
+            held
+        };
+        let ring = Tensor::zero_dt(slot.datum_type(), &ring_shape)?.into_device()?;
         self.slots_view = Some(ring.reshaped(slots_shape)?.restrided(strides)?);
         self.ring = Some(ring);
         self.heads = tvec!(0; max_lanes);
@@ -141,15 +160,16 @@ impl CudaRingGemmState {
         Ok(())
     }
 
-    /// Where each activation channel reads: the row its window starts at within
-    /// its lane, and the row its lane starts at. A seat holds `channels /
-    /// occupancy` consecutive channels of the turn, a lane as many of the ring.
+    /// Where each activation channel reads: how far its window has turned,
+    /// counted in whatever unit a slot spans along the axis the ring turns on,
+    /// and the row its lane starts at. A seat holds `channels / occupancy`
+    /// consecutive channels of the turn, a lane as many of the ring.
     fn fill_table(
         &mut self,
         ctx: &EvalContext,
         channels: usize,
         n: usize,
-        slot_rows: usize,
+        slot_unit: usize,
     ) -> TractResult<()> {
         let occupancy = ctx.seating.occupancy();
         ensure!(channels.is_multiple_of(occupancy), "{channels} channels over {occupancy} seats");
@@ -160,7 +180,7 @@ impl CudaRingGemmState {
             let head = self.heads[lane.unwrap_or(0)];
             for c in 0..per_seat {
                 let channel = seat.unwrap_or(0) * per_seat + c;
-                table[2 * channel] = (head * slot_rows) as i32;
+                table[2 * channel] = (head * slot_unit) as i32;
                 table[2 * channel + 1] = ((lane.unwrap_or(0) * per_seat + c) * n) as i32;
             }
         }
@@ -214,13 +234,22 @@ impl OpState for CudaRingGemmState {
         let channels: usize = w_shape[..w_shape.len() - 2].iter().product();
         let slots_view = self.slots_view.clone().unwrap();
         let slot_span = slots_view.strides()[axis] as usize;
-        ensure!(
-            slot_span.is_multiple_of(k) && slot_span * slots == n * k,
-            "A slot spans {slot_span} of a {n}x{k} window, which is not a run of whole rows"
-        );
-        let slot_rows = slot_span / k;
+        let (ring_axis, slot_unit) = if slot_span.is_multiple_of(k) {
+            ensure!(
+                slot_span * slots == n * k,
+                "A slot spans {slot_span} of a {n}x{k} window, which is not a run of whole rows"
+            );
+            (RingAxis::Rows, slot_span / k)
+        } else {
+            ensure!(
+                slot_span * slots == k && slot_span.is_multiple_of(2),
+                "A slot spans {slot_span} of a {n}x{k} window, which is neither a run of \
+                 whole rows nor an even run of every row's columns"
+            );
+            (RingAxis::Contracted, slot_span / 2)
+        };
 
-        self.fill_table(ctx, channels, n, slot_rows)?;
+        self.fill_table(ctx, channels, n, slot_unit)?;
         let device = get_context()?;
         for ix in 0..occupancy {
             let (seat, lane) = ctx.seating.address(ix);
@@ -242,7 +271,7 @@ impl OpState for CudaRingGemmState {
         let ring = self.ring.as_ref().unwrap();
         let table = self.table.as_ref().unwrap();
         crate::with_cuda_stream(|stream| {
-            GgmlGemm.dispatch_matvec_ring(stream, act, ring, &out, &w_shape, table)
+            GgmlGemm.dispatch_matvec_ring(stream, act, ring, &out, &w_shape, table, ring_axis)
         })?;
         Ok(tvec!(out.into_tensor().into()))
     }

--- a/cuda/src/rewrite_rules/fuse_window_into_gemm.rs
+++ b/cuda/src/rewrite_rules/fuse_window_into_gemm.rs
@@ -1,5 +1,6 @@
 use tract_core::internal::*;
 use tract_gpu::fact::DeviceTypedFactExt;
+use tract_gpu::ops::change_axes::GpuAxisOp;
 use tract_gpu::ops::pulse::GpuDelay;
 use tract_gpu::rule_ensure;
 
@@ -7,7 +8,9 @@ use crate::ops::{CudaGgmlGemm, CudaRingGemm};
 
 /// A pulsed window writing the operand its GEMM reads, and nothing else,
 /// becomes [`CudaRingGemm`]: the window stays a ring the kernel rotates as it
-/// reads, so the turn writes one slot instead of the whole window.
+/// reads, so the turn writes one slot instead of the whole window. The ring
+/// turns on the window's rows or on the axis the GEMM contracts, whichever the
+/// layout between the window and its GEMM puts the window axis in.
 ///
 /// Runs between the output-side and input-side axis-op fusions: the first is
 /// what puts the window in the GEMM's layout, the second would wrap both nodes
@@ -23,37 +26,52 @@ pub fn fuse_window_into_gemm(
     // The window is all of the ring, so the ring can hold no delay to wait out,
     // and its zeroed slots have to be what the stream's start reads.
     rule_ensure!(op.delay == 0 && op.zero_pad && op.overlap > 0);
-    rule_ensure!(!delay.out_axis_ops.is_empty());
 
     let slot = model.node_input_facts(node.id)?[0];
     let slot_shape = slot.as_device_fact().map(|f| &f.shape).unwrap_or(&slot.shape);
     rule_ensure!(slot_shape[op.axis].is_one());
 
-    rule_if_some!(gemm = model.single_succ(node.id)?);
+    // The window reaches its GEMM through the chain the delay writes through
+    // and any axis op still standing between the two, each of which the ring
+    // stands for by being held in the layout they lead to.
+    let mut window_axis_ops = delay.out_axis_ops.clone();
+    let mut window_wire = node.id;
+    let gemm = loop {
+        rule_if_some!(succ = model.single_succ(window_wire)?);
+        let Some(axis_op) = succ.op_as::<GpuAxisOp>() else { break succ };
+        window_axis_ops.push(axis_op.clone());
+        window_wire = succ.id;
+    };
+    rule_ensure!(!window_axis_ops.is_empty());
     rule_ensure!(gemm.op_is::<CudaGgmlGemm>());
-    rule_ensure!(gemm.inputs[1] == node.id.into());
+    rule_ensure!(gemm.inputs[1] == window_wire.into());
 
-    let window = model.node_output_facts(node.id)?[0].clone();
+    let window = model.node_input_facts(gemm.id)?[1].clone();
     let act = model.node_input_facts(gemm.id)?[0];
     let (window, act) = (
         window.as_device_fact().map(|f| f.clone().into_typed_fact()).unwrap_or(window),
         act.as_device_fact().map(|f| f.clone().into_typed_fact()).unwrap_or(act.clone()),
     );
-    // The kernel reading a ring is the matvec one, and the window axis has to be
-    // its rows: whole slots of them, so a slot rotation is a row rotation.
+    // The kernel reading a ring is the matvec one, and the axis it turns has to
+    // hold whole slots: rows of them, or an even run of columns of every row,
+    // the kernel reading the contracted axis two columns at a time.
     rule_ensure!(act.rank() >= 2 && window.rank() == act.rank());
     let out = CudaGgmlGemm.resolve_output_facts(&[&act, &window])?;
     rule_if_some!(m = out[0].shape[out[0].rank() - 2].as_i64());
     rule_if_some!(k = act.shape[act.rank() - 1].as_i64());
     rule_if_some!(n = window.shape[window.rank() - 2].as_i64());
     rule_ensure!(m <= 8 && k % 2 == 0);
-    rule_ensure!((n as usize).is_multiple_of(op.overlap + 1));
+    let slots = op.overlap + 1;
+    let (n, k) = (n as usize, k as usize);
+    rule_ensure!(
+        n.is_multiple_of(slots) || (k.is_multiple_of(slots) && (k / slots).is_multiple_of(2))
+    );
 
     let mut patch = TypedModelPatch::default();
     let inputs = patch.taps(model, &[gemm.inputs[0], node.inputs[0]])?;
     let wire = patch.wire_node(
         gemm.name.clone(),
-        CudaRingGemm { delay: op.clone(), window_axis_ops: delay.out_axis_ops.clone() },
+        CudaRingGemm { delay: op.clone(), window_axis_ops },
         &inputs,
     )?;
     patch.shunt_outside(model, gemm.id.into(), wire[0])?;


### PR DESCRIPTION
…ough axis ops that can put the window axis inside the axis the GEMM contracts, and the ring rule only knew how to turn a ring on the window's rows, and only where the GEMM read the window itself -- so the nemotron encoder kept a window copy and a transpose per layer for the value operand, and at batch 1, where an axis of extent one leaves an axis op standing between the two, kept them for the key operand as well. Walk those axis ops into the layout the ring is held in, turn the ring on the contracted axis where a slot spans an even run of every row's columns, and give a laned ring one stream's worth of that layout per lane, the chain being free to fold the lane axis into another. The pulsed encoder turn goes from 57.8 to 54.9 ms at batch 43 over 48 fewer nodes, from 16.2 to 15.6 ms at batch 1 over 144 fewer, and 128 laned streams need a mean occupancy of 8.1 seats a turn rather than 9.2.