### PR TITLE
cuda: a copy packed every axis beyond the innermost two into the grid…

### DIFF
--- a/cuda/src/kernels/array/dispatch.rs
+++ b/cuda/src/kernels/array/dispatch.rs
@@ -100,6 +100,102 @@ mod tests {
         // More rows than a grid dimension other than x holds.
         run_copy_case(&[70000, 300], &[70000, 300], &[70000, 300])?;
         run_copy_case(&[70000, 8], &[70000, 9], &[70000, 8])?;
+        // More of the axes beyond the innermost two than one such dimension
+        // holds, so they take two, the second of which runs past them.
+        run_copy_case(&[70000, 3, 5], &[70000, 3, 5], &[70000, 3, 5])?;
+        run_copy_case(&[260, 256, 65, 17], &[260, 256, 65, 17], &[260, 256, 65, 16])?;
+        run_copy_case(&[70001, 2, 3, 4], &[70001, 2, 3, 5], &[70001, 2, 3, 4])?;
+        // The same, with a row a block does not hold, which addresses its rows
+        // through x rather than packing them with the threads.
+        run_copy_case(&[70000, 2, 300], &[70000, 2, 300], &[70000, 2, 300])?;
+        Ok(())
+    }
+
+    /// Every shape a copy can be asked for has to land inside what the device
+    /// takes, and a launch the driver refuses is the whole failure mode here, so
+    /// this walks the shapes rather than naming them.
+    #[test]
+    fn test_copy_launch_cfg_within_device_limits() -> TractResult<()> {
+        let props = cuda_context().properties();
+        let max_grid = props.maxGridSize;
+        let max_threads = props.maxThreadsPerBlock as usize;
+        // Extents on both sides of every threshold the helper and the driver
+        // carry: a block's threads, a warp, and a grid dimension's 65535.
+        const EXTENTS: [usize; 13] =
+            [1, 2, 3, 17, 31, 32, 255, 256, 257, 1024, 65535, 65536, 70000];
+        // Past this the tensor is larger than any device holds, and the helper
+        // is never handed one. The axes beyond the innermost two are bounded
+        // separately, the helper refusing what two grid dimensions cannot hold.
+        const MAX_ELEMS: usize = 1 << 33;
+        const MAX_OUTER: usize = 65535 * 65535;
+        let mut checked = 0usize;
+        let mut shape: TVec<usize> = tvec!();
+        let mut walk = |shape: &TVec<usize>, checked: &mut usize| -> TractResult<()> {
+            let rank = shape.len();
+            if rank > 2 && shape[..rank - 2].iter().product::<usize>() > MAX_OUTER {
+                return Ok(());
+            }
+            let cfg = cuda_launch_cfg_for_cpy(shape);
+            let grid = [cfg.grid_dim.0, cfg.grid_dim.1, cfg.grid_dim.2];
+            for (axis, (asked, allowed)) in grid.iter().zip(max_grid.iter()).enumerate() {
+                ensure!(
+                    *asked >= 1 && (*asked as i64) <= *allowed as i64,
+                    "{shape:?} asks for {asked} blocks on the grid's axis {axis}, of {allowed}"
+                );
+            }
+            let block =
+                cfg.block_dim.0 as usize * cfg.block_dim.1 as usize * cfg.block_dim.2 as usize;
+            ensure!(
+                block >= 1 && block <= max_threads,
+                "{shape:?} asks for {block} threads a block, of {max_threads}"
+            );
+            // Every element of the copy has to be reachable: a block covers
+            // whole rows of the innermost axis, so the grid has to span the rest.
+            let covered = if rank == 1 {
+                cfg.grid_dim.0 as usize * cfg.block_dim.0 as usize
+            } else {
+                let inner = shape[rank - 1];
+                let rows = (cfg.block_dim.0 as usize / inner).max(1);
+                cfg.grid_dim.0 as usize * rows
+            };
+            ensure!(
+                covered >= if rank == 1 { shape[0] } else { shape[rank - 2] },
+                "{shape:?} leaves rows past the {covered} the grid covers"
+            );
+            if rank > 2 {
+                let outer: usize = shape[..rank - 2].iter().product();
+                let packed = cfg.grid_dim.1 as usize * cfg.grid_dim.2 as usize;
+                ensure!(packed >= outer, "{shape:?} leaves {outer} axes over {packed} blocks");
+            }
+            *checked += 1;
+            Ok(())
+        };
+        fn extend(
+            shape: &mut TVec<usize>,
+            elems: usize,
+            checked: &mut usize,
+            walk: &mut impl FnMut(&TVec<usize>, &mut usize) -> TractResult<()>,
+        ) -> TractResult<()> {
+            walk(shape, checked)?;
+            if shape.len() == 6 {
+                return Ok(());
+            }
+            for extent in EXTENTS {
+                let Some(elems) = elems.checked_mul(extent).filter(|e| *e <= MAX_ELEMS) else {
+                    continue;
+                };
+                shape.push(extent);
+                extend(shape, elems, checked, walk)?;
+                shape.pop();
+            }
+            Ok(())
+        }
+        for extent in EXTENTS {
+            shape.push(extent);
+            extend(&mut shape, extent, &mut checked, &mut walk)?;
+            shape.pop();
+        }
+        assert!(checked > 10_000, "only {checked} shapes walked");
         Ok(())
     }
 }

--- a/cuda/src/kernels/cu/array.cu
+++ b/cuda/src/kernels/cu/array.cu
@@ -123,7 +123,9 @@ copy_last2(const T *input, int in_offset, int in_stride_prev, int in_stride_inne
       input[in_offset + p * in_stride_prev + i * in_stride_inner];
 }
 
-/* The axes beyond the innermost two are packed into blockIdx.y. */
+/* The axes beyond the innermost two are packed into blockIdx.y and blockIdx.z,
+   neither of which holds more than 65535 blocks. The last of z's blocks can run
+   past them, so every rank checks the outermost index it decodes. */
 #define INSTANTIATE_COPY(name, T)                                              \
   extern "C" __global__ void copy_nd1_##name(                                  \
       const T *input, T *output, int32_t in_strides_0, int32_t out_shape_0,    \
@@ -147,7 +149,10 @@ copy_last2(const T *input, int in_offset, int in_stride_prev, int in_stride_inne
       int32_t in_strides_2, int32_t out_shape_0, int32_t out_shape_1,          \
       int32_t out_shape_2, int32_t out_strides_0, int32_t out_strides_1,       \
       int32_t out_strides_2) {                                                 \
-    const int i0 = blockIdx.y;                                                 \
+    const int i0 = blockIdx.y + blockIdx.z * gridDim.y;                        \
+    if (i0 >= out_shape_0) {                                                   \
+      return;                                                                  \
+    }                                                                          \
     copy_last2<T>(input, i0 * in_strides_0, in_strides_1, in_strides_2,        \
                   output, i0 * out_strides_0, out_strides_1, out_strides_2,    \
                   out_shape_1, out_shape_2);                                   \
@@ -159,10 +164,13 @@ copy_last2(const T *input, int in_offset, int in_stride_prev, int in_stride_inne
       int32_t out_shape_1, int32_t out_shape_2, int32_t out_shape_3,           \
       int32_t out_strides_0, int32_t out_strides_1, int32_t out_strides_2,     \
       int32_t out_strides_3) {                                                 \
-    int b = blockIdx.y;                                                        \
+    int b = blockIdx.y + blockIdx.z * gridDim.y;                               \
     const int i1 = b % out_shape_1;                                            \
     b /= out_shape_1;                                                          \
     const int i0 = b;                                                          \
+    if (i0 >= out_shape_0) {                                                   \
+      return;                                                                  \
+    }                                                                          \
     copy_last2<T>(input, i0 * in_strides_0 + i1 * in_strides_1, in_strides_2,  \
                   in_strides_3, output,                                        \
                   i0 * out_strides_0 + i1 * out_strides_1, out_strides_2,      \
@@ -176,12 +184,15 @@ copy_last2(const T *input, int in_offset, int in_stride_prev, int in_stride_inne
       int32_t out_shape_3, int32_t out_shape_4, int32_t out_strides_0,         \
       int32_t out_strides_1, int32_t out_strides_2, int32_t out_strides_3,     \
       int32_t out_strides_4) {                                                 \
-    int b = blockIdx.y;                                                        \
+    int b = blockIdx.y + blockIdx.z * gridDim.y;                               \
     const int i2 = b % out_shape_2;                                            \
     b /= out_shape_2;                                                          \
     const int i1 = b % out_shape_1;                                            \
     b /= out_shape_1;                                                          \
     const int i0 = b;                                                          \
+    if (i0 >= out_shape_0) {                                                   \
+      return;                                                                  \
+    }                                                                          \
     copy_last2<T>(                                                             \
         input, i0 * in_strides_0 + i1 * in_strides_1 + i2 * in_strides_2,      \
         in_strides_3, in_strides_4, output,                                    \
@@ -197,7 +208,7 @@ copy_last2(const T *input, int in_offset, int in_stride_prev, int in_stride_inne
       int32_t out_shape_5, int32_t out_strides_0, int32_t out_strides_1,       \
       int32_t out_strides_2, int32_t out_strides_3, int32_t out_strides_4,     \
       int32_t out_strides_5) {                                                 \
-    int b = blockIdx.y;                                                        \
+    int b = blockIdx.y + blockIdx.z * gridDim.y;                               \
     const int i3 = b % out_shape_3;                                            \
     b /= out_shape_3;                                                          \
     const int i2 = b % out_shape_2;                                            \
@@ -205,6 +216,9 @@ copy_last2(const T *input, int in_offset, int in_stride_prev, int in_stride_inne
     const int i1 = b % out_shape_1;                                            \
     b /= out_shape_1;                                                          \
     const int i0 = b;                                                          \
+    if (i0 >= out_shape_0) {                                                   \
+      return;                                                                  \
+    }                                                                          \
     copy_last2<T>(input,                                                       \
                   i0 * in_strides_0 + i1 * in_strides_1 + i2 * in_strides_2 +  \
                       i3 * in_strides_3,                                       \

--- a/cuda/src/kernels/utils.rs
+++ b/cuda/src/kernels/utils.rs
@@ -5,12 +5,21 @@ use cudarc::driver::LaunchConfig;
 /// copy is bandwidth-bound, so it wants every slot it can fill.
 const COPY_THREADS: usize = 256;
 
+/// What a launch may ask of the grid's `y` and `z`, each.
+const MAX_GRID_YZ: usize = 65535;
+
 pub use tract_gpu::utils::{compute_broadcast_strides, reshape_to_rank_2, reshape_to_rank_3};
 
 /// The grid a `copy_ndN` kernel runs on: a block covers whole rows of the
-/// innermost axis, `x` the rows a single block does not hold, and `y` every
-/// axis beyond the innermost two. The rows take `x` because a tensor has far
-/// more of them, and `y` and `z` hold 65535 where `x` holds 2^31.
+/// innermost axis, `x` the rows a single block does not hold, and `y` and `z`
+/// together every axis beyond the innermost two. The rows take `x` because a
+/// tensor has far more of them, and `y` and `z` hold 65535 each where `x` holds
+/// 2^31; the kernel reads the pair back as `blockIdx.y + blockIdx.z *
+/// gridDim.y`, so `z` carries only what does not fit in `y` and the last of its
+/// blocks can run past the axes and has to return. Two dimensions bound those
+/// axes at 65535 squared between them, which no tensor a device holds reaches --
+/// it would take 4 GB of a one-byte type with both innermost axes at one -- and
+/// a shape past it is refused rather than launched.
 ///
 /// `block_dim` stays a whole multiple of the innermost extent -- the kernel
 /// maps a thread to a row by dividing by it -- and only a row wider than a
@@ -30,6 +39,11 @@ pub fn cuda_launch_cfg_for_cpy(shape: &[usize]) -> LaunchConfig {
     let inner = shape[rank - 1];
     let prev = shape[rank - 2];
     let outer: usize = shape[..rank - 2].iter().product();
+    assert!(
+        outer <= MAX_GRID_YZ * MAX_GRID_YZ,
+        "A copy of {shape:?} spans {outer} of the axes beyond its innermost two, over the          {} two grid dimensions hold",
+        MAX_GRID_YZ * MAX_GRID_YZ
+    );
     let (block, rows) = if inner > COPY_THREADS {
         (COPY_THREADS, 0)
     } else {
@@ -37,7 +51,11 @@ pub fn cuda_launch_cfg_for_cpy(shape: &[usize]) -> LaunchConfig {
         (inner * rows, rows)
     };
     LaunchConfig {
-        grid_dim: (if rows == 0 { prev as _ } else { prev.div_ceil(rows) as _ }, outer as _, 1),
+        grid_dim: (
+            if rows == 0 { prev as _ } else { prev.div_ceil(rows) as _ },
+            outer.min(MAX_GRID_YZ) as _,
+            outer.div_ceil(MAX_GRID_YZ) as _,
+        ),
         block_dim: (block as _, 1, 1),
         shared_mem_bytes: 0,
     }


### PR DESCRIPTION
…'s y, which holds 65535 blocks, so a copy of more than that many rows of rows failed the launch outright -- the laned encoder's pulse pad copies a BATCH,256,65,17 tensor and died with an invalid argument the moment a turn seated 256 streams, capping where laned capacity could be measured at all. Pack those axes into y and z together and have the kernel read the pair back, the last of z's blocks returning where it runs past them.