### PR TITLE
metal: Not had no kernel, so a graph negating a bool left the device …

### DIFF
--- a/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
+++ b/harness/nemotron-3.5-asr-streaming-0.6b/ci.sh
@@ -13,7 +13,7 @@ do
 	gpu_assert=""
 	case "$rt" in
 		--cuda) gpu_assert="--assert-op-only Cuda*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub";;
-		--metal) gpu_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub,Not";;
+		--metal) gpu_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,Add,Range,Cast,Eq,Div,Sub";;
 	esac
 
 	for m in preprocessor encoder decoder joint
@@ -76,7 +76,7 @@ do
 			;;
 		--metal)
 			pp_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,Pad,PulsedSameAxisConcat,OptMulByScalar,OptSubUnicast"
-			enc_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,PulsedRange,Not"
+			enc_assert="--assert-op-only Metal*,Gpu*,DeviceSync*,Const,Source,PulsedRange"
 			;;
 		*) continue;;
 	esac

--- a/metal/src/kernels/element_wise.metal
+++ b/metal/src/kernels/element_wise.metal
@@ -307,6 +307,14 @@ struct BitNot {
     }
 };
 
+/* Core keeps Not and BitNot apart because BitNot also takes the integers, but
+   on bool they are the one operation. */
+struct Not {
+    bool operator()(bool x) {
+        return !x;
+    }
+};
+
 template<typename T, typename Op>
 [[kernel]] void eval_out_of_place(device const T *input[  [buffer(0)]],
                                   device T *output [[buffer(1)]],
@@ -389,3 +397,4 @@ INSTANTIATE_FLOAT(hardswish, HardSwish)
 INSTANTIATE_FLOAT(silu, Silu)
 INSTANTIATE_INTEGER(bitnot, BitNot)
 INSTANTIATE_ELEMENT_WISE_OP(bitnot, BitNot, bool, bool)
+INSTANTIATE_ELEMENT_WISE_OP(not, Not, bool, bool)

--- a/metal/src/kernels/element_wise.rs
+++ b/metal/src/kernels/element_wise.rs
@@ -37,6 +37,7 @@ const ALL_OP_NAMES: &[&str] = &[
     "hardswish",
     "silu",
     "bitnot",
+    "not",
 ];
 
 pub fn all_functions() -> Vec<String> {
@@ -54,10 +55,10 @@ pub fn all_functions() -> Vec<String> {
 pub fn is_supported(mini_op: &dyn ElementWiseMiniOp, dt: DatumType) -> bool {
     let name = mini_op.name().to_lowercase();
     ALL_OP_NAMES.contains(&name.as_str())
-        && if name == "bitnot" {
-            dt.is_integer() || dt.is::<bool>()
-        } else {
-            matches!(dt, DatumType::F32 | DatumType::F16)
+        && match name.as_str() {
+            "bitnot" => dt.is_integer() || dt.is::<bool>(),
+            "not" => dt.is::<bool>(),
+            _ => matches!(dt, DatumType::F32 | DatumType::F16),
         }
 }
 
@@ -109,3 +110,23 @@ crate::register_metal_op!(tract_core::ops::element_wise::ElementWiseOp, |source,
     rule_if!(is_supported(&*op.0, source.node_input_facts(node.id)?[0].datum_type));
     Ok(Some(Box::new(metal_element_wise_op(op.0.clone()))))
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::with_borrowed_metal_stream;
+    use tract_gpu::tensor::IntoDevice;
+
+    #[test]
+    fn test_element_wise_not() -> TractResult<()> {
+        with_borrowed_metal_stream(|stream| {
+            let input = tensor1(&[true, false, true, true]).into_device()?;
+            let output = unsafe { DeviceTensor::uninitialized_dt(DatumType::Bool, input.shape())? };
+            dispatch_eval(stream, &tract_core::ops::logic::Not {}, &input, &output)?;
+            stream.wait_until_completed()?;
+            let out = output.to_host()?.into_tensor();
+            assert_eq!(out.as_plain().unwrap().as_slice::<bool>()?, &[false, true, false, false]);
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
…for it and came back, the same gap cuda closed -- and the metal side of the harness's assert-op-only list was allowing it. BitNot already carries the bool operation Not wants, but core keeps the two apart because BitNot also takes the integers, so give Not its own functor over bool and drop it from the list. Not a speed win: on cuda the round trip it removes costs less than the dispatch it adds.