### PR TITLE
metal: dump --profile reported no accelerator time on metal, because …

### DIFF
--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -155,12 +155,22 @@ pub fn handle(
             #[cfg(not(all(any(target_os = "linux", target_os = "windows"), feature = "cuda")))]
             let is_cuda = false;
 
+            #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "metal"))]
+            let is_metal = matches.get_flag("metal");
+            #[cfg(not(all(any(target_os = "macos", target_os = "ios"), feature = "metal")))]
+            let is_metal = false;
+
             if is_cuda {
                 #[cfg(all(any(target_os = "linux", target_os = "windows"), feature = "cuda"))]
                 tract_cuda::with_cuda_stream(|s| {
                     s.enable_profiling();
                     Ok(())
                 })?;
+            }
+
+            if is_metal {
+                #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "metal"))]
+                tract_metal::with_metal_stream(|s| s.enable_profiling())?;
             }
 
             let before_node: Box<dyn Fn(usize)> = if is_cuda {
@@ -178,6 +188,19 @@ pub fn handle(
                     any(target_os = "linux", target_os = "windows"),
                     feature = "cuda"
                 )))]
+                Box::new(|_| {})
+            } else if is_metal {
+                #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "metal"))]
+                {
+                    Box::new(|node_id| {
+                        tract_metal::with_metal_stream(|s| {
+                            s.set_current_node(node_id);
+                            Ok(())
+                        })
+                        .ok();
+                    })
+                }
+                #[cfg(not(all(any(target_os = "macos", target_os = "ios"), feature = "metal")))]
                 Box::new(|_| {})
             } else {
                 Box::new(|_| {})
@@ -217,6 +240,25 @@ pub fn handle(
                     any(target_os = "linux", target_os = "windows"),
                     feature = "cuda"
                 )))]
+                Box::new(|_, _| Ok(()))
+            } else if is_metal {
+                #[cfg(all(any(target_os = "macos", target_os = "ios"), feature = "metal"))]
+                {
+                    Box::new(|dg, prefix| {
+                        tract_metal::with_metal_stream(|s| {
+                            s.wait_until_completed()?;
+                            for (node_id, dur) in s.drain_profile()? {
+                                let node_id =
+                                    tract_libcli::annotations::NodeQId(prefix.into(), node_id);
+                                *dg.node_mut(node_id)
+                                    .accelerator_profile
+                                    .get_or_insert(std::time::Duration::default()) += dur;
+                            }
+                            Ok(())
+                        })
+                    })
+                }
+                #[cfg(not(all(any(target_os = "macos", target_os = "ios"), feature = "metal")))]
                 Box::new(|_, _| Ok(()))
             } else {
                 Box::new(|_, _| Ok(()))

--- a/metal/src/command_buffer.rs
+++ b/metal/src/command_buffer.rs
@@ -1,28 +1,69 @@
-use metal::{CommandBuffer, ComputeCommandEncoder, ComputeCommandEncoderRef};
+use crate::profile::MetalProfileHandle;
+use metal::{
+    CommandBuffer, ComputeCommandEncoder, ComputeCommandEncoderRef, ComputePassDescriptor,
+};
+use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
 
+/// A command buffer and the compute pass its dispatches share. A profiled
+/// buffer gives each dispatch a pass of its own instead, so the device's
+/// timestamp counters -- which it samples at a pass boundary -- bracket one
+/// dispatch each.
 #[derive(Debug, Clone)]
 pub struct TCommandBuffer {
     inner: CommandBuffer,
-    encoder: ComputeCommandEncoder,
+    encoder: Rc<RefCell<Option<ComputeCommandEncoder>>>,
+    profile: Option<Rc<MetalProfileHandle>>,
 }
 
 impl TCommandBuffer {
-    pub fn new(command_buffer: CommandBuffer) -> Self {
-        let encoder = command_buffer.new_compute_command_encoder().to_owned();
-
-        TCommandBuffer { inner: command_buffer, encoder }
-    }
-
-    pub fn encoder(&self) -> &ComputeCommandEncoder {
-        &self.encoder
+    pub fn new(command_buffer: CommandBuffer, profile: Option<Rc<MetalProfileHandle>>) -> Self {
+        TCommandBuffer { inner: command_buffer, encoder: Rc::new(RefCell::new(None)), profile }
     }
 
     pub fn encode<EncodeCallback>(&self, encode_cb: EncodeCallback)
     where
         EncodeCallback: Fn(&ComputeCommandEncoderRef),
     {
-        encode_cb(&self.encoder);
+        if let Some(handle) = self.profile.as_ref() {
+            let slot = handle.profile.borrow_mut().next_slot(handle.node_id.get());
+            if let Some((buffer_ix, start, end)) = slot {
+                self.end_encoding();
+                let descriptor = ComputePassDescriptor::new();
+                let attachment = descriptor
+                    .sample_buffer_attachments()
+                    .object_at(0)
+                    .expect("A compute pass takes a sample buffer attachment at 0");
+                {
+                    let profile = handle.profile.borrow();
+                    attachment.set_sample_buffer(profile.buffer(buffer_ix));
+                }
+                attachment.set_start_of_encoder_sample_index(start);
+                attachment.set_end_of_encoder_sample_index(end);
+                let encoder = self.inner.compute_command_encoder_with_descriptor(descriptor);
+                encode_cb(encoder);
+                encoder.end_encoding();
+                return;
+            }
+        }
+        encode_cb(&self.shared_encoder());
+    }
+
+    /// Close the pass the dispatches share, if one is open. A command buffer
+    /// holds one pass at a time, so this runs before a profiled dispatch opens
+    /// its own and before the buffer is committed.
+    pub fn end_encoding(&self) {
+        if let Some(encoder) = self.encoder.borrow_mut().take() {
+            encoder.end_encoding();
+        }
+    }
+
+    fn shared_encoder(&self) -> ComputeCommandEncoder {
+        self.encoder
+            .borrow_mut()
+            .get_or_insert_with(|| self.inner.new_compute_command_encoder().to_owned())
+            .to_owned()
     }
 }
 

--- a/metal/src/context.rs
+++ b/metal/src/context.rs
@@ -1,6 +1,7 @@
 use crate::command_buffer::TCommandBuffer;
 use crate::func_constants::ConstantValues;
 use crate::kernels::{LibraryContent, LibraryName};
+use crate::profile::{MetalProfile, MetalProfileHandle};
 use crate::tensor::{MValue, MetalTensor};
 
 use metal::NSUInteger;
@@ -14,6 +15,7 @@ use std::cell::RefCell;
 use std::ffi::c_void;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 
@@ -288,6 +290,7 @@ pub struct MetalStream {
     command_buffer: RefCell<Option<TCommandBuffer>>,
     command_buffer_id: AtomicUsize,
     retained_tensors: RefCell<Vec<DeviceTensor>>,
+    profile: RefCell<Option<Rc<MetalProfileHandle>>>,
 }
 
 impl Default for MetalStream {
@@ -306,7 +309,37 @@ impl MetalStream {
             command_buffer: RefCell::new(None),
             command_buffer_id: AtomicUsize::new(0),
             retained_tensors: RefCell::new(vec![]),
+            profile: RefCell::new(None),
         }
+    }
+
+    /// Time every dispatch from here on, each against the node that asked for
+    /// it. A profiled turn runs a pass per dispatch, so it is slower than the
+    /// turn it measures.
+    pub fn enable_profiling(&self) -> TractResult<()> {
+        let profile = MetalProfile::new(&self.context.device)?;
+        *self.profile.borrow_mut() =
+            Some(Rc::new(MetalProfileHandle { profile: RefCell::new(profile), node_id: 0.into() }));
+        Ok(())
+    }
+
+    pub fn is_profiling(&self) -> bool {
+        self.profile.borrow().is_some()
+    }
+
+    /// Which node the dispatches that follow belong to.
+    pub fn set_current_node(&self, node_id: usize) {
+        if let Some(handle) = self.profile.borrow().as_ref() {
+            handle.node_id.set(node_id);
+        }
+    }
+
+    /// What each dispatch spent on the device since the last drain. Call once
+    /// the work has completed.
+    pub fn drain_profile(&self) -> TractResult<Vec<(usize, std::time::Duration)>> {
+        let handle = self.profile.borrow().clone();
+        let Some(handle) = handle else { return Ok(vec![]) };
+        handle.profile.borrow_mut().drain(&self.context.device)
     }
 
     pub fn load_library(&self, name: LibraryName) -> TractResult<Library> {
@@ -335,10 +368,11 @@ impl MetalStream {
     }
 
     pub fn command_buffer(&self) -> TCommandBuffer {
+        let profile = self.profile.borrow().clone();
         self.command_buffer
             .borrow_mut()
             .get_or_insert_with(|| {
-                TCommandBuffer::new(self.command_queue.new_command_buffer().to_owned())
+                TCommandBuffer::new(self.command_queue.new_command_buffer().to_owned(), profile)
             })
             .to_owned()
     }
@@ -346,7 +380,7 @@ impl MetalStream {
     pub fn wait_until_completed(&self) -> TractResult<()> {
         let Some(command_buffer) = self.command_buffer.borrow().to_owned() else { return Ok(()) };
 
-        command_buffer.encoder().end_encoding();
+        command_buffer.end_encoding();
 
         match command_buffer.status() {
             metal::MTLCommandBufferStatus::Committed
@@ -407,7 +441,7 @@ impl Drop for MetalStream {
             _ => {}
         }
 
-        command_buffer.encoder().end_encoding();
+        command_buffer.end_encoding();
         command_buffer.commit();
         command_buffer.wait_until_completed();
     }

--- a/metal/src/lib.rs
+++ b/metal/src/lib.rs
@@ -4,6 +4,7 @@ mod encoder;
 mod func_constants;
 pub mod kernels;
 pub mod ops;
+mod profile;
 mod rewrite_rules;
 mod tensor;
 mod tests;
@@ -18,6 +19,7 @@ use crate::kernels::LibraryName;
 pub use crate::kernels::matmul::MetalGemmImplKind;
 
 pub use crate::context::{MetalContext, MetalStream, with_metal_stream};
+pub use crate::profile::MetalProfile;
 pub use crate::transform::MetalTransform;
 
 #[derive(Debug)]

--- a/metal/src/profile.rs
+++ b/metal/src/profile.rs
@@ -1,0 +1,192 @@
+//! Per-dispatch GPU timing, from the device's own timestamp counters.
+//!
+//! A turn's dispatches share one compute pass, and an Apple GPU samples
+//! counters at a pass boundary rather than a dispatch one, so a profiled turn
+//! gives each dispatch a pass of its own and reads the two timestamps that
+//! pass is bracketed by. That serialises the turn, which is what a profile is
+//! for.
+
+use metal::{
+    CounterSampleBuffer, CounterSampleBufferDescriptor, CounterSampleBufferRef, CounterSet, Device,
+    MTLCounterSamplingPoint, MTLStorageMode, NSRange, NSUInteger,
+};
+use std::cell::{Cell, RefCell};
+use std::time::Duration;
+use tract_core::internal::*;
+
+/// The name Metal gives the counter set carrying GPU timestamps.
+const TIMESTAMP_COUNTER_SET: &str = "timestamp";
+
+/// A counter sample buffer holds 32 KB at most and a timestamp sample takes 8,
+/// so one buffer brackets this many dispatches, two samples to a dispatch. A
+/// turn takes as many buffers as its dispatches need.
+const DISPATCHES_PER_BUFFER: usize = 32768 / 8 / 2;
+
+/// Buffers a profiled turn will allocate before it stops recording.
+const MAX_BUFFERS: usize = 16;
+
+/// What a profiled command buffer needs of its stream: where the samples go,
+/// and which node is being evaluated.
+#[derive(Debug)]
+pub struct MetalProfileHandle {
+    pub profile: RefCell<MetalProfile>,
+    pub node_id: Cell<usize>,
+}
+
+#[derive(Debug)]
+pub struct MetalProfile {
+    device: Device,
+    counter_set: CounterSet,
+    /// One buffer per `DISPATCHES_PER_BUFFER` dispatches a turn reached, grown
+    /// as a turn needs them and reused by the turns after it.
+    buffers: Vec<CounterSampleBuffer>,
+    /// The node each pair of samples was taken for, in the order taken.
+    nodes: Vec<usize>,
+    /// Where the device's clock and the host's stood when profiling began, the
+    /// pair a tick is scaled to seconds by.
+    epoch: (u64, u64),
+    untimed: usize,
+}
+
+impl MetalProfile {
+    pub fn new(device: &Device) -> TractResult<MetalProfile> {
+        ensure!(
+            device.supports_counter_sampling(MTLCounterSamplingPoint::AtStageBoundary),
+            "This device samples no counter at a pass boundary, so a dispatch cannot be timed"
+        );
+        let counter_set = device
+            .counter_sets()
+            .into_iter()
+            .find(|set| set.name() == TIMESTAMP_COUNTER_SET)
+            .context("This device exposes no timestamp counter set")?;
+        Ok(MetalProfile {
+            device: device.to_owned(),
+            counter_set: counter_set.to_owned(),
+            buffers: vec![],
+            nodes: vec![],
+            epoch: sample_clocks(device),
+            untimed: 0,
+        })
+    }
+
+    fn new_buffer(&self) -> TractResult<CounterSampleBuffer> {
+        let descriptor = CounterSampleBufferDescriptor::new();
+        descriptor.set_counter_set(&self.counter_set);
+        descriptor.set_storage_mode(MTLStorageMode::Shared);
+        descriptor.set_sample_count(2 * DISPATCHES_PER_BUFFER as u64);
+        self.device
+            .new_counter_sample_buffer_with_descriptor(&descriptor)
+            .map_err(|e| anyhow!("{e}"))
+            .context("Could not allocate a counter sample buffer")
+    }
+
+    pub fn buffer(&self, ix: usize) -> &CounterSampleBufferRef {
+        &self.buffers[ix]
+    }
+
+    /// The buffer the next dispatch's pass samples into and where in it its
+    /// start and end go, or `None` once a turn has taken all the buffers it is
+    /// allowed.
+    pub fn next_slot(&mut self, node_id: usize) -> Option<(usize, NSUInteger, NSUInteger)> {
+        let taken = self.nodes.len();
+        let buffer_ix = taken / DISPATCHES_PER_BUFFER;
+        if buffer_ix >= MAX_BUFFERS {
+            self.untimed += 1;
+            return None;
+        }
+        while self.buffers.len() <= buffer_ix {
+            match self.new_buffer() {
+                Ok(buffer) => self.buffers.push(buffer),
+                Err(e) => {
+                    log::warn!("A profiled turn outgrew its counter sample buffers: {e}");
+                    self.untimed += 1;
+                    return None;
+                }
+            }
+        }
+        let start = 2 * (taken % DISPATCHES_PER_BUFFER) as NSUInteger;
+        self.nodes.push(node_id);
+        Some((buffer_ix, start, start + 1))
+    }
+
+    /// What each dispatch spent on the device, and which node asked for it.
+    /// Sound only once the command buffer carrying them has completed.
+    pub fn drain(&mut self, device: &Device) -> TractResult<Vec<(usize, Duration)>> {
+        if self.untimed > 0 {
+            log::warn!(
+                "{} dispatches went untimed past the {} a turn records",
+                self.untimed,
+                MAX_BUFFERS * DISPATCHES_PER_BUFFER
+            );
+            self.untimed = 0;
+        }
+        let nodes = std::mem::take(&mut self.nodes);
+        if nodes.is_empty() {
+            return Ok(vec![]);
+        }
+        let seconds_per_tick = self.seconds_per_tick(device);
+        let mut timings = Vec::with_capacity(nodes.len());
+        for (buffer_ix, buffer) in self.buffers.iter().enumerate() {
+            let first = buffer_ix * DISPATCHES_PER_BUFFER;
+            if first >= nodes.len() {
+                break;
+            }
+            let held = (nodes.len() - first).min(DISPATCHES_PER_BUFFER);
+            let ticks = resolve_timestamps(buffer, 2 * held)?;
+            for dispatch in 0..held {
+                let elapsed = ticks[2 * dispatch + 1].saturating_sub(ticks[2 * dispatch]);
+                timings.push((
+                    nodes[first + dispatch],
+                    Duration::from_secs_f64(elapsed as f64 * seconds_per_tick),
+                ));
+            }
+        }
+        Ok(timings)
+    }
+
+    /// The device's clock has its own unit, and the pair of clocks it can be
+    /// read against gives the scale: how far each ran between the two readings.
+    /// A device whose clock did not move leaves the ticks unscaled.
+    fn seconds_per_tick(&self, device: &Device) -> f64 {
+        let (cpu, gpu) = sample_clocks(device);
+        let device_ticks = gpu.saturating_sub(self.epoch.1);
+        let host_nanos = cpu.saturating_sub(self.epoch.0);
+        if device_ticks == 0 || host_nanos == 0 {
+            return 1e-9;
+        }
+        host_nanos as f64 * 1e-9 / device_ticks as f64
+    }
+}
+
+/// The first `wanted` timestamps a sample buffer holds.
+///
+/// `CounterSampleBufferRef::resolve_counter_range` asks for the bytes of a
+/// freshly reserved empty `Vec`, which is none of them, and then claims the
+/// range was filled -- so it hands back whatever the allocation held. This
+/// sends `resolveCounterRange:` itself and copies the length it actually
+/// wants. A timestamp resolves to one `u64` a sample.
+// The objc msg_send!/sel! macros expand to a cargo-clippy cfg check that older
+// toolchains report at the call site; the allow covers it.
+#[allow(unexpected_cfgs)]
+fn resolve_timestamps(buffer: &CounterSampleBufferRef, wanted: usize) -> TractResult<Vec<u64>> {
+    use metal::foreign_types::ForeignTypeRef;
+    use objc::runtime::Object;
+    use objc::{msg_send, sel, sel_impl};
+
+    let mut timestamps = vec![0u64; wanted];
+    let bytes = std::mem::size_of_val(timestamps.as_slice()) as u64;
+    unsafe {
+        let buffer: *mut Object = buffer.as_ptr() as *mut Object;
+        let resolved: *mut Object =
+            msg_send![buffer, resolveCounterRange: NSRange::new(0, wanted as u64)];
+        ensure!(!resolved.is_null(), "The device resolved none of {wanted} timestamps sampled");
+        let () = msg_send![resolved, getBytes: timestamps.as_mut_ptr() length: bytes];
+    }
+    Ok(timestamps)
+}
+
+fn sample_clocks(device: &Device) -> (u64, u64) {
+    let (mut cpu, mut gpu) = (0, 0);
+    device.sample_timestamps(&mut cpu, &mut gpu);
+    (cpu, gpu)
+}


### PR DESCRIPTION
…nothing measured it -- the per-kernel timing cuda records with events had no counterpart, so a metal profile showed wall time a node spent encoding and nothing about what the device did, and the op-level summary was all there was to rank work by. Read the device's timestamp counters instead: a turn's dispatches share one compute pass and an Apple GPU samples counters at a pass boundary rather than a dispatch one, so a profiled turn gives each dispatch a pass of its own and takes the two timestamps bracketing it, which serialises the turn the way recording events does. The stream carries the sample buffer and the node being evaluated, and the CLI accumulates what it drains into the same accelerator_profile the cuda path fills.