### PR TITLE
cross CI: cover wasm32-unknown-emscripten

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -100,6 +100,7 @@ jobs:
           - x86_64-unknown-linux-gnu-stretch
           - wasm32-unknown-unknown
           - wasm32-wasi
+          - wasm32-unknown-emscripten
 
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Closes #1618.

The emscripten failure reported there was in the `tar` crate (`symlink`/`_set_ownerships` duplicated under `cfg(unix)`), fixed upstream in 0.4.44; tract currently depends on tar 0.4.46.

Verified locally on aarch64 linux (rust stable, tract at `3a48929`):

- `cargo check --target wasm32-unknown-emscripten --features getrandom-js -p tract-onnx -p tract-tensorflow` (exactly what the existing `wasm32-*` catch-all in `.travis/cross.sh` runs): pass
- `cargo check -p tract-cli --target wasm32-unknown-emscripten`: pass
- `cargo check -p tract-nnef --target wasm32-unknown-emscripten`: pass

The matrix entry runs through the `wasm32-*` case of `.travis/cross.sh`, which needs no further changes.

One caveat, not part of this PR: a full `cargo check --workspace --target wasm32-unknown-emscripten` still fails, but only in the `causal_llm` example crate, which pulls tokio/axum/hyper and transitively `mio` — mio does not build for emscripten (its `cfg(unix)` selects missing platform code there). Library crates and the CLI are unaffected.

🍍